### PR TITLE
fix: Bind all service ports to localhost only (Task #59)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -50,6 +50,14 @@ MAST_DOWNLOAD_DIR=/app/data/mast
 MAST_DOWNLOAD_TIMEOUT=3600
 
 # =============================================================================
+# Network Binding
+# =============================================================================
+# All service ports are bound to 127.0.0.1 (localhost only) by default.
+# This prevents services from being accessible from other machines on the
+# network. To expose services externally, modify the port bindings in
+# docker-compose.yml and docker-compose.override.yml.
+
+# =============================================================================
 # Production TLS/HTTPS Configuration
 # =============================================================================
 # For production deployment with HTTPS:

--- a/docker/docker-compose.agent.yml
+++ b/docker/docker-compose.agent.yml
@@ -9,12 +9,12 @@ services:
   mongodb:
     container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-mongodb
     ports:
-      - "${MONGO_PORT:-27017}:27017"
+      - "127.0.0.1:${MONGO_PORT:-27017}:27017"
 
   backend:
     container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-backend
     ports:
-      - "${BACKEND_PORT:-5001}:8080"
+      - "127.0.0.1:${BACKEND_PORT:-5001}:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - CORS_ALLOWED_ORIGINS=http://localhost:${FRONTEND_PORT:-3000},http://localhost:${VITE_DEV_PORT:-5173}
@@ -24,7 +24,7 @@ services:
   processing-engine:
     container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-processing
     ports:
-      - "${PROCESSING_PORT:-8000}:8000"
+      - "127.0.0.1:${PROCESSING_PORT:-8000}:8000"
     volumes:
       - ${DATA_DIR:-../data}:/app/data
 
@@ -35,7 +35,7 @@ services:
     container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-frontend
     restart: unless-stopped
     ports:
-      - "${FRONTEND_PORT:-3000}:3000"
+      - "127.0.0.1:${FRONTEND_PORT:-3000}:3000"
     volumes:
       - ../frontend/jwst-frontend:/app
       - /app/node_modules
@@ -49,4 +49,4 @@ services:
   docs:
     container_name: ${COMPOSE_CONTAINER_PREFIX:-jwst}-docs
     ports:
-      - "${DOCS_PORT:-8001}:8000"
+      - "127.0.0.1:${DOCS_PORT:-8001}:8000"

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -4,7 +4,7 @@
 services:
   mongodb:
     ports:
-      - "27017:27017"  # Expose MongoDB for local tools
+      - "127.0.0.1:27017:27017"  # Expose MongoDB for local tools (localhost only)
 
   backend:
     environment:
@@ -18,7 +18,7 @@ services:
     container_name: jwst-frontend
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - ../frontend/jwst-frontend:/app
       - /app/node_modules
@@ -31,4 +31,4 @@ services:
 
   processing-engine:
     ports:
-      - "8000:8000"  # Expose processing engine for debugging
+      - "127.0.0.1:8000:8000"  # Expose processing engine for debugging (localhost only)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     container_name: jwst-backend
     restart: unless-stopped
     ports:
-      - "5001:8080"
+      - "127.0.0.1:5001:8080"
     environment:
       - MongoDB__ConnectionString=mongodb://${MONGO_ROOT_USERNAME:-admin}:${MONGO_ROOT_PASSWORD:-changeme}@mongodb:27017
       - MongoDB__DatabaseName=${MONGO_DATABASE:-jwst_data_analysis}
@@ -57,7 +57,7 @@ services:
     container_name: jwst-docs
     restart: unless-stopped
     ports:
-      - "8001:8000"
+      - "127.0.0.1:8001:8000"
     volumes:
       - ../mkdocs.yml:/app/mkdocs.yml
       - ../docs:/app/docs

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -6,7 +6,7 @@ This document tracks tech debt items and their resolution status.
 
 | Status | Count |
 |--------|-------|
-| **Resolved** | 45 |
+| **Resolved** | 46 |
 | **Remaining** | 33 |
 
 > **Code Style Suppressions (2026-02-03)**: Added 11 tech debt items (#77-#87) for StyleCop/CodeAnalysis rule suppressions in `.editorconfig`. These are lower priority but tracked for future cleanup.
@@ -144,19 +144,11 @@ A comprehensive security audit identified the following vulnerabilities across a
 
 ---
 
-### 59. MongoDB Port Exposed to Host Network
+### ~~59. MongoDB Port Exposed to Host Network~~ ✅ RESOLVED
 **Priority**: HIGH
-**Location**: `docker/docker-compose.override.yml:6-7`
+**Location**: `docker/docker-compose.override.yml`, `docker/docker-compose.yml`, `docker/docker-compose.agent.yml`
 **Category**: Network Exposure
-
-**Issue**: Development override exposes MongoDB on port 27017 to the host machine.
-
-**Impact**: Anyone on the network can connect to MongoDB if auth fails or credentials are weak.
-
-**Fix Approach**:
-1. Remove port mapping from override (use Docker networking)
-2. If port needed, bind to localhost only: `127.0.0.1:27017:27017`
-3. Enable MongoDB TLS for any non-local scenarios
+**Resolution**: All service ports bound to `127.0.0.1` (localhost only) across base, dev override, and agent overlay compose files. Prevents network-accessible services.
 
 ---
 
@@ -1046,10 +1038,26 @@ The following StyleCop and CodeAnalysis rules are suppressed in `backend/.editor
 
 ---
 
+### 88. Incomplete Downloads Panel Should Be Collapsible
+**Priority**: LOW
+**Location**: `frontend/jwst-frontend/src/components/MastSearch.tsx:929-965`
+**Category**: UX
+
+**Issue**: The "Incomplete Downloads" panel in MAST Search is always expanded when there are resumable jobs. It should be collapsible and default to collapsed.
+
+**Fix Approach**:
+1. Add `resumableCollapsed` state (default `true`)
+2. Add toggle button/chevron on the header
+3. Conditionally render the job list based on collapsed state
+
+**Estimated Effort**: 15 minutes
+
+---
+
 ## Adding New Tech Debt
 
 1. Add to this file under "Remaining Tasks"
-2. Assign next task number (currently: #88)
+2. Assign next task number (currently: #89)
 3. Include: Priority, Location, Issue, Impact, Fix Approach
 
 ---


### PR DESCRIPTION
## Summary
- Bind all Docker service ports to `127.0.0.1` (localhost only) instead of `0.0.0.0` (all interfaces)
- Prevents MongoDB and other services from being accessible from other machines on the network
- Applied consistently across base, development override, and agent overlay compose files

## Changes
- `docker-compose.yml`: Backend (:5001) and docs (:8001) bound to localhost
- `docker-compose.override.yml`: MongoDB (:27017), frontend (:3000), processing engine (:8000) bound to localhost
- `docker-compose.agent.yml`: All parameterized agent ports bound to localhost
- `.env.example`: Added network binding documentation section
- `docs/tech-debt.md`: Marked Task #59 as resolved (46 resolved / 32 remaining)

## Test plan
- [x] `docker compose config` validates (dev override)
- [x] `docker compose -f ... -f agent.yml config` validates (agent overlay)
- [ ] `docker compose up -d` starts all services correctly
- [ ] Services accessible at `localhost:<port>` from host machine
- [ ] Services NOT accessible from other machines on the network

🤖 Generated with [Claude Code](https://claude.com/claude-code)