### PR TITLE
fix: prevent bulk import modal from closing when first job completes

### DIFF
--- a/frontend/jwst-frontend/src/components/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/MastSearch.tsx
@@ -601,14 +601,14 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {
                 return { ...prev, failedCount: prev.failedCount + 1 };
               });
             } else if (status.result) {
-              // Mark as complete
+              // Mark as complete (don't call onImportComplete here - wait for all jobs)
               setBulkImportStatus((prev) => {
                 if (!prev) return prev;
                 return { ...prev, completedCount: prev.completedCount + 1 };
               });
-              if (status.result.importedCount > 0) {
-                onImportComplete();
-              }
+              // Note: onImportComplete is called once after ALL bulk jobs complete
+              // in handleBulkImport, not here. Calling it here would trigger a data
+              // refresh that unmounts the modal before all jobs finish.
             }
             return;
           }
@@ -708,6 +708,10 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {
     // Mark bulk import complete
     setBulkImportStatus((prev) => (prev ? { ...prev, isActive: false } : null));
     setSelectedObs(new Set());
+
+    // Refresh data once after all bulk imports complete
+    // This is done here instead of per-job to avoid unmounting the modal mid-import
+    onImportComplete();
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {


### PR DESCRIPTION
## Summary
Fixes bulk import modal unexpectedly closing when the first of multiple jobs reaches 100% completion.

## Root Cause
When a single job completed, it called `onImportComplete()` which triggered `fetchData()` in App.tsx, setting `loading=true`. This caused App.tsx to render a loading spinner instead of the dashboard, **unmounting the entire MastSearch component** and losing all bulk import state.

## Fix
Move `onImportComplete()` call from per-job completion to after all bulk jobs complete. The data refresh now happens once when the entire bulk import finishes.

## Changes
- Removed `onImportComplete()` call from `processBulkImportSingle` (per-job)
- Added `onImportComplete()` call at end of `handleBulkImport` (after all jobs)

## Test plan
- [ ] Start bulk import with 3 observations
- [ ] Wait for first job to reach 100%
- [ ] Modal should stay open (not close)
- [ ] Wait for all jobs to complete
- [ ] Modal should show all results with Close button
- [ ] Data refreshes after clicking Close


🤖 Generated with [Claude Code](https://claude.com/claude-code)