### PR TITLE
fix(security): Add API rate limiting

### DIFF
--- a/backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj
+++ b/backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -1,3 +1,4 @@
+using AspNetCoreRateLimit;
 using JwstDataAnalysis.API.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -5,6 +6,12 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.Configure<MongoDBSettings>(
     builder.Configuration.GetSection("MongoDB"));
+
+// Configure rate limiting
+builder.Services.AddMemoryCache();
+builder.Services.Configure<IpRateLimitOptions>(builder.Configuration.GetSection("IpRateLimiting"));
+builder.Services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
+builder.Services.AddInMemoryRateLimiting();
 
 builder.Services.AddSingleton<MongoDBService>();
 builder.Services.AddSingleton<ImportJobTracker>();
@@ -58,6 +65,9 @@ if (app.Environment.IsDevelopment())
 }
 
 // app.UseHttpsRedirection();
+
+// Rate limiting should be early in the pipeline
+app.UseIpRateLimiting();
 
 app.UseCors("AllowReactApp");
 

--- a/backend/JwstDataAnalysis.API/appsettings.Development.json
+++ b/backend/JwstDataAnalysis.API/appsettings.Development.json
@@ -7,5 +7,8 @@
   },
   "Downloads": {
     "BasePath": "./data/mast"
+  },
+  "IpRateLimiting": {
+    "IpWhitelist": ["127.0.0.1", "::1", "172.16.0.0/12", "192.168.0.0/16", "10.0.0.0/8"]
   }
 }

--- a/backend/JwstDataAnalysis.API/appsettings.json
+++ b/backend/JwstDataAnalysis.API/appsettings.json
@@ -26,5 +26,39 @@
   "Downloads": {
     "PollIntervalMs": 500,
     "BasePath": "/app/data/mast"
+  },
+  "IpRateLimiting": {
+    "EnableEndpointRateLimiting": true,
+    "StackBlockedRequests": false,
+    "RealIpHeader": "X-Forwarded-For",
+    "ClientIdHeader": "X-ClientId",
+    "HttpStatusCode": 429,
+    "QuotaExceededResponse": {
+      "Content": "{\"error\":\"Rate limit exceeded. Please try again later.\",\"retryAfter\":\"{RetryAfter}\"}",
+      "ContentType": "application/json"
+    },
+    "IpWhitelist": [],
+    "GeneralRules": [
+      {
+        "Endpoint": "*",
+        "Period": "1m",
+        "Limit": 100
+      },
+      {
+        "Endpoint": "*",
+        "Period": "1h",
+        "Limit": 1000
+      },
+      {
+        "Endpoint": "post:/api/mast/*",
+        "Period": "1m",
+        "Limit": 20
+      },
+      {
+        "Endpoint": "post:/api/jwstdata/*/process",
+        "Period": "1m",
+        "Limit": 10
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add AspNetCoreRateLimit package for IP-based rate limiting
- Configure sensible defaults to prevent abuse without impacting normal use
- Development mode whitelists localhost/private IPs

## Rate Limits
| Endpoint | Limit | Period |
|----------|-------|--------|
| General (all endpoints) | 100 | 1 minute |
| General (all endpoints) | 1000 | 1 hour |
| MAST endpoints (`/api/mast/*`) | 20 | 1 minute |
| Processing (`/api/jwstdata/*/process`) | 10 | 1 minute |

## Response
When rate limited, returns HTTP 429 with:
```json
{"error":"Rate limit exceeded. Please try again later.","retryAfter":"..."}
```

## Test plan
- [x] Backend builds successfully
- [x] Rate limit headers present in responses (`X-Rate-Limit-*`)
- [x] Frontend and API still work normally

## Security
Closes tech debt #20. API is now protected against abuse and resource exhaustion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)