### PR TITLE
fix: Sync MAST Files now fetches metadata and processing levels

### DIFF
--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.css
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.css
@@ -309,29 +309,12 @@
   transition: all 0.2s ease;
 }
 
-.import-mast-btn:hover {
+.import-mast-btn:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(16, 185, 129, 0.4);
 }
 
-.refresh-metadata-btn {
-  padding: 10px 20px;
-  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
-  color: white;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 500;
-  transition: all 0.2s ease;
-}
-
-.refresh-metadata-btn:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.4);
-}
-
-.refresh-metadata-btn:disabled {
+.import-mast-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
   transform: none;


### PR DESCRIPTION
## Summary

- Combined "Import MAST Files" and "Refresh Metadata" buttons into single "Sync MAST Files" button
- Updated `ScanAndImportFiles` endpoint to fetch MAST metadata for each observation group
- Now properly populates both `Metadata` dictionary and `ImageInfo` fields during disk scan import
- Automatically refreshes metadata for existing files with missing TargetName or Unknown processing level

## Problem

When using "Import MAST Files" button after a database reset, records were created without MAST metadata (no target names, observation titles, processing levels, etc.). Users had to manually click "Refresh Metadata" as a separate step.

## Solution

The scan import now:
1. Groups files by observation ID
2. Fetches metadata from MAST for each observation
3. Creates records with full metadata including processing levels
4. For existing files with missing metadata, automatically refreshes them

## Test plan

- [x] Backend builds successfully
- [x] Frontend builds successfully
- [x] "Sync MAST Files" button appears (single button instead of two)
- [x] Clicking sync imports new files with full metadata
- [x] Processing levels (L1/L2a/L2b/L3) are correctly identified
- [x] Existing files with Unknown processing level get updated
- [x] Metadata (target name, instrument, observation title) displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)