### PR TITLE
docs: Reorganize to 2-agent setup with isolated Docker stacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 # Data (ignore large downloaded mast files)
 data/mast/
 data/
+data-agent*/
 
 # Claude Code local settings
 .claude/
@@ -44,6 +45,7 @@ data/
 .env
 .env.local
 .env.*.local
+.env.agent*
 *.env
 
 # IDE

--- a/docker/docker-compose.agent.yml
+++ b/docker/docker-compose.agent.yml
@@ -1,0 +1,52 @@
+# Agent worktree Docker Compose overlay
+# Usage: docker compose -p jwst-agent1 -f docker-compose.yml -f docker-compose.agent.yml up -d
+#
+# Each agent worktree uses its own .env with unique ports and container names.
+# This overlay parameterizes ports and disables hardcoded container_name so
+# Docker Compose project isolation works correctly.
+
+services:
+  mongodb:
+    container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-mongodb
+    ports:
+      - "${MONGO_PORT:-27017}:27017"
+
+  backend:
+    container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-backend
+    ports:
+      - "${BACKEND_PORT:-5001}:8080"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - CORS_ALLOWED_ORIGINS=http://localhost:${FRONTEND_PORT:-3000},http://localhost:${VITE_DEV_PORT:-5173}
+    volumes:
+      - ${DATA_DIR:-../data}:/app/data
+
+  processing-engine:
+    container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-processing
+    ports:
+      - "${PROCESSING_PORT:-8000}:8000"
+    volumes:
+      - ${DATA_DIR:-../data}:/app/data
+
+  frontend:
+    build:
+      context: ../frontend/jwst-frontend
+      dockerfile: Dockerfile.dev
+    container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-frontend
+    restart: unless-stopped
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+    volumes:
+      - ../frontend/jwst-frontend:/app
+      - /app/node_modules
+    environment:
+      - VITE_API_URL=http://localhost:${BACKEND_PORT:-5001}
+    depends_on:
+      - backend
+    networks:
+      - jwst-network
+
+  docs:
+    container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-docs
+    ports:
+      - "${DOCS_PORT:-8001}:8000"

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -243,8 +243,8 @@ Complete React frontend application with advanced FITS visualization capabilitie
 
 #### **Image Analysis (C-series):**
 
-- [ ] C2: Image comparison/blink mode
-- [ ] C3: Region selection and statistics (mean, std, etc.)
+- [ ] C2: Region selection and statistics (mean, median, std, min, max, sum, pixel count)
+- [ ] C3: Image comparison/blink mode (toggle, side-by-side, opacity overlay)
 - [ ] C4: Color balance and curves adjustment
 
 *Note: C1 (Smoothing/Noise Reduction) moved to Phase 5 (requires backend algorithms)*


### PR DESCRIPTION
## Summary
- Consolidate from 3 agents to 2: **Agent 1** (Features), **Agent 2** (Tech Debt & Bug Fixes)
- Add `docker-compose.agent.yml` overlay so each agent runs its own isolated Docker stack on separate ports
- Reorder C-series image analysis tasks (region stats → blink mode → curves)
- Update current phase reference from Phase 3 to Phase 4

## Changes
- **CLAUDE.md**: Updated agent roles table, ownership rules, added Isolated Docker Stacks section, fixed current phase
- **docker/docker-compose.agent.yml**: New overlay that parameterizes ports and container names via env vars
- **.gitignore**: Added `.env.agent*` and `data-agent*/` patterns
- **docs/development-plan.md**: Reordered C-series tasks by priority

## Port Allocation
| Stack | Frontend | Backend | Processing | MongoDB |
|-------|----------|---------|------------|---------|
| Primary | :3000 | :5001 | :8000 | :27017 |
| Agent 1 | :3010 | :5011 | :8010 | :27027 |
| Agent 2 | :3020 | :5021 | :8020 | :27037 |

## Test plan
- [ ] Verify `docker compose -f docker-compose.yml -f docker-compose.agent.yml config` parses without errors
- [ ] Verify `.env.agent1` and `.env.agent2` are gitignored
- [ ] Review CLAUDE.md agent roles and Docker instructions for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)