### PR TITLE
feat: Add JWST processing level tracking and lineage tree view

### DIFF
--- a/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
@@ -82,6 +82,13 @@ namespace JwstDataAnalysis.API.Models
         // Processing results summary
         public int ProcessingResultsCount { get; set; }
         public DateTime? LastProcessed { get; set; }
+
+        // Lineage tracking
+        public string? ProcessingLevel { get; set; }
+        public string? ObservationBaseId { get; set; }
+        public string? ExposureId { get; set; }
+        public string? ParentId { get; set; }
+        public List<string>? DerivedFrom { get; set; }
     }
 
     public class ProcessingRequest
@@ -221,6 +228,7 @@ namespace JwstDataAnalysis.API.Models
         public Dictionary<string, int> DataTypeDistribution { get; set; } = new();
         public Dictionary<string, int> StatusDistribution { get; set; } = new();
         public Dictionary<string, int> FormatDistribution { get; set; } = new();
+        public Dictionary<string, int> ProcessingLevelDistribution { get; set; } = new();
         public int ValidatedFiles { get; set; }
         public int PublicFiles { get; set; }
         public DateTime? OldestFile { get; set; }
@@ -248,5 +256,25 @@ namespace JwstDataAnalysis.API.Models
         public DateTime? CompletedAt { get; set; }
         public int TotalRecords { get; set; }
         public long FileSize { get; set; }
+    }
+
+    // Lineage tracking models
+    public class LineageResponse
+    {
+        public string ObservationBaseId { get; set; } = string.Empty;
+        public int TotalFiles { get; set; }
+        public Dictionary<string, int> LevelCounts { get; set; } = new();
+        public List<LineageFileInfo> Files { get; set; } = new();
+    }
+
+    public class LineageFileInfo
+    {
+        public string Id { get; set; } = string.Empty;
+        public string FileName { get; set; } = string.Empty;
+        public string ProcessingLevel { get; set; } = string.Empty;
+        public string DataType { get; set; } = string.Empty;
+        public string? ParentId { get; set; }
+        public long FileSize { get; set; }
+        public DateTime UploadDate { get; set; }
     }
 } 

--- a/backend/JwstDataAnalysis.API/Models/JwstDataModel.cs
+++ b/backend/JwstDataAnalysis.API/Models/JwstDataModel.cs
@@ -66,6 +66,11 @@ namespace JwstDataAnalysis.API.Models
         public int Version { get; set; } = 1;
         public string? ParentId { get; set; } // For derived data
         public List<string> DerivedFrom { get; set; } = new(); // IDs of source data
+
+        // JWST Processing Level Tracking
+        public string? ProcessingLevel { get; set; } // "L1", "L2a", "L2b", "L3"
+        public string? ObservationBaseId { get; set; } // Groups related files (e.g., "jw02733-o001_t001_nircam")
+        public string? ExposureId { get; set; } // Finer-grained lineage (e.g., "jw02733001001_02101_00001")
     }
 
     public class ImageMetadata
@@ -196,5 +201,26 @@ namespace JwstDataAnalysis.API.Models
         public const string HDF5 = "hdf5";
         public const string ASCII = "ascii";
         public const string Binary = "binary";
+    }
+
+    public static class ProcessingLevels
+    {
+        public const string Level1 = "L1";      // _uncal - raw detector readout
+        public const string Level2a = "L2a";    // _rate, _rateints - count rate images
+        public const string Level2b = "L2b";    // _cal, _crf - calibrated exposures
+        public const string Level3 = "L3";      // _i2d, _s2d, _x1d - combined/mosaicked products
+        public const string Unknown = "unknown";
+
+        public static readonly Dictionary<string, string> SuffixToLevel = new()
+        {
+            { "_uncal", Level1 },
+            { "_rate", Level2a },
+            { "_rateints", Level2a },
+            { "_cal", Level2b },
+            { "_crf", Level2b },
+            { "_i2d", Level3 },
+            { "_s2d", Level3 },
+            { "_x1d", Level3 }
+        };
     }
 } 

--- a/backend/JwstDataAnalysis.API/Models/MastModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/MastModels.cs
@@ -136,6 +136,9 @@ namespace JwstDataAnalysis.API.Models
         public int ImportedCount { get; set; }
         public string? Error { get; set; }
         public DateTime Timestamp { get; set; }
+        // Lineage summary
+        public Dictionary<string, List<string>>? LineageTree { get; set; } // level -> list of IDs
+        public string? ObservationBaseId { get; set; }
     }
 
     // Data Products

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.css
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.css
@@ -510,3 +510,235 @@
   color: #6c757d;
   font-weight: 600;
 }
+
+/* Lineage View Styles */
+.lineage-view {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.lineage-group {
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  padding: 15px;
+  border: 1px solid #e9ecef;
+}
+
+.lineage-group.collapsed {
+  padding-bottom: 10px;
+}
+
+.lineage-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  padding: 10px;
+  margin: -10px -10px 15px -10px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.lineage-header:hover {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+.lineage-group.collapsed .lineage-header {
+  margin-bottom: 0;
+}
+
+.lineage-header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.lineage-header-left h3 {
+  margin: 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.lineage-header-right {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+.level-badges {
+  display: flex;
+  gap: 6px;
+}
+
+.level-badge {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: white;
+}
+
+/* Lineage Tree Structure */
+.lineage-tree {
+  margin-left: 20px;
+  position: relative;
+}
+
+.lineage-tree::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 0;
+  bottom: 20px;
+  width: 2px;
+  background: linear-gradient(to bottom, #e5e7eb 0%, #e5e7eb 100%);
+}
+
+.lineage-level {
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.level-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.level-header:hover {
+  background: #f9fafb;
+  border-color: #d1d5db;
+}
+
+.level-connector {
+  display: flex;
+  align-items: center;
+  margin-left: -32px;
+  margin-right: 8px;
+}
+
+.connector-line {
+  width: 20px;
+  height: 2px;
+  background: #e5e7eb;
+}
+
+.level-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.level-label {
+  font-weight: 500;
+  color: #374151;
+  flex: 1;
+}
+
+.level-count {
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.expand-icon {
+  font-size: 18px;
+  color: #9ca3af;
+  font-weight: bold;
+}
+
+/* Level Files */
+.level-files {
+  margin-left: 28px;
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lineage-file-card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  padding: 12px;
+}
+
+.lineage-file-card .file-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.lineage-file-card .file-name {
+  font-weight: 500;
+  color: #111827;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 70%;
+}
+
+.lineage-file-card .file-meta {
+  display: flex;
+  gap: 15px;
+  font-size: 12px;
+  color: #6b7280;
+  margin-bottom: 10px;
+}
+
+.lineage-file-card .file-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.lineage-file-card .file-actions button {
+  padding: 4px 10px;
+  font-size: 11px;
+  border: 1px solid #007bff;
+  background: white;
+  color: #007bff;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.lineage-file-card .file-actions button:hover {
+  background: #007bff;
+  color: white;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .lineage-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .lineage-header-right {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .level-badges {
+    flex-wrap: wrap;
+  }
+
+  .lineage-tree {
+    margin-left: 10px;
+  }
+
+  .level-files {
+    margin-left: 15px;
+  }
+}

--- a/frontend/jwst-frontend/src/types/JwstDataTypes.ts
+++ b/frontend/jwst-frontend/src/types/JwstDataTypes.ts
@@ -15,6 +15,12 @@ export interface JwstDataModel {
   imageInfo?: ImageMetadata;
   sensorInfo?: SensorMetadata;
   processingResults: ProcessingResult[];
+  // Lineage fields
+  processingLevel?: string;
+  observationBaseId?: string;
+  exposureId?: string;
+  parentId?: string;
+  derivedFrom?: string[];
 }
 
 export interface ImageMetadata {
@@ -49,4 +55,51 @@ export interface ProcessingResult {
 export interface ProcessingRequest {
   algorithm: string;
   parameters: Record<string, any>;
-} 
+}
+
+// Processing level constants
+export const ProcessingLevels = {
+  L1: 'L1',
+  L2a: 'L2a',
+  L2b: 'L2b',
+  L3: 'L3',
+  Unknown: 'unknown'
+} as const;
+
+export type ProcessingLevel = typeof ProcessingLevels[keyof typeof ProcessingLevels];
+
+// Lineage response types
+export interface LineageResponse {
+  observationBaseId: string;
+  totalFiles: number;
+  levelCounts: Record<string, number>;
+  files: LineageFileInfo[];
+}
+
+export interface LineageFileInfo {
+  id: string;
+  fileName: string;
+  processingLevel: string;
+  dataType: string;
+  parentId?: string;
+  fileSize: number;
+  uploadDate: string;
+}
+
+// Helper for display names
+export const ProcessingLevelLabels: Record<string, string> = {
+  'L1': 'Level 1 (Raw)',
+  'L2a': 'Level 2a (Rate)',
+  'L2b': 'Level 2b (Calibrated)',
+  'L3': 'Level 3 (Combined)',
+  'unknown': 'Unknown'
+};
+
+// Helper for level colors
+export const ProcessingLevelColors: Record<string, string> = {
+  'L1': '#ef4444',   // red
+  'L2a': '#f59e0b',  // amber
+  'L2b': '#10b981',  // emerald
+  'L3': '#3b82f6',   // blue
+  'unknown': '#6b7280' // gray
+}; 


### PR DESCRIPTION
## Summary
- Add JWST processing level tracking (L1/L2a/L2b/L3) based on filename suffixes
- Implement lineage tree visualization in frontend showing processing pipeline relationships
- Add API endpoints for querying lineage data and migrating existing records

## Changes

### Backend
- **JwstDataModel.cs**: Added `ProcessingLevel`, `ObservationBaseId`, `ExposureId` fields and `ProcessingLevels` static class
- **DataValidationModels.cs**: Added `LineageResponse`, `LineageFileInfo` DTOs
- **MongoDBService.cs**: Added lineage query methods (`GetLineageTreeAsync`, `GetLineageGroupedAsync`)
- **MastController.cs**: Enhanced import to parse processing levels and establish lineage relationships
- **JwstDataController.cs**: Added `/lineage` endpoints and `/migrate/processing-levels` migration endpoint
- **MastModels.cs**: Added lineage fields to `MastImportResponse`

### Frontend
- **JwstDataTypes.ts**: Added lineage types, `ProcessingLevels` constants, color/label helpers
- **JwstDataDashboard.tsx**: New "Lineage" view mode with collapsible tree structure
- **JwstDataDashboard.css**: Tree view styling with visual connectors and level badges

## Test plan
- [ ] Start Docker stack: `cd docker && docker compose up -d --build`
- [ ] Run migration: `curl -X POST http://localhost:5001/api/jwstdata/migrate/processing-levels`
- [ ] Verify lineage API: `curl http://localhost:5001/api/jwstdata/lineage`
- [ ] Open http://localhost:3000 and click "Lineage" view button
- [ ] Verify tree shows L1 → L2a → L2b → L3 hierarchy with colored badges
- [ ] Test expand/collapse on observations and processing levels

🤖 Generated with [Claude Code](https://claude.ai/code)