### PR TITLE
feat: Add observation date display and sort by download date

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/MastController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.cs
@@ -1141,10 +1141,15 @@ namespace JwstDataAnalysis.API.Controllers
                     metadata.ExposureTime = expTimeValue;
             }
 
-            if (obsMeta.TryGetValue("t_obs_release", out var obsDate) && obsDate != null)
+            // Convert MJD (Modified Julian Date) to DateTime
+            // t_min is the observation start time in MJD format
+            if (obsMeta.TryGetValue("t_min", out var tMin) && tMin != null)
             {
-                if (DateTime.TryParse(obsDate.ToString(), out var dateValue))
-                    metadata.ObservationDate = dateValue;
+                if (double.TryParse(tMin.ToString(), out var mjd))
+                {
+                    // MJD epoch is November 17, 1858
+                    metadata.ObservationDate = new DateTime(1858, 11, 17, 0, 0, 0, DateTimeKind.Utc).AddDays(mjd);
+                }
             }
 
             metadata.CoordinateSystem = "ICRS";

--- a/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
+++ b/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
@@ -18,7 +18,9 @@ namespace JwstDataAnalysis.API.Services
 
         // Basic CRUD operations
         public async Task<List<JwstDataModel>> GetAsync() =>
-            await _jwstDataCollection.Find(_ => true).ToListAsync();
+            await _jwstDataCollection.Find(_ => true)
+                .SortByDescending(x => x.UploadDate)
+                .ToListAsync();
 
         public async Task<JwstDataModel?> GetAsync(string id) =>
             await _jwstDataCollection.Find(x => x.Id == id).FirstOrDefaultAsync();
@@ -239,10 +241,14 @@ namespace JwstDataAnalysis.API.Services
         }
 
         public async Task<List<JwstDataModel>> GetNonArchivedAsync() =>
-            await _jwstDataCollection.Find(x => x.IsArchived == false).ToListAsync();
+            await _jwstDataCollection.Find(x => x.IsArchived == false)
+                .SortByDescending(x => x.UploadDate)
+                .ToListAsync();
 
         public async Task<List<JwstDataModel>> GetArchivedAsync() =>
-            await _jwstDataCollection.Find(x => x.IsArchived == true).ToListAsync();
+            await _jwstDataCollection.Find(x => x.IsArchived == true)
+                .SortByDescending(x => x.UploadDate)
+                .ToListAsync();
 
         // Statistics
         public async Task<DataStatistics> GetStatisticsAsync()


### PR DESCRIPTION
## Summary

- **Fix MJD to DateTime conversion** for MAST imports - uses `t_min` field (observation start time) with proper MJD epoch (November 17, 1858)
- **Add default sorting by upload date** (newest first) across all data retrieval methods
- **Display observation and download dates** in the dashboard lineage view

## Changes

### Backend
- `MastController.cs`: Convert MJD number to DateTime instead of trying to parse as date string
- `MongoDBService.cs`: Add `.SortByDescending(x => x.UploadDate)` to `GetAsync()`, `GetNonArchivedAsync()`, and `GetArchivedAsync()`

### Frontend
- Lineage view header now shows: Target • Instrument • Observed: [date] • Downloaded: [date]
- Lineage groups sorted by most recent download (newest first)
- Grouped view shows observation date before download date
- Expanded file cards show observation date in metadata

## Test plan

- [x] Rebuild Docker stack: `cd docker && docker compose up -d --build`
- [x] Import a new observation from MAST
- [x] Verify new imports appear at the top of the lineage view
- [x] Verify observation date (when JWST took the data) displays in header
- [x] Verify download date displays in header
- [x] Verify dates show in expanded file cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)