### PR TITLE
feat: WCS mosaic engine with reproject library (B2.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ pre-commit run --all-files
 **Processing Engine Resource Limits** (DoS protection):
 - `MAX_FITS_FILE_SIZE_MB`: Maximum FITS file size in MB (default: 2048 = 2GB)
 - `MAX_FITS_ARRAY_ELEMENTS`: Maximum array elements before loading (default: 100000000 = 100M pixels)
+- `MAX_MOSAIC_OUTPUT_PIXELS`: Maximum mosaic output grid size in pixels (default: 64000000 = 64M pixels)
 - Files/arrays exceeding limits return HTTP 413 Payload Too Large
 
 **Before Production**:
@@ -569,6 +570,9 @@ When features are added or changed, update these files:
 - `processing-engine/app/mast/download_tracker.py` - Byte-level progress tracking
 - `processing-engine/app/composite/routes.py` - RGB composite FastAPI routes
 - `processing-engine/app/composite/models.py` - Composite Pydantic models
+- `processing-engine/app/mosaic/routes.py` - WCS mosaic FastAPI routes
+- `processing-engine/app/mosaic/models.py` - Mosaic Pydantic models
+- `processing-engine/app/mosaic/mosaic_engine.py` - Core WCS reprojection logic (reproject library)
 - `processing-engine/app/processing/analysis.py` - Analysis algorithms (in progress)
 - `processing-engine/app/processing/utils.py` - FITS utilities (in progress)
 
@@ -638,6 +642,7 @@ When features are added or changed, update these files:
 - **Lineage**: `GET /jwstdata/lineage` - Groups by observation
 - **Data Management**: `/datamanagement/search`, `/statistics`, `/export`, `/bulk/tags`, `/bulk/status`
 - **Composite**: `POST /composite/generate` - RGB from 3 FITS files
+- **Mosaic**: `POST /mosaic/generate` - WCS-aware mosaic from 2+ FITS files, `POST /mosaic/footprint` - WCS footprint polygons
 - **MAST Search**: `/mast/search/target`, `/coordinates`, `/observation`, `/program`
 - **MAST Import**: `/mast/import`, `/import-progress/{jobId}`, `/import/resume/{jobId}`, `/refresh-metadata`
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - PYTHONPATH=/app
       - MAST_DOWNLOAD_DIR=${MAST_DOWNLOAD_DIR:-/app/data/mast}
       - MAST_DOWNLOAD_TIMEOUT=${MAST_DOWNLOAD_TIMEOUT:-3600}
+      - MAX_MOSAIC_OUTPUT_PIXELS=${MAX_MOSAIC_OUTPUT_PIXELS:-64000000}
     volumes:
       - ../data:/app/data
     depends_on:

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -209,7 +209,7 @@ Complete React frontend application with advanced FITS visualization capabilitie
   - [x] Export options popover UI
   - [x] Input validation (backend + processing engine)
   - [x] E2E tests for export workflow
-- [ ] A5: 3D data cube navigator for wavelength/time slices
+- [x] A5: 3D data cube navigator for wavelength/time slices
 
 #### **Color & Composite (B-series):**
 
@@ -217,12 +217,12 @@ Complete React frontend application with advanced FITS visualization capabilitie
 
 | Task | Description | Blocked By | Status |
 |------|-------------|------------|--------|
-| B1.1 | Composite generation backend (processing engine + API endpoint) | — | [ ] |
-| B1.2 | Reusable Wizard/Stepper UI component | — | [ ] |
-| B1.3 | Observation selection step (card grid with thumbnails) | B1.2 | [ ] |
-| B1.4 | Channel assignment step with auto-suggest (wavelength sorting) | B1.3 | [ ] |
-| B1.5 | Preview and export step (generate composite, download PNG/JPEG) | B1.1, B1.4 | [ ] |
-| B1.6 | Per-channel adjustment controls (enhancement - stretch/levels per channel) | B1.5 | [ ] |
+| B1.1 | Composite generation backend (processing engine + API endpoint) | — | [x] |
+| B1.2 | Reusable Wizard/Stepper UI component | — | [x] |
+| B1.3 | Observation selection step (card grid with thumbnails) | B1.2 | [x] |
+| B1.4 | Channel assignment step with auto-suggest (wavelength sorting) | B1.3 | [x] |
+| B1.5 | Preview and export step (generate composite, download PNG/JPEG) | B1.1, B1.4 | [x] |
+| B1.6 | Per-channel adjustment controls (enhancement - stretch/levels per channel) | B1.5 | [x] |
 
 **Architecture Decision**: Wizard flow chosen over simple modal for better UX, guided experience, and reusability of stepper component for future multi-step workflows (batch export, guided import, etc.)
 
@@ -230,9 +230,9 @@ Complete React frontend application with advanced FITS visualization capabilitie
 
 | Task | Description | Blocked By | Status |
 |------|-------------|------------|--------|
-| B2.1 | Add `reproject` dependency and mosaic engine (processing engine) | — | [ ] |
+| B2.1 | Add `reproject` dependency and mosaic engine (processing engine) | — | [x] |
 | B2.2 | Mosaic API endpoints (MosaicController, MosaicService) | B2.1 | [ ] |
-| B2.3 | Footprint preview endpoint (show combined coverage before generation) | B2.1 | [ ] |
+| B2.3 | Footprint preview endpoint (show combined coverage before generation) | B2.1 | [x] |
 | B2.4 | MosaicDialog component with multi-file selection | B2.2 | [ ] |
 | B2.5 | Footprint preview visualization in dialog | B2.3, B2.4 | [ ] |
 | B2.6 | Mosaic result display and export | B2.4 | [ ] |

--- a/processing-engine/app/mosaic/__init__.py
+++ b/processing-engine/app/mosaic/__init__.py
@@ -1,0 +1,4 @@
+from .routes import router
+
+
+__all__ = ["router"]

--- a/processing-engine/app/mosaic/models.py
+++ b/processing-engine/app/mosaic/models.py
@@ -1,0 +1,83 @@
+"""
+Pydantic models for WCS mosaic image generation.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class MosaicFileConfig(BaseModel):
+    """Configuration for a single input file in the mosaic."""
+
+    file_path: str = Field(..., description="Path to FITS file (relative to data directory)")
+    stretch: str = Field(
+        default="asinh",
+        description="Stretch method: zscale, asinh, log, sqrt, power, histeq, linear",
+    )
+    black_point: float = Field(
+        default=0.0, ge=0.0, le=1.0, description="Black point percentile (0.0-1.0)"
+    )
+    white_point: float = Field(
+        default=1.0, ge=0.0, le=1.0, description="White point percentile (0.0-1.0)"
+    )
+    gamma: float = Field(default=1.0, gt=0.0, le=5.0, description="Gamma correction (0.1-5.0)")
+    asinh_a: float = Field(default=0.1, ge=0.001, le=1.0, description="Asinh softening parameter")
+
+
+class MosaicRequest(BaseModel):
+    """Request to generate a WCS-aware mosaic image from multiple FITS files."""
+
+    files: list[MosaicFileConfig] = Field(..., min_length=2, description="Input files (minimum 2)")
+    output_format: Literal["png", "jpeg"] = Field(default="png", description="Output image format")
+    quality: int = Field(default=95, ge=1, le=100, description="JPEG quality (1-100)")
+    width: int | None = Field(
+        default=None, gt=0, le=8000, description="Output image width (None = native resolution)"
+    )
+    height: int | None = Field(
+        default=None, gt=0, le=8000, description="Output image height (None = native resolution)"
+    )
+    combine_method: Literal["mean", "sum", "first", "last", "min", "max"] = Field(
+        default="mean", description="Method for combining overlapping pixels"
+    )
+    cmap: str = Field(default="inferno", description="Colormap for single-channel output")
+
+
+class MosaicResponse(BaseModel):
+    """Response metadata for mosaic generation."""
+
+    success: bool
+    message: str
+    width: int
+    height: int
+    format: str
+    n_files: int
+    combine_method: str
+
+
+class FootprintRequest(BaseModel):
+    """Request to compute WCS footprints for FITS files."""
+
+    file_paths: list[str] = Field(
+        ..., min_length=1, description="Paths to FITS files (relative to data directory)"
+    )
+
+
+class FootprintEntry(BaseModel):
+    """WCS footprint for a single file."""
+
+    file_path: str
+    corners_ra: list[float] = Field(description="RA coordinates of image corners (degrees)")
+    corners_dec: list[float] = Field(description="Dec coordinates of image corners (degrees)")
+    center_ra: float = Field(description="Center RA (degrees)")
+    center_dec: float = Field(description="Center Dec (degrees)")
+
+
+class FootprintResponse(BaseModel):
+    """Response with WCS footprints for all input files."""
+
+    footprints: list[FootprintEntry]
+    bounding_box: dict[str, float] = Field(
+        description="Bounding box: min_ra, max_ra, min_dec, max_dec"
+    )
+    n_files: int

--- a/processing-engine/app/mosaic/mosaic_engine.py
+++ b/processing-engine/app/mosaic/mosaic_engine.py
@@ -1,0 +1,189 @@
+"""
+Core WCS mosaic engine using the reproject library.
+
+Reprojects multiple FITS files onto a common WCS grid and combines them.
+"""
+
+import logging
+from pathlib import Path
+
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+from reproject import reproject_interp
+from reproject.mosaicking import find_optimal_celestial_wcs, reproject_and_coadd
+
+
+logger = logging.getLogger(__name__)
+
+
+def load_fits_2d_with_wcs(file_path: Path) -> tuple[np.ndarray, WCS]:
+    """
+    Load 2D image data and celestial WCS from a FITS file.
+
+    Handles 3D+ cubes by extracting the middle slice.
+    Replaces NaN/Inf with 0.0.
+
+    Args:
+        file_path: Path to the FITS file
+
+    Returns:
+        Tuple of (2D numpy array, WCS object)
+
+    Raises:
+        ValueError: If no image data or no celestial WCS found
+    """
+    with fits.open(file_path) as hdul:
+        data = None
+        header = None
+
+        for hdu in hdul:
+            if hdu.data is not None and len(hdu.data.shape) >= 2:
+                data = hdu.data.astype(np.float64)
+                header = hdu.header
+                break
+
+        if data is None:
+            raise ValueError(f"No image data found in FITS file: {file_path.name}")
+
+        # Handle 3D+ data cubes - take middle slice
+        while len(data.shape) > 2:
+            mid_idx = data.shape[0] // 2
+            data = data[mid_idx]
+
+        # Handle NaN/Inf values
+        data = np.nan_to_num(data, nan=0.0, posinf=0.0, neginf=0.0)
+
+        # Extract celestial WCS
+        wcs = WCS(header, naxis=2)
+        if not wcs.has_celestial:
+            raise ValueError(f"No celestial WCS found in FITS file: {file_path.name}")
+
+        # Ensure WCS shape matches data
+        wcs_celestial = wcs.celestial
+        return data, wcs_celestial
+
+
+def generate_mosaic(
+    file_data: list[tuple[np.ndarray, WCS]],
+    combine_method: str = "mean",
+    max_output_pixels: int = 64_000_000,
+) -> tuple[np.ndarray, np.ndarray, WCS]:
+    """
+    Reproject and combine multiple images onto a common WCS grid.
+
+    Args:
+        file_data: List of (data, wcs) tuples from load_fits_2d_with_wcs
+        combine_method: How to combine overlapping pixels ('mean', 'median', 'sum')
+        max_output_pixels: Maximum output grid size in pixels
+
+    Returns:
+        Tuple of (mosaic_array, footprint_array, output_wcs)
+
+    Raises:
+        ValueError: If reprojection fails or output is too large
+    """
+    # Build input list for reproject_and_coadd
+    input_data = [(data, wcs) for data, wcs in file_data]
+
+    # Find optimal output WCS covering all inputs
+    try:
+        wcs_out, shape_out = find_optimal_celestial_wcs(input_data)
+    except Exception as e:
+        raise ValueError(f"Could not determine common WCS for input files: {e}") from e
+
+    # Check output size limit
+    total_pixels = shape_out[0] * shape_out[1]
+    if total_pixels > max_output_pixels:
+        raise ValueError(
+            f"Output mosaic would be {total_pixels:,} pixels "
+            f"(max {max_output_pixels:,}). "
+            f"Shape: {shape_out[1]}x{shape_out[0]}"
+        )
+
+    logger.info(
+        f"Mosaic output grid: {shape_out[1]}x{shape_out[0]} "
+        f"({total_pixels:,} pixels), combine={combine_method}"
+    )
+
+    # Validate combine_method
+    valid_methods = {"mean", "sum", "first", "last", "min", "max"}
+    combine_func = combine_method if combine_method in valid_methods else "mean"
+
+    # Reproject and combine
+    try:
+        mosaic_array, footprint_array = reproject_and_coadd(
+            input_data,
+            wcs_out,
+            shape_out=shape_out,
+            reproject_function=reproject_interp,
+            combine_function=combine_func,
+        )
+    except Exception as e:
+        raise ValueError(f"Mosaic reprojection failed: {e}") from e
+
+    # Replace any remaining NaN with 0
+    mosaic_array = np.nan_to_num(mosaic_array, nan=0.0, posinf=0.0, neginf=0.0)
+
+    return mosaic_array, footprint_array, wcs_out
+
+
+def get_footprints(
+    file_data: list[tuple[np.ndarray, WCS, str]],
+) -> tuple[list[dict], dict]:
+    """
+    Compute corner RA/Dec coordinates for each file's WCS footprint.
+
+    Args:
+        file_data: List of (data, wcs, file_path) tuples
+
+    Returns:
+        Tuple of (footprint_list, bounding_box)
+        footprint_list: List of dicts with corners_ra, corners_dec, center_ra, center_dec
+        bounding_box: Dict with min_ra, max_ra, min_dec, max_dec
+    """
+    footprints = []
+    all_ra = []
+    all_dec = []
+
+    for data, wcs, file_path in file_data:
+        height, width = data.shape
+
+        # Corner pixel coordinates (0-indexed)
+        corners_x = [0, width - 1, width - 1, 0]
+        corners_y = [0, 0, height - 1, height - 1]
+
+        # Convert pixel to world coordinates
+        corners_ra_list = []
+        corners_dec_list = []
+        for cx, cy in zip(corners_x, corners_y, strict=True):
+            world = wcs.pixel_to_world_values(cx, cy)
+            corners_ra_list.append(float(world[0]))
+            corners_dec_list.append(float(world[1]))
+
+        # Center pixel
+        center_world = wcs.pixel_to_world_values(width / 2, height / 2)
+        center_ra = float(center_world[0])
+        center_dec = float(center_world[1])
+
+        footprints.append(
+            {
+                "file_path": file_path,
+                "corners_ra": corners_ra_list,
+                "corners_dec": corners_dec_list,
+                "center_ra": center_ra,
+                "center_dec": center_dec,
+            }
+        )
+
+        all_ra.extend(corners_ra_list)
+        all_dec.extend(corners_dec_list)
+
+    bounding_box = {
+        "min_ra": min(all_ra),
+        "max_ra": max(all_ra),
+        "min_dec": min(all_dec),
+        "max_dec": max(all_dec),
+    }
+
+    return footprints, bounding_box

--- a/processing-engine/app/mosaic/routes.py
+++ b/processing-engine/app/mosaic/routes.py
@@ -1,0 +1,336 @@
+"""
+FastAPI routes for WCS-aware mosaic image generation.
+"""
+
+import io
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+from PIL import Image
+
+from app.processing.enhancement import (
+    asinh_stretch,
+    histogram_equalization,
+    log_stretch,
+    normalize_to_range,
+    power_stretch,
+    sqrt_stretch,
+    zscale_stretch,
+)
+
+from .models import (
+    FootprintRequest,
+    FootprintResponse,
+    MosaicFileConfig,
+    MosaicRequest,
+)
+from .mosaic_engine import generate_mosaic, get_footprints, load_fits_2d_with_wcs
+
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/mosaic", tags=["Mosaic"])
+
+# Security: Define allowed data directory for file access
+ALLOWED_DATA_DIR = Path(os.environ.get("DATA_DIR", "/app/data")).resolve()
+
+# Resource limits
+MAX_FITS_FILE_SIZE_BYTES = int(os.environ.get("MAX_FITS_FILE_SIZE_MB", "2048")) * 1024 * 1024
+MAX_MOSAIC_OUTPUT_PIXELS = int(
+    os.environ.get("MAX_MOSAIC_OUTPUT_PIXELS", "64000000")
+)  # Default 64M pixels
+
+# Valid colormaps
+VALID_CMAPS = {
+    "grayscale",
+    "gray",
+    "inferno",
+    "magma",
+    "viridis",
+    "plasma",
+    "hot",
+    "cool",
+    "rainbow",
+    "jet",
+}
+
+
+def validate_file_path(file_path: str) -> Path:
+    """
+    Validate that a file path is within the allowed data directory.
+    Prevents path traversal attacks.
+
+    Args:
+        file_path: The file path to validate (can be relative or absolute)
+
+    Returns:
+        Resolved Path object if valid
+
+    Raises:
+        HTTPException: 403 if path is outside allowed directory, 404 if file doesn't exist
+    """
+    try:
+        requested_path = (ALLOWED_DATA_DIR / file_path).resolve()
+
+        if not requested_path.is_relative_to(ALLOWED_DATA_DIR):
+            logger.warning(f"Path traversal attempt blocked: {file_path}")
+            raise HTTPException(
+                status_code=403, detail="Access denied: path outside allowed directory"
+            )
+
+        if not requested_path.exists():
+            raise HTTPException(status_code=404, detail=f"File not found: {requested_path.name}")
+
+        if not requested_path.is_file():
+            raise HTTPException(status_code=400, detail="Path is not a file")
+
+        return requested_path
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Path validation error: {e}")
+        raise HTTPException(status_code=400, detail="Invalid file path") from e
+
+
+def validate_fits_file_size(file_path: Path) -> None:
+    """
+    Validate that a FITS file doesn't exceed the maximum allowed size.
+
+    Args:
+        file_path: Validated Path object to check
+
+    Raises:
+        HTTPException: 413 if file exceeds maximum size
+    """
+    file_size = file_path.stat().st_size
+    if file_size > MAX_FITS_FILE_SIZE_BYTES:
+        max_mb = MAX_FITS_FILE_SIZE_BYTES / (1024 * 1024)
+        file_mb = file_size / (1024 * 1024)
+        logger.warning(f"FITS file too large: {file_mb:.1f}MB (max {max_mb:.1f}MB)")
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large: {file_mb:.1f}MB exceeds maximum {max_mb:.1f}MB",
+        )
+
+
+def apply_stretch(data: np.ndarray, config: MosaicFileConfig) -> np.ndarray:
+    """
+    Apply stretch and level adjustments to image data.
+
+    Args:
+        data: 2D numpy array of image data
+        config: File configuration with stretch settings
+
+    Returns:
+        Stretched data in range [0, 1]
+    """
+    stretch = config.stretch.lower()
+
+    try:
+        if stretch == "zscale":
+            stretched, _, _ = zscale_stretch(data)
+        elif stretch == "asinh":
+            stretched = asinh_stretch(data, a=config.asinh_a)
+        elif stretch == "log":
+            stretched = log_stretch(data)
+        elif stretch == "sqrt":
+            stretched = sqrt_stretch(data)
+        elif stretch == "power":
+            stretched = power_stretch(data, power=1.0 / config.gamma if config.gamma != 0 else 1.0)
+        elif stretch == "histeq":
+            stretched = histogram_equalization(data)
+        elif stretch == "linear":
+            stretched = normalize_to_range(data)
+        else:
+            logger.warning(f"Unknown stretch '{stretch}', falling back to zscale")
+            stretched, _, _ = zscale_stretch(data)
+    except Exception as e:
+        logger.warning(f"Stretch {stretch} failed: {e}, falling back to zscale")
+        stretched, _, _ = zscale_stretch(data)
+
+    # Apply black/white point clipping
+    if config.black_point > 0.0 or config.white_point < 1.0:
+        bp_value = np.percentile(stretched, config.black_point * 100)
+        wp_value = np.percentile(stretched, config.white_point * 100)
+        if wp_value > bp_value:
+            stretched = np.clip((stretched - bp_value) / (wp_value - bp_value), 0, 1)
+        else:
+            stretched = np.clip(stretched, 0, 1)
+
+    # Apply gamma correction (skip for power stretch which already uses gamma)
+    if stretch != "power" and config.gamma != 1.0:
+        stretched = np.power(np.clip(stretched, 0, 1), 1.0 / config.gamma)
+
+    return np.clip(stretched, 0, 1)
+
+
+@router.post("/generate")
+async def generate_mosaic_image(request: MosaicRequest):
+    """
+    Generate a WCS-aware mosaic image from 2+ FITS files.
+
+    Files are reprojected onto a common WCS grid and combined using the
+    specified method (mean/median/sum). The stretch from the first file's
+    config is applied to the combined mosaic.
+
+    Returns:
+        Binary image data (PNG or JPEG) with appropriate content type
+    """
+    try:
+        logger.info(f"Generating mosaic from {len(request.files)} files")
+
+        # Validate colormap
+        cmap = request.cmap
+        if cmap not in VALID_CMAPS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid colormap '{cmap}'. Must be one of: {', '.join(sorted(VALID_CMAPS))}",
+            )
+
+        # Validate and load all files
+        file_data = []
+        for file_config in request.files:
+            validated_path = validate_file_path(file_config.file_path)
+            validate_fits_file_size(validated_path)
+
+            try:
+                data, wcs = load_fits_2d_with_wcs(validated_path)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+
+            file_data.append((data, wcs))
+            logger.info(f"Loaded: {validated_path.name}, shape={data.shape}")
+
+        # Generate mosaic
+        try:
+            mosaic_array, footprint_array, wcs_out = generate_mosaic(
+                file_data,
+                combine_method=request.combine_method,
+                max_output_pixels=MAX_MOSAIC_OUTPUT_PIXELS,
+            )
+        except ValueError as e:
+            error_msg = str(e)
+            if "Could not determine common WCS" in error_msg:
+                raise HTTPException(status_code=400, detail=error_msg) from e
+            if "pixels" in error_msg and "max" in error_msg:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"Mosaic output too large: exceeds MAX_MOSAIC_OUTPUT_PIXELS ({MAX_MOSAIC_OUTPUT_PIXELS:,})",
+                ) from e
+            raise HTTPException(status_code=500, detail=f"Mosaic reprojection failed: {e}") from e
+
+        logger.info(f"Mosaic generated: shape={mosaic_array.shape}")
+
+        # Apply stretch from first file's config to the combined mosaic
+        stretched = apply_stretch(mosaic_array, request.files[0])
+
+        # Mask no-coverage areas as black using footprint
+        stretched[footprint_array == 0] = 0.0
+
+        # Flip vertically for correct astronomical orientation (origin='lower')
+        stretched = np.flipud(stretched)
+
+        # Apply colormap
+        if cmap == "grayscale":
+            cmap = "gray"
+
+        import matplotlib.pyplot as plt
+
+        colormap = plt.get_cmap(cmap)
+        rgb_array = colormap(stretched)[:, :, :3]  # Drop alpha channel
+
+        # Mask no-coverage areas as black (colormap may have mapped 0 to non-black)
+        footprint_flipped = np.flipud(footprint_array)
+        for c in range(3):
+            rgb_array[:, :, c][footprint_flipped == 0] = 0.0
+
+        # Convert to 8-bit
+        rgb_8bit = (rgb_array * 255).astype(np.uint8)
+
+        # Create PIL Image
+        image = Image.fromarray(rgb_8bit, mode="RGB")
+
+        # Resize if requested
+        if request.width is not None and request.height is not None:
+            image = image.resize((request.width, request.height), Image.Resampling.LANCZOS)
+        elif request.width is not None:
+            ratio = request.width / image.width
+            new_height = int(image.height * ratio)
+            image = image.resize((request.width, new_height), Image.Resampling.LANCZOS)
+        elif request.height is not None:
+            ratio = request.height / image.height
+            new_width = int(image.width * ratio)
+            image = image.resize((new_width, request.height), Image.Resampling.LANCZOS)
+
+        # Save to buffer
+        buf = io.BytesIO()
+        if request.output_format == "jpeg":
+            image.save(buf, format="JPEG", quality=request.quality)
+            media_type = "image/jpeg"
+        else:
+            image.save(buf, format="PNG", optimize=True)
+            media_type = "image/png"
+
+        buf.seek(0)
+
+        logger.info(
+            f"Mosaic output: {image.width}x{image.height} {request.output_format}, "
+            f"{len(request.files)} files, combine={request.combine_method}, "
+            f"size: {buf.getbuffer().nbytes} bytes"
+        )
+
+        return Response(content=buf.getvalue(), media_type=media_type)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error generating mosaic: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Mosaic generation failed: {str(e)}") from e
+
+
+@router.post("/footprint", response_model=FootprintResponse)
+async def get_mosaic_footprint(request: FootprintRequest):
+    """
+    Get WCS footprint polygons (RA/Dec corners) for FITS files.
+
+    Used for previewing coverage area before generating a mosaic.
+
+    Returns:
+        JSON with footprints (corner coordinates), bounding box, and file count
+    """
+    try:
+        logger.info(f"Computing footprints for {len(request.file_paths)} files")
+
+        # Validate and load all files
+        file_data = []
+        for file_path in request.file_paths:
+            validated_path = validate_file_path(file_path)
+            validate_fits_file_size(validated_path)
+
+            try:
+                data, wcs = load_fits_2d_with_wcs(validated_path)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+
+            file_data.append((data, wcs, file_path))
+
+        # Compute footprints
+        footprint_list, bounding_box = get_footprints(file_data)
+
+        return FootprintResponse(
+            footprints=footprint_list,
+            bounding_box=bounding_box,
+            n_files=len(file_data),
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error computing footprints: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"Footprint computation failed: {str(e)}"
+        ) from e

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from app.composite.routes import router as composite_router
 from app.mast.routes import router as mast_router
+from app.mosaic.routes import router as mosaic_router
 from app.processing.enhancement import (
     asinh_stretch,
     histogram_equalization,
@@ -139,6 +140,9 @@ app.include_router(mast_router)
 
 # Include Composite routes
 app.include_router(composite_router)
+
+# Include Mosaic routes
+app.include_router(mosaic_router)
 
 
 @app.on_event("startup")

--- a/processing-engine/requirements.txt
+++ b/processing-engine/requirements.txt
@@ -13,6 +13,7 @@ pandas==2.2.3
 astropy==6.1.7
 astroquery==0.4.11
 photutils>=1.10.0
+reproject>=0.13.0
 
 # Image processing
 scikit-image>=0.22.0

--- a/processing-engine/tests/test_mosaic_engine.py
+++ b/processing-engine/tests/test_mosaic_engine.py
@@ -1,0 +1,421 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Unit tests for the WCS mosaic engine module.
+
+Tests cover FITS loading with WCS, mosaic generation, footprint computation,
+and API route validation.
+"""
+
+import io
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from app.mosaic.mosaic_engine import (
+    generate_mosaic,
+    get_footprints,
+    load_fits_2d_with_wcs,
+)
+
+
+def _make_fits_with_wcs(
+    data: np.ndarray,
+    crval1: float = 180.0,
+    crval2: float = 45.0,
+    cdelt: float = -0.001,
+    tmp_dir: str | None = None,
+) -> Path:
+    """Helper to create a FITS file with a valid celestial WCS."""
+    header = fits.Header()
+    header["NAXIS"] = 2
+    header["NAXIS1"] = data.shape[1]
+    header["NAXIS2"] = data.shape[0]
+    header["CTYPE1"] = "RA---TAN"
+    header["CTYPE2"] = "DEC--TAN"
+    header["CRPIX1"] = data.shape[1] / 2.0
+    header["CRPIX2"] = data.shape[0] / 2.0
+    header["CRVAL1"] = crval1
+    header["CRVAL2"] = crval2
+    header["CDELT1"] = cdelt
+    header["CDELT2"] = abs(cdelt)
+
+    hdu = fits.PrimaryHDU(data=data, header=header)
+    with tempfile.NamedTemporaryFile(suffix=".fits", dir=tmp_dir, delete=False) as fd:
+        hdu.writeto(fd.name, overwrite=True)
+        return Path(fd.name)
+
+
+def _make_fits_no_wcs(data: np.ndarray, tmp_dir: str | None = None) -> Path:
+    """Helper to create a FITS file without WCS."""
+    hdu = fits.PrimaryHDU(data=data)
+    with tempfile.NamedTemporaryFile(suffix=".fits", dir=tmp_dir, delete=False) as fd:
+        hdu.writeto(fd.name, overwrite=True)
+        return Path(fd.name)
+
+
+class TestLoadFits2dWithWcs:
+    """Tests for load_fits_2d_with_wcs."""
+
+    def test_load_2d_with_valid_wcs(self, tmp_path):
+        data = np.random.default_rng(42).random((100, 100))
+        path = _make_fits_with_wcs(data, tmp_dir=str(tmp_path))
+
+        loaded_data, wcs = load_fits_2d_with_wcs(path)
+
+        assert loaded_data.shape == (100, 100)
+        assert wcs.has_celestial
+        np.testing.assert_allclose(loaded_data, data, atol=1e-10)
+
+    def test_load_3d_cube_extracts_middle_slice(self, tmp_path):
+        cube = np.random.default_rng(42).random((10, 50, 50))
+        header = fits.Header()
+        header["NAXIS"] = 3
+        header["NAXIS1"] = 50
+        header["NAXIS2"] = 50
+        header["NAXIS3"] = 10
+        header["CTYPE1"] = "RA---TAN"
+        header["CTYPE2"] = "DEC--TAN"
+        header["CRPIX1"] = 25.0
+        header["CRPIX2"] = 25.0
+        header["CRVAL1"] = 180.0
+        header["CRVAL2"] = 45.0
+        header["CDELT1"] = -0.001
+        header["CDELT2"] = 0.001
+
+        hdu = fits.PrimaryHDU(data=cube, header=header)
+        path = tmp_path / "cube.fits"
+        hdu.writeto(str(path), overwrite=True)
+
+        loaded_data, wcs = load_fits_2d_with_wcs(path)
+
+        assert loaded_data.shape == (50, 50)
+        # Middle slice is index 5
+        np.testing.assert_allclose(
+            loaded_data,
+            np.nan_to_num(cube[5], nan=0.0, posinf=0.0, neginf=0.0),
+            atol=1e-10,
+        )
+
+    def test_load_handles_nan_and_inf(self, tmp_path):
+        data = np.array([[1.0, np.nan], [np.inf, -np.inf]])
+        path = _make_fits_with_wcs(data, tmp_dir=str(tmp_path))
+
+        loaded_data, _ = load_fits_2d_with_wcs(path)
+
+        assert not np.any(np.isnan(loaded_data))
+        assert not np.any(np.isinf(loaded_data))
+        assert loaded_data[0, 0] == 1.0
+        assert loaded_data[0, 1] == 0.0  # NaN -> 0
+
+    def test_load_no_image_data_raises(self, tmp_path):
+        # Create FITS with only a table, no image data
+        hdu = fits.PrimaryHDU()  # Empty primary HDU
+        path = tmp_path / "empty.fits"
+        hdu.writeto(str(path), overwrite=True)
+
+        with pytest.raises(ValueError, match="No image data found"):
+            load_fits_2d_with_wcs(path)
+
+    def test_load_no_wcs_raises(self, tmp_path):
+        data = np.random.default_rng(42).random((50, 50))
+        path = _make_fits_no_wcs(data, tmp_dir=str(tmp_path))
+
+        with pytest.raises(ValueError, match="No celestial WCS found"):
+            load_fits_2d_with_wcs(path)
+
+
+class TestGenerateMosaic:
+    """Tests for generate_mosaic."""
+
+    def _make_file_data(self, n=2, offset=0.05):
+        """Create test file data with slightly offset WCS."""
+        file_data = []
+        for i in range(n):
+            data = np.random.default_rng(42 + i).random((50, 50)) * 100
+            wcs = WCS(naxis=2)
+            wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+            wcs.wcs.crpix = [25.0, 25.0]
+            wcs.wcs.crval = [180.0 + i * offset, 45.0]
+            wcs.wcs.cdelt = [-0.001, 0.001]
+            file_data.append((data, wcs))
+        return file_data
+
+    def test_mosaic_two_files_mean(self):
+        file_data = self._make_file_data(n=2)
+        mosaic, footprint, wcs_out = generate_mosaic(file_data, combine_method="mean")
+
+        assert mosaic.ndim == 2
+        assert footprint.ndim == 2
+        assert mosaic.shape == footprint.shape
+        assert wcs_out.has_celestial
+        # Mosaic should be wider than individual files due to offset
+        assert mosaic.shape[1] >= 50
+
+    def test_mosaic_combine_methods(self):
+        file_data = self._make_file_data(n=2)
+        for method in ("mean", "sum", "first", "last", "min", "max"):
+            mosaic, _, _ = generate_mosaic(file_data, combine_method=method)
+            assert mosaic.ndim == 2
+
+    def test_mosaic_output_pixel_limit(self):
+        file_data = self._make_file_data(n=2, offset=0.0)
+        with pytest.raises(ValueError, match="pixels"):
+            generate_mosaic(file_data, max_output_pixels=10)
+
+    def test_mosaic_no_nan_in_output(self):
+        file_data = self._make_file_data(n=2)
+        mosaic, _, _ = generate_mosaic(file_data)
+        assert not np.any(np.isnan(mosaic))
+
+
+class TestGetFootprints:
+    """Tests for get_footprints."""
+
+    def test_footprints_basic(self):
+        data = np.zeros((50, 50))
+        wcs = WCS(naxis=2)
+        wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+        wcs.wcs.crpix = [25.0, 25.0]
+        wcs.wcs.crval = [180.0, 45.0]
+        wcs.wcs.cdelt = [-0.001, 0.001]
+
+        file_data = [(data, wcs, "test.fits")]
+        footprints, bbox = get_footprints(file_data)
+
+        assert len(footprints) == 1
+        fp = footprints[0]
+        assert fp["file_path"] == "test.fits"
+        assert len(fp["corners_ra"]) == 4
+        assert len(fp["corners_dec"]) == 4
+        assert "center_ra" in fp
+        assert "center_dec" in fp
+
+        assert "min_ra" in bbox
+        assert "max_ra" in bbox
+        assert "min_dec" in bbox
+        assert "max_dec" in bbox
+
+    def test_footprints_multiple_files(self):
+        file_data = []
+        for i in range(3):
+            data = np.zeros((50, 50))
+            wcs = WCS(naxis=2)
+            wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+            wcs.wcs.crpix = [25.0, 25.0]
+            wcs.wcs.crval = [180.0 + i * 0.1, 45.0]
+            wcs.wcs.cdelt = [-0.001, 0.001]
+            file_data.append((data, wcs, f"file_{i}.fits"))
+
+        footprints, bbox = get_footprints(file_data)
+
+        assert len(footprints) == 3
+        # Bounding box should span all three files
+        assert bbox["max_ra"] > bbox["min_ra"]
+
+    def test_footprint_center_near_crval(self):
+        data = np.zeros((100, 100))
+        wcs = WCS(naxis=2)
+        wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+        wcs.wcs.crpix = [50.0, 50.0]
+        wcs.wcs.crval = [200.0, 30.0]
+        wcs.wcs.cdelt = [-0.001, 0.001]
+
+        footprints, _ = get_footprints([(data, wcs, "test.fits")])
+        fp = footprints[0]
+
+        # Center should be close to CRVAL
+        assert abs(fp["center_ra"] - 200.0) < 0.01
+        assert abs(fp["center_dec"] - 30.0) < 0.01
+
+
+class TestMosaicRoutes:
+    """Tests for mosaic API routes."""
+
+    @pytest.fixture
+    def client(self):
+        from main import app
+
+        return TestClient(app)
+
+    def test_generate_requires_at_least_2_files(self, client):
+        response = client.post(
+            "/mosaic/generate",
+            json={
+                "files": [{"file_path": "test.fits"}],
+            },
+        )
+        assert response.status_code == 422  # Pydantic validation error
+
+    def test_generate_invalid_colormap(self, client):
+        response = client.post(
+            "/mosaic/generate",
+            json={
+                "files": [
+                    {"file_path": "test1.fits"},
+                    {"file_path": "test2.fits"},
+                ],
+                "cmap": "nonexistent_colormap",
+            },
+        )
+        assert response.status_code == 400
+        assert "colormap" in response.json()["detail"].lower()
+
+    def test_footprint_empty_paths(self, client):
+        response = client.post(
+            "/mosaic/footprint",
+            json={"file_paths": []},
+        )
+        assert response.status_code == 422  # Pydantic validation error
+
+    @patch("app.mosaic.routes.ALLOWED_DATA_DIR", Path("/app/data").resolve())
+    def test_path_traversal_blocked(self, client):
+        response = client.post(
+            "/mosaic/generate",
+            json={
+                "files": [
+                    {"file_path": "../../etc/passwd"},
+                    {"file_path": "test2.fits"},
+                ],
+            },
+        )
+        assert response.status_code in (403, 404)
+
+    def test_generate_file_not_found(self, client, tmp_path):
+        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+            response = client.post(
+                "/mosaic/generate",
+                json={
+                    "files": [
+                        {"file_path": "nonexistent1.fits"},
+                        {"file_path": "nonexistent2.fits"},
+                    ],
+                },
+            )
+            assert response.status_code == 404
+
+    def test_generate_success(self, client, tmp_path):
+        """End-to-end test: generate mosaic from two FITS files with WCS."""
+        data1 = np.random.default_rng(42).random((50, 50)).astype(np.float64) * 100
+        data2 = np.random.default_rng(43).random((50, 50)).astype(np.float64) * 100
+
+        path1 = _make_fits_with_wcs(data1, crval1=180.0, tmp_dir=str(tmp_path))
+        path2 = _make_fits_with_wcs(data2, crval1=180.05, tmp_dir=str(tmp_path))
+
+        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+            response = client.post(
+                "/mosaic/generate",
+                json={
+                    "files": [
+                        {"file_path": path1.name},
+                        {"file_path": path2.name},
+                    ],
+                    "output_format": "png",
+                    "cmap": "inferno",
+                    "combine_method": "mean",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+        # Verify it's a valid PNG
+        img = Image.open(io.BytesIO(response.content))
+        assert img.width > 0
+        assert img.height > 0
+
+    def test_generate_jpeg(self, client, tmp_path):
+        """Test JPEG output format."""
+        data1 = np.random.default_rng(42).random((50, 50)).astype(np.float64) * 100
+        data2 = np.random.default_rng(43).random((50, 50)).astype(np.float64) * 100
+
+        path1 = _make_fits_with_wcs(data1, crval1=180.0, tmp_dir=str(tmp_path))
+        path2 = _make_fits_with_wcs(data2, crval1=180.05, tmp_dir=str(tmp_path))
+
+        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+            response = client.post(
+                "/mosaic/generate",
+                json={
+                    "files": [
+                        {"file_path": path1.name},
+                        {"file_path": path2.name},
+                    ],
+                    "output_format": "jpeg",
+                    "quality": 80,
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/jpeg"
+
+    def test_footprint_success(self, client, tmp_path):
+        """End-to-end test: compute footprints for FITS files with WCS."""
+        data = np.random.default_rng(42).random((50, 50)).astype(np.float64)
+        path1 = _make_fits_with_wcs(data, crval1=180.0, tmp_dir=str(tmp_path))
+        path2 = _make_fits_with_wcs(data, crval1=180.05, tmp_dir=str(tmp_path))
+
+        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+            response = client.post(
+                "/mosaic/footprint",
+                json={"file_paths": [path1.name, path2.name]},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["n_files"] == 2
+        assert len(body["footprints"]) == 2
+        assert "bounding_box" in body
+        assert "min_ra" in body["bounding_box"]
+
+    def test_generate_no_wcs_returns_400(self, client, tmp_path):
+        """Files without celestial WCS should return 400."""
+        data = np.random.default_rng(42).random((50, 50)).astype(np.float64)
+        path1 = _make_fits_no_wcs(data, tmp_dir=str(tmp_path))
+        path2 = _make_fits_no_wcs(data, tmp_dir=str(tmp_path))
+
+        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+            response = client.post(
+                "/mosaic/generate",
+                json={
+                    "files": [
+                        {"file_path": path1.name},
+                        {"file_path": path2.name},
+                    ],
+                },
+            )
+
+        assert response.status_code == 400
+        assert "WCS" in response.json()["detail"]
+
+    def test_generate_with_resize(self, client, tmp_path):
+        """Test mosaic with explicit width/height resize."""
+        data1 = np.random.default_rng(42).random((50, 50)).astype(np.float64) * 100
+        data2 = np.random.default_rng(43).random((50, 50)).astype(np.float64) * 100
+
+        path1 = _make_fits_with_wcs(data1, crval1=180.0, tmp_dir=str(tmp_path))
+        path2 = _make_fits_with_wcs(data2, crval1=180.05, tmp_dir=str(tmp_path))
+
+        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+            response = client.post(
+                "/mosaic/generate",
+                json={
+                    "files": [
+                        {"file_path": path1.name},
+                        {"file_path": path2.name},
+                    ],
+                    "width": 200,
+                    "height": 200,
+                },
+            )
+
+        assert response.status_code == 200
+        img = Image.open(io.BytesIO(response.content))
+        assert img.width == 200
+        assert img.height == 200


### PR DESCRIPTION
## Summary
- Add `processing-engine/app/mosaic/` module for WCS-aware mosaic generation from multiple FITS files
- Uses `reproject` library (`reproject_interp` + `reproject_and_coadd`) for celestial reprojection
- Two new endpoints: `POST /mosaic/generate` (combine 2+ files into mosaic image) and `POST /mosaic/footprint` (WCS footprint polygons for preview)
- Follows existing `app/composite/` pattern exactly (path validation, file size checks, stretch functions)
- New `MAX_MOSAIC_OUTPUT_PIXELS` env var (default 64M) caps output grid size

## Changes
| File | Change |
|------|--------|
| `processing-engine/app/mosaic/__init__.py` | Module init, export router |
| `processing-engine/app/mosaic/models.py` | Pydantic request/response models |
| `processing-engine/app/mosaic/mosaic_engine.py` | Core WCS reprojection logic |
| `processing-engine/app/mosaic/routes.py` | FastAPI endpoints with security |
| `processing-engine/requirements.txt` | Add `reproject>=0.13.0` |
| `processing-engine/main.py` | Register mosaic router |
| `docker/docker-compose.yml` | Add `MAX_MOSAIC_OUTPUT_PIXELS` env var |
| `processing-engine/tests/test_mosaic_engine.py` | 22 unit tests |
| `CLAUDE.md` | Document new endpoints and files |
| `docs/development-plan.md` | Mark B2.1 and B2.3 complete |

## Test plan
- [x] `ruff check . && ruff format --check .` — all pass
- [x] `pytest tests/test_mosaic_engine.py -v` — 22/22 pass
- [x] `pytest tests/ -v` — 109/109 pass (no regressions)
- [x] Docker build: `docker compose up -d --build processing-engine` — starts successfully
- [x] Path traversal returns 403
- [x] Missing WCS returns 400
- [x] Invalid colormap returns 400
- [x] File not found returns 404
- [x] < 2 files returns 422 (Pydantic validation)
- [x] PNG and JPEG output verified via PIL Image.open
- [x] Resize with explicit width/height verified
- [ ] E2E with real MAST FITS files (requires imported data with WCS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)