### PR TITLE
fix: Replace N+1 query with batch fetch in export endpoint (Task #5)

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/DataManagementController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/DataManagementController.cs
@@ -162,16 +162,8 @@ namespace JwstDataAnalysis.API.Controllers
                 var exportsDir = Path.Combine(Directory.GetCurrentDirectory(), "exports");
                 Directory.CreateDirectory(exportsDir);
 
-                // Get data for export
-                var dataToExport = new List<JwstDataModel>();
-                foreach (var id in request.DataIds)
-                {
-                    var data = await _mongoDBService.GetAsync(id);
-                    if (data != null)
-                    {
-                        dataToExport.Add(data);
-                    }
-                }
+                // Get data for export (batch fetch to avoid N+1 queries)
+                var dataToExport = await _mongoDBService.GetManyAsync(request.DataIds);
 
                 // Create export data
                 var exportData = new

--- a/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
+++ b/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
@@ -26,6 +26,12 @@ namespace JwstDataAnalysis.API.Services
         public async Task<JwstDataModel?> GetAsync(string id) =>
             await _jwstDataCollection.Find(x => x.Id == id).FirstOrDefaultAsync();
 
+        public async Task<List<JwstDataModel>> GetManyAsync(IEnumerable<string> ids)
+        {
+            var filter = Builders<JwstDataModel>.Filter.In(x => x.Id, ids);
+            return await _jwstDataCollection.Find(filter).ToListAsync();
+        }
+
         public async Task<List<JwstDataModel>> GetByDataTypeAsync(string dataType) =>
             await _jwstDataCollection.Find(x => x.DataType == dataType).ToListAsync();
 


### PR DESCRIPTION
## Summary
- Add `GetManyAsync(IEnumerable<string> ids)` method to MongoDBService that fetches multiple records in a single database query using MongoDB's `$in` operator
- Update export endpoint to use batch fetch instead of looping through individual `GetAsync` calls

**Before**: Exporting 100 records made 100 database queries
**After**: Exporting 100 records makes 1 database query

## Test plan
- [ ] Start Docker environment: `cd docker && docker compose up -d --build`
- [ ] Verify the application starts without errors: check `docker compose logs backend`
- [ ] Create test data: Import a few observations via MAST search or upload some files
- [ ] Test export with multiple IDs:
  ```bash
  # Get some data IDs first
  curl http://localhost:5001/api/jwstdata | jq '.[0:3] | .[].id'
  
  # Export with those IDs
  curl -X POST http://localhost:5001/api/datamanagement/export \
    -H "Content-Type: application/json" \
    -d '{"dataIds": ["<id1>", "<id2>", "<id3>"], "includeMetadata": true}'
  ```
- [ ] Verify the export response contains all requested records
- [ ] Download the export file and verify content:
  ```bash
  curl http://localhost:5001/api/datamanagement/export/<exportId> -o export.json
  cat export.json | jq '.TotalRecords'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)