### PR TITLE
fix: Escape regex patterns in MongoDB search to prevent ReDoS (Task #3)

### DIFF
--- a/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
+++ b/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using JwstDataAnalysis.API.Models;
 using MongoDB.Bson;
+using System.Text.RegularExpressions;
 
 namespace JwstDataAnalysis.API.Services
 {
@@ -70,12 +71,13 @@ namespace JwstDataAnalysis.API.Services
         {
             var filter = Builders<JwstDataModel>.Filter.Empty;
 
-            // Search term
+            // Search term - escape special regex characters to prevent ReDoS attacks
             if (!string.IsNullOrEmpty(request.SearchTerm))
             {
+                var escapedSearchTerm = Regex.Escape(request.SearchTerm);
                 var searchFilter = Builders<JwstDataModel>.Filter.Or(
-                    Builders<JwstDataModel>.Filter.Regex(x => x.FileName, new BsonRegularExpression(request.SearchTerm, "i")),
-                    Builders<JwstDataModel>.Filter.Regex(x => x.Description, new BsonRegularExpression(request.SearchTerm, "i")),
+                    Builders<JwstDataModel>.Filter.Regex(x => x.FileName, new BsonRegularExpression(escapedSearchTerm, "i")),
+                    Builders<JwstDataModel>.Filter.Regex(x => x.Description, new BsonRegularExpression(escapedSearchTerm, "i")),
                     Builders<JwstDataModel>.Filter.AnyIn(x => x.Tags, new[] { request.SearchTerm })
                 );
                 filter = Builders<JwstDataModel>.Filter.And(filter, searchFilter);
@@ -182,9 +184,10 @@ namespace JwstDataAnalysis.API.Services
 
             if (!string.IsNullOrEmpty(request.SearchTerm))
             {
+                var escapedSearchTerm = Regex.Escape(request.SearchTerm);
                 var searchFilter = Builders<JwstDataModel>.Filter.Or(
-                    Builders<JwstDataModel>.Filter.Regex(x => x.FileName, new BsonRegularExpression(request.SearchTerm, "i")),
-                    Builders<JwstDataModel>.Filter.Regex(x => x.Description, new BsonRegularExpression(request.SearchTerm, "i")),
+                    Builders<JwstDataModel>.Filter.Regex(x => x.FileName, new BsonRegularExpression(escapedSearchTerm, "i")),
+                    Builders<JwstDataModel>.Filter.Regex(x => x.Description, new BsonRegularExpression(escapedSearchTerm, "i")),
                     Builders<JwstDataModel>.Filter.AnyIn(x => x.Tags, new[] { request.SearchTerm })
                 );
                 filter = Builders<JwstDataModel>.Filter.And(filter, searchFilter);


### PR DESCRIPTION
## Summary
- Escape user-provided search terms with `Regex.Escape()` before using in MongoDB regex filters
- Prevents Regular Expression Denial of Service (ReDoS) attacks via malicious regex patterns
- Applied fix to both `AdvancedSearchAsync` and `GetSearchCountAsync` methods

## Security Issue
User-provided search terms were used directly in `BsonRegularExpression` without sanitization, allowing attackers to inject patterns like `(a+)+$` that cause catastrophic backtracking.

## Test Plan
- [ ] Start Docker environment: `cd docker && docker compose up -d --build`
- [ ] Verify backend builds and starts successfully
- [ ] Test normal search: Search for "NGC" - should return matching results
- [ ] Test special characters: Search for "test.fits" - should find literal match (dot treated as literal)
- [ ] Test regex injection: Search for `(a+)+$` - should not cause timeout/hang
- [ ] Test edge cases: Search for `[bracket]` and `star*` - should work without regex interpretation
- [ ] Verify pagination still works with search term

🤖 Generated with [Claude Code](https://claude.com/claude-code)