### PR TITLE
chore: upgrade Node.js from 18 to 22 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: frontend/jwst-frontend/package-lock.json
 
@@ -83,7 +83,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: frontend/jwst-frontend/package-lock.json
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -6,7 +6,7 @@ Before setting up the application, ensure you have the following installed:
 
 - **Docker** and **Docker Compose** (recommended for easy setup)
 - **.NET 10 SDK** (for backend development)
-- **Node.js 18+** (for frontend development)
+- **Node.js 22+** (for frontend development)
 - **Python 3.9+** (for processing engine development)
 - **MongoDB** (if running locally without Docker)
 

--- a/frontend/jwst-frontend/Dockerfile
+++ b/frontend/jwst-frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS build
+FROM node:22-alpine AS build
 
 WORKDIR /app
 

--- a/frontend/jwst-frontend/Dockerfile.dev
+++ b/frontend/jwst-frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Upgrade Node.js from version 18 to 22 LTS across all Docker images and CI workflows
- Node.js 22 is the current LTS version with improved performance and modern JS features
- All frontend dependencies already support Node.js 22 (checked package-lock.json)

## Changes
- `frontend/jwst-frontend/Dockerfile`: Update base image to `node:22-alpine`
- `frontend/jwst-frontend/Dockerfile.dev`: Update base image to `node:22-alpine`
- `.github/workflows/ci.yml`: Update both Node.js setup steps to use version 22
- `docs/setup-guide.md`: Update prerequisite to Node.js 22+

## Test plan
- [x] Docker build succeeds: `docker compose build frontend` ✅
- [x] Full stack starts: `docker compose up -d` ✅
- [x] Node.js version verified: `docker compose exec frontend node --version` returns v22.22.0 ✅
- [x] E2E tests pass: `npm run test:e2e` - 39 tests passed ✅
- [ ] CI workflow passes (verify after PR creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)