### PR TITLE
feat: add filter badge to dashboard cards for RGB composite selection

### DIFF
--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.css
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.css
@@ -816,6 +816,26 @@
   font-size: 10px;
 }
 
+/* Filter badge - purple/violet to contrast with blue (image) and amber (table) */
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;
+  white-space: nowrap;
+  background-color: #ede9fe;
+  color: #6d28d9;
+  border: 1px solid #c4b5fd;
+}
+
+.filter-badge.small {
+  padding: 1px 4px;
+  font-size: 10px;
+}
+
 .fits-type-label {
   background-color: #f3f4f6;
   color: #6b7280;

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -675,6 +675,14 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                                   >
                                     {fitsInfo.viewable ? '🖼️' : '📊'} {fitsInfo.label}
                                   </span>
+                                  {item.imageInfo?.filter && (
+                                    <span
+                                      className="filter-badge"
+                                      title={`Filter: ${item.imageInfo.filter}`}
+                                    >
+                                      {item.imageInfo.filter}
+                                    </span>
+                                  )}
                                   <span
                                     className={`status ${item.processingStatus}`}
                                     style={{ color: getStatusColor(item.processingStatus) }}
@@ -964,6 +972,14 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                                             >
                                               {fitsInfo.viewable ? '🖼️' : '📊'}
                                             </span>
+                                            {item.imageInfo?.filter && (
+                                              <span
+                                                className="filter-badge small"
+                                                title={`Filter: ${item.imageInfo.filter}`}
+                                              >
+                                                {item.imageInfo.filter}
+                                              </span>
+                                            )}
                                             <span
                                               className={`status ${item.processingStatus}`}
                                               style={{


### PR DESCRIPTION
## Summary

- Display JWST filter name (e.g., F1130W, F770W) as a purple badge in card headers
- Helps users quickly identify images from different filters when selecting 3 images for RGB composites
- Badge shown in both By Target view (full size) and Lineage view (compact size)
- Conditionally rendered only when filter data exists

## Test plan

- [ ] Start Docker: `cd docker && docker compose up -d --build frontend`
- [ ] Open frontend: http://localhost:3000
- [ ] Log in and navigate to dashboard with MAST-imported data
- [ ] Verify in **By Target** view:
  - [ ] Filter badge appears next to file type badge (e.g., "🖼️ CAL  F1130W")
  - [ ] Badge is purple/violet colored
  - [ ] Hover shows tooltip "Filter: F1130W"
  - [ ] Cards without filter show no badge (no errors)
- [ ] Verify in **Lineage** view:
  - [ ] Filter badge appears in compact file cards
  - [ ] Badge is smaller (`.small` variant)
  - [ ] Same purple styling
- [ ] Test RGB composite workflow:
  - [ ] Filter badges help identify different filters at a glance
  - [ ] Can easily pick 3 different filters for composite

🤖 Generated with [Claude Code](https://claude.ai/code)