### PR TITLE
fix: enable XML documentation for Swagger API descriptions

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -164,6 +164,8 @@ namespace JwstDataAnalysis.API.Controllers
         /// <param name="whitePoint">White point percentile (0.0 to 1.0).</param>
         /// <param name="asinhA">Asinh softening parameter (only used when stretch=asinh).</param>
         /// <param name="sliceIndex">For 3D data cubes, which slice to show (-1 = middle).</param>
+        /// <param name="format">Output format: png (default) or jpeg.</param>
+        /// <param name="quality">JPEG quality 1-100 (only applies when format=jpeg).</param>
         [HttpGet("{id:length(24)}/preview")]
         [AllowAnonymous]
         public async Task<IActionResult> GetPreview(

--- a/backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj
+++ b/backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <!-- Expose internal members to test project for unit testing -->

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -92,6 +92,14 @@ builder.Services.AddSwaggerGen(options =>
         Description = "API for analyzing James Webb Space Telescope data",
     });
 
+    // Include XML comments from the generated documentation file
+    var xmlFilename = $"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFilename);
+    if (File.Exists(xmlPath))
+    {
+        options.IncludeXmlComments(xmlPath);
+    }
+
     // Add JWT Authentication to Swagger
     options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {

--- a/backend/JwstDataAnalysis.API/Services/FileContentValidator.cs
+++ b/backend/JwstDataAnalysis.API/Services/FileContentValidator.cs
@@ -42,8 +42,7 @@ namespace JwstDataAnalysis.API.Services
         /// Validates that a file's content matches its declared extension.
         /// </summary>
         /// <param name="file">The uploaded file to validate.</param>
-        /// <param name="errorMessage">Error message if validation fails.</param>
-        /// <returns>True if valid, false otherwise.</returns>
+        /// <returns>Tuple with IsValid flag and ErrorMessage (null if valid).</returns>
         public static async Task<(bool IsValid, string? ErrorMessage)> ValidateFileContentAsync(IFormFile file)
         {
             var fileName = file.FileName.ToLowerInvariant();


### PR DESCRIPTION
## Summary
- Enable XML documentation generation in the .csproj file
- Configure SwaggerGen to read from the generated XML documentation file
- Fix a few XML doc warnings (missing param tags)

## Problem
After adding XML documentation comments to API endpoints in PR #139, the descriptions were not appearing in Swagger UI because:
1. XML documentation file generation was not enabled
2. Swagger was not configured to include XML comments

## Solution
- Added `<GenerateDocumentationFile>true</GenerateDocumentationFile>` to .csproj
- Added `<NoWarn>$(NoWarn);1591</NoWarn>` to suppress warnings about missing XML comments on non-public members
- Configured `options.IncludeXmlComments(xmlPath)` in SwaggerGen setup

## Test plan
- [x] Backend builds successfully (verified in pre-commit)
- [x] All 164 tests pass (verified in pre-commit)
- [ ] Restart backend and verify descriptions now appear in Swagger UI at http://localhost:5001/swagger

🤖 Generated with [Claude Code](https://claude.com/claude-code)