### PR TITLE
feat: add documentation viewer with MkDocs

### DIFF
--- a/.agent/workflows/fix-bug.md
+++ b/.agent/workflows/fix-bug.md
@@ -1,0 +1,95 @@
+---
+description: Fix a bug with a focused branch and verification steps
+---
+
+## 1. Setup and Branching
+
+// turbo
+1. Ensure you're on the main branch and up to date:
+   ```bash
+   # cwd: /Users/shanon/Source/Astronomy
+   git checkout main && git pull origin main
+   ```
+
+2. Create a bugfix branch:
+   ```bash
+   # cwd: /Users/shanon/Source/Astronomy
+   git checkout -b fix/<short-bug-description>
+   ```
+
+## 2. Reproduction & Fix
+
+3. **Reproduction**: Before fixing, try to reproduce the bug.
+   - If possible, write a failing unit test or E2E test.
+   - If manual, document the steps in your task.md.
+
+4. Apply the fix.
+
+5. **Verify Fix**:
+   - Run the test that failed before (it should pass now).
+   - Perform manual verification.
+
+## 3. Quality Checks
+
+<!-- SYNC_START: quality_checks -->
+6. Run Code Quality Tools:
+   ```bash
+   # cwd: /Users/shanon/Source/Astronomy/frontend/jwst-frontend
+   npm run lint && npm run format
+
+   # cwd: /Users/shanon/Source/Astronomy
+   dotnet format backend/JwstDataAnalysis.sln
+   ```
+<!-- SYNC_END -->
+
+## 4. Record and Commit
+
+7. Update `docs/bugs.md`:
+   - If the bug was listed in "Open Bugs", move it to "Resolved Bugs".
+   - If it wasn't listed, add it to "Resolved Bugs" directly.
+
+8. Commit changes:
+   ```bash
+   # cwd: /Users/shanon/Source/Astronomy
+   git add -A && git commit -m "fix: <description of fix>"
+   ```
+
+## 5. Push and PR
+
+// turbo
+9. Push the branch:
+   ```bash
+   # cwd: /Users/shanon/Source/Astronomy
+   git push -u origin fix/<short-bug-description>
+   ```
+
+10. Create Pull Request:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    gh pr create --title "fix: <description>" --body "## 🐛 Bug Description
+    <What was broken>
+ 
+    ## 🛠️ Fix
+    <What you changed>
+ 
+    ## ✅ Verification
+    - **Reproduction**: <How you reproduced it>
+    - **Test Coverage**: <New or existing tests run>
+    "
+    ```
+
+## 6. Review and Merge
+
+11. Open PR for user review:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    gh pr view --web
+    ```
+
+12. **Notify User**: Ask for review.
+
+13. After approval, merge:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    gh pr merge --squash --delete-branch
+    ```

--- a/.agent/workflows/view-docs.md
+++ b/.agent/workflows/view-docs.md
@@ -1,0 +1,36 @@
+---
+description: Open the project documentation site in your browser
+---
+
+## Ensure Documentation Server is Running
+
+// turbo
+1. Start the docs container if not already running:
+   ```bash
+   # cwd: /Users/shanon/Source/Astronomy/docker
+   docker compose up -d docs
+   ```
+
+## Determine Target URL
+
+2. **Check the user's Active Document** from the metadata. Map it to the docs URL:
+
+   | Active Document Path | Docs URL |
+   |---------------------|----------|
+   | `docs/tech-debt.md` | `http://localhost:8001/content/tech-debt/` |
+   | `docs/bugs.md` | `http://localhost:8001/content/bugs/` |
+   | `docs/architecture.md` | `http://localhost:8001/content/architecture/` |
+   | `docs/standards/*.md` | `http://localhost:8001/content/standards/<filename>/` |
+   | `.agent/workflows/fix-bug.md` | `http://localhost:8001/workflows/fix-bug/` |
+   | `.agent/workflows/create-feature.md` | `http://localhost:8001/workflows/create-feature/` |
+   | `.agent/workflows/resolve-tech-debt.md` | `http://localhost:8001/workflows/resolve-tech-debt/` |
+   | `.agent/workflows/start-application.md` | `http://localhost:8001/workflows/start-application/` |
+   | `README.md` | `http://localhost:8001/` |
+   | (any other or none) | `http://localhost:8001/` |
+
+// turbo
+3. Open the mapped URL in the user's default browser:
+   ```bash
+   # cwd: /Users/shanon/Source/Astronomy
+   open <mapped-url>
+   ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,8 +51,27 @@ services:
     networks:
       - jwst-network
 
+  docs:
+    image: squidfunk/mkdocs-material
+    container_name: jwst-docs
+    restart: unless-stopped
+    ports:
+      - "8001:8000"
+    volumes:
+      - ../mkdocs.yml:/app/mkdocs.yml
+      - ../docs:/app/docs/content
+      - ../README.md:/app/docs/index.md
+      - ../.agent/workflows:/app/docs/workflows
+      - ../CLAUDE.md:/app/docs/CLAUDE.md
+      - ../CONTRIBUTING.md:/app/docs/CONTRIBUTING.md
+    working_dir: /app
+    command: [ "serve", "--dev-addr=0.0.0.0:8000" ]
+    networks:
+      - jwst-network
+
 volumes:
   mongodb_data:
+
 
 networks:
   jwst-network:

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,0 +1,33 @@
+# Bug Tracker
+
+This document tracks known bugs and their resolution status.
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| **Open** | 0 |
+| **Resolved** | 0 |
+
+## Open Bugs
+
+> No known open bugs at this time.
+
+<!-- Template for new bugs
+### [Bug ID]. [Brief Description]
+**Priority**: High/Medium/Low
+**Location**: [File or Component]
+
+**Issue**: [Description of what is wrong]
+
+**Reproduction Steps**:
+1. [Step 1]
+2. [Step 2]
+
+**Expected Behavior**: [What should happen]
+-->
+
+## Resolved Bugs
+
+| Bug ID | Description | PR |
+|--------|-------------|----|

--- a/docs/standards/development-workflow.md
+++ b/docs/standards/development-workflow.md
@@ -11,23 +11,33 @@
 When using AI agents, follow these standardized workflows located in `.agent/workflows/`:
 
 ### 1. Feature Creation (`/create-feature`)
-Use for generic new features or ad-hoc bug fixes.
+Use for new features or capabilities.
 - **Trigger**: "Create a feature for..."
 - **Process**: Implementation -> E2E Test -> Unit Test -> PR -> Interactive Review -> Merge
 
-### 2. Tech Debt Resolution (`/resolve-tech-debt`)
+### 2. Bug Fixing (`/fix-bug`)
+Use for fixing bugs and issues.
+- **Trigger**: "Fix the bug where..."
+- **Process**: Reproduction -> Fix -> Verify -> Update `docs/bugs.md` -> PR -> Interactive Review -> Merge
+
+### 3. Tech Debt Resolution (`/resolve-tech-debt`)
 Use for specific items tracked in `docs/tech-debt.md`.
 - **Trigger**: "Resolve tech debt #17"
 - **Process**: Update `tech-debt.md` (InProgress) -> Implementation -> Verification -> PR -> Interactive Review -> Merge -> Update `tech-debt.md` (Resolved)
 
+### 4. View Documentation (`/view-docs`)
+Opens the documentation site in your browser.
+- **Trigger**: "View docs" or just `/view-docs`
+- **Behavior**: Opens the MkDocs site at `http://localhost:8001`, navigating to the page corresponding to your currently open markdown file.
+
 ### Workflow Comparison
 
-| Aspect | Feature Workflow | Tech Debt Workflow |
-| :--- | :--- | :--- |
-| **Trigger** | Generic Request | **Specific Task ID** |
-| **Start** | `git checkout -b` | **1. Update Doc** -> 2. Branch |
-| **PR Title** | Generic | **"Resolves Task #..."** |
-| **Completion** | Merge | Merge -> **Update Doc (Resolved)** |
+| Aspect | Feature | Bug Fix | Tech Debt |
+| :--- | :--- | :--- | :--- |
+| **Branch Prefix** | `feature/` | `fix/` | `chore/` or `refactor/` |
+| **Commit Prefix** | `feat:` | `fix:` | `refactor:` |
+| **Doc Update** | Optional | `docs/bugs.md` | `docs/tech-debt.md` |
+| **PR Title** | `feat: ...` | `fix: ...` | `Resolves Task #...` |
 
 
 ## Development Phases

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -282,3 +282,14 @@ This document tracks tech debt items and their resolution status.
 1. Install Husky
 2. Add `pre-push` hook to run linting and subset of tests
 
+### 43. Generate and Host OpenAPI Spec
+**Priority**: Medium
+**Location**: `docs/api/openapi.json`
+
+**Issue**: The API Spec link in the documentation is broken (404) because the `openapi.json` file has not been generated or exported from the backend.
+**Impact**: Developers and agents cannot easily reference the API contracts.
+**Fix Approach**:
+1. Export the OpenAPI/Swagger JSON from the running .NET backend.
+2. Save it to `docs/api/openapi.json`.
+3. Uncomment the API Spec link in `mkdocs.yml`.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,37 @@
+site_name: JWST Data Analysis Docs
+docs_dir: docs
+theme:
+  name: material
+  palette: 
+    scheme: slate
+    primary: deep purple
+    accent: teal
+  features:
+    - navigation.expand
+    - content.code.copy
+    - content.code.annotate
+
+nav:
+  - Home: index.md
+  - Documentation:
+    - Tech Debt: content/tech-debt.md
+    - Bugs: content/bugs.md
+    - Architecture: content/architecture.md
+    # API Spec: content/api/openapi.json
+    - Standards:
+      - Overview: content/standards/project-overview.md
+      - Backend Development: content/standards/backend-development.md
+      - Frontend Development: content/standards/frontend-development.md
+      - Processing Engine: content/standards/processing-engine.md
+      - Database Models: content/standards/database-models.md
+      - Docker Deployment: content/standards/docker-deployment.md
+      - Development Workflow: content/standards/development-workflow.md
+  - Workflows:
+    - Create Feature: workflows/create-feature.md
+    - Fix Bug: workflows/fix-bug.md
+    - Tech Debt: workflows/resolve-tech-debt.md
+    - Start App: workflows/start-application.md
+    - View Docs: workflows/view-docs.md
+  - Project Info:
+    - CLAUDE.md: CLAUDE.md
+    - Contributing: CONTRIBUTING.md


### PR DESCRIPTION
## 📝 Summary
Add a local documentation viewer powered by MkDocs Material, accessible at http://localhost:8001.

## 🛠️ Changes
- **docker-compose.yml**: Add `docs` service using `squidfunk/mkdocs-material` image
- **mkdocs.yml**: Configure navigation and theme for documentation
- **.agent/workflows/fix-bug.md**: New workflow for bug fixing process
- **.agent/workflows/view-docs.md**: New context-aware workflow to open docs in browser
- **docs/bugs.md**: New bug tracking document
- **docs/tech-debt.md**: Add Task #43 for OpenAPI spec generation
- **docs/standards/development-workflow.md**: Document all four agentic workflows

## ✅ Verification
- Documentation site verified accessible at http://localhost:8001
- Navigation tested for Tech Debt, Bugs, Workflows, and Standards pages
- All broken links fixed (API Spec commented out pending Task #43)

## 🔍 Quality Check
- [x] Markdown files validated
- [x] Docker service starts successfully
