### PR TITLE
feat: Add interactive stretch and level controls to FITS viewer

### DIFF
--- a/frontend/jwst-frontend/src/components/AdvancedFitsViewer.css
+++ b/frontend/jwst-frontend/src/components/AdvancedFitsViewer.css
@@ -337,3 +337,13 @@
     border: 1px solid #ff4d4d;
     z-index: 10;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Stretch Controls Panel                                                      */
+/* -------------------------------------------------------------------------- */
+.viewer-stretch-panel {
+    position: absolute;
+    bottom: 100px;
+    left: 24px;
+    z-index: 20;
+}

--- a/frontend/jwst-frontend/src/components/StretchControls.css
+++ b/frontend/jwst-frontend/src/components/StretchControls.css
@@ -1,0 +1,218 @@
+.stretch-controls {
+    background: rgba(20, 20, 30, 0.95);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    overflow: hidden;
+    min-width: 220px;
+    backdrop-filter: blur(10px);
+}
+
+.stretch-controls.collapsed {
+    min-width: auto;
+}
+
+.stretch-controls-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 12px;
+    background: rgba(30, 30, 45, 0.8);
+    cursor: pointer;
+    user-select: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.stretch-controls-header:hover {
+    background: rgba(40, 40, 60, 0.8);
+}
+
+.stretch-header-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.stretch-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.stretch-header-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.btn-reset {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.5);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+}
+
+.btn-reset:hover {
+    color: rgba(255, 255, 255, 0.9);
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.collapse-icon {
+    color: rgba(255, 255, 255, 0.5);
+    display: flex;
+    align-items: center;
+}
+
+.stretch-controls-body {
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.control-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.control-label-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.control-label {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.6);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.control-value {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.9);
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    background: rgba(255, 255, 255, 0.05);
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+.stretch-select {
+    width: 100%;
+    background: rgba(30, 30, 45, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 6px;
+    color: #fff;
+    padding: 8px 10px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.stretch-select:hover {
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.stretch-select:focus {
+    outline: none;
+    border-color: #4db8ff;
+    box-shadow: 0 0 0 2px rgba(77, 184, 255, 0.2);
+}
+
+.stretch-select option {
+    background: #1a1a2e;
+    color: #fff;
+}
+
+.control-hint {
+    font-size: 10px;
+    color: rgba(255, 255, 255, 0.4);
+    font-style: italic;
+}
+
+.stretch-slider {
+    width: 100%;
+    height: 4px;
+    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.1);
+    appearance: none;
+    cursor: pointer;
+}
+
+.stretch-slider::-webkit-slider-thumb {
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #4db8ff;
+    cursor: pointer;
+    border: 2px solid rgba(255, 255, 255, 0.9);
+    transition: all 0.15s;
+}
+
+.stretch-slider::-webkit-slider-thumb:hover {
+    transform: scale(1.15);
+    background: #66c4ff;
+}
+
+.stretch-slider::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #4db8ff;
+    cursor: pointer;
+    border: 2px solid rgba(255, 255, 255, 0.9);
+    transition: all 0.15s;
+}
+
+.stretch-slider::-moz-range-thumb:hover {
+    transform: scale(1.15);
+    background: #66c4ff;
+}
+
+.stretch-slider:focus {
+    outline: none;
+}
+
+.stretch-slider::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 2px;
+}
+
+.stretch-slider::-moz-range-track {
+    height: 4px;
+    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.slider-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 9px;
+    color: rgba(255, 255, 255, 0.35);
+    margin-top: 2px;
+}
+
+/* Animation for collapsing */
+.stretch-controls-body {
+    animation: slideDown 0.2s ease-out;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/frontend/jwst-frontend/src/components/StretchControls.tsx
+++ b/frontend/jwst-frontend/src/components/StretchControls.tsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import './StretchControls.css';
+
+export interface StretchParams {
+    stretch: string;
+    gamma: number;
+    blackPoint: number;
+    whitePoint: number;
+    asinhA: number;
+}
+
+interface StretchControlsProps {
+    params: StretchParams;
+    onChange: (params: StretchParams) => void;
+    collapsed?: boolean;
+    onToggleCollapse?: () => void;
+}
+
+const STRETCH_OPTIONS = [
+    { value: 'zscale', label: 'ZScale', description: 'Automatic robust scaling (default)' },
+    { value: 'asinh', label: 'Asinh', description: 'High dynamic range, preserves faint detail' },
+    { value: 'log', label: 'Logarithmic', description: 'Extended emission, nebulae' },
+    { value: 'sqrt', label: 'Square Root', description: 'Moderate compression' },
+    { value: 'power', label: 'Power Law', description: 'Customizable with gamma' },
+    { value: 'histeq', label: 'Histogram Eq.', description: 'Maximum contrast' },
+    { value: 'linear', label: 'Linear', description: 'No compression' },
+];
+
+// SVG Icons
+const Icons = {
+    Sliders: () => (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="4" y1="21" x2="4" y2="14"></line>
+            <line x1="4" y1="10" x2="4" y2="3"></line>
+            <line x1="12" y1="21" x2="12" y2="12"></line>
+            <line x1="12" y1="8" x2="12" y2="3"></line>
+            <line x1="20" y1="21" x2="20" y2="16"></line>
+            <line x1="20" y1="12" x2="20" y2="3"></line>
+            <line x1="1" y1="14" x2="7" y2="14"></line>
+            <line x1="9" y1="8" x2="15" y2="8"></line>
+            <line x1="17" y1="16" x2="23" y2="16"></line>
+        </svg>
+    ),
+    ChevronDown: () => (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+    ),
+    ChevronUp: () => (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="18 15 12 9 6 15"></polyline>
+        </svg>
+    ),
+    Reset: () => (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="1 4 1 10 7 10"></polyline>
+            <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+        </svg>
+    ),
+};
+
+const StretchControls: React.FC<StretchControlsProps> = ({
+    params,
+    onChange,
+    collapsed = false,
+    onToggleCollapse,
+}) => {
+    const { stretch, gamma, blackPoint, whitePoint, asinhA } = params;
+
+    const handleStretchChange = (newStretch: string) => {
+        onChange({ ...params, stretch: newStretch });
+    };
+
+    const handleGammaChange = (value: number) => {
+        onChange({ ...params, gamma: value });
+    };
+
+    const handleBlackPointChange = (value: number) => {
+        // Ensure black point stays below white point
+        onChange({ ...params, blackPoint: Math.min(value, whitePoint - 0.01) });
+    };
+
+    const handleWhitePointChange = (value: number) => {
+        // Ensure white point stays above black point
+        onChange({ ...params, whitePoint: Math.max(value, blackPoint + 0.01) });
+    };
+
+    const handleAsinhAChange = (value: number) => {
+        onChange({ ...params, asinhA: value });
+    };
+
+    const handleReset = () => {
+        onChange({
+            stretch: 'zscale',
+            gamma: 1.0,
+            blackPoint: 0.0,
+            whitePoint: 1.0,
+            asinhA: 0.1,
+        });
+    };
+
+    const currentStretchOption = STRETCH_OPTIONS.find(opt => opt.value === stretch);
+
+    return (
+        <div className={`stretch-controls ${collapsed ? 'collapsed' : ''}`}>
+            <div className="stretch-controls-header" onClick={onToggleCollapse}>
+                <div className="stretch-header-left">
+                    <Icons.Sliders />
+                    <span className="stretch-title">Levels</span>
+                </div>
+                <div className="stretch-header-right">
+                    {!collapsed && (
+                        <button
+                            className="btn-reset"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                handleReset();
+                            }}
+                            title="Reset to defaults"
+                        >
+                            <Icons.Reset />
+                        </button>
+                    )}
+                    {onToggleCollapse && (
+                        <span className="collapse-icon">
+                            {collapsed ? <Icons.ChevronDown /> : <Icons.ChevronUp />}
+                        </span>
+                    )}
+                </div>
+            </div>
+
+            {!collapsed && (
+                <div className="stretch-controls-body">
+                    {/* Stretch Algorithm Selector */}
+                    <div className="control-group">
+                        <label className="control-label">Stretch Function</label>
+                        <select
+                            value={stretch}
+                            onChange={(e) => handleStretchChange(e.target.value)}
+                            className="stretch-select"
+                            title={currentStretchOption?.description}
+                        >
+                            {STRETCH_OPTIONS.map(opt => (
+                                <option key={opt.value} value={opt.value}>
+                                    {opt.label}
+                                </option>
+                            ))}
+                        </select>
+                        <span className="control-hint">{currentStretchOption?.description}</span>
+                    </div>
+
+                    {/* Gamma Slider */}
+                    <div className="control-group">
+                        <div className="control-label-row">
+                            <label className="control-label">Gamma</label>
+                            <span className="control-value">{gamma.toFixed(2)}</span>
+                        </div>
+                        <input
+                            type="range"
+                            min="0.1"
+                            max="5.0"
+                            step="0.05"
+                            value={gamma}
+                            onChange={(e) => handleGammaChange(parseFloat(e.target.value))}
+                            className="stretch-slider"
+                        />
+                        <div className="slider-labels">
+                            <span>Darker</span>
+                            <span>Brighter</span>
+                        </div>
+                    </div>
+
+                    {/* Black Point Slider */}
+                    <div className="control-group">
+                        <div className="control-label-row">
+                            <label className="control-label">Black Point</label>
+                            <span className="control-value">{(blackPoint * 100).toFixed(1)}%</span>
+                        </div>
+                        <input
+                            type="range"
+                            min="0"
+                            max="0.5"
+                            step="0.005"
+                            value={blackPoint}
+                            onChange={(e) => handleBlackPointChange(parseFloat(e.target.value))}
+                            className="stretch-slider"
+                        />
+                    </div>
+
+                    {/* White Point Slider */}
+                    <div className="control-group">
+                        <div className="control-label-row">
+                            <label className="control-label">White Point</label>
+                            <span className="control-value">{(whitePoint * 100).toFixed(1)}%</span>
+                        </div>
+                        <input
+                            type="range"
+                            min="0.5"
+                            max="1.0"
+                            step="0.005"
+                            value={whitePoint}
+                            onChange={(e) => handleWhitePointChange(parseFloat(e.target.value))}
+                            className="stretch-slider"
+                        />
+                    </div>
+
+                    {/* Asinh Softening (only visible when asinh stretch selected) */}
+                    {stretch === 'asinh' && (
+                        <div className="control-group">
+                            <div className="control-label-row">
+                                <label className="control-label">Asinh Softening</label>
+                                <span className="control-value">{asinhA.toFixed(3)}</span>
+                            </div>
+                            <input
+                                type="range"
+                                min="0.001"
+                                max="1.0"
+                                step="0.001"
+                                value={asinhA}
+                                onChange={(e) => handleAsinhAChange(parseFloat(e.target.value))}
+                                className="stretch-slider"
+                            />
+                            <div className="slider-labels">
+                                <span>More compression</span>
+                                <span>More linear</span>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default StretchControls;


### PR DESCRIPTION
## Summary
- Adds 7 stretch algorithms (zscale, asinh, log, sqrt, power, histogram equalization, linear) to the FITS preview
- Adds gamma correction, black point, and white point controls for fine-tuning image display
- Creates a collapsible StretchControls panel in the image viewer UI
- Implements 500ms debouncing to prevent request flooding during slider adjustments

## Test plan
- [ ] Open any FITS image in the viewer
- [ ] Verify "Levels" panel appears in bottom-left corner
- [ ] Change stretch function dropdown → image should update
- [ ] Drag gamma slider → image brightness should change after releasing
- [ ] Adjust black/white point sliders → contrast should change
- [ ] Select "Asinh" stretch → asinh softening slider should appear
- [ ] Verify no request flooding when dragging sliders rapidly

🤖 Generated with [Claude Code](https://claude.com/claude-code)