### PR TITLE
feat: show 'Imported' status for already-downloaded observations in MAST search

### DIFF
--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   JwstDataModel,
   ProcessingLevelLabels,
@@ -46,6 +46,17 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
   const [isSyncingMast, setIsSyncingMast] = useState<boolean>(false);
   const [selectedForComposite, setSelectedForComposite] = useState<Set<string>>(new Set());
   const [showCompositeWizard, setShowCompositeWizard] = useState<boolean>(false);
+
+  // Extract unique observation IDs that have been imported (for MAST search display)
+  const importedObsIds = useMemo(() => {
+    const ids = new Set<string>();
+    data.forEach((item) => {
+      if (item.observationBaseId) {
+        ids.add(item.observationBaseId);
+      }
+    });
+    return ids;
+  }, [data]);
 
   const toggleGroupCollapse = (groupId: string) => {
     setCollapsedGroups((prev) => {
@@ -523,7 +534,9 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
         </div>
       </div>
 
-      {showMastSearch && <MastSearch onImportComplete={onDataUpdate} />}
+      {showMastSearch && (
+        <MastSearch onImportComplete={onDataUpdate} importedObsIds={importedObsIds} />
+      )}
 
       {showWhatsNew && <WhatsNewPanel onImportComplete={onDataUpdate} />}
 

--- a/frontend/jwst-frontend/src/components/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/MastSearch.css
@@ -329,6 +329,12 @@
   transform: none;
 }
 
+.import-btn.imported {
+  background: linear-gradient(135deg, #2d7a4f 0%, #1e5c3a 100%);
+  cursor: default;
+  font-size: 11px;
+}
+
 /* Checkbox styling */
 .results-table input[type='checkbox'] {
   width: 16px;

--- a/frontend/jwst-frontend/src/components/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/MastSearch.tsx
@@ -38,11 +38,13 @@ const formatEta = (seconds: number | undefined | null): string => {
 
 interface MastSearchProps {
   onImportComplete: () => void;
+  /** Set of observation IDs that have already been imported */
+  importedObsIds?: Set<string>;
 }
 
 const SEARCH_TIMEOUT_MS = 120000; // 2 minutes
 
-const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {
+const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete, importedObsIds }) => {
   const [searchType, setSearchType] = useState<MastSearchType>('target');
   const [targetName, setTargetName] = useState('');
   const [ra, setRa] = useState('');
@@ -957,13 +959,19 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete }) => {
                       <td className="col-exptime">{formatExposureTime(result.t_exptime)}</td>
                       <td className="col-date">{formatDate(result.t_min)}</td>
                       <td className="col-actions">
-                        <button
-                          onClick={() => result.obs_id && handleImport(result.obs_id)}
-                          disabled={importing === result.obs_id || !result.obs_id}
-                          className="import-btn"
-                        >
-                          {importing === result.obs_id ? 'Importing...' : 'Import'}
-                        </button>
+                        {result.obs_id && importedObsIds?.has(result.obs_id) ? (
+                          <button className="import-btn imported" disabled>
+                            Imported
+                          </button>
+                        ) : (
+                          <button
+                            onClick={() => result.obs_id && handleImport(result.obs_id)}
+                            disabled={importing === result.obs_id || !result.obs_id}
+                            className="import-btn"
+                          >
+                            {importing === result.obs_id ? 'Importing...' : 'Import'}
+                          </button>
+                        )}
                       </td>
                     </tr>
                   );


### PR DESCRIPTION
## Summary
Shows which observations have already been imported when browsing MAST search results, preventing accidental re-imports.

## Changes
- Add `importedObsIds` prop to MastSearch component
- Extract unique observation IDs from existing data using `useMemo` in JwstDataDashboard
- Display green "Imported" button instead of "Import" for already-imported observations

## Screenshot Description
When searching MAST, observations that have already been downloaded now show a green "Imported" button instead of the blue "Import" button. The button is disabled to prevent re-importing.

## Test plan
- [ ] Import an observation from MAST
- [ ] Search MAST again for the same target
- [ ] The imported observation should show green "Imported" button
- [ ] New observations should still show blue "Import" button
- [ ] Clicking "Imported" button should do nothing (disabled)


🤖 Generated with [Claude Code](https://claude.com/claude-code)