### PR TITLE
chore: add mandatory Docker verification to all workflows

### DIFF
--- a/.agent/workflows/create-feature.md
+++ b/.agent/workflows/create-feature.md
@@ -48,86 +48,92 @@ description: Create a new feature with a feature branch and GitHub PR workflow
 
 ## Verify Changes
 
-<!-- SYNC_START: verification_steps (Keep in sync with resolve-tech-debt.md) -->
-5. Run E2E tests to ensure no regressions:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy/frontend/jwst-frontend
-   npm run test:e2e
-   ```
-
-6. **Deploy for Manual Testing**:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy/docker
-   # Rebuild only the changed services to save time
-   docker compose build frontend && docker compose up -d --no-deps frontend
-   ```
-
-7. Run Unit Tests (if applicable):
+<!-- SYNC_START: verification_steps (Keep in sync with resolve-tech-debt.md, fix-bug.md) -->
+7. Run Unit Tests:
    ```bash
    # Backend
+   # cwd: /Users/shanon/Source/Astronomy
    dotnet test backend/JwstDataAnalysis.sln
-   
-   # Frontend Unit (If logic changes - Task #27)
-   # cd frontend/jwst-frontend && npm run test:unit
    ```
+
+8. **Docker Verification (REQUIRED before PR)**:
+   ```bash
+   # cwd: /Users/shanon/Source/Astronomy/docker
+   # Rebuild ALL services to verify integration
+   docker compose up -d --build
+   ```
+
+9. **Verify in Docker Environment**:
+   - Wait for containers to be healthy: `docker compose ps`
+   - Test the feature manually at http://localhost:3000
+   - Check backend API: `curl http://localhost:5001/api/jwstdata | head`
+   - Check processing engine: `curl http://localhost:8000/health`
+   - If feature involves new endpoints, test them directly
+
+10. Run E2E tests (if applicable):
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy/frontend/jwst-frontend
+    npm run test:e2e
+    ```
 <!-- SYNC_END -->
 
 ## Push and Create PR
 
 // turbo
-5. Push the feature branch to origin:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy
-   git push -u origin feature/<feature-name>
-   ```
+11. Push the feature branch to origin:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    git push -u origin feature/<feature-name>
+    ```
 
 // turbo
-6. Create a Pull Request on GitHub:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy
-   gh pr create --title "feat: <feature-name>" --body "## 📝 Summary
-   <Brief description>
+12. Create a Pull Request on GitHub:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    gh pr create --title "feat: <feature-name>" --body "## 📝 Summary
+    <Brief description>
 
-   ## 🛠️ Tech Changes
-   - **<File>**: <Change>
+    ## 🛠️ Tech Changes
+    - **<File>**: <Change>
 
-   ## ✅ Verification
-   - **Automated Tests**: <Command run>
-   - **Manual Verification**:
-     1. <Step 1>
+    ## ✅ Verification
+    - **Docker Verified**: Yes
+    - **Automated Tests**: <Command run>
+    - **Manual Verification**:
+      1. <Step 1>
 
-   ## 🔍 Quality Check
-   - [x] Linting Passed
-   - [x] Formatting Applied
-   "
-   ```
+    ## 🔍 Quality Check
+    - [x] Linting Passed
+    - [x] Formatting Applied
+    "
+    ```
 
 ## PR Review and Merge
 
 <!-- SYNC_START: pr_review_steps (Match logic in resolve-tech-debt.md) -->
-7. Open the PR for review:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy
-   gh pr view --web
-   ```
+13. Open the PR for review:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    gh pr view --web
+    ```
 
-8. **STOP and notify user**:
-   - Inform them of the PR number.
-   - Wait for their review.
-   - Ask for instructions: "Request changes", "Merge it", or "I merged it manually".
+14. **STOP and notify user**:
+    - Inform them of the PR number.
+    - Wait for their review.
+    - Ask for instructions: "Request changes", "Merge it", or "I merged it manually".
 
-9. **Scenario A: User requests changes**:
-   - Make changes.
-   - Commit and push (updates existing PR).
-   - Go back to Step 8.
+15. **Scenario A: User requests changes**:
+    - Make changes.
+    - Commit and push (updates existing PR).
+    - Go back to Step 14.
 
-10. **Scenario B: User says "Merge it"**:
+16. **Scenario B: User says "Merge it"**:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     gh pr merge --squash --delete-branch
     ```
 
-11. **Scenario C: User says "I merged it manually"**:
+17. **Scenario C: User says "I merged it manually"**:
     - Verify with `git fetch --prune`.
     - Proceed to cleanup.
 <!-- SYNC_END -->
@@ -135,18 +141,18 @@ description: Create a new feature with a feature branch and GitHub PR workflow
 ## Cleanup
 
 // turbo
-12. Switch back to main and pull:
+18. Switch back to main and pull:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     git checkout main && git pull origin main
     ```
 
 // turbo
-13. Delete the local feature branch:
+19. Delete the local feature branch:
     ```bash
-   # cwd: /Users/shanon/Source/Astronomy
-   git branch -d feature/<feature-name>
-   ```
+    # cwd: /Users/shanon/Source/Astronomy
+    git branch -d feature/<feature-name>
+    ```
 
 ## Commit Message Conventions
 

--- a/.agent/workflows/fix-bug.md
+++ b/.agent/workflows/fix-bug.md
@@ -43,71 +43,102 @@ description: Fix a bug with a focused branch and verification steps
    ```
 <!-- SYNC_END -->
 
-## 4. Record and Commit
+## 4. Docker Verification (REQUIRED before PR)
 
-7. Update `docs/bugs.md`:
-   - If the bug was listed in "Open Bugs", move it to "Resolved Bugs".
-   - If it wasn't listed, add it to "Resolved Bugs" directly.
-
-// turbo
-8. Commit changes:
+<!-- SYNC_START: verification_steps (Keep in sync with create-feature.md, resolve-tech-debt.md) -->
+7. Run Unit Tests:
    ```bash
+   # Backend
    # cwd: /Users/shanon/Source/Astronomy
-   git add -A && git commit -m "fix: <description of fix>"
+   dotnet test backend/JwstDataAnalysis.sln
    ```
 
-## 5. Push and PR
-
-// turbo
-9. Push the branch:
+8. **Docker Verification (REQUIRED before PR)**:
    ```bash
-   # cwd: /Users/shanon/Source/Astronomy
-   git push -u origin fix/<short-bug-description>
+   # cwd: /Users/shanon/Source/Astronomy/docker
+   # Rebuild ALL services to verify integration
+   docker compose up -d --build
    ```
 
+9. **Verify in Docker Environment**:
+   - Wait for containers to be healthy: `docker compose ps`
+   - Verify the bug is fixed at http://localhost:3000
+   - Check backend API: `curl http://localhost:5001/api/jwstdata | head`
+   - Check processing engine: `curl http://localhost:8000/health`
+
+10. Run E2E tests (if applicable):
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy/frontend/jwst-frontend
+    npm run test:e2e
+    ```
+<!-- SYNC_END -->
+
+## 6. Record and Commit
+
+11. Update `docs/bugs.md`:
+    - If the bug was listed in "Open Bugs", move it to "Resolved Bugs".
+    - If it wasn't listed, add it to "Resolved Bugs" directly.
+
 // turbo
-10. Create Pull Request:
+12. Commit changes:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    git add -A && git commit -m "fix: <description of fix>"
+    ```
+
+## 7. Push and PR
+
+// turbo
+13. Push the branch:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    git push -u origin fix/<short-bug-description>
+    ```
+
+// turbo
+14. Create Pull Request:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     gh pr create --title "fix: <description>" --body "## 🐛 Bug Description
     <What was broken>
- 
+
     ## 🛠️ Fix
     <What you changed>
- 
+
     ## ✅ Verification
     - **Reproduction**: <How you reproduced it>
+    - **Docker Verified**: Yes
     - **Test Coverage**: <New or existing tests run>
     "
     ```
 
-## 6. Review and Merge
+## 8. Review and Merge
 
-11. Open PR for user review:
+15. Open PR for user review:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     gh pr view --web
     ```
 
-12. **Notify User**: Ask for review.
+16. **Notify User**: Ask for review.
 
-13. After approval, merge:
+17. After approval, merge:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     gh pr merge --squash --delete-branch
     ```
 
-## 7. Cleanup
+## 9. Cleanup
 
 // turbo
-14. Switch back to main and pull:
+18. Switch back to main and pull:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     git checkout main && git pull origin main
     ```
 
 // turbo
-15. Delete the local fix branch:
+19. Delete the local fix branch:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     git branch -d fix/<short-bug-description>

--- a/.agent/workflows/resolve-tech-debt.md
+++ b/.agent/workflows/resolve-tech-debt.md
@@ -45,105 +45,111 @@ description: Resolve a tech debt item or issue from docs/tech-debt.md
 
 ## Verification
 
-<!-- SYNC_START: verification_steps (Keep in sync with create-feature.md) -->
-6. Run E2E tests to ensure no regressions:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy/frontend/jwst-frontend
-   npm run test:e2e
-   ```
-
-7. **Deploy for Manual Testing**:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy/docker
-   # Rebuild only the changed services to save time
-   docker compose build frontend && docker compose up -d --no-deps frontend
-   ```
-
-8. Run Unit Tests (if applicable):
+<!-- SYNC_START: verification_steps (Keep in sync with create-feature.md, fix-bug.md) -->
+8. Run Unit Tests:
    ```bash
    # Backend
+   # cwd: /Users/shanon/Source/Astronomy
    dotnet test backend/JwstDataAnalysis.sln
-   
-   # Frontend Unit (If logic changes - Task #27)
-   # cd frontend/jwst-frontend && npm run test:unit
    ```
+
+9. **Docker Verification (REQUIRED before PR)**:
+   ```bash
+   # cwd: /Users/shanon/Source/Astronomy/docker
+   # Rebuild ALL services to verify integration
+   docker compose up -d --build
+   ```
+
+10. **Verify in Docker Environment**:
+    - Wait for containers to be healthy: `docker compose ps`
+    - Test the changes manually at http://localhost:3000
+    - Check backend API: `curl http://localhost:5001/api/jwstdata | head`
+    - Check processing engine: `curl http://localhost:8000/health`
+    - If changes involve new endpoints, test them directly
+
+11. Run E2E tests (if applicable):
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy/frontend/jwst-frontend
+    npm run test:e2e
+    ```
 <!-- SYNC_END -->
 
 ## Completion
 
 // turbo
-7. Commit changes:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy
-   git add -A && git commit -m "feat: <Description> (Task #<id>)"
-   ```
+12. Commit changes:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    git add -A && git commit -m "feat: <Description> (Task #<id>)"
+    ```
 
 // turbo
-8. Push and Create PR:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy
-   git push -u origin feature/task-<id>-<brief-description>
-   gh pr create --title "feat: <Description> (Task #<id>)" --body "## 📝 Summary
-   Resolves **Task #<id>** in \`docs/tech-debt.md\`.
+13. Push and Create PR:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    git push -u origin feature/task-<id>-<brief-description>
+    gh pr create --title "feat: <Description> (Task #<id>)" --body "## 📝 Summary
+    Resolves **Task #<id>** in \`docs/tech-debt.md\`.
 
-   ## 🛠️ Tech Changes
-   - **<File>**: <Change>
+    ## 🛠️ Tech Changes
+    - **<File>**: <Change>
 
-   ## ✅ Verification
-   - **Automated Tests**: <Command run>
-   - **Manual Verification**:
-     1. <Step 1>
+    ## ✅ Verification
+    - **Docker Verified**: Yes
+    - **Automated Tests**: <Command run>
+    - **Manual Verification**:
+      1. <Step 1>
 
-   ## 🔍 Quality Check
-   - [x] Linting Passed
-   - [x] Formatting Applied
-   "
-   ```
+    ## 🔍 Quality Check
+    - [x] Linting Passed
+    - [x] Formatting Applied
+    "
+    ```
 
 ## PR Review and Merge
 
 <!-- SYNC_START: pr_review_steps (Match logic in create-feature.md) -->
-9. Open the PR for review:
-   ```bash
-   # cwd: /Users/shanon/Source/Astronomy
-   gh pr view --web
-   ```
+14. Open the PR for review:
+    ```bash
+    # cwd: /Users/shanon/Source/Astronomy
+    gh pr view --web
+    ```
 
-10. **STOP and notify user**:
+15. **STOP and notify user**:
     - Inform them of the execution and PR number.
     - Wait for their review.
     - Ask for instructions: "Request changes", "Merge it", or "I merged it manually".
 
-11. **Scenario A: User requests changes**:
+16. **Scenario A: User requests changes**:
     - Make changes.
     - Commit and push.
-    - Go back to Step 10.
+    - Go back to Step 15.
 
-12. **Scenario B: User says "Merge it"**:
+17. **Scenario B: User says "Merge it"**:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     gh pr merge --squash --delete-branch
     ```
 
-13. **Scenario C: User says "I merged it manually"**:
+18. **Scenario C: User says "I merged it manually"**:
     - Verify with `git fetch --prune`.
 <!-- SYNC_END -->
 
-14. Update `docs/tech-debt.md`:
+19. Update `docs/tech-debt.md`:
     - Move the item from "Remaining Tasks" to "Resolved Tasks" table.
     - Include the PR number in the table.
 
 ## Cleanup
 
 // turbo
-15. Switch back to main and pull:
+20. Switch back to main and pull:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     git checkout main && git pull origin main
     ```
 
 // turbo
-16. Delete the local feature branch:
+21. Delete the local feature branch:
     ```bash
     # cwd: /Users/shanon/Source/Astronomy
     git branch -d feature/task-<id>-<brief-description>


### PR DESCRIPTION
## Summary

Updates all three workflow files to include mandatory Docker verification steps **before** creating PRs. This prevents integration issues from being discovered post-PR creation.

## Changes

| Workflow | Updates |
|----------|---------|
| `create-feature.md` | Added steps 8-10 for Docker verification |
| `fix-bug.md` | Added new section 4 with Docker verification steps |
| `resolve-tech-debt.md` | Updated verification steps 8-11 |

## Motivation

During PR #91 implementation, Docker verification was skipped before PR creation. This update ensures the workflow explicitly requires:

1. Running unit tests
2. Rebuilding Docker containers (`docker compose up -d --build`)
3. Verifying containers are healthy
4. Testing the feature/fix manually
5. Running E2E tests (if applicable)

All PRs now include "Docker Verified: Yes" in the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)