### PR TITLE
docs: add /compliance-check skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,8 +517,11 @@ Skills are simple, single-purpose commands. No git branches or PRs. Located in `
 | `/start-application` | Start the full Docker stack |
 | `/view-docs` | Open documentation site in browser |
 | `/keybindings-help` | Customize keyboard shortcuts |
+| `/compliance-check` | Run all quality checks before PR merge |
 
 **Rule of thumb**: If it changes tracked files → workflow. If it's a helper action → skill.
+
+> **Proactive Compliance**: Claude should automatically run `/compliance-check` before asking the user to review or merge a PR. Don't wait to be asked.
 
 ### Task Tracking
 


### PR DESCRIPTION
## Summary

- Add `/compliance-check` skill for automated pre-merge verification
- Add proactive usage note to CLAUDE.md so Claude runs it automatically before asking for merge review

The skill runs all quality checks:
- Git status (no dangling changes)
- PR/CI status
- Backend tests
- Frontend lint & format
- Python lint & format
- Docker services
- Documentation completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)