### PR TITLE
chore: Separate dev and production Docker configs

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -3,6 +3,10 @@
 #
 # IMPORTANT: Never commit .env files with real credentials to git!
 #
+# Usage:
+#   Development: docker compose up -d
+#   Production:  docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
 # MIGRATION NOTE: If you have an existing MongoDB volume initialized with
 # different credentials, either:
 #   1. Set MONGO_ROOT_PASSWORD below to match your existing password, OR

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,0 +1,34 @@
+# Development overrides (auto-loaded by docker compose)
+# This file adds development conveniences like exposed ports and hot reload
+
+services:
+  mongodb:
+    ports:
+      - "27017:27017"  # Expose MongoDB for local tools
+
+  backend:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173}
+
+  frontend:
+    build:
+      context: ../frontend/jwst-frontend
+      dockerfile: Dockerfile.dev
+    container_name: jwst-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - ../frontend/jwst-frontend:/app
+      - /app/node_modules
+    environment:
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:5001}
+    depends_on:
+      - backend
+    networks:
+      - jwst-network
+
+  processing-engine:
+    ports:
+      - "8000:8000"  # Expose processing engine for debugging

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,0 +1,29 @@
+# Production overrides
+# Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+services:
+  mongodb:
+    # MongoDB not exposed externally in production
+    ports: []
+
+  backend:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:?CORS_ALLOWED_ORIGINS must be set for production}
+
+  frontend:
+    build:
+      context: ../frontend/jwst-frontend
+      dockerfile: Dockerfile
+    container_name: jwst-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+    networks:
+      - jwst-network
+
+  processing-engine:
+    # Processing engine not exposed externally in production
+    ports: []

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,12 @@
+# Base Docker Compose configuration
+# For development: docker compose up -d (auto-loads docker-compose.override.yml)
+# For production: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+
 services:
   mongodb:
     image: mongo:latest
     container_name: jwst-mongodb
     restart: unless-stopped
-    ports:
-      - "27017:27017"
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME:-admin}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-changeme}
@@ -22,33 +24,13 @@ services:
     ports:
       - "5001:8080"
     environment:
-      - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Development}
       - MongoDB__ConnectionString=mongodb://${MONGO_ROOT_USERNAME:-admin}:${MONGO_ROOT_PASSWORD:-changeme}@mongodb:27017
       - MongoDB__DatabaseName=${MONGO_DATABASE:-jwst_data_analysis}
       - ProcessingEngine__BaseUrl=http://processing-engine:8000
-      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173}
     volumes:
       - ../data:/app/data
     depends_on:
       - mongodb
-    networks:
-      - jwst-network
-
-  frontend:
-    build:
-      context: ../frontend/jwst-frontend
-      dockerfile: Dockerfile.dev
-    container_name: jwst-frontend
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    volumes:
-      - ../frontend/jwst-frontend:/app
-      - /app/node_modules
-    environment:
-      - VITE_API_URL=${VITE_API_URL:-http://localhost:5001}
-    depends_on:
-      - backend
     networks:
       - jwst-network
 
@@ -58,8 +40,6 @@ services:
       dockerfile: Dockerfile
     container_name: jwst-processing
     restart: unless-stopped
-    ports:
-      - "8000:8000"
     environment:
       - PYTHONPATH=/app
       - MAST_DOWNLOAD_DIR=${MAST_DOWNLOAD_DIR:-/app/data/mast}
@@ -73,7 +53,6 @@ services:
 
 volumes:
   mongodb_data:
-
 
 networks:
   jwst-network:


### PR DESCRIPTION
## Summary
- Split docker-compose.yml into base + override files
- `docker-compose.override.yml`: Dev defaults (auto-loaded)
- `docker-compose.prod.yml`: Production overrides

## Usage
```bash
# Development (default)
docker compose up -d

# Production
docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
```

## Changes
| Config | Dev | Prod |
|--------|-----|------|
| MongoDB port | Exposed (27017) | Not exposed |
| Processing port | Exposed (8000) | Not exposed |
| Frontend | Dockerfile.dev (hot reload) | Dockerfile (nginx) |
| ASPNETCORE_ENVIRONMENT | Development | Production |
| CORS | Defaults to localhost | Required env var |

## Test plan
- [x] `docker compose up -d` works (dev mode)
- [x] All services start correctly
- [x] Frontend accessible at localhost:3000
- [x] API accessible at localhost:5001

Closes tech debt #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)