### PR TITLE
fix(security): Configure CORS for production

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -23,6 +23,11 @@ MONGO_DATABASE=jwst_data_analysis
 # ASP.NET Core environment (Development, Staging, Production)
 ASPNETCORE_ENVIRONMENT=Development
 
+# CORS allowed origins (comma-separated)
+# For local development: http://localhost:3000,http://localhost:5173
+# For production: https://your-frontend-domain.com
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+
 # =============================================================================
 # Frontend Configuration (Vite)
 # =============================================================================

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - MongoDB__ConnectionString=mongodb://${MONGO_ROOT_USERNAME:-admin}:${MONGO_ROOT_PASSWORD:-changeme}@mongodb:27017
       - MongoDB__DatabaseName=${MONGO_DATABASE:-jwst_data_analysis}
       - ProcessingEngine__BaseUrl=http://processing-engine:8000
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173}
     volumes:
       - ../data:/app/data
     depends_on:


### PR DESCRIPTION
## Summary
- Replace `AllowAnyOrigin()` with environment-configurable allowed origins
- Add `CORS_ALLOWED_ORIGINS` environment variable (comma-separated)
- Development mode defaults to localhost origins
- Production mode requires explicit configuration

## Changes
- `Program.cs`: CORS policy reads from env var or config, with sensible defaults
- `docker-compose.yml`: Pass CORS_ALLOWED_ORIGINS to backend
- `.env.example`: Document the new variable

## Test plan
- [x] Backend builds successfully
- [x] CORS headers returned for allowed origin (localhost:3000)
- [x] No CORS headers for non-allowed origins (evil-site.com)
- [x] Frontend still loads and works

## Security
Closes tech debt #19. Cross-origin requests are now restricted to configured origins only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)