### PR TITLE
feat: add PNG export to FITS viewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -593,8 +593,7 @@ When features are added or changed, update these files:
 **Frontend Utilities**:
 - `frontend/jwst-frontend/src/utils/fitsUtils.ts` - FITS file type detection and classification
 - `frontend/jwst-frontend/src/utils/colormaps.ts` - Color maps for FITS visualization
-- `frontend/jwst-frontend/src/components/AdvancedFitsViewer.tsx` - FITS image viewer
-- `frontend/jwst-frontend/src/components/ImageViewer.tsx` - Image viewer modal wrapper
+- `frontend/jwst-frontend/src/components/ImageViewer.tsx` - FITS image viewer with color maps, stretch controls, and PNG export
 
 ## Common Patterns
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -292,8 +292,7 @@ flowchart TB
     end
 
     subgraph Modals
-        ImageViewer["ImageViewer.tsx"]
-        FitsViewer["AdvancedFitsViewer.tsx"]
+        ImageViewer["ImageViewer.tsx (FITS viewer with stretch controls, PNG export)"]
         UploadModal["Upload Modal (TODO)"]
     end
 

--- a/docs/standards/frontend-development.md
+++ b/docs/standards/frontend-development.md
@@ -13,8 +13,7 @@
 - Components:
   - [JwstDataDashboard.tsx](../../frontend/jwst-frontend/src/components/JwstDataDashboard.tsx) - Main dashboard with grid, list, grouped, and lineage views
   - [MastSearch.tsx](../../frontend/jwst-frontend/src/components/MastSearch.tsx) - MAST portal search interface with progress tracking
-  - [AdvancedFitsViewer.tsx](../../frontend/jwst-frontend/src/components/AdvancedFitsViewer.tsx) - FITS image viewer with color maps
-  - [ImageViewer.tsx](../../frontend/jwst-frontend/src/components/ImageViewer.tsx) - Image viewer modal wrapper
+  - [ImageViewer.tsx](../../frontend/jwst-frontend/src/components/ImageViewer.tsx) - FITS image viewer with color maps, stretch controls, and PNG export
 - Types:
   - [JwstDataTypes.ts](../../frontend/jwst-frontend/src/types/JwstDataTypes.ts) - Core data types, lineage types, processing levels
   - [MastTypes.ts](../../frontend/jwst-frontend/src/types/MastTypes.ts) - MAST search/import types, progress tracking
@@ -31,7 +30,8 @@
   - [App.css](../../frontend/jwst-frontend/src/App.css) - Global styles
   - [JwstDataDashboard.css](../../frontend/jwst-frontend/src/components/JwstDataDashboard.css) - Dashboard and lineage view styles
   - [MastSearch.css](../../frontend/jwst-frontend/src/components/MastSearch.css) - MAST search and progress styles
-  - [AdvancedFitsViewer.css](../../frontend/jwst-frontend/src/components/AdvancedFitsViewer.css) - FITS viewer styles
+  - [FitsViewer.css](../../frontend/jwst-frontend/src/components/FitsViewer.css) - FITS viewer styles
+  - [ImageViewer.css](../../frontend/jwst-frontend/src/components/ImageViewer.css) - Image viewer modal styles
 - Package config: [frontend/jwst-frontend/package.json](../../frontend/jwst-frontend/package.json)
 
 ## Coding Standards
@@ -58,12 +58,14 @@
   - Bulk import with progress tracking
   - Byte-level progress display (speed, ETA, per-file status)
   - Resume capability for interrupted downloads
-- **AdvancedFitsViewer**: FITS image viewer with:
-  - Multiple color maps (grayscale, heat, cool, rainbow, viridis, magma, inferno)
+- **ImageViewer**: FITS image viewer with:
+  - Multiple color maps (grayscale, hot, cool, rainbow, viridis, plasma, magma, inferno)
+  - Stretch controls (linear, log, sqrt, asinh, zscale) with histogram visualization
   - Zoom and pan controls
-  - Header metadata display
+  - Pixel coordinate display with WCS conversion
+  - PNG export with current visualization settings
+  - Header metadata display in sidebar
   - Graceful handling of non-image FITS files
-- **ImageViewer**: Modal wrapper for FITS viewer
 - **Types**:
   - JwstDataModel, ImageMetadata, SensorMetadata, ProcessingResult
   - LineageResponse, LineageFileInfo

--- a/frontend/jwst-frontend/src/components/FitsViewer.css
+++ b/frontend/jwst-frontend/src/components/FitsViewer.css
@@ -488,3 +488,13 @@
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
+
+/* Export button loading state */
+.btn-icon .mini-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-top-color: rgba(255, 255, 255, 0.8);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}


### PR DESCRIPTION
## Summary

- Add PNG export button to FITS viewer that downloads current visualization with all settings applied
- Generate meaningful filenames from MAST metadata (e.g., `jw02733-o001_nircam_f090w_2024-01-15_143022.png`)
- Show loading spinner during export, disable button while image is loading
- Update documentation to fix outdated `AdvancedFitsViewer` references → `ImageViewer`

## Test plan

- [ ] Start application with `docker compose up -d`
- [ ] Open http://localhost:3000
- [ ] Import or select a FITS observation
- [ ] Click "View" to open the FITS viewer
- [ ] Verify export button appears next to Download FITS button
- [ ] Change colormap and stretch settings
- [ ] Click "Export as PNG"
- [ ] Verify PNG downloads with correct filename pattern
- [ ] Verify exported image matches current viewer settings
- [ ] Verify button shows spinner during export
- [ ] Verify button is disabled while image is loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)