### PR TITLE
fix: allow anonymous access to MAST search endpoints

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/MastController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.cs
@@ -87,6 +87,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// Search MAST by target name (e.g., "NGC 1234", "Carina Nebula").
         /// </summary>
         [HttpPost("search/target")]
+        [AllowAnonymous]
         public async Task<ActionResult<MastSearchResponse>> SearchByTarget(
             [FromBody] MastTargetSearchRequest request)
         {
@@ -111,6 +112,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// Search MAST by RA/Dec coordinates.
         /// </summary>
         [HttpPost("search/coordinates")]
+        [AllowAnonymous]
         public async Task<ActionResult<MastSearchResponse>> SearchByCoordinates(
             [FromBody] MastCoordinateSearchRequest request)
         {
@@ -135,6 +137,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// Search MAST by observation ID.
         /// </summary>
         [HttpPost("search/observation")]
+        [AllowAnonymous]
         public async Task<ActionResult<MastSearchResponse>> SearchByObservationId(
             [FromBody] MastObservationSearchRequest request)
         {
@@ -159,6 +162,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// Search MAST by program/proposal ID.
         /// </summary>
         [HttpPost("search/program")]
+        [AllowAnonymous]
         public async Task<ActionResult<MastSearchResponse>> SearchByProgramId(
             [FromBody] MastProgramSearchRequest request)
         {
@@ -183,6 +187,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// Search MAST for recently released JWST observations ("What's New").
         /// </summary>
         [HttpPost("whats-new")]
+        [AllowAnonymous]
         public async Task<ActionResult<MastSearchResponse>> GetWhatsNew(
             [FromBody] MastRecentReleasesRequest request)
         {
@@ -207,6 +212,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// Get available data products for an observation.
         /// </summary>
         [HttpPost("products")]
+        [AllowAnonymous]
         public async Task<ActionResult<MastDataProductsResponse>> GetDataProducts(
             [FromBody] MastDataProductsRequest request)
         {


### PR DESCRIPTION
## Summary

- Add `[AllowAnonymous]` attribute to read-only MAST search endpoints to fix 401 Unauthorized errors for unauthenticated users
- Aligns with project API documentation: "Read operations (GET) allow anonymous access"

**Endpoints now allowing anonymous access:**
- `POST /api/mast/search/target` - Search by target name
- `POST /api/mast/search/coordinates` - Search by RA/Dec
- `POST /api/mast/search/observation` - Search by observation ID
- `POST /api/mast/search/program` - Search by program ID
- `POST /api/mast/whats-new` - Browse recent JWST releases
- `POST /api/mast/products` - Get data products for observation

**Write operations remain protected (require authentication):**
- Import, download, cancel, resume, refresh metadata endpoints

## Test plan

- [ ] Start Docker stack: `docker compose up -d`
- [ ] Open app at http://localhost:3000 (without logging in)
- [ ] Click "What's New" button - should load MAST results (no 401)
- [ ] Try MAST search by target name - should work without login
- [ ] Try to import an observation - should require login (401 expected)

🤖 Generated with [Claude Code](https://claude.ai/code)