### PR TITLE
docs: Update documentation for MAST metadata preservation feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,6 +435,8 @@ App.tsx (root)
 - `GET /mast/import/resumable` - List all resumable download jobs
 - `POST /mast/import/from-existing/{obsId}` - Import from already-downloaded files
 - `GET /mast/import/check-files/{obsId}` - Check if downloaded files exist
+- `POST /mast/refresh-metadata/{obsId}` - Re-fetch and update metadata for a single observation
+- `POST /mast/refresh-metadata-all` - Re-fetch and update metadata for all MAST imports
 
 **Swagger UI**: http://localhost:5001/swagger
 
@@ -510,7 +512,35 @@ curl -X POST http://localhost:5001/api/mast/import/resume/{jobId}
 
 # Import from existing files (if download completed but timed out)
 curl -X POST http://localhost:5001/api/mast/import/from-existing/{obsId}
+
+# Refresh metadata for a single observation (re-fetch from MAST)
+curl -X POST http://localhost:5001/api/mast/refresh-metadata/{obsId}
+
+# Refresh metadata for ALL MAST imports (useful after updates)
+curl -X POST http://localhost:5001/api/mast/refresh-metadata-all
 ```
+
+### MAST Metadata Preservation
+
+When importing observations from MAST, all metadata fields (~30+) are preserved with `mast_` prefix in the record's `metadata` dictionary. Key fields include:
+
+**Stored in ImageInfo** (typed fields):
+- `observationDate` - Converted from MJD (t_min) with fallback to t_max, t_obs_release
+- `targetName`, `instrument`, `filter`, `exposureTime`
+- `calibrationLevel` - MAST calib_level (0-4)
+- `proposalId`, `proposalPi`, `observationTitle`
+- `wavelengthRange` - e.g., "INFRARED", "OPTICAL"
+- `wcs` - World coordinate system (CRVAL1, CRVAL2)
+
+**Stored in Metadata** (all MAST fields with `mast_` prefix):
+- `mast_obs_id`, `mast_target_name`, `mast_instrument_name`
+- `mast_t_min`, `mast_t_max`, `mast_t_exptime`
+- `mast_proposal_id`, `mast_proposal_pi`, `mast_obs_title`
+- `mast_s_ra`, `mast_s_dec`, `mast_s_region`
+- `mast_dataURL`, `mast_jpegURL`
+- And many more...
+
+**Refresh Metadata Button**: Click "Refresh Metadata" in the dashboard to re-fetch metadata from MAST for all existing imports. This is useful after updates that add new metadata fields.
 
 ### FITS File Types
 

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -161,6 +161,16 @@ This document outlines the comprehensive development plan for building a JWST da
 - [x] Disable View button for non-viewable table files
 - [x] Graceful error handling for non-image FITS files in viewer
 
+#### **MAST Metadata Preservation:** ✅ *Complete*
+
+- [x] Preserve ALL MAST fields (~30+) with `mast_` prefix in Metadata dictionary
+- [x] Enhanced ImageMetadata with proposal info, calibration level, wavelength range
+- [x] Robust observation date extraction with fallbacks (t_min → t_max → t_obs_release)
+- [x] Refresh metadata endpoint for single observation
+- [x] Bulk refresh metadata endpoint for all MAST imports
+- [x] Frontend "Refresh Metadata" button in dashboard
+- [x] JsonElement to basic type conversion for MongoDB serialization
+
 #### **Known Issues & Future Improvements:**
 
 **Remaining Enhancements:**
@@ -178,6 +188,7 @@ This document outlines the comprehensive development plan for building a JWST da
 - ✅ Chunked downloads with HTTP Range headers and resume capability
 - ✅ Byte-level progress tracking with speed and ETA
 - ✅ FITS file type detection and viewer improvements
+- ✅ MAST metadata preservation and refresh capability
 - [ ] Basic image and spectral processing algorithms
 - [ ] Processing job queue system
 

--- a/docs/standards/backend-development.md
+++ b/docs/standards/backend-development.md
@@ -51,13 +51,25 @@
 
 ### MastController (`/api/mast`)
 
+**Search:**
 - POST /api/mast/search/target - Search by target name
 - POST /api/mast/search/coordinates - Search by RA/Dec
 - POST /api/mast/search/observation - Search by observation ID
 - POST /api/mast/search/program - Search by program ID
 - POST /api/mast/products - Get data products for observation
-- POST /api/mast/download - Download FITS files
+
+**Import:**
+- POST /api/mast/download - Download FITS files (no DB records)
 - POST /api/mast/import - Download and import into MongoDB
+- GET /api/mast/import-progress/{jobId} - Get import progress
+- POST /api/mast/import/resume/{jobId} - Resume paused import
+- GET /api/mast/import/resumable - List resumable jobs
+- POST /api/mast/import/from-existing/{obsId} - Import from downloaded files
+- GET /api/mast/import/check-files/{obsId} - Check if files exist
+
+**Metadata Management:**
+- POST /api/mast/refresh-metadata/{obsId} - Re-fetch metadata for observation
+- POST /api/mast/refresh-metadata-all - Re-fetch metadata for all imports
 
 ### DataManagementController (`/api/datamanagement`)
 
@@ -69,16 +81,24 @@
 
 ## Data Models
 
-- JwstDataModel: Main data entity with flexible metadata
-  - ProcessingLevel: JWST pipeline stage (L1, L2a, L2b, L3)
-  - ObservationBaseId: Groups related files by observation
-  - ExposureId: Finer-grained lineage tracking
-- ImageMetadata: For image-specific data
-- SensorMetadata: For sensor/spectral data
-- SpectralMetadata: For spectral analysis data
-- CalibrationMetadata: For calibration files
-- ProcessingResult: For processing outcomes
-- LineageResponse/LineageFileInfo: DTOs for lineage queries
+- **JwstDataModel**: Main data entity with flexible metadata
+  - `ProcessingLevel`: JWST pipeline stage (L1, L2a, L2b, L3)
+  - `ObservationBaseId`: Groups related files by observation
+  - `ExposureId`: Finer-grained lineage tracking
+  - `Metadata`: Dictionary storing all MAST fields with `mast_` prefix
+  - `IsViewable`: true for images, false for tables/catalogs
+
+- **ImageMetadata**: For image-specific data
+  - Core: `targetName`, `instrument`, `filter`, `exposureTime`, `observationDate`
+  - MAST fields: `wavelengthRange`, `calibrationLevel`, `proposalId`, `proposalPi`, `observationTitle`
+  - WCS: `coordinateSystem`, `wcs` (CRVAL1, CRVAL2)
+
+- **SensorMetadata**: For sensor/spectral data
+- **SpectralMetadata**: For spectral analysis data
+- **CalibrationMetadata**: For calibration files
+- **ProcessingResult**: For processing outcomes
+- **LineageResponse/LineageFileInfo**: DTOs for lineage queries
+- **MetadataRefreshResponse**: Response for metadata refresh operations
 
 ## Security Notes
 

--- a/docs/standards/database-models.md
+++ b/docs/standards/database-models.md
@@ -11,10 +11,48 @@
 
 ## Data Models
 
-- JwstDataModel: Main data entity
-- ImageMetadata: Image-specific information
-- SensorMetadata: Sensor and spectral data
-- ProcessingResult: Processing outcomes and results
+### JwstDataModel (Main Entity)
+Primary document model for all JWST data records.
+
+**Core Fields:**
+- `id`: MongoDB ObjectId
+- `fileName`, `filePath`, `fileSize`, `fileFormat`
+- `dataType`: image, sensor, spectral, metadata, calibration, raw
+- `processingStatus`: pending, processing, completed, failed
+- `uploadDate`, `tags`, `description`
+
+**Lineage Fields:**
+- `processingLevel`: L1, L2a, L2b, L3, unknown
+- `observationBaseId`: Groups related files (e.g., "jw02733-o001_t001_nircam")
+- `exposureId`: Fine-grained lineage tracking
+- `parentId`, `derivedFrom`: Parent-child relationships
+
+**MAST Import Fields:**
+- `metadata`: Dictionary with `mast_*` prefixed fields from MAST
+- `isViewable`: true for image files, false for tables/catalogs
+
+### ImageMetadata
+Image-specific metadata attached to JwstDataModel.
+
+**Astronomical Fields:**
+- `targetName`: Object name (e.g., "NGC-3132")
+- `instrument`, `filter`, `exposureTime`
+- `observationDate`: Converted from MAST MJD format
+- `coordinateSystem`, `wcs`: World coordinate system
+
+**MAST-Specific Fields:**
+- `wavelengthRange`: "INFRARED", "OPTICAL", "UV"
+- `calibrationLevel`: MAST calib_level (0-4)
+- `proposalId`, `proposalPi`: JWST program info
+- `observationTitle`: Program title
+
+### SensorMetadata
+- `instrument`, `wavelength`, `dataPoints`
+- `samplingRate`, `integrationTime`, `detectorType`
+
+### ProcessingResult
+- `algorithm`, `processedDate`, `status`
+- `parameters`, `results`, `outputFilePath`
 
 ## MongoDB Configuration
 

--- a/docs/standards/frontend-development.md
+++ b/docs/standards/frontend-development.md
@@ -46,6 +46,7 @@
   - Grouped view: By data type
   - Lineage view: Tree hierarchy showing processing levels (L1→L2a→L2b→L3)
   - FITS type badges: Visual indicators for image vs table files
+  - Refresh Metadata button: Re-fetch MAST metadata for all imports
 - **MastSearch**: MAST portal integration with:
   - Search by target, coordinates, observation, or program
   - Bulk import with progress tracking
@@ -62,7 +63,8 @@
   - LineageResponse, LineageFileInfo
   - ProcessingLevels, ProcessingLevelLabels, ProcessingLevelColors
   - MastSearchResult, MastImportResponse, ImportJobStatus
-  - FileProgressInfo, ResumableJobSummary
+  - FileProgressInfo, ResumableJobSummary, MetadataRefreshResponse
+  - ImageMetadata now includes: wavelengthRange, calibrationLevel, proposalId, proposalPi, observationTitle
 - **Utilities**:
   - getFitsFileInfo(): Classify FITS files by suffix (image vs table)
   - isFitsViewable(): Check if FITS file is viewable


### PR DESCRIPTION
## Summary

Updates all project documentation to reflect the new MAST metadata preservation feature merged in PR #21.

## Changes

- **CLAUDE.md**: Add refresh-metadata API endpoints and new MAST Metadata Preservation section
- **development-plan.md**: Add MAST Metadata Preservation section to Phase 3, mark as complete
- **backend-development.md**: Add metadata management endpoints, update data model documentation
- **database-models.md**: Expand JwstDataModel and ImageMetadata documentation with new fields
- **frontend-development.md**: Add MetadataRefreshResponse type, document Refresh Metadata button

## Test plan

- [ ] Documentation renders correctly in GitHub
- [ ] All links work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)