### PR TITLE
security: Add MCP server security policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,27 @@ pre-commit run --all-files
 - Update CORS to whitelist specific origins (Task #19)
 - Review all environment variables for production values
 
+**MCP Server Security Policy**:
+
+This project does NOT require any MCP (Model Context Protocol) servers for its core functionality. The following policies apply:
+
+| Policy | Rule |
+|--------|------|
+| **No MCP server installation** | The `mcp-add`, `mcp-config-set` permissions are explicitly denied in `.claude/settings.local.json` |
+| **No credential embedding** | Never store API tokens, passwords, or secrets in MCP config files. Use Docker secrets or environment variables |
+| **Approved MCP tools only** | If MCP tools are needed in future, they must be explicitly documented here and added to settings.local.json |
+
+**If you need MCP servers** (e.g., for MongoDB management via MCP_DOCKER):
+1. Document the specific tools required and their purpose
+2. Add only the minimum required tool permissions to `.claude/settings.local.json`
+3. Store any credentials using Docker secrets:
+   ```bash
+   docker mcp secret set SECRET_NAME
+   ```
+4. Reference secrets in config instead of embedding values
+
+**Currently Approved MCP Tools**: None (project uses direct API calls and Docker Compose services)
+
 ### Git Workflow
 
 > ⛔ **ABSOLUTE RULE**: Every change to the codebase—including documentation-only


### PR DESCRIPTION
## Summary
- Add MCP (Model Context Protocol) server security policy to CLAUDE.md
- Document that this project does NOT require MCP servers for core functionality
- Prohibit dangerous MCP tool permissions (mcp-add, mcp-config-set)
- Establish credential management policy (use Docker secrets, not embedded values)

## Security Issues Addressed

This PR addresses potential security risks from MCP server configurations:

| Risk | Mitigation |
|------|------------|
| Arbitrary MCP server installation | Policy prohibits `mcp-add` permission |
| MCP config tampering | Policy prohibits `mcp-config-set` permission |
| Embedded credentials | Policy requires Docker secrets for sensitive values |
| Undocumented capabilities | Policy requires explicit documentation before adding MCP tools |

## Changes

### CLAUDE.md
- Added "MCP Server Security Policy" section under Security Notes
- Documents approved MCP tools (currently: none)
- Provides guidance for future MCP usage if needed

## Note on Local Settings

The `.claude/settings.local.json` file is gitignored (user-specific). Each developer should:
1. Review their local settings
2. Remove any `mcp__MCP_DOCKER__mcp-add`, `mcp__MCP_DOCKER__mcp-config-set` permissions
3. Follow the documented policy for any future MCP tool needs

## Test plan
- [x] Documentation renders correctly in GitHub
- [x] Policy table displays properly
- [x] Code block for Docker secrets is formatted correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)