### PR TITLE
feat: Add MAST import progress indicator with async downloads

### DIFF
--- a/backend/JwstDataAnalysis.API/Models/MastModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/MastModels.cs
@@ -169,4 +169,87 @@ namespace JwstDataAnalysis.API.Models
         public long? Size { get; set; }
         public string? DataUri { get; set; }
     }
+
+    // Import Job Progress Tracking
+    public class ImportJobStatus
+    {
+        public string JobId { get; set; } = string.Empty;
+        public string ObsId { get; set; } = string.Empty;
+        public int Progress { get; set; } // 0-100
+        public string Stage { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+        public bool IsComplete { get; set; }
+        public string? Error { get; set; }
+        public DateTime StartedAt { get; set; }
+        public DateTime? CompletedAt { get; set; }
+        public MastImportResponse? Result { get; set; }
+    }
+
+    public class ImportJobStartResponse
+    {
+        public string JobId { get; set; } = string.Empty;
+        public string ObsId { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+    }
+
+    public static class ImportStages
+    {
+        public const string Starting = "Starting";
+        public const string Downloading = "Downloading";
+        public const string SavingRecords = "Saving records";
+        public const string Complete = "Complete";
+        public const string Failed = "Failed";
+    }
+
+    // Async Download Job DTOs (for processing engine communication)
+    public class DownloadJobStartResponse
+    {
+        [JsonPropertyName("job_id")]
+        public string JobId { get; set; } = string.Empty;
+
+        [JsonPropertyName("obs_id")]
+        public string ObsId { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+    }
+
+    public class DownloadJobProgress
+    {
+        [JsonPropertyName("job_id")]
+        public string JobId { get; set; } = string.Empty;
+
+        [JsonPropertyName("obs_id")]
+        public string ObsId { get; set; } = string.Empty;
+
+        [JsonPropertyName("stage")]
+        public string Stage { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+
+        [JsonPropertyName("progress")]
+        public int Progress { get; set; }
+
+        [JsonPropertyName("total_files")]
+        public int TotalFiles { get; set; }
+
+        [JsonPropertyName("downloaded_files")]
+        public int DownloadedFiles { get; set; }
+
+        [JsonPropertyName("current_file")]
+        public string? CurrentFile { get; set; }
+
+        [JsonPropertyName("files")]
+        public List<string> Files { get; set; } = new();
+
+        [JsonPropertyName("error")]
+        public string? Error { get; set; }
+
+        [JsonPropertyName("is_complete")]
+        public bool IsComplete { get; set; }
+
+        [JsonPropertyName("download_dir")]
+        public string? DownloadDir { get; set; }
+    }
 }

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -7,7 +7,7 @@ builder.Services.Configure<MongoDBSettings>(
     builder.Configuration.GetSection("MongoDB"));
 
 builder.Services.AddSingleton<MongoDBService>();
-
+builder.Services.AddSingleton<ImportJobTracker>();
 
 // Configure HttpClient for MastService with extended timeout for downloads
 builder.Services.AddHttpClient<MastService>(client =>

--- a/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using JwstDataAnalysis.API.Models;
+
+namespace JwstDataAnalysis.API.Services
+{
+    public class ImportJobTracker
+    {
+        private readonly ConcurrentDictionary<string, ImportJobStatus> _jobs = new();
+        private readonly ILogger<ImportJobTracker> _logger;
+        private readonly TimeSpan _jobRetentionPeriod = TimeSpan.FromMinutes(30);
+
+        public ImportJobTracker(ILogger<ImportJobTracker> logger)
+        {
+            _logger = logger;
+        }
+
+        public string CreateJob(string obsId)
+        {
+            var jobId = Guid.NewGuid().ToString("N")[..12];
+            var job = new ImportJobStatus
+            {
+                JobId = jobId,
+                ObsId = obsId,
+                Progress = 0,
+                Stage = ImportStages.Starting,
+                Message = "Initializing import...",
+                IsComplete = false,
+                StartedAt = DateTime.UtcNow
+            };
+
+            _jobs[jobId] = job;
+            _logger.LogInformation("Created import job {JobId} for observation {ObsId}", jobId, obsId);
+
+            // Clean up old jobs
+            CleanupOldJobs();
+
+            return jobId;
+        }
+
+        public void UpdateProgress(string jobId, int progress, string stage, string message)
+        {
+            if (_jobs.TryGetValue(jobId, out var job))
+            {
+                job.Progress = Math.Clamp(progress, 0, 100);
+                job.Stage = stage;
+                job.Message = message;
+                _logger.LogDebug("Job {JobId} progress: {Progress}% - {Stage}: {Message}",
+                    jobId, progress, stage, message);
+            }
+        }
+
+        public void CompleteJob(string jobId, MastImportResponse result)
+        {
+            if (_jobs.TryGetValue(jobId, out var job))
+            {
+                job.Progress = 100;
+                job.Stage = ImportStages.Complete;
+                job.Message = $"Successfully imported {result.ImportedCount} file(s)";
+                job.IsComplete = true;
+                job.CompletedAt = DateTime.UtcNow;
+                job.Result = result;
+                _logger.LogInformation("Job {JobId} completed: imported {Count} files",
+                    jobId, result.ImportedCount);
+            }
+        }
+
+        public void FailJob(string jobId, string error)
+        {
+            if (_jobs.TryGetValue(jobId, out var job))
+            {
+                job.Stage = ImportStages.Failed;
+                job.Message = error;
+                job.IsComplete = true;
+                job.Error = error;
+                job.CompletedAt = DateTime.UtcNow;
+                _logger.LogError("Job {JobId} failed: {Error}", jobId, error);
+            }
+        }
+
+        public ImportJobStatus? GetJob(string jobId)
+        {
+            _jobs.TryGetValue(jobId, out var job);
+            return job;
+        }
+
+        public bool RemoveJob(string jobId)
+        {
+            return _jobs.TryRemove(jobId, out _);
+        }
+
+        private void CleanupOldJobs()
+        {
+            var cutoff = DateTime.UtcNow - _jobRetentionPeriod;
+            var oldJobs = _jobs
+                .Where(kvp => kvp.Value.IsComplete && kvp.Value.CompletedAt < cutoff)
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var jobId in oldJobs)
+            {
+                _jobs.TryRemove(jobId, out _);
+                _logger.LogDebug("Cleaned up old job {JobId}", jobId);
+            }
+        }
+    }
+}

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -137,12 +137,32 @@ This document outlines the comprehensive development plan for building a JWST da
 - [x] Color-coded level badges (L1:red, L2a:amber, L2b:emerald, L3:blue)
 - [x] Migration endpoint to backfill existing data
 
+#### **MAST Import Progress Indicator:** ✅ *Complete*
+
+- [x] Background job tracking for import operations
+- [x] Real-time progress polling from frontend
+- [x] Visual progress bar with stage indicators
+- [x] Async download with file-by-file progress tracking
+
+#### **Known Issues & Future Improvements:**
+
+**MAST Download Timeouts:**
+Large JWST observations with many FITS files can timeout during download. Current implementation:
+- ✅ Async downloads with file-by-file progress (implemented)
+- ✅ 10-minute polling timeout in backend
+- [ ] **TODO:** Implement chunked/resumable downloads for very large files
+- [ ] **TODO:** Add download queue with persistence (survive restarts)
+- [ ] **TODO:** Consider using MAST's async download API for bulk operations
+- [ ] **TODO:** Add retry logic for failed individual file downloads
+- [ ] **TODO:** WebSocket support for real-time progress (replace polling)
+
 #### **Phase 3 Deliverables:**
 
 - ✅ Python microservice with scientific computing capabilities
 - ✅ Integration with .NET backend (HTTP client communication)
 - ✅ MAST Portal search and download functionality
 - ✅ Processing level tracking and lineage visualization
+- ✅ Import progress indicator with real-time updates
 - [ ] Basic image and spectral processing algorithms
 - [ ] Processing job queue system
 

--- a/frontend/jwst-frontend/src/components/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/MastSearch.css
@@ -114,6 +114,33 @@
   transform: none;
 }
 
+.search-button.searching {
+  background: linear-gradient(135deg, #357abd 0%, #4a90d9 50%, #357abd 100%);
+  background-size: 200% 100%;
+  animation: search-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes search-pulse {
+  0%, 100% {
+    background-position: 0% 0%;
+  }
+  50% {
+    background-position: 100% 0%;
+  }
+}
+
+.search-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  margin-right: 8px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  vertical-align: middle;
+}
+
 .error-message {
   color: #ff6b6b;
   padding: 12px 16px;
@@ -392,4 +419,150 @@
 .pagination-size select:focus {
   outline: none;
   border-color: #4a90d9;
+}
+
+/* Import Progress Indicator */
+.import-progress-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.import-progress-container {
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  border-radius: 12px;
+  padding: 32px;
+  min-width: 400px;
+  max-width: 500px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(74, 144, 217, 0.3);
+}
+
+.import-progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.import-progress-title {
+  color: #fff;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.import-progress-percent {
+  color: #4a90d9;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.progress-bar-container {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 8px;
+  height: 12px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #4a90d9 0%, #357abd 50%, #4a90d9 100%);
+  background-size: 200% 100%;
+  border-radius: 8px;
+  transition: width 0.3s ease;
+  animation: progress-shimmer 2s infinite linear;
+}
+
+@keyframes progress-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.progress-bar-fill.complete {
+  background: linear-gradient(90deg, #28a745 0%, #1e7e34 100%);
+  animation: none;
+}
+
+.progress-bar-fill.failed {
+  background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
+  animation: none;
+}
+
+.import-progress-stage {
+  color: #aaa;
+  font-size: 0.9rem;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.import-progress-stage .spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(74, 144, 217, 0.3);
+  border-top-color: #4a90d9;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.import-progress-obs-id {
+  color: #666;
+  font-size: 0.8rem;
+  margin-top: 12px;
+  font-family: monospace;
+}
+
+.import-progress-error {
+  color: #ff6b6b;
+  background: rgba(255, 107, 107, 0.1);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  border-radius: 6px;
+  padding: 12px;
+  margin-top: 16px;
+  font-size: 0.9rem;
+}
+
+.import-progress-success {
+  color: #28a745;
+  font-size: 0.9rem;
+  margin-top: 8px;
+}
+
+.import-progress-close {
+  margin-top: 20px;
+  padding: 10px 24px;
+  background: linear-gradient(135deg, #4a90d9 0%, #357abd 100%);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  width: 100%;
+  transition: all 0.2s ease;
+}
+
+.import-progress-close:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(74, 144, 217, 0.4);
 }

--- a/frontend/jwst-frontend/src/types/MastTypes.ts
+++ b/frontend/jwst-frontend/src/types/MastTypes.ts
@@ -77,3 +77,31 @@ export interface MastDataProductsResponse {
 }
 
 export type MastSearchType = 'target' | 'coordinates' | 'observation' | 'program';
+
+// Import Job Progress Types
+export interface ImportJobStartResponse {
+  jobId: string;
+  obsId: string;
+  message: string;
+}
+
+export interface ImportJobStatus {
+  jobId: string;
+  obsId: string;
+  progress: number; // 0-100
+  stage: string;
+  message: string;
+  isComplete: boolean;
+  error?: string;
+  startedAt: string;
+  completedAt?: string;
+  result?: MastImportResponse;
+}
+
+export const ImportStages = {
+  Starting: 'Starting',
+  Downloading: 'Downloading',
+  SavingRecords: 'Saving records',
+  Complete: 'Complete',
+  Failed: 'Failed',
+} as const;

--- a/processing-engine/Dockerfile
+++ b/processing-engine/Dockerfile
@@ -16,4 +16,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"] 
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-keep-alive", "600"] 

--- a/processing-engine/app/mast/download_tracker.py
+++ b/processing-engine/app/mast/download_tracker.py
@@ -1,0 +1,142 @@
+"""
+Download job tracking for MAST file downloads.
+Tracks progress of background download operations.
+"""
+
+import uuid
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Optional
+from enum import Enum
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class DownloadStage(str, Enum):
+    QUEUED = "queued"
+    FETCHING_PRODUCTS = "fetching_products"
+    DOWNLOADING = "downloading"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+@dataclass
+class DownloadProgress:
+    job_id: str
+    obs_id: str
+    stage: DownloadStage = DownloadStage.QUEUED
+    message: str = "Queued for download"
+    progress: int = 0  # 0-100
+    total_files: int = 0
+    downloaded_files: int = 0
+    current_file: Optional[str] = None
+    files: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+    started_at: datetime = field(default_factory=datetime.utcnow)
+    completed_at: Optional[datetime] = None
+    download_dir: Optional[str] = None
+
+    def to_dict(self) -> Dict:
+        return {
+            "job_id": self.job_id,
+            "obs_id": self.obs_id,
+            "stage": self.stage.value,
+            "message": self.message,
+            "progress": self.progress,
+            "total_files": self.total_files,
+            "downloaded_files": self.downloaded_files,
+            "current_file": self.current_file,
+            "files": self.files,
+            "error": self.error,
+            "started_at": self.started_at.isoformat(),
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "download_dir": self.download_dir,
+            "is_complete": self.stage in (DownloadStage.COMPLETE, DownloadStage.FAILED)
+        }
+
+
+class DownloadTracker:
+    """Tracks download job progress in memory."""
+
+    def __init__(self):
+        self._jobs: Dict[str, DownloadProgress] = {}
+        self._lock = asyncio.Lock()
+
+    def create_job(self, obs_id: str) -> str:
+        """Create a new download job and return its ID."""
+        job_id = uuid.uuid4().hex[:12]
+        self._jobs[job_id] = DownloadProgress(
+            job_id=job_id,
+            obs_id=obs_id
+        )
+        logger.info(f"Created download job {job_id} for observation {obs_id}")
+        self._cleanup_old_jobs()
+        return job_id
+
+    def get_job(self, job_id: str) -> Optional[DownloadProgress]:
+        """Get job progress by ID."""
+        return self._jobs.get(job_id)
+
+    def update_stage(self, job_id: str, stage: DownloadStage, message: str):
+        """Update job stage."""
+        if job := self._jobs.get(job_id):
+            job.stage = stage
+            job.message = message
+            logger.debug(f"Job {job_id}: {stage.value} - {message}")
+
+    def set_total_files(self, job_id: str, total: int):
+        """Set total number of files to download."""
+        if job := self._jobs.get(job_id):
+            job.total_files = total
+
+    def update_file_progress(self, job_id: str, filename: str, downloaded: int):
+        """Update progress for current file being downloaded."""
+        if job := self._jobs.get(job_id):
+            job.current_file = filename
+            job.downloaded_files = downloaded
+            if job.total_files > 0:
+                job.progress = int((downloaded / job.total_files) * 100)
+            job.message = f"Downloading file {downloaded}/{job.total_files}: {filename}"
+
+    def add_completed_file(self, job_id: str, filepath: str):
+        """Add a completed file to the job."""
+        if job := self._jobs.get(job_id):
+            job.files.append(filepath)
+
+    def complete_job(self, job_id: str, download_dir: str):
+        """Mark job as complete."""
+        if job := self._jobs.get(job_id):
+            job.stage = DownloadStage.COMPLETE
+            job.progress = 100
+            job.message = f"Downloaded {len(job.files)} files"
+            job.completed_at = datetime.utcnow()
+            job.download_dir = download_dir
+            job.current_file = None
+            logger.info(f"Job {job_id} completed: {len(job.files)} files")
+
+    def fail_job(self, job_id: str, error: str):
+        """Mark job as failed."""
+        if job := self._jobs.get(job_id):
+            job.stage = DownloadStage.FAILED
+            job.error = error
+            job.message = f"Failed: {error}"
+            job.completed_at = datetime.utcnow()
+            logger.error(f"Job {job_id} failed: {error}")
+
+    def _cleanup_old_jobs(self):
+        """Remove completed jobs older than 30 minutes."""
+        from datetime import timedelta
+        cutoff = datetime.utcnow() - timedelta(minutes=30)
+        old_jobs = [
+            job_id for job_id, job in self._jobs.items()
+            if job.completed_at and job.completed_at < cutoff
+        ]
+        for job_id in old_jobs:
+            del self._jobs[job_id]
+            logger.debug(f"Cleaned up old job {job_id}")
+
+
+# Global instance
+download_tracker = DownloadTracker()

--- a/processing-engine/app/mast/routes.py
+++ b/processing-engine/app/mast/routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException
 from datetime import datetime
 import logging
 import os
+import asyncio
 
 from .models import (
     MastTargetSearchRequest,
@@ -19,6 +20,7 @@ from .models import (
     MastDataProductsResponse
 )
 from .mast_service import MastService
+from .download_tracker import download_tracker, DownloadStage
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/mast", tags=["MAST"])
@@ -27,15 +29,23 @@ router = APIRouter(prefix="/mast", tags=["MAST"])
 download_dir = os.environ.get("MAST_DOWNLOAD_DIR", os.path.join(os.getcwd(), "data", "mast"))
 mast_service = MastService(download_dir=download_dir)
 
+# Configurable timeout for MAST searches (default 2 minutes)
+MAST_SEARCH_TIMEOUT = int(os.environ.get("MAST_SEARCH_TIMEOUT", "120"))
+
 
 @router.post("/search/target", response_model=MastSearchResponse)
 async def search_by_target(request: MastTargetSearchRequest):
     """Search MAST by target name (e.g., 'NGC 1234', 'Carina Nebula')."""
     try:
-        results = mast_service.search_by_target(
-            target_name=request.target_name,
-            radius=request.radius,
-            filters=request.filters
+        # Run synchronous MAST call in thread pool with timeout
+        results = await asyncio.wait_for(
+            asyncio.to_thread(
+                mast_service.search_by_target,
+                target_name=request.target_name,
+                radius=request.radius,
+                filters=request.filters
+            ),
+            timeout=MAST_SEARCH_TIMEOUT
         )
         return MastSearchResponse(
             search_type="target",
@@ -44,6 +54,9 @@ async def search_by_target(request: MastTargetSearchRequest):
             result_count=len(results),
             timestamp=datetime.utcnow().isoformat()
         )
+    except asyncio.TimeoutError:
+        logger.error(f"Target search timed out after {MAST_SEARCH_TIMEOUT}s for: {request.target_name}")
+        raise HTTPException(status_code=504, detail=f"MAST search timed out after {MAST_SEARCH_TIMEOUT} seconds. Try a smaller search radius or more specific target name.")
     except Exception as e:
         logger.error(f"Target search failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -53,10 +66,15 @@ async def search_by_target(request: MastTargetSearchRequest):
 async def search_by_coordinates(request: MastCoordinateSearchRequest):
     """Search MAST by RA/Dec coordinates."""
     try:
-        results = mast_service.search_by_coordinates(
-            ra=request.ra,
-            dec=request.dec,
-            radius=request.radius
+        # Run synchronous MAST call in thread pool with timeout
+        results = await asyncio.wait_for(
+            asyncio.to_thread(
+                mast_service.search_by_coordinates,
+                ra=request.ra,
+                dec=request.dec,
+                radius=request.radius
+            ),
+            timeout=MAST_SEARCH_TIMEOUT
         )
         return MastSearchResponse(
             search_type="coordinates",
@@ -65,6 +83,9 @@ async def search_by_coordinates(request: MastCoordinateSearchRequest):
             result_count=len(results),
             timestamp=datetime.utcnow().isoformat()
         )
+    except asyncio.TimeoutError:
+        logger.error(f"Coordinate search timed out after {MAST_SEARCH_TIMEOUT}s for RA={request.ra}, Dec={request.dec}")
+        raise HTTPException(status_code=504, detail=f"MAST search timed out after {MAST_SEARCH_TIMEOUT} seconds. Try a smaller search radius.")
     except Exception as e:
         logger.error(f"Coordinate search failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -74,7 +95,14 @@ async def search_by_coordinates(request: MastCoordinateSearchRequest):
 async def search_by_observation_id(request: MastObservationSearchRequest):
     """Search MAST by observation ID."""
     try:
-        results = mast_service.search_by_observation_id(obs_id=request.obs_id)
+        # Run synchronous MAST call in thread pool with timeout
+        results = await asyncio.wait_for(
+            asyncio.to_thread(
+                mast_service.search_by_observation_id,
+                obs_id=request.obs_id
+            ),
+            timeout=MAST_SEARCH_TIMEOUT
+        )
         return MastSearchResponse(
             search_type="observation_id",
             query_params={"obs_id": request.obs_id},
@@ -82,6 +110,9 @@ async def search_by_observation_id(request: MastObservationSearchRequest):
             result_count=len(results),
             timestamp=datetime.utcnow().isoformat()
         )
+    except asyncio.TimeoutError:
+        logger.error(f"Observation ID search timed out after {MAST_SEARCH_TIMEOUT}s for: {request.obs_id}")
+        raise HTTPException(status_code=504, detail=f"MAST search timed out after {MAST_SEARCH_TIMEOUT} seconds.")
     except Exception as e:
         logger.error(f"Observation ID search failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -91,7 +122,14 @@ async def search_by_observation_id(request: MastObservationSearchRequest):
 async def search_by_program_id(request: MastProgramSearchRequest):
     """Search MAST by program/proposal ID."""
     try:
-        results = mast_service.search_by_program_id(program_id=request.program_id)
+        # Run synchronous MAST call in thread pool with timeout
+        results = await asyncio.wait_for(
+            asyncio.to_thread(
+                mast_service.search_by_program_id,
+                program_id=request.program_id
+            ),
+            timeout=MAST_SEARCH_TIMEOUT
+        )
         return MastSearchResponse(
             search_type="program_id",
             query_params={"program_id": request.program_id},
@@ -99,6 +137,9 @@ async def search_by_program_id(request: MastProgramSearchRequest):
             result_count=len(results),
             timestamp=datetime.utcnow().isoformat()
         )
+    except asyncio.TimeoutError:
+        logger.error(f"Program ID search timed out after {MAST_SEARCH_TIMEOUT}s for: {request.program_id}")
+        raise HTTPException(status_code=504, detail=f"MAST search timed out after {MAST_SEARCH_TIMEOUT} seconds.")
     except Exception as e:
         logger.error(f"Program ID search failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -108,30 +149,53 @@ async def search_by_program_id(request: MastProgramSearchRequest):
 async def get_data_products(request: MastDataProductsRequest):
     """Get available data products for an observation."""
     try:
-        products = mast_service.get_data_products(obs_id=request.obs_id)
+        # Run synchronous MAST call in thread pool with timeout
+        products = await asyncio.wait_for(
+            asyncio.to_thread(
+                mast_service.get_data_products,
+                obs_id=request.obs_id
+            ),
+            timeout=MAST_SEARCH_TIMEOUT
+        )
         return MastDataProductsResponse(
             obs_id=request.obs_id,
             products=products,
             product_count=len(products)
         )
+    except asyncio.TimeoutError:
+        logger.error(f"Get products timed out after {MAST_SEARCH_TIMEOUT}s for: {request.obs_id}")
+        raise HTTPException(status_code=504, detail=f"Request timed out after {MAST_SEARCH_TIMEOUT} seconds.")
     except Exception as e:
         logger.error(f"Get products failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+# Longer timeout for downloads (default 10 minutes)
+MAST_DOWNLOAD_TIMEOUT = int(os.environ.get("MAST_DOWNLOAD_TIMEOUT", "600"))
 
 
 @router.post("/download", response_model=MastDownloadResponse)
 async def download_observation(request: MastDownloadRequest):
     """Download FITS files for an observation."""
     try:
+        # Run synchronous MAST download in thread pool with longer timeout
         if request.product_id:
-            result = mast_service.download_product(
-                product_id=request.product_id,
-                obs_id=request.obs_id
+            result = await asyncio.wait_for(
+                asyncio.to_thread(
+                    mast_service.download_product,
+                    product_id=request.product_id,
+                    obs_id=request.obs_id
+                ),
+                timeout=MAST_DOWNLOAD_TIMEOUT
             )
         else:
-            result = mast_service.download_observation(
-                obs_id=request.obs_id,
-                product_type=request.product_type
+            result = await asyncio.wait_for(
+                asyncio.to_thread(
+                    mast_service.download_observation,
+                    obs_id=request.obs_id,
+                    product_type=request.product_type
+                ),
+                timeout=MAST_DOWNLOAD_TIMEOUT
             )
 
         return MastDownloadResponse(
@@ -143,6 +207,89 @@ async def download_observation(request: MastDownloadRequest):
             error=result.get("error"),
             timestamp=result.get("timestamp", datetime.utcnow().isoformat())
         )
+    except asyncio.TimeoutError:
+        logger.error(f"Download timed out after {MAST_DOWNLOAD_TIMEOUT}s for: {request.obs_id}")
+        raise HTTPException(status_code=504, detail=f"Download timed out after {MAST_DOWNLOAD_TIMEOUT} seconds. The files may be very large.")
     except Exception as e:
         logger.error(f"Download failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+# === Async Download Endpoints ===
+
+@router.post("/download/start")
+async def start_async_download(request: MastDownloadRequest):
+    """
+    Start an asynchronous download job. Returns immediately with a job ID.
+    Use /download/progress/{job_id} to check status.
+    """
+    job_id = download_tracker.create_job(request.obs_id)
+
+    # Start download in background
+    asyncio.create_task(
+        _run_download_job(job_id, request.obs_id, request.product_type or "SCIENCE")
+    )
+
+    return {
+        "job_id": job_id,
+        "obs_id": request.obs_id,
+        "message": "Download started"
+    }
+
+
+@router.get("/download/progress/{job_id}")
+async def get_download_progress(job_id: str):
+    """Get the progress of an async download job."""
+    job = download_tracker.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    return job.to_dict()
+
+
+async def _run_download_job(job_id: str, obs_id: str, product_type: str):
+    """Background task to run the download with progress updates."""
+    try:
+        download_tracker.update_stage(
+            job_id, DownloadStage.FETCHING_PRODUCTS, "Fetching product list from MAST..."
+        )
+
+        # Get product count first (run in thread to not block)
+        product_count = await asyncio.to_thread(
+            mast_service.get_product_count, obs_id, product_type
+        )
+
+        if product_count == 0:
+            download_tracker.update_stage(
+                job_id, DownloadStage.COMPLETE, "No files to download"
+            )
+            download_tracker.complete_job(job_id, "")
+            return
+
+        download_tracker.set_total_files(job_id, product_count)
+        download_tracker.update_stage(
+            job_id, DownloadStage.DOWNLOADING, f"Downloading {product_count} files..."
+        )
+
+        # Progress callback
+        def on_progress(filename: str, current: int, total: int):
+            download_tracker.update_file_progress(job_id, filename, current)
+
+        # Run download in thread pool
+        result = await asyncio.to_thread(
+            mast_service.download_observation_with_progress,
+            obs_id,
+            product_type,
+            on_progress
+        )
+
+        if result["status"] == "completed":
+            # Add all files to tracker
+            for filepath in result.get("files", []):
+                download_tracker.add_completed_file(job_id, filepath)
+            download_tracker.complete_job(job_id, result.get("download_dir", ""))
+        else:
+            download_tracker.fail_job(job_id, result.get("error", "Unknown error"))
+
+    except Exception as e:
+        logger.error(f"Download job {job_id} failed: {e}")
+        download_tracker.fail_job(job_id, str(e))


### PR DESCRIPTION
## Summary
- Add visual progress bar for MAST import operations with real-time updates
- Implement async file-by-file downloads to avoid timeout issues
- Add progress polling from frontend to backend to processing engine

## Changes

### Backend
- `ImportJobTracker` service for in-memory job state management
- Async import execution with background jobs
- New endpoint `GET /api/mast/import-progress/{jobId}` for polling
- Poll processing engine for download progress

### Processing Engine
- `DownloadTracker` for async download job management
- File-by-file download with progress callbacks
- New endpoints: `POST /mast/download/start`, `GET /mast/download/progress/{jobId}`
- Non-blocking MAST queries using `asyncio.to_thread`
- Configurable timeouts via environment variables

### Frontend
- Progress bar modal with animated fill and stage indicators
- Polling loop for real-time progress updates
- Search button spinner animation
- User-friendly timeout error messages

## Test plan
- [ ] Start Docker stack: `cd docker && docker compose up -d --build`
- [ ] Open http://localhost:3000
- [ ] Click "Search MAST" and search for "NGC 3132"
- [ ] Click Import on a result
- [ ] Verify progress bar appears and updates through stages
- [ ] Verify success message on completion

## Known Limitations
Large downloads may still timeout after 10 minutes. Future improvements documented in `docs/development-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)