### PR TITLE
docs: remove duplicated architecture and phase content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,24 +135,6 @@ pytest test_specific.py
 
 > **Visual Diagrams**: See [`docs/architecture.md`](docs/architecture.md) for Mermaid diagrams of system architecture, data flows, and component hierarchies.
 
-### Microservices Communication Flow
-
-```
-User Browser
-    ↓
-React Frontend (port 3000)
-    ↓ HTTP/REST
-.NET Backend API (port 5001/8080)
-    ↓ MongoDB.Driver          ↓ HTTP POST
-MongoDB (port 27017)    Python Processing Engine (port 8000)
-                              ↓                    ↓
-                        Scientific Libraries    MAST Portal
-                        (NumPy, Astropy, SciPy) (astroquery.mast)
-                                                   ↓
-                                            STScI Archive
-                                            (JWST Data)
-```
-
 ### Data Flow Architecture
 
 **Local Upload Flow:**
@@ -274,29 +256,9 @@ App.tsx (root)
 
 ### Current Phase: Phase 3 (Data Processing Engine)
 
-**Focus Areas**:
-- Implement actual scientific processing algorithms
-- Complete FITS file handling integration
-- Replace placeholder implementations in `processing-engine/main.py`
+**Focus**: Implement scientific processing algorithms, complete FITS handling, replace placeholder implementations.
 
-**Completed**:
-- ✅ Phase 1: Foundation & Architecture
-- ✅ Phase 2: Core Infrastructure (enhanced data models, advanced API endpoints)
-- ✅ MAST Portal Integration (search, download, import workflow)
-- ✅ Processing Level Tracking & Lineage Visualization
-- ✅ Chunked Downloads with HTTP Range headers (5MB chunks, 3 parallel files)
-- ✅ Resume Capability for interrupted downloads
-- ✅ Byte-level Progress Tracking (speed, ETA, per-file progress)
-- ✅ FITS File Type Detection (image vs table indicators)
-- ✅ FITS Viewer with graceful handling of non-image files
-
-**Remaining Phase 3 Work**:
-- [ ] Implement actual image processing algorithms
-- [ ] Implement spectral analysis tools
-- [ ] Processing job queue system
-- [ ] Table data viewer for non-image FITS files
-
-**See**: `docs/development-plan.md` for full 6-phase roadmap
+See [`docs/development-plan.md`](docs/development-plan.md) for full 6-phase roadmap, completed items, and remaining work.
 
 ### Verification Standards
 


### PR DESCRIPTION
## Summary
- Remove ASCII architecture diagram (17 lines) - `docs/architecture.md` has better Mermaid diagrams
- Condense phase status section (24 lines) - `docs/development-plan.md` has full details

Both sections already referenced their detailed docs but included redundant inline content.

## Changes
**CLAUDE.md**: -38 lines net
- ASCII diagram removed (already had reference to docs/architecture.md on same line)
- Phase status condensed to 3 lines with link

## Test plan
- [x] Verify docs/architecture.md link still present
- [x] Verify docs/development-plan.md link still present
- [x] Verify no unique content lost (all was duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)