### PR TITLE
security: fix SSRF risk in MAST URL construction (Task #52)

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -6,8 +6,8 @@ This document tracks tech debt items and their resolution status.
 
 | Status | Count |
 |--------|-------|
-| **Resolved** | 34 |
-| **Remaining** | 28 |
+| **Resolved** | 35 |
+| **Remaining** | 27 |
 
 > **Security Audit (2026-02-02)**: Comprehensive audit identified 18 new security issues across all layers. See "Security Tech Debt" section below.
 
@@ -37,22 +37,9 @@ A comprehensive security audit identified the following vulnerabilities across a
 
 ---
 
-### 52. SSRF Risk in MAST URL Construction
-**Priority**: CRITICAL
-**Location**: `processing-engine/app/mast/mast_service.py:495-500`
-**Category**: Server-Side Request Forgery
-
-**Issue**: URL parameters from MAST API responses are interpolated without validation:
-```python
-download_url = f"https://mast.stsci.edu/api/v0.1/Download/file?uri={data_uri}"
-```
-
-**Attack Vector**: Malicious `data_uri` could inject arbitrary URLs or parameters.
-
-**Fix Approach**:
-1. URL encode the `data_uri` parameter: `urllib.parse.quote(data_uri, safe='')`
-2. Validate URI starts with expected prefix: `mast:`
-3. Reject URIs containing unexpected characters
+### ~~52. SSRF Risk in MAST URL Construction~~ ✅ RESOLVED (PR #110)
+**Status**: Fixed in PR #110
+**Fix**: Added `_is_valid_mast_uri()` regex validation and `_build_mast_download_url()` with URL encoding. Invalid URIs are rejected and logged. Also added 38 security tests.
 
 ---
 
@@ -547,6 +534,7 @@ These security issues were addressed in earlier PRs but may warrant re-review gi
 | #47 | Fix GetSearchCountAsync Incomplete Filter Logic | PR #95 |
 | #50 | Exposed MongoDB Password (FALSE POSITIVE) | Verified no exposure |
 | #51 | Path Traversal via obsId Parameter | PR #108 |
+| #52 | SSRF Risk in MAST URL Construction | PR #110 |
 
 ### 37. Re-enable CodeQL Security Analysis
 **Priority**: Medium (before public release)

--- a/processing-engine/tests/__init__.py
+++ b/processing-engine/tests/__init__.py
@@ -1,0 +1,1 @@
+# Processing Engine Tests

--- a/processing-engine/tests/test_mast_service_security.py
+++ b/processing-engine/tests/test_mast_service_security.py
@@ -1,0 +1,138 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Security tests for MastService URI validation.
+
+These tests verify that SSRF attacks via malicious data URIs are blocked.
+"""
+
+import pytest
+
+from app.mast.mast_service import MastService
+
+
+class TestMastUriValidation:
+    """Test cases for MAST data URI validation to prevent SSRF attacks."""
+
+    # Valid MAST URIs that should be accepted
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "mast:JWST/product/jw02733-o001_t001_nircam_clear-f090w_i2d.fits",
+            "mast:JWST/product/jw12345-o001_t001_miri_f770w_cal.fits",
+            "mast:JWST/product/jw01234-c1001_t001_nirspec_g140h-f100lp_s2d.fits",
+            "mast:HST/product/some_file.fits",
+            "mast:TESS/product/data.fits",
+        ],
+    )
+    def test_valid_mast_uri_accepted(self, uri: str):
+        """Valid MAST URIs should be accepted."""
+        assert MastService._is_valid_mast_uri(uri) is True
+
+    # Invalid URIs that should be rejected (SSRF attempts)
+    @pytest.mark.parametrize(
+        "uri,description",
+        [
+            # Missing mast: prefix
+            ("JWST/product/file.fits", "missing mast: prefix"),
+            ("http://evil.com/steal?data=", "HTTP URL instead of mast: URI"),
+            ("https://attacker.com/file.fits", "HTTPS URL instead of mast: URI"),
+            # URL injection attempts
+            ("mast:JWST/product/file.fits?evil=param", "query string injection"),
+            ("mast:JWST/product/file.fits#fragment", "fragment injection"),
+            ("mast:JWST/product/file.fits&extra=param", "ampersand injection"),
+            # Path traversal attempts
+            ("mast:JWST/product/../../../etc/passwd", "path traversal with .."),
+            ("mast:../../../etc/passwd", "path traversal at start"),
+            ("mast:JWST/../../../secret", "nested path traversal"),
+            # Protocol smuggling
+            ("mast:JWST/product/file.fits\nHost: evil.com", "newline injection"),
+            ("mast:JWST/product/file.fits\r\nX-Injected: header", "CRLF injection"),
+            # Special characters that could break URL parsing
+            ("mast:JWST/product/file.fits;rm -rf /", "semicolon injection"),
+            ("mast:JWST/product/`whoami`.fits", "backtick injection"),
+            ("mast:JWST/product/$(id).fits", "command substitution"),
+            ("mast:JWST/product/file.fits|cat /etc/passwd", "pipe injection"),
+            # Unicode/encoding attacks
+            ("mast:JWST/product/file%2e%2e%2f.fits", "URL encoded traversal"),
+            # Empty or whitespace
+            ("", "empty string"),
+            ("   ", "whitespace only"),
+            ("mast:", "mast prefix only"),
+            # Null bytes
+            ("mast:JWST/product/file\x00.fits", "null byte injection"),
+        ],
+    )
+    def test_invalid_uri_rejected(self, uri: str, description: str):
+        """Invalid or malicious URIs should be rejected."""
+        assert MastService._is_valid_mast_uri(uri) is False, f"Should reject: {description}"
+
+
+class TestMastDownloadUrlBuilder:
+    """Test cases for safe MAST download URL construction."""
+
+    def test_valid_uri_builds_url(self):
+        """Valid URI should produce a properly encoded URL."""
+        uri = "mast:JWST/product/jw02733-o001_t001_nircam_clear-f090w_i2d.fits"
+        url = MastService._build_mast_download_url(uri)
+
+        assert url is not None
+        assert url.startswith("https://mast.stsci.edu/api/v0.1/Download/file?uri=")
+        # URI should be URL-encoded
+        assert "mast%3AJWST" in url  # : encoded as %3A
+        assert "jw02733" in url
+
+    def test_invalid_uri_returns_none(self):
+        """Invalid URI should return None instead of building a URL."""
+        malicious_uris = [
+            "http://evil.com/steal",
+            "mast:../../../etc/passwd",
+            "mast:JWST/product/file.fits?inject=true",
+        ]
+
+        for uri in malicious_uris:
+            result = MastService._build_mast_download_url(uri)
+            assert result is None, f"Should return None for: {uri}"
+
+    def test_url_encoding_prevents_injection(self):
+        """URL encoding should prevent parameter injection even if validation is bypassed."""
+        # Even if a URI somehow passed validation, encoding would neutralize it
+        # This tests the defense-in-depth approach
+        uri = "mast:JWST/product/safe_file.fits"
+        url = MastService._build_mast_download_url(uri)
+
+        assert url is not None
+        # The URI parameter should be encoded, making injection impossible
+        assert "?" not in url.split("uri=")[1] if url else True
+        assert "&" not in url.split("uri=")[1] if url else True
+
+
+class TestFilenameValidation:
+    """Test filename validation in download URL generation."""
+
+    @pytest.mark.parametrize(
+        "filename,should_pass",
+        [
+            # Valid JWST filenames
+            ("jw02733-o001_t001_nircam_clear-f090w_i2d.fits", True),
+            ("jw12345-o001_t001_miri_f770w_cal.fits", True),
+            ("simple_file.fits", True),
+            # Invalid filenames
+            ("../../../etc/passwd", False),
+            ("file.fits;rm -rf /", False),
+            ("file`whoami`.fits", False),
+            ("file$(id).fits", False),
+            ("file|cat.fits", False),
+            ("file.fits.exe", False),  # Not a .fits file
+            ("", False),
+        ],
+    )
+    def test_filename_validation(self, filename: str, should_pass: bool):
+        """Filenames should be validated before being used in URLs."""
+        import re
+
+        # This tests the regex pattern used in get_download_urls
+        pattern = r"^[A-Za-z0-9_\-./]+\.fits$"
+        result = bool(re.match(pattern, filename)) if filename else False
+        assert result == should_pass, f"Filename '{filename}' validation mismatch"


### PR DESCRIPTION
## Summary

- Fix critical SSRF vulnerability in MAST URL construction where `data_uri` from API responses was interpolated without validation
- Add regex validation ensuring URIs match expected `mast:{collection}/product/{filename}` format
- Add URL encoding as defense-in-depth to neutralize any bypassed injection
- Add 38 security tests covering various attack vectors

## Changes

**processing-engine/app/mast/mast_service.py**:
- Add `MAST_URI_PATTERN` regex for URI validation
- Add `_is_valid_mast_uri()` static method - validates format, prefix, and rejects path traversal
- Add `_build_mast_download_url()` - safely builds URL with encoding, returns None for invalid URIs
- Update `get_download_urls()` to use safe builder, skip invalid products with warning logs
- Add `from __future__ import annotations` for Python 3.9 compatibility

**processing-engine/tests/test_mast_service_security.py** (new):
- 38 tests covering URI validation, URL building, and filename validation
- Tests for: missing prefix, HTTP URLs, query/fragment injection, path traversal, CRLF injection, command injection, null bytes, etc.

## Test plan

- [x] Run security tests in Docker: `docker compose run --rm processing-engine python -m pytest tests/ -v` (38 passed)
- [x] Run backend tests: `dotnet test` (164 passed)
- [x] Verify linting passes: `ruff check` (all checks passed)
- [x] CI pipeline passes

## Workflow Compliance

| Step | Status |
|------|--------|
| Branch-first rule | ✅ |
| Implement fix | ✅ |
| Quality checks (linting) | ✅ |
| Tests | ✅ |
| Docker verification | ✅ |
| Documentation updates | ✅ |

## Security Impact

**Before**: Malicious `data_uri` from compromised MAST response could inject arbitrary URLs
**After**: Only URIs matching `mast:[A-Za-z0-9_\-./]+` pattern are accepted, all others rejected

🤖 Generated with [Claude Code](https://claude.ai/code)