### PR TITLE
feat: enable parallel multi-observation downloads in MAST bulk import

### DIFF
--- a/frontend/jwst-frontend/src/components/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/MastSearch.css
@@ -816,3 +816,176 @@
 .file-progress-list::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.3);
 }
+
+/* Bulk Import Modal Styles */
+.bulk-import-modal {
+  max-width: 600px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.bulk-overall-progress {
+  margin-bottom: 20px;
+}
+
+.bulk-progress-stats {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+  font-size: 0.85rem;
+}
+
+.bulk-stat {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-weight: 500;
+}
+
+.bulk-stat.completed {
+  background: rgba(40, 167, 69, 0.2);
+  color: #28a745;
+}
+
+.bulk-stat.failed {
+  background: rgba(220, 53, 69, 0.2);
+  color: #dc3545;
+}
+
+.bulk-stat.pending {
+  background: rgba(255, 255, 255, 0.1);
+  color: #aaa;
+}
+
+.bulk-jobs-list {
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+  max-height: 250px;
+  overflow-y: auto;
+  margin-bottom: 16px;
+}
+
+.bulk-jobs-header {
+  padding: 10px 14px;
+  font-size: 0.8rem;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  position: sticky;
+  top: 0;
+  background: rgba(15, 15, 35, 0.95);
+}
+
+.bulk-job-row {
+  display: flex;
+  align-items: center;
+  padding: 10px 14px;
+  gap: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.bulk-job-row:last-child {
+  border-bottom: none;
+}
+
+.bulk-job-row.complete {
+  background: rgba(40, 167, 69, 0.05);
+}
+
+.bulk-job-row.failed {
+  background: rgba(220, 53, 69, 0.05);
+}
+
+.bulk-job-row.active {
+  background: rgba(74, 144, 217, 0.05);
+}
+
+.bulk-job-obs-id {
+  flex: 0 0 180px;
+  font-size: 0.8rem;
+  color: #ccc;
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bulk-job-stage {
+  flex: 0 0 100px;
+  font-size: 0.75rem;
+  color: #888;
+  text-transform: capitalize;
+}
+
+.bulk-job-progress-bar {
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.bulk-job-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #4a90d9 0%, #357abd 100%);
+  border-radius: 3px;
+  transition: width 0.2s ease;
+  animation: progress-shimmer 2s infinite linear;
+}
+
+.bulk-job-status-icon {
+  flex: 0 0 24px;
+  text-align: center;
+  font-size: 1rem;
+}
+
+.bulk-job-status-icon.complete {
+  color: #28a745;
+}
+
+.bulk-job-status-icon.failed {
+  color: #dc3545;
+}
+
+.bulk-job-loading {
+  color: #888;
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+.bulk-pending-queue {
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 6px;
+  margin-bottom: 16px;
+}
+
+.bulk-pending-label {
+  color: #888;
+  font-size: 0.85rem;
+}
+
+/* Partial success progress bar style */
+.progress-bar-fill.partial {
+  background: linear-gradient(90deg, #ffc107 0%, #e0a800 100%);
+  animation: none;
+}
+
+/* Scrollbar for bulk jobs list */
+.bulk-jobs-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.bulk-jobs-list::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 3px;
+}
+
+.bulk-jobs-list::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+}
+
+.bulk-jobs-list::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
+}

--- a/frontend/jwst-frontend/src/types/MastTypes.ts
+++ b/frontend/jwst-frontend/src/types/MastTypes.ts
@@ -161,3 +161,21 @@ export interface MetadataRefreshResponse {
   updatedCount: number;
   message: string;
 }
+
+/**
+ * Status of a bulk import operation (multiple observations)
+ */
+export interface BulkImportStatus {
+  /** All jobs being tracked, keyed by observation ID */
+  jobs: Map<string, ImportJobStatus>;
+  /** Observation IDs still pending (not started) */
+  pendingObsIds: string[];
+  /** Total number of observations in this bulk import */
+  totalCount: number;
+  /** Number completed successfully */
+  completedCount: number;
+  /** Number failed */
+  failedCount: number;
+  /** Whether the bulk import is still active */
+  isActive: boolean;
+}


### PR DESCRIPTION
## Summary
- Enable parallel downloading of multiple MAST observations (up to 3 concurrent)
- Add dedicated bulk import progress modal with multi-job tracking
- Improve bulk import performance by ~3x compared to sequential downloads

## Changes
- **MastTypes.ts**: Add `BulkImportStatus` interface for tracking multiple concurrent imports
- **MastSearch.tsx**: 
  - Refactor `handleBulkImport` to use semaphore pattern for concurrency control
  - Add `processBulkImportSingle` function for individual observation processing in bulk context
  - Add bulk import progress modal with overall progress, active downloads list, and pending queue
  - Keep single-observation import path unchanged
- **MastSearch.css**: Add styles for bulk import modal and multi-job progress display

## Test plan
- [ ] TypeScript builds without errors
- [ ] ESLint passes
- [ ] Single observation import still works (click "Import" button on individual row)
- [ ] Bulk import of 2 observations runs in parallel (both start immediately)
- [ ] Bulk import of 5+ observations runs with max 3 concurrent (others queue)
- [ ] Progress modal shows all active downloads with individual progress
- [ ] Failed import doesn't block other observations
- [ ] Overall progress (X/Y complete) is accurate
- [ ] Modal can be closed after bulk import completion
- [ ] Selecting 1 observation and clicking "Import Selected" uses single-import flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)