### PR TITLE
fix: Add MongoDB indexes for commonly queried fields (Task #10)

### DIFF
--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -43,6 +43,13 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
+// Initialize MongoDB indexes during startup
+using (var scope = app.Services.CreateScope())
+{
+    var mongoService = scope.ServiceProvider.GetRequiredService<MongoDBService>();
+    await mongoService.EnsureIndexesAsync();
+}
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary
- Adds 11 MongoDB indexes during application startup for commonly queried fields
- Improves query performance for filtered searches, lineage queries, and text search
- Indexes created with `Background = true` to avoid blocking application startup

### Indexes Created:
| Index Name | Type | Field(s) |
|------------|------|----------|
| idx_dataType | Single | DataType |
| idx_processingStatus | Single | ProcessingStatus |
| idx_observationBaseId | Single | ObservationBaseId |
| idx_uploadDate_desc | Single | UploadDate (descending) |
| idx_userId | Single | UserId |
| idx_tags | Single | Tags |
| idx_isPublic | Single | IsPublic |
| idx_isArchived | Single | IsArchived |
| idx_processingLevel | Single | ProcessingLevel |
| idx_lineage_compound | Compound | ObservationBaseId + ProcessingLevel + FileName |
| idx_text_search | Text | FileName + Description |

## Test plan
- [x] Backend builds successfully (`dotnet build`)
- [x] Docker container starts without errors
- [x] Indexes created on startup (verified in logs: "MongoDB indexes created/verified successfully")
- [x] Indexes exist in MongoDB (verified with `getIndexes()`)
- [x] API health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)