### PR TITLE
docs: add Branch-First Rule to harden git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,6 +390,13 @@ pre-commit run --all-files
 > fixes—MUST go through a feature branch and PR. Direct pushes to `main` bypass
 > CI checks, skip user review, and make rollbacks harder. No exceptions.
 
+> 🔒 **BRANCH-FIRST RULE**: Before making ANY file edits (Edit, Write tools), you MUST:
+> 1. Run `git status` to confirm current branch and state
+> 2. Create the feature branch: `git checkout -b feature/name`
+> 3. ONLY THEN begin making file changes
+>
+> This prevents accidental work on `main` and ensures all changes are tracked from the start.
+
 - **NEVER** push directly to `main`. Not even for "quick fixes" or "just docs".
 - **ALWAYS** create a feature branch first, then push and create a PR.
 - **ALWAYS check CI tests pass before merging** (`gh pr checks <pr-number>`).


### PR DESCRIPTION
## Summary

- Add explicit **Branch-First Rule** to Git Workflow section in CLAUDE.md
- Requires creating feature branch BEFORE any file edits (Edit, Write tools)
- Prevents accidental work on `main` branch

## Context

During the PNG export feature implementation, file edits were made on `main` before creating a feature branch. While the changes were successfully moved to a branch, this workflow gap could lead to:
- Accidental commits to main
- Lost work if branch creation fails
- Confusion about which changes belong to which feature

## Test plan

- [x] Documentation change only - no code impact
- [x] Verify CLAUDE.md renders correctly with new callout block

🤖 Generated with [Claude Code](https://claude.com/claude-code)