### PR TITLE
fix: Add input validation for numeric parameters (Tech Debt #57)

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
@@ -754,6 +754,154 @@ public class JwstDataControllerTests
         Assert.True(true, "FormatFileSize is private - tested through DeleteObservation endpoint");
     }
 
+    // ===== GetPreview Parameter Validation Tests =====
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.1)]
+    public async Task GetPreview_ReturnsBadRequest_WhenBlackPointOutOfRange(double blackPoint)
+    {
+        // Act
+        var result = await sut.GetPreview("507f1f77bcf86cd799439011", blackPoint: blackPoint);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.1)]
+    public async Task GetPreview_ReturnsBadRequest_WhenWhitePointOutOfRange(double whitePoint)
+    {
+        // Act
+        var result = await sut.GetPreview("507f1f77bcf86cd799439011", whitePoint: whitePoint);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Theory]
+    [InlineData(0.0001)]
+    [InlineData(1.1)]
+    public async Task GetPreview_ReturnsBadRequest_WhenAsinhAOutOfRange(double asinhA)
+    {
+        // Act
+        var result = await sut.GetPreview("507f1f77bcf86cd799439011", asinhA: asinhA);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetPreview_ReturnsBadRequest_WhenBlackPointNotLessThanWhitePoint()
+    {
+        // Act - blackPoint == whitePoint
+        var result = await sut.GetPreview("507f1f77bcf86cd799439011", blackPoint: 0.5, whitePoint: 0.5);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetPreview_ReturnsBadRequest_WhenStretchInvalid()
+    {
+        // Act
+        var result = await sut.GetPreview("507f1f77bcf86cd799439011", stretch: "invalid_stretch");
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetPreview_ReturnsBadRequest_WhenCmapInvalid()
+    {
+        // Act
+        var result = await sut.GetPreview("507f1f77bcf86cd799439011", cmap: "invalid_cmap");
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    // ===== GetHistogram Parameter Validation Tests =====
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10001)]
+    public async Task GetHistogram_ReturnsBadRequest_WhenBinsOutOfRange(int bins)
+    {
+        // Act
+        var result = await sut.GetHistogram("507f1f77bcf86cd799439011", bins: bins);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Theory]
+    [InlineData(0.0f)]
+    [InlineData(5.1f)]
+    public async Task GetHistogram_ReturnsBadRequest_WhenGammaOutOfRange(float gamma)
+    {
+        // Act
+        var result = await sut.GetHistogram("507f1f77bcf86cd799439011", gamma: gamma);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Theory]
+    [InlineData(-0.1f)]
+    [InlineData(1.1f)]
+    public async Task GetHistogram_ReturnsBadRequest_WhenBlackPointOutOfRange(float blackPoint)
+    {
+        // Act
+        var result = await sut.GetHistogram("507f1f77bcf86cd799439011", blackPoint: blackPoint);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Theory]
+    [InlineData(-0.1f)]
+    [InlineData(1.1f)]
+    public async Task GetHistogram_ReturnsBadRequest_WhenWhitePointOutOfRange(float whitePoint)
+    {
+        // Act
+        var result = await sut.GetHistogram("507f1f77bcf86cd799439011", whitePoint: whitePoint);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetHistogram_ReturnsBadRequest_WhenBlackPointNotLessThanWhitePoint()
+    {
+        // Act - blackPoint == whitePoint
+        var result = await sut.GetHistogram("507f1f77bcf86cd799439011", blackPoint: 0.5f, whitePoint: 0.5f);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetHistogram_ReturnsBadRequest_WhenStretchInvalid()
+    {
+        // Act
+        var result = await sut.GetHistogram("507f1f77bcf86cd799439011", stretch: "invalid_stretch");
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Theory]
+    [InlineData(0.0001f)]
+    [InlineData(1.1f)]
+    public async Task GetHistogram_ReturnsBadRequest_WhenAsinhAOutOfRange(float asinhA)
+    {
+        // Act
+        var result = await sut.GetHistogram("507f1f77bcf86cd799439011", asinhA: asinhA);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
     /// <summary>
     /// Sets up a mock HttpContext with the specified user claims.
     /// </summary>

--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -210,6 +210,38 @@ namespace JwstDataAnalysis.API.Controllers
                     return BadRequest("Format must be 'png' or 'jpeg'");
                 }
 
+                string[] validStretches = ["zscale", "asinh", "log", "sqrt", "power", "histeq", "linear"];
+                if (!validStretches.Contains(stretch))
+                {
+                    return BadRequest($"Invalid stretch '{stretch}'. Must be one of: {string.Join(", ", validStretches)}");
+                }
+
+                string[] validCmaps = ["grayscale", "gray", "inferno", "magma", "viridis", "plasma", "hot", "cool", "rainbow", "jet"];
+                if (!validCmaps.Contains(cmap))
+                {
+                    return BadRequest($"Invalid colormap '{cmap}'. Must be one of: {string.Join(", ", validCmaps)}");
+                }
+
+                if (blackPoint < 0.0 || blackPoint > 1.0)
+                {
+                    return BadRequest("Black point must be between 0.0 and 1.0");
+                }
+
+                if (whitePoint < 0.0 || whitePoint > 1.0)
+                {
+                    return BadRequest("White point must be between 0.0 and 1.0");
+                }
+
+                if (blackPoint >= whitePoint)
+                {
+                    return BadRequest("Black point must be less than white point");
+                }
+
+                if (asinhA < 0.001 || asinhA > 1.0)
+                {
+                    return BadRequest("Asinh softening parameter must be between 0.001 and 1.0");
+                }
+
                 var data = await mongoDBService.GetAsync(id);
                 if (data == null)
                 {
@@ -316,6 +348,43 @@ namespace JwstDataAnalysis.API.Controllers
         {
             try
             {
+                // Validate parameters
+                if (bins < 1 || bins > 10000)
+                {
+                    return BadRequest("Bins must be between 1 and 10000");
+                }
+
+                if (gamma < 0.1f || gamma > 5.0f)
+                {
+                    return BadRequest("Gamma must be between 0.1 and 5.0");
+                }
+
+                string[] validStretches = ["zscale", "asinh", "log", "sqrt", "power", "histeq", "linear"];
+                if (!validStretches.Contains(stretch))
+                {
+                    return BadRequest($"Invalid stretch '{stretch}'. Must be one of: {string.Join(", ", validStretches)}");
+                }
+
+                if (blackPoint < 0.0f || blackPoint > 1.0f)
+                {
+                    return BadRequest("Black point must be between 0.0 and 1.0");
+                }
+
+                if (whitePoint < 0.0f || whitePoint > 1.0f)
+                {
+                    return BadRequest("White point must be between 0.0 and 1.0");
+                }
+
+                if (blackPoint >= whitePoint)
+                {
+                    return BadRequest("Black point must be less than white point");
+                }
+
+                if (asinhA < 0.001f || asinhA > 1.0f)
+                {
+                    return BadRequest("Asinh softening parameter must be between 0.001 and 1.0");
+                }
+
                 var data = await mongoDBService.GetAsync(id);
                 if (data == null)
                 {

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -6,8 +6,8 @@ This document tracks tech debt items and their resolution status.
 
 | Status | Count |
 |--------|-------|
-| **Resolved** | 40 |
-| **Remaining** | 41 |
+| **Resolved** | 41 |
+| **Remaining** | 40 |
 
 > **Code Style Suppressions (2026-02-03)**: Added 11 tech debt items (#77-#87) for StyleCop/CodeAnalysis rule suppressions in `.editorconfig`. These are lower priority but tracked for future cleanup.
 
@@ -87,20 +87,14 @@ A comprehensive security audit identified the following vulnerabilities across a
 
 ---
 
-### 57. Missing Input Validation on Numeric Parameters
-**Priority**: HIGH
-**Location**: `processing-engine/main.py:249-257` and `backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs:85-96`
-**Category**: Input Validation / DoS
-
-**Issue**: Preview endpoint parameters lack range validation:
-- `width`, `height`: No maximum (could request 999999x999999 image)
-- `gamma`: No minimum (gamma=0 causes division by zero)
-- `blackPoint`, `whitePoint`: No bounds checking
-
-**Fix Approach**:
-1. Backend: Add `[Range]` attributes to parameters
-2. Python: Use FastAPI `Query()` with `ge`/`le` constraints
-3. Set reasonable limits: width/height 10-8000, gamma 0.1-5.0
+### ~~57. Missing Input Validation on Numeric Parameters~~ ✅ RESOLVED
+**Status**: Fixed
+**Fix**: Added comprehensive input validation to all 4 endpoint locations:
+- Backend `GetPreview`: stretch/cmap whitelist, blackPoint/whitePoint/asinhA range checks
+- Backend `GetHistogram`: bins (1-10000), gamma (0.1-5.0), stretch whitelist, blackPoint/whitePoint/asinhA range checks
+- Python `generate_preview`: stretch/cmap whitelist, black_point/white_point/asinh_a range; removed silent fallbacks
+- Python `get_histogram`: bins, gamma, stretch, black_point/white_point/asinh_a validation; removed silent fallbacks
+- Added 13 backend test methods and 26 Python test cases
 
 ---
 

--- a/processing-engine/requirements.txt
+++ b/processing-engine/requirements.txt
@@ -25,4 +25,5 @@ aiohttp==3.9.1
 aiofiles==25.1.0
 
 # Testing
-pytest==7.4.3 
+pytest==7.4.3
+httpx>=0.24.0,<0.28

--- a/processing-engine/tests/test_validation.py
+++ b/processing-engine/tests/test_validation.py
@@ -1,0 +1,137 @@
+"""Tests for input validation on preview and histogram endpoints."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+# A fake data_id — validation rejects before file path check, so no real FITS needed.
+DATA_ID = "test123"
+# A file_path that won't exist but validation fires first.
+BASE_PARAMS = {"file_path": "nonexistent.fits"}
+
+
+# ===== Preview Endpoint Validation =====
+
+
+class TestPreviewValidation:
+    """Tests for /preview/{data_id} parameter validation."""
+
+    def _url(self) -> str:
+        return f"/preview/{DATA_ID}"
+
+    def test_invalid_stretch_returns_400(self):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "stretch": "bogus"})
+        assert resp.status_code == 400
+        assert "stretch" in resp.json()["detail"].lower()
+
+    def test_invalid_cmap_returns_400(self):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "cmap": "bogus"})
+        assert resp.status_code == 400
+        assert "colormap" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
+    def test_black_point_out_of_range_returns_400(self, value):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "black_point": value})
+        assert resp.status_code == 400
+        assert "black point" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
+    def test_white_point_out_of_range_returns_400(self, value):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "white_point": value})
+        assert resp.status_code == 400
+        assert "white point" in resp.json()["detail"].lower()
+
+    def test_black_point_not_less_than_white_point_returns_400(self):
+        resp = client.get(
+            self._url(), params={**BASE_PARAMS, "black_point": 0.5, "white_point": 0.5}
+        )
+        assert resp.status_code == 400
+        assert "black point" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("value", [0.0001, 1.1])
+    def test_asinh_a_out_of_range_returns_400(self, value):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "asinh_a": value})
+        assert resp.status_code == 400
+        assert "asinh" in resp.json()["detail"].lower()
+
+    def test_valid_stretch_values_pass_validation(self):
+        """Valid stretch values should not return 400 for stretch validation."""
+        for stretch in ["zscale", "asinh", "log", "sqrt", "power", "histeq", "linear"]:
+            resp = client.get(self._url(), params={**BASE_PARAMS, "stretch": stretch})
+            # Should fail with 404 (file not found), not 400 (validation)
+            assert resp.status_code != 400 or "stretch" not in resp.json().get("detail", "").lower()
+
+    def test_valid_cmap_values_pass_validation(self):
+        """Valid cmap values should not return 400 for cmap validation."""
+        for cmap in [
+            "grayscale",
+            "gray",
+            "inferno",
+            "magma",
+            "viridis",
+            "plasma",
+            "hot",
+            "cool",
+            "rainbow",
+            "jet",
+        ]:
+            resp = client.get(self._url(), params={**BASE_PARAMS, "cmap": cmap})
+            assert (
+                resp.status_code != 400 or "colormap" not in resp.json().get("detail", "").lower()
+            )
+
+
+# ===== Histogram Endpoint Validation =====
+
+
+class TestHistogramValidation:
+    """Tests for /histogram/{data_id} parameter validation."""
+
+    def _url(self) -> str:
+        return f"/histogram/{DATA_ID}"
+
+    @pytest.mark.parametrize("value", [0, 10001, -1, 999999999])
+    def test_bins_out_of_range_returns_400(self, value):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "bins": value})
+        assert resp.status_code == 400
+        assert "bins" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("value", [0.0, 5.1, -1.0])
+    def test_gamma_out_of_range_returns_400(self, value):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "gamma": value})
+        assert resp.status_code == 400
+        assert "gamma" in resp.json()["detail"].lower()
+
+    def test_invalid_stretch_returns_400(self):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "stretch": "bogus"})
+        assert resp.status_code == 400
+        assert "stretch" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
+    def test_black_point_out_of_range_returns_400(self, value):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "black_point": value})
+        assert resp.status_code == 400
+        assert "black point" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
+    def test_white_point_out_of_range_returns_400(self, value):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "white_point": value})
+        assert resp.status_code == 400
+        assert "white point" in resp.json()["detail"].lower()
+
+    def test_black_point_not_less_than_white_point_returns_400(self):
+        resp = client.get(
+            self._url(), params={**BASE_PARAMS, "black_point": 0.5, "white_point": 0.5}
+        )
+        assert resp.status_code == 400
+        assert "black point" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("value", [0.0001, 1.1])
+    def test_asinh_a_out_of_range_returns_400(self, value):
+        resp = client.get(self._url(), params={**BASE_PARAMS, "asinh_a": value})
+        assert resp.status_code == 400
+        assert "asinh" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- Adds comprehensive input validation for `blackPoint`, `whitePoint`, `asinhA`, `bins`, `stretch`, and `cmap` parameters across all 4 endpoint locations
- Prevents DoS attacks (e.g., `bins=999999999` causing memory exhaustion) and unhandled exceptions from invalid stretch/cmap names
- Replaces silent fallback behavior with explicit HTTP 400 errors for invalid parameters
- Adds `httpx` test dependency for FastAPI TestClient support

## Changes
| Location | What was added |
|----------|---------------|
| Backend `GetPreview` | stretch/cmap whitelist, blackPoint/whitePoint (0-1), asinhA (0.001-1.0), blackPoint < whitePoint |
| Backend `GetHistogram` | bins (1-10000), gamma (0.1-5.0), stretch whitelist, blackPoint/whitePoint/asinhA range checks |
| Python `generate_preview` | stretch/cmap whitelist, black_point/white_point/asinh_a range; removed silent fallbacks |
| Python `get_histogram` | bins, gamma, stretch, black_point/white_point/asinh_a validation; removed silent fallback |
| Backend tests | 13 new test methods (Theory + Fact) for preview and histogram validation |
| Python tests | 26 new tests in `tests/test_validation.py` using FastAPI TestClient |

## Test plan
- [x] Backend build: 0 errors, 0 warnings
- [x] Backend tests: 185 passed (13 new validation tests)
- [x] Python lint: `ruff check .` all passed, `ruff format --check .` all formatted
- [x] Python tests: 26 passed in Docker (Python 3.12)
- [ ] Docker E2E: `curl localhost:5001/api/jwstdata/test/preview?blackPoint=5` → 400
- [ ] Docker E2E: `curl localhost:5001/api/jwstdata/test/histogram?bins=999999` → 400
- [ ] Docker E2E: `curl localhost:5001/api/jwstdata/test/preview?stretch=invalid` → 400

Resolves Tech Debt #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)