### PR TITLE
fix: Add TypeScript interfaces for API responses (Task #7)

### DIFF
--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { JwstDataModel, ProcessingLevelLabels, ProcessingLevelColors, DeleteObservationResponse } from '../types/JwstDataTypes';
+import { JwstDataModel, ProcessingLevelLabels, ProcessingLevelColors, DeleteObservationResponse, BulkImportResponse, ApiErrorResponse, MetadataRefreshAllResponse } from '../types/JwstDataTypes';
 import MastSearch from './MastSearch';
 import ImageViewer from './ImageViewer';
 import { getFitsFileInfo } from '../utils/fitsUtils';
@@ -217,7 +217,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
       });
 
       if (response.ok) {
-        const result = await response.json();
+        const result: BulkImportResponse = await response.json();
         alert(`Import complete: ${result.importedCount} files imported, ${result.skippedCount} skipped`);
         onDataUpdate();
       } else {
@@ -241,11 +241,11 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
       });
 
       if (response.ok) {
-        const result = await response.json();
+        const result: MetadataRefreshAllResponse = await response.json();
         alert(result.message);
         onDataUpdate();
       } else {
-        const errorData = await response.json();
+        const errorData: ApiErrorResponse = await response.json();
         alert(`Failed to refresh metadata: ${errorData.error || 'Unknown error'}`);
       }
     } catch (error) {
@@ -270,7 +270,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
         const previewData: DeleteObservationResponse = await response.json();
         setDeleteModalData(previewData);
       } else {
-        const errorData = await response.json();
+        const errorData: ApiErrorResponse = await response.json();
         alert(`Failed to get observation info: ${errorData.message || 'Unknown error'}`);
       }
     } catch (error) {
@@ -295,7 +295,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
         setDeleteModalData(null);
         onDataUpdate();
       } else {
-        const errorData = await response.json();
+        const errorData: ApiErrorResponse = await response.json();
         alert(`Failed to delete observation: ${errorData.message || 'Unknown error'}`);
       }
     } catch (error) {

--- a/frontend/jwst-frontend/src/types/JwstDataTypes.ts
+++ b/frontend/jwst-frontend/src/types/JwstDataTypes.ts
@@ -132,4 +132,29 @@ export interface DeleteObservationResponse {
   fileNames: string[];
   deleted: boolean;
   message: string;
+}
+
+// Bulk import response from /api/datamanagement/import/scan
+export interface BulkImportResponse {
+  importedCount: number;
+  skippedCount: number;
+  errorCount: number;
+  importedFiles: string[];
+  skippedFiles: string[];
+  errors: string[];
+  message: string;
+}
+
+// Generic API error response
+export interface ApiErrorResponse {
+  error?: string;
+  message?: string;
+  details?: string;
+}
+
+// Metadata refresh response for all records
+export interface MetadataRefreshAllResponse {
+  obsId: string;
+  updatedCount: number;
+  message: string;
 } 


### PR DESCRIPTION
## Summary
- Add `BulkImportResponse` interface for `/api/datamanagement/import/scan` endpoint responses
- Add `ApiErrorResponse` interface for generic error handling across API calls
- Add `MetadataRefreshAllResponse` interface for `/api/mast/refresh-metadata-all` endpoint
- Update `JwstDataDashboard.tsx` to use typed responses instead of implicit `any`

## Changes
- `frontend/jwst-frontend/src/types/JwstDataTypes.ts`: Added 3 new interfaces
- `frontend/jwst-frontend/src/components/JwstDataDashboard.tsx`: Updated 5 `response.json()` calls to use proper types

## Test plan
- [ ] Verify TypeScript compilation succeeds (already confirmed - `npm run build` passes)
- [ ] Verify frontend loads correctly in Docker environment
- [ ] Verify IDE provides autocomplete for typed response properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)