### PR TITLE
fix: add 401 interceptor with automatic token refresh retry (Task #1)

### DIFF
--- a/frontend/jwst-frontend/src/services/authService.test.ts
+++ b/frontend/jwst-frontend/src/services/authService.test.ts
@@ -152,9 +152,13 @@ describe('authService', () => {
         refreshToken: 'old-refresh-token',
       });
 
-      expect(apiClient.post).toHaveBeenCalledWith('/api/auth/refresh', {
-        refreshToken: 'old-refresh-token',
-      });
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/auth/refresh',
+        {
+          refreshToken: 'old-refresh-token',
+        },
+        { skipAuthRetry: true }
+      );
       expect(result).toEqual(mockResponse);
     });
   });

--- a/frontend/jwst-frontend/src/services/authService.ts
+++ b/frontend/jwst-frontend/src/services/authService.ts
@@ -37,9 +37,11 @@ class AuthService {
   /**
    * Refresh the access token using a refresh token
    * Returns new tokens on success
+   *
+   * Note: Uses skipAuthRetry to prevent infinite loop if refresh itself returns 401
    */
   async refreshToken(request: RefreshTokenRequest): Promise<TokenResponse> {
-    return apiClient.post<TokenResponse>('/api/auth/refresh', request);
+    return apiClient.post<TokenResponse>('/api/auth/refresh', request, { skipAuthRetry: true });
   }
 
   /**

--- a/frontend/jwst-frontend/src/services/index.ts
+++ b/frontend/jwst-frontend/src/services/index.ts
@@ -5,7 +5,14 @@
  *   import { jwstDataService, mastService, authService, ApiError } from '../services';
  */
 
-export { apiClient, ApiClient, setTokenGetter, clearTokenGetter } from './apiClient';
+export {
+  apiClient,
+  ApiClient,
+  setTokenGetter,
+  clearTokenGetter,
+  setTokenRefresher,
+  clearTokenRefresher,
+} from './apiClient';
 export { ApiError } from './ApiError';
 export { jwstDataService } from './jwstDataService';
 export { mastService } from './mastService';


### PR DESCRIPTION
## Summary

- Adds automatic 401 handling to apiClient that detects expired tokens and refreshes them
- Uses a shared promise to prevent multiple simultaneous refresh calls when several requests fail at once
- Retries the original request once with the new access token
- Auth endpoints use `skipAuthRetry` option to prevent infinite retry loops

This fixes the issue where users are kicked to the login screen during long-running MAST imports when their access token expires.

## Test plan

- [ ] Start Docker: `cd docker && docker compose up -d --build`
- [ ] Log in to the app
- [ ] Start a MAST import for a target with multiple files
- [ ] Monitor network tab for 401 responses
- [ ] Verify 401 triggers automatic refresh (check for /api/auth/refresh call)
- [ ] Verify import completes successfully
- [ ] Verify not kicked to login during long import
- [ ] Test normal logout still works
- [ ] Test manual page refresh maintains session

## Files changed

- `frontend/jwst-frontend/src/services/apiClient.ts` - Added `setTokenRefresher`/`clearTokenRefresher` and `handleResponseWithRetry` method
- `frontend/jwst-frontend/src/services/authService.ts` - Added `skipAuthRetry` option for refresh endpoint
- `frontend/jwst-frontend/src/services/index.ts` - Exported new functions
- `frontend/jwst-frontend/src/context/AuthContext.tsx` - Registers token refresher on mount
- `frontend/jwst-frontend/src/context/AuthContext.test.tsx` - Updated tests for new functionality
- `frontend/jwst-frontend/src/services/authService.test.ts` - Updated test for skipAuthRetry option

🤖 Generated with [Claude Code](https://claude.com/claude-code)