### PR TITLE
feat: Add chunked downloads with resume capability and FITS file type indicators

### DIFF
--- a/backend/JwstDataAnalysis.API/Models/MastModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/MastModels.cs
@@ -183,6 +183,15 @@ namespace JwstDataAnalysis.API.Models
         public DateTime StartedAt { get; set; }
         public DateTime? CompletedAt { get; set; }
         public MastImportResponse? Result { get; set; }
+        // Byte-level progress tracking
+        public long TotalBytes { get; set; }
+        public long DownloadedBytes { get; set; }
+        public double DownloadProgressPercent { get; set; }
+        public double SpeedBytesPerSec { get; set; }
+        public double? EtaSeconds { get; set; }
+        public List<FileDownloadProgress>? FileProgress { get; set; }
+        public bool IsResumable { get; set; }
+        public string? DownloadJobId { get; set; }
     }
 
     public class ImportJobStartResponse
@@ -251,5 +260,127 @@ namespace JwstDataAnalysis.API.Models
 
         [JsonPropertyName("download_dir")]
         public string? DownloadDir { get; set; }
+
+        // Byte-level progress fields
+        [JsonPropertyName("total_bytes")]
+        public long TotalBytes { get; set; }
+
+        [JsonPropertyName("downloaded_bytes")]
+        public long DownloadedBytes { get; set; }
+
+        [JsonPropertyName("download_progress_percent")]
+        public double DownloadProgressPercent { get; set; }
+
+        [JsonPropertyName("speed_bytes_per_sec")]
+        public double SpeedBytesPerSec { get; set; }
+
+        [JsonPropertyName("eta_seconds")]
+        public double? EtaSeconds { get; set; }
+
+        [JsonPropertyName("file_progress")]
+        public List<FileDownloadProgress>? FileProgress { get; set; }
+
+        [JsonPropertyName("is_resumable")]
+        public bool IsResumable { get; set; }
+    }
+
+    // Enhanced progress tracking for chunked downloads
+    public class FileDownloadProgress
+    {
+        [JsonPropertyName("filename")]
+        public string FileName { get; set; } = string.Empty;
+
+        [JsonPropertyName("total_bytes")]
+        public long TotalBytes { get; set; }
+
+        [JsonPropertyName("downloaded_bytes")]
+        public long DownloadedBytes { get; set; }
+
+        [JsonPropertyName("progress_percent")]
+        public double ProgressPercent { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; } = "pending";
+    }
+
+    // Request to start chunked download
+    public class ChunkedDownloadRequest
+    {
+        [Required]
+        public string ObsId { get; set; } = string.Empty;
+
+        public string ProductType { get; set; } = "SCIENCE";
+
+        public string? ResumeJobId { get; set; }
+    }
+
+    // Response from starting chunked download
+    public class ChunkedDownloadStartResponse
+    {
+        [JsonPropertyName("job_id")]
+        public string JobId { get; set; } = string.Empty;
+
+        [JsonPropertyName("obs_id")]
+        public string ObsId { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+
+        [JsonPropertyName("is_resume")]
+        public bool IsResume { get; set; }
+    }
+
+    // Resumable job summary
+    public class ResumableJobSummary
+    {
+        [JsonPropertyName("job_id")]
+        public string JobId { get; set; } = string.Empty;
+
+        [JsonPropertyName("obs_id")]
+        public string ObsId { get; set; } = string.Empty;
+
+        [JsonPropertyName("total_bytes")]
+        public long TotalBytes { get; set; }
+
+        [JsonPropertyName("downloaded_bytes")]
+        public long DownloadedBytes { get; set; }
+
+        [JsonPropertyName("progress_percent")]
+        public double ProgressPercent { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; } = string.Empty;
+
+        [JsonPropertyName("total_files")]
+        public int TotalFiles { get; set; }
+
+        [JsonPropertyName("completed_files")]
+        public int CompletedFiles { get; set; }
+
+        [JsonPropertyName("started_at")]
+        public string? StartedAt { get; set; }
+    }
+
+    // Response listing resumable jobs
+    public class ResumableJobsResponse
+    {
+        [JsonPropertyName("jobs")]
+        public List<ResumableJobSummary> Jobs { get; set; } = new();
+
+        [JsonPropertyName("count")]
+        public int Count { get; set; }
+    }
+
+    // Pause/resume response
+    public class PauseResumeResponse
+    {
+        [JsonPropertyName("job_id")]
+        public string JobId { get; set; } = string.Empty;
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
     }
 }

--- a/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
@@ -49,6 +49,46 @@ namespace JwstDataAnalysis.API.Services
             }
         }
 
+        public void UpdateByteProgress(
+            string jobId,
+            long downloadedBytes,
+            long totalBytes,
+            double speedBytesPerSec,
+            double? etaSeconds,
+            List<FileDownloadProgress>? fileProgress = null)
+        {
+            if (_jobs.TryGetValue(jobId, out var job))
+            {
+                job.DownloadedBytes = downloadedBytes;
+                job.TotalBytes = totalBytes;
+                job.SpeedBytesPerSec = speedBytesPerSec;
+                job.EtaSeconds = etaSeconds;
+                job.DownloadProgressPercent = totalBytes > 0 ? (downloadedBytes / (double)totalBytes) * 100 : 0;
+                if (fileProgress != null)
+                {
+                    job.FileProgress = fileProgress;
+                }
+                _logger.LogDebug("Job {JobId} byte progress: {Downloaded}/{Total} bytes ({Speed} B/s)",
+                    jobId, downloadedBytes, totalBytes, speedBytesPerSec);
+            }
+        }
+
+        public void SetDownloadJobId(string jobId, string downloadJobId)
+        {
+            if (_jobs.TryGetValue(jobId, out var job))
+            {
+                job.DownloadJobId = downloadJobId;
+            }
+        }
+
+        public void SetResumable(string jobId, bool isResumable)
+        {
+            if (_jobs.TryGetValue(jobId, out var job))
+            {
+                job.IsResumable = isResumable;
+            }
+        }
+
         public void CompleteJob(string jobId, MastImportResponse result)
         {
             if (_jobs.TryGetValue(jobId, out var job))

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.css
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.css
@@ -742,3 +742,98 @@
     margin-left: 15px;
   }
 }
+/* FITS File Type Badges */
+.card-badges,
+.file-badges {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fits-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.fits-type-badge.image {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+  border: 1px solid #93c5fd;
+}
+
+.fits-type-badge.table {
+  background-color: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fcd34d;
+}
+
+.fits-type-badge.unknown {
+  background-color: #f3f4f6;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+}
+
+.fits-type-badge.small {
+  padding: 1px 4px;
+  font-size: 10px;
+}
+
+.fits-type-label {
+  background-color: #f3f4f6;
+  color: #6b7280;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+/* View button states */
+.view-file-btn {
+  padding: 6px 12px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  transition: all 0.2s;
+}
+
+.view-file-btn:hover:not(.disabled) {
+  background-color: #0056b3;
+}
+
+.view-file-btn.disabled,
+.lineage-file-card .file-actions button.disabled {
+  background-color: #f3f4f6;
+  color: #9ca3af;
+  border-color: #d1d5db;
+  cursor: not-allowed;
+}
+
+.lineage-file-card .file-actions button.disabled:hover {
+  background-color: #f3f4f6;
+  color: #9ca3af;
+}
+
+/* Card header adjustments for badges */
+.data-card .card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.data-card .card-header h4 {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { JwstDataModel, ProcessingLevelLabels, ProcessingLevelColors } from '../types/JwstDataTypes';
 import MastSearch from './MastSearch';
 import ImageViewer from './ImageViewer';
+import { getFitsFileInfo } from '../utils/fitsUtils';
 import './JwstDataDashboard.css';
 
 interface JwstDataDashboardProps {
@@ -385,16 +386,26 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                 </div>
                 {!collapsedGroups.has(groupId) && (
                 <div className="data-grid">
-                  {items.map((item) => (
+                  {items.map((item) => {
+                    const fitsInfo = getFitsFileInfo(item.fileName);
+                    return (
                     <div key={item.id} className="data-card">
                       <div className="card-header">
                         <h4>{item.fileName}</h4>
-                        <span
-                          className={`status ${item.processingStatus}`}
-                          style={{ color: getStatusColor(item.processingStatus) }}
-                        >
-                          {item.processingStatus}
-                        </span>
+                        <div className="card-badges">
+                          <span
+                            className={`fits-type-badge ${fitsInfo.type}`}
+                            title={fitsInfo.description}
+                          >
+                            {fitsInfo.viewable ? '🖼️' : '📊'} {fitsInfo.label}
+                          </span>
+                          <span
+                            className={`status ${item.processingStatus}`}
+                            style={{ color: getStatusColor(item.processingStatus) }}
+                          >
+                            {item.processingStatus}
+                          </span>
+                        </div>
                       </div>
                       <div className="card-content">
                         <p><strong>Type:</strong> {item.dataType}</p>
@@ -417,9 +428,11 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                             setViewingImageId(item.id);
                             setViewingImageTitle(item.fileName);
                           }}
-                          className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded"
+                          className={`view-file-btn ${!fitsInfo.viewable ? 'disabled' : ''}`}
+                          disabled={!fitsInfo.viewable}
+                          title={fitsInfo.viewable ? 'View FITS image' : fitsInfo.description}
                         >
-                          View
+                          {fitsInfo.viewable ? 'View' : 'Table'}
                         </button>
                         <button onClick={() => handleProcessData(item.id, 'basic_analysis')}>
                           Analyze
@@ -435,7 +448,8 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                         </button>
                       </div>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
                 )}
               </div>
@@ -525,22 +539,33 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
 
                               {isExpanded && (
                                 <div className="level-files">
-                                  {filesAtLevel.map(item => (
+                                  {filesAtLevel.map(item => {
+                                    const fitsInfo = getFitsFileInfo(item.fileName);
+                                    return (
                                     <div key={item.id} className="lineage-file-card">
                                       <div className="file-header">
                                         <span className="file-name" title={item.fileName}>
                                           {item.fileName}
                                         </span>
-                                        <span
-                                          className={`status ${item.processingStatus}`}
-                                          style={{ color: getStatusColor(item.processingStatus) }}
-                                        >
-                                          {item.processingStatus}
-                                        </span>
+                                        <div className="file-badges">
+                                          <span
+                                            className={`fits-type-badge small ${fitsInfo.type}`}
+                                            title={fitsInfo.description}
+                                          >
+                                            {fitsInfo.viewable ? '🖼️' : '📊'}
+                                          </span>
+                                          <span
+                                            className={`status ${item.processingStatus}`}
+                                            style={{ color: getStatusColor(item.processingStatus) }}
+                                          >
+                                            {item.processingStatus}
+                                          </span>
+                                        </div>
                                       </div>
                                       <div className="file-meta">
                                         <span>Type: {item.dataType}</span>
                                         <span>Size: {(item.fileSize / 1024 / 1024).toFixed(2)} MB</span>
+                                        <span className="fits-type-label">{fitsInfo.label}</span>
                                       </div>
                                       <div className="file-actions">
                                         <button
@@ -548,15 +573,19 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                                             setViewingImageId(item.id);
                                             setViewingImageTitle(item.fileName);
                                           }}
+                                          className={!fitsInfo.viewable ? 'disabled' : ''}
+                                          disabled={!fitsInfo.viewable}
+                                          title={fitsInfo.viewable ? 'View FITS image' : fitsInfo.description}
                                         >
-                                          View
+                                          {fitsInfo.viewable ? 'View' : 'Table'}
                                         </button>
                                         <button onClick={() => handleProcessData(item.id, 'basic_analysis')}>
                                           Analyze
                                         </button>
                                       </div>
                                     </div>
-                                  ))}
+                                    );
+                                  })}
                                 </div>
                               )}
                             </div>

--- a/frontend/jwst-frontend/src/components/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/MastSearch.css
@@ -566,3 +566,185 @@
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(74, 144, 217, 0.4);
 }
+
+/* Byte-level download details */
+.download-details {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  margin-bottom: 12px;
+  font-size: 0.85rem;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.download-bytes {
+  color: #ccc;
+}
+
+.download-speed {
+  color: #4a90d9;
+  font-weight: 500;
+}
+
+.download-eta {
+  color: #aaa;
+}
+
+/* File progress list */
+.file-progress-list {
+  max-height: 150px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+.file-progress-header {
+  padding: 8px 12px;
+  font-size: 0.75rem;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  position: sticky;
+  top: 0;
+  background: rgba(15, 15, 35, 0.95);
+}
+
+.file-progress-item {
+  display: flex;
+  align-items: center;
+  padding: 6px 12px;
+  gap: 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.file-progress-item:last-child {
+  border-bottom: none;
+}
+
+.file-progress-item .file-name {
+  flex: 0 0 150px;
+  font-size: 0.75rem;
+  color: #aaa;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: monospace;
+}
+
+.file-progress-bar {
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.file-progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.2s ease;
+}
+
+.file-progress-fill.pending {
+  background: #555;
+  width: 0%;
+}
+
+.file-progress-fill.downloading {
+  background: linear-gradient(90deg, #4a90d9 0%, #357abd 100%);
+  animation: progress-shimmer 2s infinite linear;
+}
+
+.file-progress-fill.complete {
+  background: #28a745;
+}
+
+.file-progress-fill.failed {
+  background: #dc3545;
+}
+
+.file-progress-fill.paused {
+  background: #ffc107;
+}
+
+.file-progress-item .file-status {
+  flex: 0 0 40px;
+  text-align: center;
+  font-size: 0.75rem;
+  color: #aaa;
+}
+
+.file-progress-item.complete .file-status {
+  color: #28a745;
+}
+
+.file-progress-item.failed .file-status {
+  color: #dc3545;
+}
+
+.file-progress-item.downloading .file-status {
+  color: #4a90d9;
+}
+
+/* Resumable indicator */
+.import-progress-resumable {
+  color: #ffc107;
+  font-size: 0.85rem;
+  margin-top: 8px;
+}
+
+/* Progress actions container */
+.import-progress-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.import-progress-actions .import-progress-close {
+  flex: 1;
+  margin-top: 0;
+}
+
+/* Resume button */
+.import-resume-btn {
+  flex: 1;
+  padding: 10px 24px;
+  background: linear-gradient(135deg, #28a745 0%, #1e7e34 100%);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  transition: all 0.2s ease;
+}
+
+.import-resume-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(40, 167, 69, 0.4);
+}
+
+/* Scrollbar styling for file list */
+.file-progress-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.file-progress-list::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 3px;
+}
+
+.file-progress-list::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+}
+
+.file-progress-list::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
+}

--- a/frontend/jwst-frontend/src/types/MastTypes.ts
+++ b/frontend/jwst-frontend/src/types/MastTypes.ts
@@ -85,6 +85,15 @@ export interface ImportJobStartResponse {
   message: string;
 }
 
+// File-level progress tracking
+export interface FileProgressInfo {
+  filename: string;
+  totalBytes: number;
+  downloadedBytes: number;
+  progressPercent: number;
+  status: string; // pending, downloading, complete, failed, paused
+}
+
 export interface ImportJobStatus {
   jobId: string;
   obsId: string;
@@ -96,6 +105,15 @@ export interface ImportJobStatus {
   startedAt: string;
   completedAt?: string;
   result?: MastImportResponse;
+  // Byte-level progress tracking
+  totalBytes?: number;
+  downloadedBytes?: number;
+  downloadProgressPercent?: number;
+  speedBytesPerSec?: number;
+  etaSeconds?: number;
+  fileProgress?: FileProgressInfo[];
+  isResumable?: boolean;
+  downloadJobId?: string;
 }
 
 export const ImportStages = {
@@ -105,3 +123,21 @@ export const ImportStages = {
   Complete: 'Complete',
   Failed: 'Failed',
 } as const;
+
+// Resumable job summary
+export interface ResumableJobSummary {
+  jobId: string;
+  obsId: string;
+  totalBytes: number;
+  downloadedBytes: number;
+  progressPercent: number;
+  status: string;
+  totalFiles: number;
+  completedFiles: number;
+  startedAt?: string;
+}
+
+export interface ResumableJobsResponse {
+  jobs: ResumableJobSummary[];
+  count: number;
+}

--- a/processing-engine/app/mast/chunked_downloader.py
+++ b/processing-engine/app/mast/chunked_downloader.py
@@ -1,0 +1,463 @@
+"""
+Chunked file downloader with HTTP Range support for large MAST FITS files.
+Supports parallel downloads, progress reporting, and resume capability.
+"""
+
+import aiohttp
+import aiofiles
+import asyncio
+import os
+import time
+import logging
+from dataclasses import dataclass, field
+from typing import List, Optional, Callable, Dict, Any
+from pathlib import Path
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+# Configuration
+CHUNK_SIZE = 5 * 1024 * 1024  # 5MB chunks
+MAX_CONCURRENT_FILES = 3  # Parallel file downloads
+MAX_RETRIES = 3  # Retry failed chunks
+RETRY_BASE_DELAY = 1.0  # Exponential backoff base (seconds)
+CONNECTION_TIMEOUT = 30  # Connection timeout in seconds
+READ_TIMEOUT = 300  # Read timeout in seconds (5 minutes for large chunks)
+
+
+@dataclass
+class FileDownloadProgress:
+    """Progress info for a single file download."""
+    filename: str
+    url: str
+    local_path: str
+    total_bytes: int = 0
+    downloaded_bytes: int = 0
+    status: str = "pending"  # pending, downloading, complete, failed, paused
+    error: Optional[str] = None
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+    @property
+    def progress_percent(self) -> float:
+        if self.total_bytes == 0:
+            return 0.0
+        return (self.downloaded_bytes / self.total_bytes) * 100
+
+
+@dataclass
+class DownloadJobState:
+    """State of an entire download job for persistence."""
+    job_id: str
+    obs_id: str
+    download_dir: str
+    files: List[FileDownloadProgress] = field(default_factory=list)
+    total_bytes: int = 0
+    downloaded_bytes: int = 0
+    status: str = "pending"  # pending, downloading, complete, failed, paused
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    error: Optional[str] = None
+
+    @property
+    def progress_percent(self) -> float:
+        if self.total_bytes == 0:
+            return 0.0
+        return (self.downloaded_bytes / self.total_bytes) * 100
+
+
+# Progress callback type
+ProgressCallback = Callable[[DownloadJobState], None]
+
+
+class ChunkedDownloader:
+    """
+    Downloads files in chunks with parallel file downloads,
+    progress reporting, and resume capability.
+    """
+
+    def __init__(
+        self,
+        chunk_size: int = CHUNK_SIZE,
+        max_concurrent_files: int = MAX_CONCURRENT_FILES,
+        max_retries: int = MAX_RETRIES,
+        retry_base_delay: float = RETRY_BASE_DELAY
+    ):
+        self.chunk_size = chunk_size
+        self.max_concurrent_files = max_concurrent_files
+        self.max_retries = max_retries
+        self.retry_base_delay = retry_base_delay
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._pause_event = asyncio.Event()
+        self._pause_event.set()  # Not paused by default
+        self._cancelled = False
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create an aiohttp session with connection pooling."""
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(
+                connect=CONNECTION_TIMEOUT,
+                sock_read=READ_TIMEOUT
+            )
+            connector = aiohttp.TCPConnector(
+                limit=self.max_concurrent_files * 2,
+                limit_per_host=self.max_concurrent_files,
+                enable_cleanup_closed=True
+            )
+            self._session = aiohttp.ClientSession(
+                timeout=timeout,
+                connector=connector
+            )
+        return self._session
+
+    async def close(self):
+        """Close the HTTP session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    def pause(self):
+        """Pause all downloads."""
+        self._pause_event.clear()
+        logger.info("Downloads paused")
+
+    def resume(self):
+        """Resume paused downloads."""
+        self._pause_event.set()
+        logger.info("Downloads resumed")
+
+    def cancel(self):
+        """Cancel all downloads."""
+        self._cancelled = True
+        self.resume()  # Unblock any paused operations
+        logger.info("Downloads cancelled")
+
+    async def _wait_if_paused(self):
+        """Wait if downloads are paused."""
+        await self._pause_event.wait()
+        if self._cancelled:
+            raise asyncio.CancelledError("Download cancelled")
+
+    async def get_file_size(self, url: str) -> int:
+        """Get file size from HTTP HEAD request."""
+        session = await self._get_session()
+        try:
+            async with session.head(url, allow_redirects=True) as response:
+                if response.status == 200:
+                    return int(response.headers.get('Content-Length', 0))
+                elif response.status == 405:  # Method not allowed, try GET with Range
+                    async with session.get(
+                        url,
+                        headers={'Range': 'bytes=0-0'},
+                        allow_redirects=True
+                    ) as range_resp:
+                        content_range = range_resp.headers.get('Content-Range', '')
+                        if '/' in content_range:
+                            return int(content_range.split('/')[-1])
+                return 0
+        except Exception as e:
+            logger.warning(f"Failed to get file size for {url}: {e}")
+            return 0
+
+    async def download_file_chunked(
+        self,
+        url: str,
+        local_path: str,
+        file_progress: FileDownloadProgress,
+        on_progress: Optional[Callable[[int, int], None]] = None
+    ) -> bool:
+        """
+        Download a single file in chunks with resume capability.
+
+        Args:
+            url: URL to download from
+            local_path: Local file path to save to
+            file_progress: FileDownloadProgress object to update
+            on_progress: Optional callback(downloaded_bytes, total_bytes)
+
+        Returns:
+            True if download completed successfully
+        """
+        session = await self._get_session()
+        part_path = f"{local_path}.part"
+
+        # Ensure directory exists
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+
+        # Check for existing partial download
+        start_byte = 0
+        if os.path.exists(part_path):
+            start_byte = os.path.getsize(part_path)
+            file_progress.downloaded_bytes = start_byte
+            logger.info(f"Resuming download from byte {start_byte}: {file_progress.filename}")
+
+        file_progress.status = "downloading"
+        file_progress.started_at = datetime.utcnow()
+
+        try:
+            # Get total size if not known
+            if file_progress.total_bytes == 0:
+                file_progress.total_bytes = await self.get_file_size(url)
+
+            total_bytes = file_progress.total_bytes
+
+            # If file already complete, just rename
+            if start_byte >= total_bytes > 0:
+                if os.path.exists(part_path):
+                    os.rename(part_path, local_path)
+                file_progress.status = "complete"
+                file_progress.completed_at = datetime.utcnow()
+                return True
+
+            # Download in chunks
+            retry_count = 0
+            while file_progress.downloaded_bytes < total_bytes or total_bytes == 0:
+                await self._wait_if_paused()
+
+                headers = {}
+                if start_byte > 0 or file_progress.downloaded_bytes > 0:
+                    current_byte = max(start_byte, file_progress.downloaded_bytes)
+                    headers['Range'] = f'bytes={current_byte}-'
+
+                try:
+                    async with session.get(url, headers=headers, allow_redirects=True) as response:
+                        if response.status == 416:  # Range not satisfiable - file complete
+                            break
+
+                        if response.status not in (200, 206):
+                            raise aiohttp.ClientError(f"HTTP {response.status}: {response.reason}")
+
+                        # Update total bytes from response if available
+                        if total_bytes == 0:
+                            content_length = response.headers.get('Content-Length')
+                            if content_length:
+                                total_bytes = int(content_length)
+                                file_progress.total_bytes = total_bytes
+
+                        # Open file for appending
+                        mode = 'ab' if os.path.exists(part_path) else 'wb'
+                        async with aiofiles.open(part_path, mode) as f:
+                            async for chunk in response.content.iter_chunked(self.chunk_size):
+                                await self._wait_if_paused()
+
+                                await f.write(chunk)
+                                file_progress.downloaded_bytes += len(chunk)
+
+                                if on_progress:
+                                    on_progress(file_progress.downloaded_bytes, total_bytes)
+
+                        # If we got here without chunked transfer and no content-length,
+                        # the download is complete
+                        if total_bytes == 0:
+                            total_bytes = file_progress.downloaded_bytes
+                            file_progress.total_bytes = total_bytes
+
+                        retry_count = 0  # Reset retry count on success
+
+                except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                    retry_count += 1
+                    if retry_count > self.max_retries:
+                        raise
+
+                    delay = self.retry_base_delay * (2 ** (retry_count - 1))
+                    logger.warning(
+                        f"Download error (retry {retry_count}/{self.max_retries}): {e}. "
+                        f"Waiting {delay}s before retry..."
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+
+                # Check if complete
+                if file_progress.downloaded_bytes >= total_bytes > 0:
+                    break
+
+            # Download complete - rename part file to final
+            if os.path.exists(part_path):
+                os.rename(part_path, local_path)
+
+            file_progress.status = "complete"
+            file_progress.completed_at = datetime.utcnow()
+            logger.info(f"Downloaded: {file_progress.filename} ({file_progress.downloaded_bytes} bytes)")
+            return True
+
+        except asyncio.CancelledError:
+            file_progress.status = "paused"
+            logger.info(f"Download paused/cancelled: {file_progress.filename}")
+            return False
+
+        except Exception as e:
+            file_progress.status = "failed"
+            file_progress.error = str(e)
+            logger.error(f"Download failed for {file_progress.filename}: {e}")
+            return False
+
+    async def download_files(
+        self,
+        files_info: List[Dict[str, Any]],
+        download_dir: str,
+        job_state: DownloadJobState,
+        progress_callback: Optional[ProgressCallback] = None
+    ) -> DownloadJobState:
+        """
+        Download multiple files in parallel with progress tracking.
+
+        Args:
+            files_info: List of dicts with 'url' and 'filename' keys
+            download_dir: Directory to save files
+            job_state: DownloadJobState to track progress
+            progress_callback: Optional callback for progress updates
+
+        Returns:
+            Updated DownloadJobState
+        """
+        self._cancelled = False
+        self._pause_event.set()
+
+        job_state.status = "downloading"
+        job_state.started_at = datetime.utcnow()
+        job_state.download_dir = download_dir
+
+        # Initialize file progress for each file
+        for file_info in files_info:
+            url = file_info.get('url', '')
+            filename = file_info.get('filename', os.path.basename(url))
+            local_path = os.path.join(download_dir, filename)
+
+            # Check if already tracked
+            existing = next((f for f in job_state.files if f.filename == filename), None)
+            if not existing:
+                file_progress = FileDownloadProgress(
+                    filename=filename,
+                    url=url,
+                    local_path=local_path,
+                    total_bytes=file_info.get('size', 0)
+                )
+                job_state.files.append(file_progress)
+
+        # Calculate total bytes (if sizes are known)
+        job_state.total_bytes = sum(f.total_bytes for f in job_state.files)
+
+        # Get file sizes for files where we don't know the size
+        size_tasks = []
+        for file_progress in job_state.files:
+            if file_progress.total_bytes == 0 and file_progress.status == "pending":
+                size_tasks.append(self._update_file_size(file_progress))
+
+        if size_tasks:
+            await asyncio.gather(*size_tasks)
+            job_state.total_bytes = sum(f.total_bytes for f in job_state.files)
+
+        if progress_callback:
+            progress_callback(job_state)
+
+        # Create semaphore for limiting concurrent downloads
+        semaphore = asyncio.Semaphore(self.max_concurrent_files)
+
+        # Track speed calculations
+        speed_tracker = SpeedTracker()
+
+        async def download_with_semaphore(file_progress: FileDownloadProgress):
+            async with semaphore:
+                if file_progress.status in ("complete", "failed"):
+                    return
+
+                def on_file_progress(downloaded: int, total: int):
+                    # Update job state
+                    job_state.downloaded_bytes = sum(f.downloaded_bytes for f in job_state.files)
+                    speed_tracker.add_sample(downloaded)
+                    if progress_callback:
+                        progress_callback(job_state)
+
+                await self.download_file_chunked(
+                    url=file_progress.url,
+                    local_path=file_progress.local_path,
+                    file_progress=file_progress,
+                    on_progress=on_file_progress
+                )
+
+        # Download all files
+        try:
+            tasks = [download_with_semaphore(fp) for fp in job_state.files if fp.status == "pending"]
+            await asyncio.gather(*tasks, return_exceptions=True)
+        except asyncio.CancelledError:
+            job_state.status = "paused"
+            logger.info(f"Download job {job_state.job_id} paused")
+
+        # Update final state
+        job_state.downloaded_bytes = sum(f.downloaded_bytes for f in job_state.files)
+
+        failed_files = [f for f in job_state.files if f.status == "failed"]
+        paused_files = [f for f in job_state.files if f.status == "paused"]
+        complete_files = [f for f in job_state.files if f.status == "complete"]
+
+        if failed_files:
+            job_state.status = "failed"
+            job_state.error = f"{len(failed_files)} file(s) failed to download"
+        elif paused_files:
+            job_state.status = "paused"
+        elif len(complete_files) == len(job_state.files):
+            job_state.status = "complete"
+            job_state.completed_at = datetime.utcnow()
+
+        if progress_callback:
+            progress_callback(job_state)
+
+        await self.close()
+        return job_state
+
+    async def _update_file_size(self, file_progress: FileDownloadProgress):
+        """Update file size from URL."""
+        size = await self.get_file_size(file_progress.url)
+        file_progress.total_bytes = size
+
+
+class SpeedTracker:
+    """Tracks download speed using a sliding window."""
+
+    def __init__(self, window_size: float = 5.0):
+        self.window_size = window_size
+        self.samples: List[tuple] = []  # (timestamp, bytes)
+        self._last_bytes = 0
+
+    def add_sample(self, total_bytes: int):
+        """Add a new sample."""
+        now = time.time()
+        bytes_delta = total_bytes - self._last_bytes
+        self._last_bytes = total_bytes
+
+        self.samples.append((now, bytes_delta))
+
+        # Remove old samples
+        cutoff = now - self.window_size
+        self.samples = [(t, b) for t, b in self.samples if t > cutoff]
+
+    def get_speed(self) -> float:
+        """Get current speed in bytes per second."""
+        if len(self.samples) < 2:
+            return 0.0
+
+        total_bytes = sum(b for _, b in self.samples)
+        time_span = self.samples[-1][0] - self.samples[0][0]
+
+        if time_span <= 0:
+            return 0.0
+
+        return total_bytes / time_span
+
+    def get_eta(self, remaining_bytes: int) -> Optional[float]:
+        """Get estimated time remaining in seconds."""
+        speed = self.get_speed()
+        if speed <= 0:
+            return None
+        return remaining_bytes / speed
+
+
+def calculate_speed_and_eta(
+    job_state: DownloadJobState,
+    speed_tracker: SpeedTracker
+) -> tuple[float, Optional[float]]:
+    """Calculate current speed and ETA for a download job."""
+    speed = speed_tracker.get_speed()
+    remaining = job_state.total_bytes - job_state.downloaded_bytes
+    eta = speed_tracker.get_eta(remaining) if remaining > 0 else 0.0
+    return speed, eta

--- a/processing-engine/app/mast/download_state_manager.py
+++ b/processing-engine/app/mast/download_state_manager.py
@@ -1,0 +1,344 @@
+"""
+Download state persistence for resume capability.
+Stores download job state to JSON files for recovery after interruption.
+"""
+
+import json
+import os
+import logging
+from datetime import datetime, timedelta
+from typing import Optional, List, Dict, Any
+from pathlib import Path
+from dataclasses import asdict
+
+from .chunked_downloader import DownloadJobState, FileDownloadProgress
+
+logger = logging.getLogger(__name__)
+
+# Configuration
+STATE_RETENTION_DAYS = 7  # Auto-cleanup state files older than this
+STATE_DIR_NAME = ".download_state"
+
+
+class DownloadStateManager:
+    """
+    Manages persistent state for download jobs to enable resume capability.
+    State is stored as JSON files in a hidden directory within the download directory.
+    """
+
+    def __init__(self, base_download_dir: str):
+        """
+        Initialize the state manager.
+
+        Args:
+            base_download_dir: Base directory for MAST downloads (e.g., /app/data/mast)
+        """
+        self.base_download_dir = base_download_dir
+        self.state_dir = os.path.join(base_download_dir, STATE_DIR_NAME)
+        os.makedirs(self.state_dir, exist_ok=True)
+
+    def _get_state_path(self, job_id: str) -> str:
+        """Get the file path for a job's state file."""
+        return os.path.join(self.state_dir, f"{job_id}.json")
+
+    def _serialize_datetime(self, dt: Optional[datetime]) -> Optional[str]:
+        """Serialize datetime to ISO format string."""
+        return dt.isoformat() if dt else None
+
+    def _deserialize_datetime(self, dt_str: Optional[str]) -> Optional[datetime]:
+        """Deserialize ISO format string to datetime."""
+        if dt_str:
+            return datetime.fromisoformat(dt_str)
+        return None
+
+    def _file_progress_to_dict(self, fp: FileDownloadProgress) -> Dict[str, Any]:
+        """Convert FileDownloadProgress to dictionary."""
+        return {
+            "filename": fp.filename,
+            "url": fp.url,
+            "local_path": fp.local_path,
+            "total_bytes": fp.total_bytes,
+            "downloaded_bytes": fp.downloaded_bytes,
+            "status": fp.status,
+            "error": fp.error,
+            "started_at": self._serialize_datetime(fp.started_at),
+            "completed_at": self._serialize_datetime(fp.completed_at)
+        }
+
+    def _dict_to_file_progress(self, data: Dict[str, Any]) -> FileDownloadProgress:
+        """Convert dictionary to FileDownloadProgress."""
+        fp = FileDownloadProgress(
+            filename=data["filename"],
+            url=data["url"],
+            local_path=data["local_path"],
+            total_bytes=data.get("total_bytes", 0),
+            downloaded_bytes=data.get("downloaded_bytes", 0),
+            status=data.get("status", "pending"),
+            error=data.get("error")
+        )
+        fp.started_at = self._deserialize_datetime(data.get("started_at"))
+        fp.completed_at = self._deserialize_datetime(data.get("completed_at"))
+        return fp
+
+    def _job_state_to_dict(self, job_state: DownloadJobState) -> Dict[str, Any]:
+        """Convert DownloadJobState to dictionary for JSON serialization."""
+        return {
+            "job_id": job_state.job_id,
+            "obs_id": job_state.obs_id,
+            "download_dir": job_state.download_dir,
+            "files": [self._file_progress_to_dict(f) for f in job_state.files],
+            "total_bytes": job_state.total_bytes,
+            "downloaded_bytes": job_state.downloaded_bytes,
+            "status": job_state.status,
+            "started_at": self._serialize_datetime(job_state.started_at),
+            "completed_at": self._serialize_datetime(job_state.completed_at),
+            "error": job_state.error,
+            "saved_at": datetime.utcnow().isoformat()
+        }
+
+    def _dict_to_job_state(self, data: Dict[str, Any]) -> DownloadJobState:
+        """Convert dictionary to DownloadJobState."""
+        job_state = DownloadJobState(
+            job_id=data["job_id"],
+            obs_id=data["obs_id"],
+            download_dir=data.get("download_dir", ""),
+            total_bytes=data.get("total_bytes", 0),
+            downloaded_bytes=data.get("downloaded_bytes", 0),
+            status=data.get("status", "pending"),
+            error=data.get("error")
+        )
+        job_state.started_at = self._deserialize_datetime(data.get("started_at"))
+        job_state.completed_at = self._deserialize_datetime(data.get("completed_at"))
+        job_state.files = [
+            self._dict_to_file_progress(f) for f in data.get("files", [])
+        ]
+        return job_state
+
+    def save_job_state(self, job_state: DownloadJobState) -> bool:
+        """
+        Save job state to disk.
+
+        Args:
+            job_state: The job state to save
+
+        Returns:
+            True if saved successfully
+        """
+        try:
+            state_path = self._get_state_path(job_state.job_id)
+            state_data = self._job_state_to_dict(job_state)
+
+            # Write atomically using temp file
+            temp_path = f"{state_path}.tmp"
+            with open(temp_path, 'w') as f:
+                json.dump(state_data, f, indent=2)
+
+            os.replace(temp_path, state_path)
+            logger.debug(f"Saved state for job {job_state.job_id}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to save state for job {job_state.job_id}: {e}")
+            return False
+
+    def load_job_state(self, job_id: str) -> Optional[DownloadJobState]:
+        """
+        Load job state from disk.
+
+        Args:
+            job_id: The job ID to load
+
+        Returns:
+            DownloadJobState if found, None otherwise
+        """
+        try:
+            state_path = self._get_state_path(job_id)
+            if not os.path.exists(state_path):
+                return None
+
+            with open(state_path, 'r') as f:
+                data = json.load(f)
+
+            job_state = self._dict_to_job_state(data)
+
+            # Verify that partial files exist and update downloaded bytes
+            for file_progress in job_state.files:
+                if file_progress.status not in ("complete", "failed"):
+                    part_path = f"{file_progress.local_path}.part"
+                    if os.path.exists(part_path):
+                        actual_bytes = os.path.getsize(part_path)
+                        file_progress.downloaded_bytes = actual_bytes
+                        file_progress.status = "paused"
+                    elif os.path.exists(file_progress.local_path):
+                        # Full file exists - mark as complete
+                        actual_bytes = os.path.getsize(file_progress.local_path)
+                        file_progress.downloaded_bytes = actual_bytes
+                        file_progress.total_bytes = actual_bytes
+                        file_progress.status = "complete"
+                    else:
+                        # No file exists - reset progress
+                        file_progress.downloaded_bytes = 0
+                        file_progress.status = "pending"
+
+            # Recalculate total downloaded bytes
+            job_state.downloaded_bytes = sum(f.downloaded_bytes for f in job_state.files)
+
+            logger.info(f"Loaded state for job {job_id}: {job_state.downloaded_bytes}/{job_state.total_bytes} bytes")
+            return job_state
+
+        except Exception as e:
+            logger.error(f"Failed to load state for job {job_id}: {e}")
+            return None
+
+    def delete_job_state(self, job_id: str) -> bool:
+        """
+        Delete job state from disk.
+
+        Args:
+            job_id: The job ID to delete
+
+        Returns:
+            True if deleted successfully
+        """
+        try:
+            state_path = self._get_state_path(job_id)
+            if os.path.exists(state_path):
+                os.remove(state_path)
+                logger.debug(f"Deleted state for job {job_id}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to delete state for job {job_id}: {e}")
+            return False
+
+    def get_resumable_jobs(self) -> List[Dict[str, Any]]:
+        """
+        Get list of jobs that can be resumed.
+
+        Returns:
+            List of job summaries with id, obs_id, progress, etc.
+        """
+        resumable = []
+
+        try:
+            for filename in os.listdir(self.state_dir):
+                if not filename.endswith('.json'):
+                    continue
+
+                job_id = filename[:-5]  # Remove .json
+                job_state = self.load_job_state(job_id)
+
+                if job_state and job_state.status in ("paused", "failed", "downloading"):
+                    # Check if any files are resumable
+                    has_resumable = any(
+                        f.status in ("pending", "paused", "downloading")
+                        for f in job_state.files
+                    )
+
+                    if has_resumable:
+                        resumable.append({
+                            "job_id": job_state.job_id,
+                            "obs_id": job_state.obs_id,
+                            "total_bytes": job_state.total_bytes,
+                            "downloaded_bytes": job_state.downloaded_bytes,
+                            "progress_percent": job_state.progress_percent,
+                            "status": job_state.status,
+                            "total_files": len(job_state.files),
+                            "completed_files": sum(1 for f in job_state.files if f.status == "complete"),
+                            "started_at": self._serialize_datetime(job_state.started_at)
+                        })
+
+        except Exception as e:
+            logger.error(f"Failed to list resumable jobs: {e}")
+
+        return resumable
+
+    def cleanup_completed(self, max_age_days: int = STATE_RETENTION_DAYS) -> int:
+        """
+        Remove state files for completed jobs older than max_age_days.
+
+        Args:
+            max_age_days: Maximum age in days for completed job states
+
+        Returns:
+            Number of state files removed
+        """
+        removed = 0
+        cutoff = datetime.utcnow() - timedelta(days=max_age_days)
+
+        try:
+            for filename in os.listdir(self.state_dir):
+                if not filename.endswith('.json'):
+                    continue
+
+                state_path = os.path.join(self.state_dir, filename)
+
+                try:
+                    with open(state_path, 'r') as f:
+                        data = json.load(f)
+
+                    status = data.get("status", "")
+                    saved_at = data.get("saved_at") or data.get("completed_at")
+
+                    if status == "complete" and saved_at:
+                        saved_dt = datetime.fromisoformat(saved_at)
+                        if saved_dt < cutoff:
+                            os.remove(state_path)
+                            removed += 1
+                            logger.debug(f"Cleaned up old state file: {filename}")
+
+                except Exception as e:
+                    logger.warning(f"Failed to process state file {filename}: {e}")
+
+        except Exception as e:
+            logger.error(f"Failed to cleanup state files: {e}")
+
+        if removed > 0:
+            logger.info(f"Cleaned up {removed} old state file(s)")
+
+        return removed
+
+    def cleanup_orphaned_partial_files(self) -> int:
+        """
+        Remove orphaned .part files that don't have corresponding state files.
+
+        Returns:
+            Number of files removed
+        """
+        removed = 0
+
+        try:
+            # Get all job IDs from state files
+            state_job_ids = set()
+            for filename in os.listdir(self.state_dir):
+                if filename.endswith('.json'):
+                    state_job_ids.add(filename[:-5])
+
+            # Walk through download directories
+            for obs_dir in os.listdir(self.base_download_dir):
+                if obs_dir == STATE_DIR_NAME:
+                    continue
+
+                obs_path = os.path.join(self.base_download_dir, obs_dir)
+                if not os.path.isdir(obs_path):
+                    continue
+
+                for filename in os.listdir(obs_path):
+                    if filename.endswith('.part'):
+                        file_path = os.path.join(obs_path, filename)
+
+                        # Check if file is very old (more than retention period)
+                        mtime = datetime.fromtimestamp(os.path.getmtime(file_path))
+                        cutoff = datetime.utcnow() - timedelta(days=STATE_RETENTION_DAYS)
+
+                        if mtime < cutoff:
+                            os.remove(file_path)
+                            removed += 1
+                            logger.debug(f"Removed orphaned partial file: {file_path}")
+
+        except Exception as e:
+            logger.error(f"Failed to cleanup orphaned partial files: {e}")
+
+        if removed > 0:
+            logger.info(f"Removed {removed} orphaned partial file(s)")
+
+        return removed

--- a/processing-engine/app/mast/models.py
+++ b/processing-engine/app/mast/models.py
@@ -62,3 +62,73 @@ class MastDataProductsResponse(BaseModel):
     obs_id: str
     products: List[Dict[str, Any]]
     product_count: int
+
+
+# === Chunked Download Models ===
+
+class ChunkedDownloadRequest(BaseModel):
+    """Request to start a chunked download job."""
+    obs_id: str = Field(..., description="Observation ID to download")
+    product_type: str = Field(default="SCIENCE", description="Product type filter")
+    resume_job_id: Optional[str] = Field(None, description="Job ID to resume (if resuming)")
+
+
+class FileProgressResponse(BaseModel):
+    """Progress information for a single file."""
+    filename: str
+    total_bytes: int = 0
+    downloaded_bytes: int = 0
+    progress_percent: float = 0.0
+    status: str = "pending"
+
+
+class ChunkedDownloadProgressResponse(BaseModel):
+    """Enhanced progress response with byte-level tracking."""
+    job_id: str
+    obs_id: str
+    stage: str
+    message: str
+    progress: int = 0  # 0-100, file-level progress
+    total_files: int = 0
+    downloaded_files: int = 0
+    current_file: Optional[str] = None
+    files: List[str] = []  # Completed file paths
+    error: Optional[str] = None
+    started_at: str
+    completed_at: Optional[str] = None
+    download_dir: Optional[str] = None
+    is_complete: bool = False
+    # Byte-level progress
+    total_bytes: int = 0
+    downloaded_bytes: int = 0
+    download_progress_percent: float = 0.0
+    speed_bytes_per_sec: float = 0.0
+    eta_seconds: Optional[float] = None
+    file_progress: List[FileProgressResponse] = []
+    is_resumable: bool = False
+
+
+class ResumableJobSummary(BaseModel):
+    """Summary of a resumable download job."""
+    job_id: str
+    obs_id: str
+    total_bytes: int = 0
+    downloaded_bytes: int = 0
+    progress_percent: float = 0.0
+    status: str
+    total_files: int = 0
+    completed_files: int = 0
+    started_at: Optional[str] = None
+
+
+class ResumableJobsResponse(BaseModel):
+    """Response listing resumable jobs."""
+    jobs: List[ResumableJobSummary]
+    count: int
+
+
+class PauseResumeResponse(BaseModel):
+    """Response for pause/resume operations."""
+    job_id: str
+    status: str
+    message: str

--- a/processing-engine/requirements.txt
+++ b/processing-engine/requirements.txt
@@ -10,4 +10,6 @@ pandas==2.1.4
 requests==2.31.0
 python-multipart==0.0.6
 pydantic==2.5.0
-pytest==7.4.3 
+pytest==7.4.3
+aiohttp==3.9.1
+aiofiles==23.2.1 


### PR DESCRIPTION
## Summary

- **Chunked Downloads**: Implement HTTP Range header support for downloading large FITS files in 5MB chunks with parallel downloads (3 concurrent files)
- **Resume Capability**: Add state persistence and resume functionality for interrupted downloads
- **FITS File Type Indicators**: Show visual badges indicating whether files are viewable images or non-viewable tables
- **Improved Error Handling**: Graceful handling of non-image FITS files and better recovery from timeout scenarios

## Changes

### Backend (.NET)
- Add endpoints for chunked downloads: `start-chunked`, `resume`, `pause`, `resumable`
- Add `import-from-existing` endpoint to recover downloads where files exist on disk
- Add `check-files` endpoint to verify downloaded files
- Fix `HttpRequestException` to properly set StatusCode for 404 handling
- Add byte-level progress tracking with speed and ETA

### Processing Engine (Python)
- Add `ChunkedDownloader` class with HTTP Range header support
- Add `DownloadStateManager` for JSON-based state persistence
- Add parallel file downloads using asyncio
- Add pause/resume/cancel operations

### Frontend (React)
- Add byte-level progress display (MB downloaded, speed, ETA)
- Add per-file progress bars in import modal
- Add Resume Download button for failed resumable imports
- Add FITS file type badges (🖼️ image vs 📊 table)
- Disable View button for non-viewable table files
- Graceful error messages for non-image FITS files

## Test plan

- [ ] Start a large MAST import and verify byte-level progress displays correctly
- [ ] Interrupt a download and verify resume works from last byte position
- [ ] Verify non-image FITS files show table badge and disabled View button
- [ ] Verify clicking View on a table file no longer crashes (shows error message)
- [ ] Verify import-from-existing works when download completed but backend timed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)