### PR TITLE
feat: Improve bulk import progress UI with distinguishable rows

### DIFF
--- a/frontend/jwst-frontend/src/components/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/MastSearch.css
@@ -900,9 +900,18 @@
   background: rgba(74, 144, 217, 0.05);
 }
 
+/* Row number for identification */
+.bulk-job-index {
+  flex: 0 0 24px;
+  font-size: 0.85rem;
+  color: #4a90d9;
+  font-weight: 600;
+}
+
+/* Shorter obs-id to make room for more info */
 .bulk-job-obs-id {
-  flex: 0 0 180px;
-  font-size: 0.8rem;
+  flex: 0 0 120px;
+  font-size: 0.75rem;
   color: #ccc;
   font-family: monospace;
   overflow: hidden;
@@ -910,11 +919,29 @@
   white-space: nowrap;
 }
 
-.bulk-job-stage {
-  flex: 0 0 100px;
-  font-size: 0.75rem;
+/* Combined progress section */
+.bulk-job-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+
+/* Percentage number */
+.bulk-job-percent {
+  flex: 0 0 36px;
+  font-size: 0.8rem;
+  color: #4a90d9;
+  font-weight: 500;
+  text-align: right;
+}
+
+/* Download speed */
+.bulk-job-speed {
+  flex: 0 0 70px;
+  font-size: 0.7rem;
   color: #888;
-  text-transform: capitalize;
+  text-align: right;
 }
 
 .bulk-job-progress-bar {

--- a/frontend/jwst-frontend/src/components/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/MastSearch.tsx
@@ -1236,33 +1236,61 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {
             {/* Active Jobs List */}
             <div className="bulk-jobs-list">
               <div className="bulk-jobs-header">Active Downloads</div>
-              {Array.from(bulkImportStatus.jobs.entries()).map(([obsId, job]) => (
-                <div
-                  key={obsId}
-                  className={`bulk-job-row ${job.isComplete ? (job.error ? 'failed' : 'complete') : 'active'}`}
-                >
-                  <span className="bulk-job-obs-id" title={obsId}>
-                    {obsId.length > 25 ? `...${obsId.slice(-25)}` : obsId}
-                  </span>
-                  <span className="bulk-job-stage">{job.stage}</span>
-                  {!job.isComplete && job.downloadProgressPercent !== undefined && (
-                    <div className="bulk-job-progress-bar">
-                      <div
-                        className="bulk-job-progress-fill"
-                        style={{ width: `${job.downloadProgressPercent}%` }}
-                      />
-                    </div>
-                  )}
-                  {job.isComplete && !job.error && (
-                    <span className="bulk-job-status-icon complete">✓</span>
-                  )}
-                  {job.error && (
-                    <span className="bulk-job-status-icon failed" title={job.error}>
-                      ✗
+              {Array.from(bulkImportStatus.jobs.entries()).map(([obsId, job], index) => {
+                // Extract unique identifier from obs_id (last two segments for uniqueness)
+                const obsIdParts = obsId.split('_');
+                const uniquePart =
+                  obsIdParts.length > 2 ? obsIdParts.slice(-2).join('_') : obsId.slice(-15);
+
+                return (
+                  <div
+                    key={obsId}
+                    className={`bulk-job-row ${job.isComplete ? (job.error ? 'failed' : 'complete') : 'active'}`}
+                  >
+                    {/* Row number for quick identification */}
+                    <span className="bulk-job-index">{index + 1}.</span>
+
+                    {/* Shorter, unique identifier */}
+                    <span className="bulk-job-obs-id" title={obsId}>
+                      {uniquePart}
                     </span>
-                  )}
-                </div>
-              ))}
+
+                    {/* Progress section: bar + percentage */}
+                    {!job.isComplete && (
+                      <div className="bulk-job-progress">
+                        <div className="bulk-job-progress-bar">
+                          <div
+                            className="bulk-job-progress-fill"
+                            style={{ width: `${job.downloadProgressPercent ?? 0}%` }}
+                          />
+                        </div>
+                        <span className="bulk-job-percent">
+                          {(job.downloadProgressPercent ?? 0).toFixed(0)}%
+                        </span>
+                      </div>
+                    )}
+
+                    {/* Speed when downloading */}
+                    {!job.isComplete &&
+                      job.speedBytesPerSec !== undefined &&
+                      job.speedBytesPerSec > 0 && (
+                        <span className="bulk-job-speed">
+                          {formatBytes(job.speedBytesPerSec)}/s
+                        </span>
+                      )}
+
+                    {/* Status icons for complete/failed */}
+                    {job.isComplete && !job.error && (
+                      <span className="bulk-job-status-icon complete">✓</span>
+                    )}
+                    {job.error && (
+                      <span className="bulk-job-status-icon failed" title={job.error}>
+                        ✗
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
               {bulkImportStatus.jobs.size === 0 && bulkImportStatus.pendingObsIds.length > 0 && (
                 <div className="bulk-job-row pending">
                   <span className="bulk-job-loading">Starting imports...</span>


### PR DESCRIPTION
## Summary

- Add row numbers (1, 2, 3...) for quick identification of each download
- Extract unique observation ID suffix instead of truncating from start (e.g., `02101_nircam` instead of `...clear-f115w`)
- Show percentage as numeric value (e.g., "45%") next to progress bar
- Display download speed (MB/s) when available during active downloads
- Reorganize row layout for better visual distinction between jobs

**Before:**
```
| ...1_t017_nircam_clear... | Downloading | [====    ] |
| ...1_t017_nircam_clear... | Downloading | [======  ] |
```

**After:**
```
| 1. | 02101_nircam | [====    ] 32% | 2.4 MB/s |
| 2. | 02103_miri   | [======  ] 58% | 1.8 MB/s |
```

## Test plan

- [ ] TypeScript builds without errors
- [ ] ESLint passes (0 errors)
- [ ] Each job row shows unique row number
- [ ] Each job row shows unique observation identifier
- [ ] Percentage displayed as numeric value
- [ ] Download speed shown when available
- [ ] Complete/failed icons still work
- [ ] Tooltip on obs-id shows full ID

🤖 Generated with [Claude Code](https://claude.ai/code)