### PR TITLE
chore: Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Screenshots
+If applicable, add screenshots to help explain the problem.
+
+## Environment
+- OS: [e.g., macOS 14, Windows 11, Ubuntu 22.04]
+- Browser: [e.g., Chrome 120, Firefox 121]
+- Docker version: [e.g., 24.0.7]
+
+## Additional Context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/Snoww3d/jwst-data-analysis/blob/main/README.md
+    about: Check the documentation before opening an issue
+  - name: Security Vulnerabilities
+    url: https://github.com/Snoww3d/jwst-data-analysis/blob/main/SECURITY.md
+    about: Please report security vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+A clear description of the problem you're trying to solve. Ex. "I'm always frustrated when..."
+
+## Proposed Solution
+A clear description of what you want to happen.
+
+## Alternatives Considered
+Any alternative solutions or features you've considered.
+
+## Additional Context
+Add any other context, mockups, or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+Brief description of changes.
+
+## Type of Change
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Changes Made
+-
+
+## Test Plan
+- [ ] Tested locally with Docker (`docker compose up -d`)
+- [ ] Verified in browser at http://localhost:3000
+- [ ] API endpoints tested (if applicable)
+
+## Checklist
+- [ ] My code follows the project's coding standards
+- [ ] I have updated documentation as needed
+- [ ] I have added/updated tests as appropriate
+- [ ] All CI checks pass


### PR DESCRIPTION
## Summary
- Add bug report issue template
- Add feature request issue template
- Add template chooser config with links to docs and security policy
- Add PR template with type checklist

Closes tech debt #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)