### PR TITLE
security: Externalize credentials to environment variables (Task #18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,12 @@ JWST Data Analysis Application - A microservices-based platform for analyzing Ja
 ### Docker (Recommended for full stack)
 
 ```bash
-# Start all services (from docker/ directory)
+# First time setup: copy environment template
 cd docker
+cp .env.example .env
+# Edit .env to set your own MONGO_ROOT_PASSWORD (optional for local dev)
+
+# Start all services
 docker compose up -d
 
 # View logs
@@ -26,6 +30,8 @@ docker compose down
 # Rebuild after code changes
 docker compose up -d --build
 ```
+
+**Note**: The `.env` file is gitignored. Default values work for local development, but you should set a strong `MONGO_ROOT_PASSWORD` for any shared or production environment.
 
 **Service URLs**:
 - Frontend: http://localhost:3000
@@ -302,15 +308,17 @@ App.tsx (root)
 
 ### Security Notes
 
-**Development Credentials** (DO NOT use in production):
-- MongoDB: username `admin`, password `password`
-- CORS: Configured for localhost development (allows all origins)
+**Environment Configuration**:
+- All credentials are configured via environment variables in `docker/.env`
+- Copy `docker/.env.example` to `docker/.env` and customize values
+- The `.env` file is gitignored and should never be committed
+- Default values in docker-compose.yml are for local development only
 
 **Before Production**:
+- Set strong, unique `MONGO_ROOT_PASSWORD` in `.env`
 - Implement authentication/authorization (Phase 2 placeholder exists)
-- Use environment variables for all secrets
-- Update CORS to whitelist specific origins
-- Review `appsettings.json` and `docker-compose.yml` for hardcoded credentials
+- Update CORS to whitelist specific origins (Task #19)
+- Review all environment variables for production values
 
 ### Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ data, and spectral information.
 
    ```bash
    cd docker
+   cp .env.example .env  # First time only - customize if needed
    docker compose up -d
    ```
 
@@ -124,19 +125,21 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed instructions on our Pull R
 
 ## Security Note
 
-This repository uses default development credentials (e.g., MongoDB username:
-`admin`, password: `password`) and local connection strings for demonstration
-and local development purposes only. **Do not use these credentials in
-production.**
+All credentials are managed via environment variables. For local development:
 
-For production deployments:
+```bash
+cd docker
+cp .env.example .env
+# Edit .env to customize values (optional for local dev)
+docker compose up -d
+```
 
-- Always use strong, unique passwords and secrets.
-- Store sensitive information in environment variables or a secrets manager.
-- Add a `.env` file (not committed to version control) for real secrets, and
-  provide a `.env.example` for reference.
-- Review all configuration files for hardcoded secrets before deploying or
-  making the repository public.
+**For production deployments:**
+
+- Set strong, unique values for `MONGO_ROOT_PASSWORD` in your `.env` file
+- The `.env` file is gitignored and should never be committed
+- Store sensitive information in environment variables or a secrets manager
+- Review all environment variables before deploying
 
 ## License
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,41 @@
+# JWST Data Analysis - Environment Configuration
+# Copy this file to .env and update values for your environment
+#
+# IMPORTANT: Never commit .env files with real credentials to git!
+#
+# MIGRATION NOTE: If you have an existing MongoDB volume initialized with
+# different credentials, either:
+#   1. Set MONGO_ROOT_PASSWORD below to match your existing password, OR
+#   2. Remove the volume to reinitialize: docker volume rm docker_mongodb_data
+
+# =============================================================================
+# MongoDB Configuration
+# =============================================================================
+MONGO_ROOT_USERNAME=admin
+MONGO_ROOT_PASSWORD=changeme_use_strong_password
+
+# Database name for the application
+MONGO_DATABASE=jwst_data_analysis
+
+# =============================================================================
+# Backend Configuration
+# =============================================================================
+# ASP.NET Core environment (Development, Staging, Production)
+ASPNETCORE_ENVIRONMENT=Development
+
+# =============================================================================
+# Frontend Configuration
+# =============================================================================
+# API URL that the frontend will use to connect to the backend
+# For local development: http://localhost:5001
+# For production: https://your-api-domain.com
+REACT_APP_API_URL=http://localhost:5001
+
+# =============================================================================
+# Processing Engine Configuration
+# =============================================================================
+# Directory where MAST downloads will be stored
+MAST_DOWNLOAD_DIR=/app/data/mast
+
+# Timeout for MAST downloads in seconds
+MAST_DOWNLOAD_TIMEOUT=3600

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - "27017:27017"
     environment:
-      MONGO_INITDB_ROOT_USERNAME: admin
-      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME:-admin}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-changeme}
     volumes:
       - mongodb_data:/data/db
     networks:
@@ -22,9 +22,9 @@ services:
     ports:
       - "5001:8080"
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-      - MongoDB__ConnectionString=mongodb://admin:password@mongodb:27017
-      - MongoDB__DatabaseName=jwst_data_analysis
+      - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Development}
+      - MongoDB__ConnectionString=mongodb://${MONGO_ROOT_USERNAME:-admin}:${MONGO_ROOT_PASSWORD:-changeme}@mongodb:27017
+      - MongoDB__DatabaseName=${MONGO_DATABASE:-jwst_data_analysis}
       - ProcessingEngine__BaseUrl=http://processing-engine:8000
     volumes:
       - ../data:/app/data
@@ -45,7 +45,7 @@ services:
       - ../frontend/jwst-frontend:/app
       - /app/node_modules
     environment:
-      - REACT_APP_API_URL=http://localhost:5001
+      - REACT_APP_API_URL=${REACT_APP_API_URL:-http://localhost:5001}
       - CHOKIDAR_USEPOLLING=true # Essential for hot reload on some systems
     depends_on:
       - backend
@@ -62,8 +62,8 @@ services:
       - "8000:8000"
     environment:
       - PYTHONPATH=/app
-      - MAST_DOWNLOAD_DIR=/app/data/mast
-      - MAST_DOWNLOAD_TIMEOUT=3600
+      - MAST_DOWNLOAD_DIR=${MAST_DOWNLOAD_DIR:-/app/data/mast}
+      - MAST_DOWNLOAD_TIMEOUT=${MAST_DOWNLOAD_TIMEOUT:-3600}
     volumes:
       - ../data:/app/data
     depends_on:


### PR DESCRIPTION
## Summary

Remove hardcoded MongoDB credentials from docker-compose.yml and externalize all configuration to environment variables.

**This is a critical security fix required before making the repository public.**

## Changes

### New Files
- `docker/.env.example` - Template with all configurable environment variables

### Modified Files
- `docker/docker-compose.yml` - Use `${VAR:-default}` syntax for all credentials
- `CLAUDE.md` - Updated Docker quick start with .env setup instructions
- `README.md` - Updated security section and quick start guide

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `MONGO_ROOT_USERNAME` | admin | MongoDB admin username |
| `MONGO_ROOT_PASSWORD` | changeme | MongoDB admin password |
| `MONGO_DATABASE` | jwst_data_analysis | Database name |
| `ASPNETCORE_ENVIRONMENT` | Development | .NET environment |
| `REACT_APP_API_URL` | http://localhost:5001 | Frontend API URL |
| `MAST_DOWNLOAD_DIR` | /app/data/mast | MAST download directory |
| `MAST_DOWNLOAD_TIMEOUT` | 3600 | Download timeout in seconds |

## Usage

```bash
cd docker
cp .env.example .env
# Edit .env to set MONGO_ROOT_PASSWORD for production
docker compose up -d
```

## Test Plan

- [ ] Verify `docker compose config` validates successfully
- [ ] Verify `docker compose up -d` starts all services
- [ ] Verify backend connects to MongoDB with default credentials
- [ ] Verify frontend loads and can communicate with backend
- [ ] Verify .env file is gitignored (already confirmed)

## Security Notes

- Default values are provided for local development convenience
- The `.env` file is gitignored and will never be committed
- Production deployments MUST set strong `MONGO_ROOT_PASSWORD`

🤖 Generated with [Claude Code](https://claude.ai/code)