### PR TITLE
fix: validate dataId as MongoDB ObjectId before URL construction (Bug #60)

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -6,12 +6,49 @@ This document tracks known bugs and their resolution status.
 
 | Status | Count |
 |--------|-------|
-| **Open** | 0 |
-| **Resolved** | 0 |
+| **Open** | 2 |
+| **Resolved** | 1 |
 
 ## Open Bugs
 
-> No known open bugs at this time.
+### 65. Information Disclosure in Error Messages
+**Priority**: Medium
+**Location**: `backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs:140-142, 238-240`
+
+**Issue**: Error messages expose internal processing engine responses and file paths to clients.
+
+**Reproduction Steps**:
+1. Trigger a processing engine error (e.g., invalid FITS file)
+2. Observe the HTTP response includes internal error details and file paths
+
+**Expected Behavior**: Return generic error messages to clients. Log detailed errors server-side only.
+
+**Fix Approach**:
+1. Log detailed errors server-side
+2. Return generic error messages to clients
+3. Use correlation IDs for debugging
+
+---
+
+### 66. Race Condition in Download Resume
+**Priority**: Medium
+**Location**: `processing-engine/app/mast/routes.py:422-439`
+
+**Issue**: No check for duplicate resume requests - two clients could resume the same download job simultaneously, corrupting state.
+
+**Reproduction Steps**:
+1. Start a MAST download that gets interrupted
+2. Send two concurrent resume requests for the same job ID
+3. Both proceed without conflict detection
+
+**Expected Behavior**: Second resume request should return 409 Conflict while first is in progress.
+
+**Fix Approach**:
+1. Track in-progress resumes in a set with async lock
+2. Return 409 Conflict if job already being resumed
+3. Clean up tracking on completion/failure
+
+---
 
 <!-- Template for new bugs
 ### [Bug ID]. [Brief Description]
@@ -31,3 +68,4 @@ This document tracks known bugs and their resolution status.
 
 | Bug ID | Description | PR |
 |--------|-------------|----|
+| 60 | Unsafe URL Construction in Frontend | #TBD |

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -7,7 +7,7 @@ This document tracks tech debt items and their resolution status.
 | Status | Count |
 |--------|-------|
 | **Resolved** | 41 |
-| **Remaining** | 40 |
+| **Remaining** | 37 |
 
 > **Code Style Suppressions (2026-02-03)**: Added 11 tech debt items (#77-#87) for StyleCop/CodeAnalysis rule suppressions in `.editorconfig`. These are lower priority but tracked for future cleanup.
 
@@ -192,22 +192,7 @@ USER appuser
 
 ---
 
-### 60. Unsafe URL Construction in Frontend
-**Priority**: HIGH
-**Location**: `frontend/jwst-frontend/src/components/ImageViewer.tsx:597`
-**Category**: Open Redirect
-
-**Issue**: Direct URL concatenation without validation:
-```typescript
-window.open(`${API_BASE_URL}/api/jwstdata/${dataId}/file`, '_blank')
-```
-
-**Attack Vector**: Malicious `dataId` containing URL could redirect users.
-
-**Fix Approach**:
-1. Validate `dataId` format (alphanumeric/UUID only)
-2. Use URL constructor to properly build and validate URLs
-3. Whitelist allowed domains
+### ~~60. Unsafe URL Construction in Frontend~~ -> Moved to `docs/bugs.md`
 
 ---
 
@@ -268,31 +253,11 @@ window.open(`${API_BASE_URL}/api/jwstdata/${dataId}/file`, '_blank')
 
 ---
 
-### 65. Information Disclosure in Error Messages
-**Priority**: MEDIUM
-**Location**: `backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs:140-142, 238-240`
-**Category**: Error Handling
-
-**Issue**: Error messages expose internal processing engine responses and file paths.
-
-**Fix Approach**:
-1. Log detailed errors server-side
-2. Return generic error messages to clients
-3. Use correlation IDs for debugging
+### ~~65. Information Disclosure in Error Messages~~ -> Moved to `docs/bugs.md`
 
 ---
 
-### 66. Race Condition in Download Resume
-**Priority**: MEDIUM
-**Location**: `processing-engine/app/mast/routes.py:422-439`
-**Category**: Concurrency
-
-**Issue**: No check for duplicate resume requests - two clients could resume same job simultaneously.
-
-**Fix Approach**:
-1. Track in-progress resumes in a set with async lock
-2. Return 409 Conflict if job already being resumed
-3. Clean up tracking on completion/failure
+### ~~66. Race Condition in Download Resume~~ -> Moved to `docs/bugs.md`
 
 ---
 

--- a/frontend/jwst-frontend/src/components/ImageViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageViewer.tsx
@@ -22,6 +22,7 @@ import {
   formatPixelValue,
 } from '../utils/coordinateUtils';
 import { getDefaultPlaybackSpeed } from '../utils/cubeUtils';
+import { isValidObjectId } from '../utils/validationUtils';
 
 interface ImageViewerProps {
   dataId: string;
@@ -692,7 +693,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ dataId, title, onClose, isOpe
   const filter = (metadata?.mast_filters as string) || '';
   const obsTitle = (metadata?.mast_obs_title as string) || '';
 
-  if (!isOpen) return null;
+  if (!isOpen || !isValidObjectId(dataId)) return null;
 
   return (
     <div className="image-viewer-overlay" onClick={onClose}>

--- a/frontend/jwst-frontend/src/services/jwstDataService.ts
+++ b/frontend/jwst-frontend/src/services/jwstDataService.ts
@@ -19,6 +19,7 @@ import {
   PixelDataResponse,
   CubeInfoResponse,
 } from '../types/JwstDataTypes';
+import { isValidObjectId } from '../utils/validationUtils';
 
 export interface ProcessingResponse {
   status: string;
@@ -78,6 +79,9 @@ export async function process(
   algorithm: string,
   parameters: Record<string, unknown> = {}
 ): Promise<ProcessingResponse> {
+  if (!isValidObjectId(dataId)) {
+    throw new Error(`Invalid data ID: ${dataId}`);
+  }
   return apiClient.post<ProcessingResponse>(`/api/jwstdata/${dataId}/process`, {
     algorithm,
     parameters,
@@ -89,6 +93,9 @@ export async function process(
  * @param dataId - ID of the data record to archive
  */
 export async function archive(dataId: string): Promise<void> {
+  if (!isValidObjectId(dataId)) {
+    throw new Error(`Invalid data ID: ${dataId}`);
+  }
   return apiClient.post<void>(`/api/jwstdata/${dataId}/archive`);
 }
 
@@ -97,6 +104,9 @@ export async function archive(dataId: string): Promise<void> {
  * @param dataId - ID of the data record to unarchive
  */
 export async function unarchive(dataId: string): Promise<void> {
+  if (!isValidObjectId(dataId)) {
+    throw new Error(`Invalid data ID: ${dataId}`);
+  }
   return apiClient.post<void>(`/api/jwstdata/${dataId}/unarchive`);
 }
 
@@ -184,6 +194,9 @@ export async function getPixelData(
   maxSize: number = 1200,
   sliceIndex: number = -1
 ): Promise<PixelDataResponse> {
+  if (!isValidObjectId(dataId)) {
+    throw new Error(`Invalid data ID: ${dataId}`);
+  }
   return apiClient.get<PixelDataResponse>(
     `/api/jwstdata/${dataId}/pixeldata?maxSize=${maxSize}&sliceIndex=${sliceIndex}`
   );
@@ -195,6 +208,9 @@ export async function getPixelData(
  * @returns Cube info including slice count, WCS info, and axis labels
  */
 export async function getCubeInfo(dataId: string): Promise<CubeInfoResponse> {
+  if (!isValidObjectId(dataId)) {
+    throw new Error(`Invalid data ID: ${dataId}`);
+  }
   return apiClient.get<CubeInfoResponse>(`/api/jwstdata/${dataId}/cubeinfo`);
 }
 

--- a/frontend/jwst-frontend/src/utils/validationUtils.ts
+++ b/frontend/jwst-frontend/src/utils/validationUtils.ts
@@ -1,0 +1,5 @@
+const OBJECT_ID_REGEX = /^[a-f\d]{24}$/i;
+
+export function isValidObjectId(id: string): boolean {
+  return OBJECT_ID_REGEX.test(id);
+}


### PR DESCRIPTION
## Summary
- Add `isValidObjectId()` utility that validates 24-char hex MongoDB ObjectId format
- Guard `ImageViewer` component — returns null if `dataId` is invalid, preventing all URL constructions (`window.open`, `<img src>`, `fetch`)
- Guard `jwstDataService` functions (`process`, `archive`, `unarchive`, `getPixelData`, `getCubeInfo`) — throw on invalid `dataId`
- Move Bug #60 from open to resolved in `docs/bugs.md` and update `docs/tech-debt.md`

## Test plan
- [ ] `npm run lint` passes with no new errors
- [ ] `npm run build` succeeds
- [ ] Pre-commit hooks pass (ESLint, Prettier, unit tests)
- [ ] Docker: `docker compose up -d --build` — app starts normally
- [ ] Open a FITS image in viewer — renders correctly (valid ObjectId works)
- [ ] No console errors during normal usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)