### PR TITLE
chore: add git workflow protection to prevent direct pushes to main

### DIFF
--- a/.agent/workflows/create-feature.md
+++ b/.agent/workflows/create-feature.md
@@ -2,6 +2,9 @@
 description: Create a new feature with a feature branch and GitHub PR workflow
 ---
 
+> ⛔ **CRITICAL**: ALL changes require a feature branch and PR. NEVER push directly to `main`.
+> Even for single-line documentation fixes, create a branch first.
+
 ## Create Feature Branch
 
 // turbo

--- a/.agent/workflows/fix-bug.md
+++ b/.agent/workflows/fix-bug.md
@@ -2,6 +2,9 @@
 description: Fix a bug with a focused branch and verification steps
 ---
 
+> ⛔ **CRITICAL**: ALL changes require a feature branch and PR. NEVER push directly to `main`.
+> Even for single-line documentation fixes, create a branch first.
+
 ## 1. Setup and Branching
 
 // turbo

--- a/.agent/workflows/resolve-tech-debt.md
+++ b/.agent/workflows/resolve-tech-debt.md
@@ -2,6 +2,9 @@
 description: Resolve a tech debt item or issue from docs/tech-debt.md
 ---
 
+> ⛔ **CRITICAL**: ALL changes require a feature branch and PR. NEVER push directly to `main`.
+> Even for single-line documentation fixes, create a branch first.
+
 ## Start the Task
 
 1. Identify the Tech Debt item number you want to work on (e.g., #17).

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Pre-push hook to prevent direct pushes to main branch.
+# All changes must go through feature branches and PRs.
+#
+# Install with: ./scripts/setup-hooks.sh
+
+protected_branch='main'
+current_branch=$(git symbolic-ref HEAD 2>/dev/null | sed -e 's,.*/\(.*\),\1,')
+
+if [ "$current_branch" = "$protected_branch" ]; then
+    echo ""
+    echo "⛔ ERROR: Direct push to '$protected_branch' is not allowed."
+    echo ""
+    echo "All changes must go through a feature branch and Pull Request."
+    echo "Even for documentation-only fixes, create a branch first:"
+    echo ""
+    echo "  git checkout -b docs/your-change-name"
+    echo "  git push -u origin docs/your-change-name"
+    echo "  gh pr create"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,15 @@ docker compose up -d --build
 - Processing Engine: http://localhost:8000
 - MongoDB: localhost:27017
 
+### Git Hooks Setup (Recommended)
+
+```bash
+# Install git hooks (prevents direct pushes to main)
+./scripts/setup-hooks.sh
+```
+
+This installs a pre-push hook that blocks accidental direct pushes to the `main` branch, enforcing the PR workflow.
+
 ### Backend Development (.NET 10)
 
 ```bash
@@ -377,8 +386,12 @@ pre-commit run --all-files
 
 ### Git Workflow
 
-- **ALWAYS create a Pull Request (PR) after pushing**.
-- **NEVER** push directly to `main` or stop at the `push` step.
+> ⛔ **ABSOLUTE RULE**: Every change to the codebase—including documentation-only
+> fixes—MUST go through a feature branch and PR. Direct pushes to `main` bypass
+> CI checks, skip user review, and make rollbacks harder. No exceptions.
+
+- **NEVER** push directly to `main`. Not even for "quick fixes" or "just docs".
+- **ALWAYS** create a feature branch first, then push and create a PR.
 - **ALWAYS check CI tests pass before merging** (`gh pr checks <pr-number>`).
 - **ALWAYS include documentation updates in the same PR**.
 - Workflow:

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Setup script to install git hooks for this repository.
+#
+# Usage: ./scripts/setup-hooks.sh
+#
+# This installs hooks that:
+# - Prevent direct pushes to main branch (pre-push)
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_SOURCE="$REPO_ROOT/.githooks"
+HOOKS_TARGET="$REPO_ROOT/.git/hooks"
+
+echo "Setting up git hooks for JWST Data Analysis..."
+echo ""
+
+# Check we're in a git repo
+if [ ! -d "$REPO_ROOT/.git" ]; then
+    echo "❌ Error: Not a git repository. Run this from the project root."
+    exit 1
+fi
+
+# Check hooks source exists
+if [ ! -d "$HOOKS_SOURCE" ]; then
+    echo "❌ Error: .githooks directory not found."
+    exit 1
+fi
+
+# Install pre-push hook
+if [ -f "$HOOKS_SOURCE/pre-push" ]; then
+    cp "$HOOKS_SOURCE/pre-push" "$HOOKS_TARGET/pre-push"
+    chmod +x "$HOOKS_TARGET/pre-push"
+    echo "✅ Installed pre-push hook (blocks direct pushes to main)"
+fi
+
+echo ""
+echo "Git hooks installed successfully!"
+echo ""
+echo "Hooks active:"
+echo "  - pre-push: Prevents direct pushes to main branch"
+echo ""


### PR DESCRIPTION
## Summary
- Add pre-push git hook that blocks direct pushes to `main` branch
- Add setup script (`scripts/setup-hooks.sh`) to install hooks
- Add warning boxes to all workflow files
- Strengthen CLAUDE.md git workflow section

## Changes

### New Files
- `.githooks/pre-push` - Hook that blocks direct pushes to main with helpful error message
- `scripts/setup-hooks.sh` - One-time setup script to install hooks

### Updated Files
- `.agent/workflows/*.md` - Added warning box at top of each workflow
- `CLAUDE.md` - Strengthened git workflow section, added hooks setup instructions

## Why
Direct push to main today bypassed CI and user review. This adds multiple layers of protection:
1. **Documentation** - Explicit rules in CLAUDE.md and workflow files
2. **Technical** - Pre-push hook blocks the action locally

## Test plan
- [x] Verify hook blocks push to main: `git checkout main && git push` should fail
- [x] Verify hook allows feature branch push
- [x] Verify setup script installs hook correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)