### PR TITLE
fix: Centralize hardcoded API URLs in frontend (Task #8)

### DIFF
--- a/frontend/jwst-frontend/src/App.tsx
+++ b/frontend/jwst-frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import './App.css';
 import JwstDataDashboard from './components/JwstDataDashboard';
 import { JwstDataModel } from './types/JwstDataTypes';
+import { API_BASE_URL } from './config/api';
 
 function App() {
   const [data, setData] = useState<JwstDataModel[]>([]);
@@ -15,7 +16,7 @@ function App() {
   const fetchData = async () => {
     try {
       setLoading(true);
-      const response = await fetch('http://localhost:5001/api/jwstdata?includeArchived=true');
+      const response = await fetch(`${API_BASE_URL}/api/jwstdata?includeArchived=true`);
       if (!response.ok) {
         throw new Error('Failed to fetch data');
       }

--- a/frontend/jwst-frontend/src/components/ImageViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageViewer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './ImageViewer.css';
 import AdvancedFitsViewer from './AdvancedFitsViewer';
+import { API_BASE_URL } from '../config/api';
 
 interface ImageViewerProps {
     dataId: string;
@@ -23,13 +24,11 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ dataId, title, onClose, isOpe
             const isFitsFile = title.toLowerCase().endsWith('.fits') || title.toLowerCase().endsWith('.fits.gz');
             setIsFits(isFitsFile);
 
-            const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:5001';
-
             // If it's a FITS file, we need the raw file URL for the advanced viewer
             // Otherwise we use the preview endpoint
             const url = isFitsFile
-                ? `${apiUrl}/api/jwstdata/${dataId}/file`
-                : `${apiUrl}/api/jwstdata/${dataId}/preview`;
+                ? `${API_BASE_URL}/api/jwstdata/${dataId}/file`
+                : `${API_BASE_URL}/api/jwstdata/${dataId}/preview`;
 
             setImageUrl(url);
             setLoading(false);

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -3,6 +3,7 @@ import { JwstDataModel, ProcessingLevelLabels, ProcessingLevelColors, DeleteObse
 import MastSearch from './MastSearch';
 import ImageViewer from './ImageViewer';
 import { getFitsFileInfo } from '../utils/fitsUtils';
+import { API_BASE_URL } from '../config/api';
 import './JwstDataDashboard.css';
 
 interface JwstDataDashboardProps {
@@ -135,7 +136,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     }
 
     try {
-      const response = await fetch('http://localhost:5001/api/jwstdata/upload', {
+      const response = await fetch(`${API_BASE_URL}/api/jwstdata/upload`, {
         method: 'POST',
         body: formData,
       });
@@ -156,7 +157,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
 
   const handleProcessData = async (dataId: string, algorithm: string) => {
     try {
-      const response = await fetch(`http://localhost:5001/api/jwstdata/${dataId}/process`, {
+      const response = await fetch(`${API_BASE_URL}/api/jwstdata/${dataId}/process`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -191,7 +192,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
   const handleArchive = async (dataId: string, isCurrentlyArchived: boolean) => {
     try {
       const endpoint = isCurrentlyArchived ? 'unarchive' : 'archive';
-      const response = await fetch(`http://localhost:5001/api/jwstdata/${dataId}/${endpoint}`, {
+      const response = await fetch(`${API_BASE_URL}/api/jwstdata/${dataId}/${endpoint}`, {
         method: 'POST',
       });
 
@@ -208,7 +209,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
 
   const handleImportMast = async () => {
     try {
-      const response = await fetch('http://localhost:5001/api/datamanagement/import/scan', {
+      const response = await fetch(`${API_BASE_URL}/api/datamanagement/import/scan`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -236,7 +237,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
 
     setIsRefreshingMetadata(true);
     try {
-      const response = await fetch('http://localhost:5001/api/mast/refresh-metadata-all', {
+      const response = await fetch(`${API_BASE_URL}/api/mast/refresh-metadata-all`, {
         method: 'POST',
       });
 
@@ -262,7 +263,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     try {
       // Fetch preview data
       const response = await fetch(
-        `http://localhost:5001/api/jwstdata/observation/${encodeURIComponent(observationBaseId)}`,
+        `${API_BASE_URL}/api/jwstdata/observation/${encodeURIComponent(observationBaseId)}`,
         { method: 'DELETE' }
       );
 
@@ -285,7 +286,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     setIsDeleting(true);
     try {
       const response = await fetch(
-        `http://localhost:5001/api/jwstdata/observation/${encodeURIComponent(deleteModalData.observationBaseId)}?confirm=true`,
+        `${API_BASE_URL}/api/jwstdata/observation/${encodeURIComponent(deleteModalData.observationBaseId)}?confirm=true`,
         { method: 'DELETE' }
       );
 

--- a/frontend/jwst-frontend/src/components/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/MastSearch.tsx
@@ -8,6 +8,7 @@ import {
   ImportStages,
   FileProgressInfo
 } from '../types/MastTypes';
+import { API_BASE_URL } from '../config/api';
 import './MastSearch.css';
 
 // Helper function to format bytes as human-readable string
@@ -37,7 +38,6 @@ interface MastSearchProps {
   onImportComplete: () => void;
 }
 
-const API_BASE_URL = 'http://localhost:5001';
 const SEARCH_TIMEOUT_MS = 120000; // 2 minutes
 
 const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {

--- a/frontend/jwst-frontend/src/config/api.ts
+++ b/frontend/jwst-frontend/src/config/api.ts
@@ -1,0 +1,11 @@
+/**
+ * Centralized API configuration
+ *
+ * The base URL can be overridden via the REACT_APP_API_URL environment variable.
+ * Default: http://localhost:5001 (development)
+ *
+ * Usage:
+ *   import { API_BASE_URL } from '../config/api';
+ *   const response = await fetch(`${API_BASE_URL}/api/jwstdata`);
+ */
+export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001';


### PR DESCRIPTION
## Summary
- Create centralized API configuration at `src/config/api.ts`
- Replace 10 hardcoded `http://localhost:5001` URLs across 4 files
- Support `REACT_APP_API_URL` environment variable for production deployments

## Changes
| File | Change |
|------|--------|
| `src/config/api.ts` | New file - centralized API_BASE_URL constant |
| `src/App.tsx` | Import and use API_BASE_URL |
| `src/components/JwstDataDashboard.tsx` | Replace 8 hardcoded URLs |
| `src/components/MastSearch.tsx` | Remove local constant, use centralized |
| `src/components/ImageViewer.tsx` | Replace inline env check with import |

## Test plan
- [ ] Verify TypeScript build passes (confirmed - `npm run build` successful)
- [ ] Verify frontend loads and API calls work in Docker environment
- [ ] Verify env var override works: `REACT_APP_API_URL=http://other:5001 npm start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)