### PR TITLE
refactor: Extract duplicated import logic into shared helper (Task #6)

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/MastController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.cs
@@ -1273,9 +1273,10 @@ namespace JwstDataAnalysis.API.Controllers
                         fileSize = fileInfo.Length;
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // File might be in docker volume, size unknown
+                    // File might be in docker volume, size unknown - log but continue
+                    _logger.LogDebug(ex, "Could not get file size for {FilePath}", filePath);
                 }
 
                 // Build tags list


### PR DESCRIPTION
## Summary
- Add `CreateRecordsForFilesAsync` helper method that consolidates record creation logic
- Update `ExecuteImportAsync`, `ExecuteResumedImportAsync`, and `CompleteImportFromExistingFilesAsync` to use shared helper
- Remove unused `BuildTags` helper method

**Before**: ~210 lines of duplicated code across 3 methods
**After**: Single 90-line helper method called from all 3 locations

## Test plan
- [ ] Start Docker environment: `cd docker && docker compose up -d --build`
- [ ] Verify backend starts without errors: `docker compose logs backend`
- [ ] Test MAST import (uses ExecuteImportAsync):
  ```bash
  curl -X POST http://localhost:5001/api/mast/search/target \
    -H "Content-Type: application/json" \
    -d '{"targetName": "NGC 3132", "radius": 0.01}'
  # Pick an obs_id from results and import
  ```
- [ ] Test import from existing files (uses CompleteImportFromExistingFilesAsync):
  ```bash
  curl http://localhost:5001/api/mast/import/check-files/{obsId}
  ```
- [ ] Verify imported records have correct metadata, tags, and lineage

🤖 Generated with [Claude Code](https://claude.com/claude-code)