### PR TITLE
feat: Add pagination to MAST search results

### DIFF
--- a/frontend/jwst-frontend/src/components/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/MastSearch.css
@@ -301,4 +301,95 @@
   .bulk-import-btn {
     width: 100%;
   }
+
+  .pagination {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .pagination-controls {
+    justify-content: center;
+  }
+
+  .pagination-size {
+    justify-content: center;
+  }
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 20px;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.pagination-info {
+  color: #aaa;
+  font-size: 13px;
+}
+
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pagination-btn {
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #ccc;
+  border: 1px solid #333;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s ease;
+}
+
+.pagination-btn:hover:not(:disabled) {
+  background: rgba(74, 144, 217, 0.3);
+  border-color: #4a90d9;
+  color: #fff;
+}
+
+.pagination-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.pagination-pages {
+  color: #fff;
+  font-size: 14px;
+  padding: 0 12px;
+}
+
+.pagination-size {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pagination-size label {
+  color: #aaa;
+  font-size: 13px;
+}
+
+.pagination-size select {
+  padding: 6px 10px;
+  background: #0f0f23;
+  color: #eee;
+  border: 1px solid #333;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.pagination-size select:focus {
+  outline: none;
+  border-color: #4a90d9;
 }

--- a/frontend/jwst-frontend/src/components/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/MastSearch.tsx
@@ -28,11 +28,22 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {
   const [selectedObs, setSelectedObs] = useState<Set<string>>(new Set());
   const [importing, setImporting] = useState<string | null>(null);
 
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
+
+  // Calculate paginated results
+  const totalPages = Math.ceil(searchResults.length / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const paginatedResults = searchResults.slice(startIndex, endIndex);
+
   const handleSearch = async () => {
     setLoading(true);
     setError(null);
     setSearchResults([]);
     setSelectedObs(new Set());
+    setCurrentPage(1); // Reset to first page on new search
 
     try {
       let endpoint = '';
@@ -336,13 +347,13 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {
                   <th className="col-instrument">Instrument</th>
                   <th className="col-filter">Filter</th>
                   <th className="col-exptime">Exp Time</th>
-                  <th className="col-date">Date</th>
+                  <th className="col-date">Obs Date</th>
                   <th className="col-actions">Actions</th>
                 </tr>
               </thead>
               <tbody>
-                {searchResults.map((result, index) => {
-                  const resultObsId = result.obs_id || `result-${index}`;
+                {paginatedResults.map((result, index) => {
+                  const resultObsId = result.obs_id || `result-${startIndex + index}`;
                   return (
                     <tr key={resultObsId}>
                       <td className="col-checkbox">
@@ -369,7 +380,7 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {
                         {formatExposureTime(result.t_exptime)}
                       </td>
                       <td className="col-date">
-                        {formatDate(result.t_obs_release)}
+                        {formatDate(result.t_min)}
                       </td>
                       <td className="col-actions">
                         <button
@@ -386,6 +397,68 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {
               </tbody>
             </table>
           </div>
+
+          {/* Pagination Controls */}
+          {totalPages > 1 && (
+            <div className="pagination">
+              <div className="pagination-info">
+                Showing {startIndex + 1}-{Math.min(endIndex, searchResults.length)} of {searchResults.length} results
+              </div>
+              <div className="pagination-controls">
+                <button
+                  onClick={() => setCurrentPage(1)}
+                  disabled={currentPage === 1}
+                  className="pagination-btn"
+                  title="First page"
+                >
+                  ««
+                </button>
+                <button
+                  onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  className="pagination-btn"
+                  title="Previous page"
+                >
+                  «
+                </button>
+                <span className="pagination-pages">
+                  Page {currentPage} of {totalPages}
+                </span>
+                <button
+                  onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                  className="pagination-btn"
+                  title="Next page"
+                >
+                  »
+                </button>
+                <button
+                  onClick={() => setCurrentPage(totalPages)}
+                  disabled={currentPage === totalPages}
+                  className="pagination-btn"
+                  title="Last page"
+                >
+                  »»
+                </button>
+              </div>
+              <div className="pagination-size">
+                <label htmlFor="page-size">Per page:</label>
+                <select
+                  id="page-size"
+                  value={itemsPerPage}
+                  onChange={(e) => {
+                    setItemsPerPage(Number(e.target.value));
+                    setCurrentPage(1);
+                  }}
+                >
+                  <option value={10}>10</option>
+                  <option value={25}>25</option>
+                  <option value={50}>50</option>
+                  <option value={100}>100</option>
+                </select>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/jwst-frontend/src/types/MastTypes.ts
+++ b/frontend/jwst-frontend/src/types/MastTypes.ts
@@ -35,7 +35,9 @@ export interface MastObservationResult {
   t_exptime?: number;
   dataproduct_type?: string;
   calib_level?: number;
-  t_obs_release?: number; // Modified Julian Date (MJD)
+  t_min?: number; // Observation start time (MJD)
+  t_max?: number; // Observation end time (MJD)
+  t_obs_release?: number; // Data release date (MJD)
   proposal_id?: string;
   proposal_pi?: string;
   obs_collection?: string;

--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 class MastService:
     """Service for interacting with MAST portal via astroquery."""
 
+    # Default page size for MAST queries (astroquery defaults to 10)
+    DEFAULT_PAGE_SIZE = 500
+
     def __init__(self, download_dir: str = "/app/data/mast"):
         self.download_dir = download_dir
         os.makedirs(download_dir, exist_ok=True)
@@ -42,7 +45,8 @@ class MastService:
             logger.info(f"Searching MAST for target: {target_name}, radius: {radius} deg")
             obs_table = Observations.query_object(
                 target_name,
-                radius=radius * u.deg
+                radius=radius * u.deg,
+                pagesize=self.DEFAULT_PAGE_SIZE
             )
             # Filter to JWST observations
             if len(obs_table) > 0:
@@ -77,7 +81,8 @@ class MastService:
             coord = SkyCoord(ra=ra, dec=dec, unit="deg")
             obs_table = Observations.query_region(
                 coord,
-                radius=radius * u.deg
+                radius=radius * u.deg,
+                pagesize=self.DEFAULT_PAGE_SIZE
             )
             # Filter to JWST observations
             if len(obs_table) > 0:
@@ -107,7 +112,8 @@ class MastService:
             logger.info(f"Searching MAST for observation ID: {obs_id}")
             obs_table = Observations.query_criteria(
                 obs_id=obs_id,
-                obs_collection="JWST"
+                obs_collection="JWST",
+                pagesize=self.DEFAULT_PAGE_SIZE
             )
             logger.info(f"Found {len(obs_table)} observations")
             return self._table_to_dict_list(obs_table)
@@ -132,7 +138,8 @@ class MastService:
             logger.info(f"Searching MAST for program ID: {program_id}")
             obs_table = Observations.query_criteria(
                 proposal_id=program_id,
-                obs_collection="JWST"
+                obs_collection="JWST",
+                pagesize=self.DEFAULT_PAGE_SIZE
             )
             logger.info(f"Found {len(obs_table)} observations")
             return self._table_to_dict_list(obs_table)


### PR DESCRIPTION
## Summary
- Add pagination to MAST search results panel
- Increase query limit from 10 to 500 results
- Fix dates showing as future dates (was using release date instead of observation date)

## Changes

### Processing Engine
- `mast_service.py`: Added `DEFAULT_PAGE_SIZE = 500` and updated all search methods to use it

### Frontend
- `MastSearch.tsx`: Added pagination state, controls, and per-page selector
- `MastSearch.css`: Added pagination styling
- `MastTypes.ts`: Added `t_min` and `t_max` type definitions

## Test plan
- [ ] Search MAST for "M31" with 0.5° radius - should return ~294 results with pagination
- [ ] Verify pagination controls work (first/prev/next/last, page info)
- [ ] Verify per-page selector changes items displayed
- [ ] Verify dates show observation dates (e.g., NGC 3132 shows 6/3/2022)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)