### PR TITLE
fix: Include Metadata in API response and add Docker verification docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,13 @@ App.tsx (root)
 
 **See**: `docs/development-plan.md` for full 6-phase roadmap
 
+### Verification Standards
+
+**CRITICAL**: All implementation plans and verification steps MUST include testing using the Docker environment.
+- Any feature that involves backend/frontend integration or database changes must be verified in the full Docker stack.
+- "Works on my machine" (local npm/dotnet run) is insufficient for final verification.
+- Always include `docker compose up -d` instructions in verification plans.
+
 ### Coding Standards
 
 **Backend (.NET)**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ We use a **Pull Request (PR)** workflow for all changes. Direct pushes to the `m
     *   Link to any relevant issues.
 7.  **Wait for CI Checks**: Our GitHub Actions workflow will automatically run tests. Ensure all checks pass.
 8.  **Code Review**: A team member will review your PR. Address any feedback.
-9.  **Merge**: Once approved and checks pass, your code will be merged!
+9.  **Docker Verification**: Before submitting, verify your changes using the full Docker stack (`docker compose up -d`).
+10. **Merge**: Once approved and checks pass, your code will be merged!
 
 ## Project Structure
 

--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -673,6 +673,7 @@ namespace JwstDataAnalysis.API.Controllers
                 DataType = model.DataType,
                 UploadDate = model.UploadDate,
                 Description = model.Description,
+                Metadata = model.Metadata,
                 FileSize = model.FileSize,
                 ProcessingStatus = model.ProcessingStatus,
                 Tags = model.Tags,

--- a/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
@@ -61,6 +61,7 @@ namespace JwstDataAnalysis.API.Models
         public DateTime UploadDate { get; set; }
         public string? Description { get; set; }
         public long FileSize { get; set; }
+        public Dictionary<string, object> Metadata { get; set; } = new();
         public string? ProcessingStatus { get; set; }
         public List<string> Tags { get; set; } = new();
         public string? UserId { get; set; }


### PR DESCRIPTION
## Summary
- Fix API response to include Metadata field (required for grouping feature)
- Add Docker verification documentation

## Changes
- `JwstDataController.cs`: Add Metadata to response mapping
- `DataValidationModels.cs`: Add Metadata property to DataResponse
- `CLAUDE.md`: Add Docker verification standards section
- `CONTRIBUTING.md`: Add Docker verification step to PR workflow

## Test plan
- [ ] Verify API returns metadata: `curl http://localhost:5001/api/jwstdata | jq '.[0].metadata'`
- [ ] Verify grouped view works with mast_obs_id from metadata

🤖 Generated with [Claude Code](https://claude.ai/claude-code)