### PR TITLE
chore: enhance PR template with documentation checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,34 @@
 ## Summary
-Brief description of changes.
+<!-- Brief description of what this PR does -->
+
 
 ## Type of Change
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
 - [ ] Documentation update
-- [ ] Refactoring (no functional changes)
+- [ ] Refactoring
+- [ ] Tech debt resolution
 
 ## Changes Made
 -
 
 ## Test Plan
-- [ ] Tested locally with Docker (`docker compose up -d`)
+- [ ] Tested locally with Docker (`docker compose up -d --build`)
 - [ ] Verified in browser at http://localhost:3000
 - [ ] API endpoints tested (if applicable)
+- [ ] Unit tests pass (`dotnet test`)
 
-## Checklist
-- [ ] My code follows the project's coding standards
-- [ ] I have updated documentation as needed
-- [ ] I have added/updated tests as appropriate
+## Documentation Checklist
+<!-- Check all that apply -->
+- [ ] No documentation updates needed
+- [ ] `CLAUDE.md` - API endpoints, features, or usage patterns
+- [ ] `docs/development-plan.md` - Completed milestones/features marked
+- [ ] `docs/tech-debt.md` - Resolved items moved to table
+- [ ] `docs/standards/*.md` - Model/API/frontend pattern changes
+
+## Quality Checklist
+- [ ] Code follows project coding standards
+- [ ] Linting passes (`npm run lint`, `dotnet format`, `ruff check`)
 - [ ] All CI checks pass
+- [ ] Created via feature branch and PR (not direct push to main)


### PR DESCRIPTION
## Summary
Enhance the existing PR template with more specific documentation reminders.

## Type of Change
- [x] Documentation update

## Changes Made
- Added specific documentation file checklist (CLAUDE.md, development-plan.md, tech-debt.md)
- Added reminder about feature branch workflow
- Added linting commands to quality checklist
- Reorganized sections for clarity

## Test Plan
- [x] Template renders correctly in GitHub

## Documentation Checklist
- [x] No documentation updates needed (this IS the documentation)

## Quality Checklist
- [x] Created via feature branch and PR (not direct push to main)

---

**Note:** Attempted to enable GitHub branch protection but it requires Pro for private repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)