### PR TITLE
feat: Preserve all MAST metadata on import and add refresh functionality

### DIFF
--- a/backend/JwstDataAnalysis.API/Models/JwstDataModel.cs
+++ b/backend/JwstDataAnalysis.API/Models/JwstDataModel.cs
@@ -84,7 +84,7 @@ namespace JwstDataAnalysis.API.Models
         public int? BitDepth { get; set; }
         public List<string>? Channels { get; set; }
         public Dictionary<string, double>? Statistics { get; set; } // min, max, mean, std, median
-        
+
         // Astronomical specific fields
         public string? TargetName { get; set; } // Astronomical object name (e.g., "NGC-6804")
         public string? Wavelength { get; set; }
@@ -95,6 +95,13 @@ namespace JwstDataAnalysis.API.Models
         public string? CoordinateSystem { get; set; }
         public Dictionary<string, double>? WCS { get; set; } // World Coordinate System
         public string? Units { get; set; } // "adu", "mjy/sr", "erg/s/cm2/angstrom", etc.
+
+        // MAST-specific fields
+        public string? WavelengthRange { get; set; } // e.g., "INFRARED", "OPTICAL", "UV"
+        public int? CalibrationLevel { get; set; } // MAST calib_level (0-4)
+        public string? ProposalId { get; set; } // JWST program/proposal ID
+        public string? ProposalPi { get; set; } // Principal investigator name
+        public string? ObservationTitle { get; set; } // Title of the observation program
     }
 
     public class SensorMetadata

--- a/backend/JwstDataAnalysis.API/Models/MastModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/MastModels.cs
@@ -384,4 +384,12 @@ namespace JwstDataAnalysis.API.Models
         [JsonPropertyName("message")]
         public string Message { get; set; } = string.Empty;
     }
+
+    // Metadata refresh response
+    public class MetadataRefreshResponse
+    {
+        public string ObsId { get; set; } = string.Empty;
+        public int UpdatedCount { get; set; }
+        public string Message { get; set; } = string.Empty;
+    }
 }

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.css
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.css
@@ -314,6 +314,29 @@
   box-shadow: 0 4px 12px rgba(16, 185, 129, 0.4);
 }
 
+.refresh-metadata-btn {
+  padding: 10px 20px;
+  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.refresh-metadata-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.4);
+}
+
+.refresh-metadata-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
 .no-data {
   grid-column: 1 / -1;
   text-align: center;

--- a/frontend/jwst-frontend/src/types/JwstDataTypes.ts
+++ b/frontend/jwst-frontend/src/types/JwstDataTypes.ts
@@ -42,6 +42,12 @@ export interface ImageMetadata {
   coordinateSystem?: string;
   wcs?: Record<string, number>;
   units?: string;
+  // MAST-specific fields
+  wavelengthRange?: string;
+  calibrationLevel?: number;
+  proposalId?: string;
+  proposalPi?: string;
+  observationTitle?: string;
 }
 
 export interface SensorMetadata {

--- a/frontend/jwst-frontend/src/types/MastTypes.ts
+++ b/frontend/jwst-frontend/src/types/MastTypes.ts
@@ -142,3 +142,10 @@ export interface ResumableJobsResponse {
   jobs: ResumableJobSummary[];
   count: number;
 }
+
+// Metadata refresh response
+export interface MetadataRefreshResponse {
+  obsId: string;
+  updatedCount: number;
+  message: string;
+}


### PR DESCRIPTION
## Summary

- Previously only ~10 fields from MAST were saved during import (4 generic + 6 ImageMetadata fields)
- Now all ~30+ fields are preserved with `mast_` prefix in the Metadata dictionary
- Added "Refresh Metadata" button to fix existing imports that are missing metadata

## Changes

**Backend:**
- Add `BuildMastMetadata()` helper method to preserve ALL MAST fields with `mast_` prefix
- Enhance `CreateImageMetadata()` with fallback date extraction (`t_min` → `t_max` → `t_obs_release`) and logging when dates are missing
- Add new ImageMetadata fields: `wavelengthRange`, `calibrationLevel`, `proposalId`, `proposalPi`, `observationTitle`
- Add `POST /mast/refresh-metadata/{obsId}` endpoint to refresh metadata for a single observation
- Add `POST /mast/refresh-metadata-all` endpoint to refresh metadata for all MAST imports

**Frontend:**
- Add "Refresh Metadata" button to dashboard UI
- Add corresponding TypeScript types

## Test plan

- [ ] Import a new MAST observation and verify all metadata fields are saved
- [ ] Check that `mast_t_min`, `mast_proposal_id`, `mast_proposal_pi`, `mast_obs_title` are present in record metadata
- [ ] Click "Refresh Metadata" button and verify existing imports are updated
- [ ] Verify observation dates display correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)