### PR TITLE
fix: Increase panel spacing to prevent overlap

### DIFF
--- a/frontend/jwst-frontend/src/components/FitsViewer.css
+++ b/frontend/jwst-frontend/src/components/FitsViewer.css
@@ -374,7 +374,7 @@
 /* -------------------------------------------------------------------------- */
 .viewer-stretch-panel {
     position: absolute;
-    top: 80px;
+    top: 140px;  /* Below header (24px top + 72px min-height + 24px padding = ~120px) + 20px gap */
     left: 24px;
     z-index: 20;
 }
@@ -384,7 +384,7 @@
 /* -------------------------------------------------------------------------- */
 .viewer-histogram-panel {
     position: absolute;
-    top: 260px;
+    top: 500px;  /* Below stretch panel (~480px with asinh softening slider) + 20px gap */
     left: 24px;
     z-index: 20;
     width: 320px;


### PR DESCRIPTION
## Summary
- Fixes overlap between header and Levels panel in FITS viewer
- Fixes overlap between Levels and Histogram panels
- Accounts for variable panel height when using Asinh stretch (adds SOFTENING slider)

## Changes
| Panel | Before | After |
|-------|--------|-------|
| Levels | `top: 80px` | `top: 140px` |
| Histogram | `top: 260px` | `top: 500px` |

## Test plan
- [x] Open FITS viewer and verify header is not overlapped
- [x] Verify Levels panel has clear separation from header
- [x] Verify Histogram panel has clear separation from Levels panel
- [x] Test with ZScale stretch function
- [x] Test with Asinh stretch function (has extra SOFTENING slider)

## Note
This is a temporary fix using fixed pixel positioning. A follow-up refactor should use a more scalable approach (flexbox or relative positioning) as we add more panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)