### PR TITLE
feat: Image comparison/blink mode (C3)

### DIFF
--- a/frontend/jwst-frontend/src/components/ComparisonImagePicker.css
+++ b/frontend/jwst-frontend/src/components/ComparisonImagePicker.css
@@ -1,0 +1,233 @@
+/* Comparison Image Picker Modal */
+.comparison-picker-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 20px;
+}
+
+.comparison-picker-modal {
+  background: #1a1a2e;
+  border: 1px solid #333;
+  border-radius: 12px;
+  max-width: 900px;
+  width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+.comparison-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid #333;
+}
+
+.comparison-picker-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #fff;
+  font-weight: 600;
+}
+
+.comparison-picker-close {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.comparison-picker-close:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.comparison-picker-body {
+  flex: 1;
+  display: flex;
+  gap: 16px;
+  padding: 16px 24px;
+  overflow: hidden;
+}
+
+.comparison-picker-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.comparison-picker-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.comparison-picker-column-header h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #4cc9f0;
+  font-weight: 600;
+}
+
+.comparison-picker-selected-label {
+  font-size: 0.75rem;
+  color: #10b981;
+  font-weight: 500;
+}
+
+.comparison-picker-search {
+  width: 100%;
+  padding: 8px 12px;
+  background: #0a0a15;
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: #e0e0e0;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.comparison-picker-search:focus {
+  border-color: #4cc9f0;
+}
+
+.comparison-picker-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.comparison-picker-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.comparison-picker-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.comparison-picker-list::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+.comparison-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid transparent;
+}
+
+.comparison-picker-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.comparison-picker-item.selected {
+  background: rgba(76, 201, 240, 0.1);
+  border-color: rgba(76, 201, 240, 0.3);
+}
+
+.comparison-picker-item.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.comparison-picker-item-thumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+  object-fit: cover;
+  background: #0a0a15;
+  flex-shrink: 0;
+}
+
+.comparison-picker-item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.comparison-picker-item-name {
+  font-size: 0.8rem;
+  color: #e0e0e0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.comparison-picker-item-meta {
+  font-size: 0.7rem;
+  color: #888;
+  margin-top: 2px;
+}
+
+.comparison-picker-divider {
+  width: 1px;
+  background: #333;
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+.comparison-picker-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 16px 24px;
+  border-top: 1px solid #333;
+}
+
+.comparison-picker-btn {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.comparison-picker-btn.primary {
+  background: #4cc9f0;
+  color: #000;
+}
+
+.comparison-picker-btn.primary:hover:not(:disabled) {
+  background: #7dd8f5;
+}
+
+.comparison-picker-btn.primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.comparison-picker-btn.secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e0e0e0;
+}
+
+.comparison-picker-btn.secondary:hover {
+  background: rgba(255, 255, 255, 0.15);
+}

--- a/frontend/jwst-frontend/src/components/ComparisonImagePicker.tsx
+++ b/frontend/jwst-frontend/src/components/ComparisonImagePicker.tsx
@@ -1,0 +1,196 @@
+import React, { useState, useMemo, useCallback } from 'react';
+import { JwstDataModel } from '../types/JwstDataTypes';
+import { API_BASE_URL } from '../config/api';
+import './ComparisonImagePicker.css';
+
+export interface ImageSelection {
+  dataId: string;
+  title: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface ComparisonImagePickerProps {
+  allImages: JwstDataModel[];
+  initialImageA?: ImageSelection;
+  onSelect: (imageA: ImageSelection, imageB: ImageSelection) => void;
+  onClose: () => void;
+}
+
+function getImageMeta(item: JwstDataModel): string {
+  const parts: string[] = [];
+  const instrument = item.metadata?.mast_instrument_name;
+  const filter = item.metadata?.mast_filters;
+  const target = item.metadata?.mast_target_name;
+  if (target) parts.push(String(target));
+  if (instrument) parts.push(String(instrument));
+  if (filter) parts.push(String(filter));
+  return parts.join(' / ') || item.dataType || '';
+}
+
+function getThumbnailUrl(dataId: string): string {
+  return `${API_BASE_URL}/api/jwstdata/${dataId}/preview?cmap=inferno&width=96&height=96`;
+}
+
+const ComparisonImagePicker: React.FC<ComparisonImagePickerProps> = ({
+  allImages,
+  initialImageA,
+  onSelect,
+  onClose,
+}) => {
+  const [selectedA, setSelectedA] = useState<string | null>(initialImageA?.dataId ?? null);
+  const [selectedB, setSelectedB] = useState<string | null>(null);
+  const [searchA, setSearchA] = useState('');
+  const [searchB, setSearchB] = useState('');
+
+  const filterImages = useCallback(
+    (search: string) => {
+      if (!search.trim()) return allImages;
+      const lower = search.toLowerCase();
+      return allImages.filter(
+        (item) =>
+          item.fileName.toLowerCase().includes(lower) ||
+          getImageMeta(item).toLowerCase().includes(lower)
+      );
+    },
+    [allImages]
+  );
+
+  const filteredA = useMemo(() => filterImages(searchA), [filterImages, searchA]);
+  const filteredB = useMemo(() => filterImages(searchB), [filterImages, searchB]);
+
+  const canCompare = selectedA !== null && selectedB !== null && selectedA !== selectedB;
+
+  const handleCompare = () => {
+    if (!canCompare) return;
+    const itemA = allImages.find((i) => i.id === selectedA);
+    const itemB = allImages.find((i) => i.id === selectedB);
+    if (!itemA || !itemB) return;
+
+    onSelect(
+      { dataId: itemA.id, title: itemA.fileName, metadata: itemA.metadata },
+      { dataId: itemB.id, title: itemB.fileName, metadata: itemB.metadata }
+    );
+  };
+
+  const renderColumn = (
+    label: string,
+    selectedId: string | null,
+    onItemSelect: (id: string) => void,
+    otherId: string | null,
+    search: string,
+    onSearchChange: (val: string) => void,
+    filtered: JwstDataModel[]
+  ) => {
+    const selectedItem = selectedId ? allImages.find((i) => i.id === selectedId) : null;
+    return (
+      <div className="comparison-picker-column">
+        <div className="comparison-picker-column-header">
+          <h3>{label}</h3>
+          {selectedItem && (
+            <span className="comparison-picker-selected-label">
+              {selectedItem.fileName.length > 25
+                ? selectedItem.fileName.slice(0, 22) + '...'
+                : selectedItem.fileName}
+            </span>
+          )}
+        </div>
+        <input
+          type="text"
+          className="comparison-picker-search"
+          placeholder="Search images..."
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+        <div className="comparison-picker-list">
+          {filtered.map((item) => {
+            const isSelected = item.id === selectedId;
+            const isDisabled = item.id === otherId;
+            return (
+              <div
+                key={item.id}
+                className={`comparison-picker-item${isSelected ? ' selected' : ''}${isDisabled ? ' disabled' : ''}`}
+                onClick={() => {
+                  if (!isDisabled) onItemSelect(item.id);
+                }}
+              >
+                <img
+                  className="comparison-picker-item-thumb"
+                  src={getThumbnailUrl(item.id)}
+                  alt=""
+                  loading="lazy"
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).style.display = 'none';
+                  }}
+                />
+                <div className="comparison-picker-item-info">
+                  <div className="comparison-picker-item-name" title={item.fileName}>
+                    {item.fileName}
+                  </div>
+                  <div className="comparison-picker-item-meta">{getImageMeta(item)}</div>
+                </div>
+              </div>
+            );
+          })}
+          {filtered.length === 0 && (
+            <div
+              style={{ color: '#666', fontSize: '0.8rem', padding: '16px', textAlign: 'center' }}
+            >
+              No matching images
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="comparison-picker-overlay" onClick={onClose}>
+      <div className="comparison-picker-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="comparison-picker-header">
+          <h2>Select Images to Compare</h2>
+          <button className="comparison-picker-close" onClick={onClose}>
+            &times;
+          </button>
+        </div>
+
+        <div className="comparison-picker-body">
+          {renderColumn(
+            'Image A',
+            selectedA,
+            setSelectedA,
+            selectedB,
+            searchA,
+            setSearchA,
+            filteredA
+          )}
+          <div className="comparison-picker-divider" />
+          {renderColumn(
+            'Image B',
+            selectedB,
+            setSelectedB,
+            selectedA,
+            searchB,
+            setSearchB,
+            filteredB
+          )}
+        </div>
+
+        <div className="comparison-picker-footer">
+          <button className="comparison-picker-btn secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="comparison-picker-btn primary"
+            disabled={!canCompare}
+            onClick={handleCompare}
+            title={canCompare ? 'Open comparison viewer' : 'Select two different images to compare'}
+          >
+            Compare
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ComparisonImagePicker;

--- a/frontend/jwst-frontend/src/components/ImageComparisonViewer.css
+++ b/frontend/jwst-frontend/src/components/ImageComparisonViewer.css
@@ -1,0 +1,522 @@
+/* ========================================================================== */
+/* Image Comparison Viewer                                                    */
+/* ========================================================================== */
+
+.comparison-viewer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #000;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  z-index: 1000;
+}
+
+.comparison-viewer-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #050505;
+  color: #e0e0e0;
+  font-family:
+    'Inter',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Header                                                                     */
+/* -------------------------------------------------------------------------- */
+.comparison-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  background: rgba(15, 15, 20, 0.95);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+  gap: 16px;
+  z-index: 10;
+}
+
+.comparison-header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  flex: 1;
+}
+
+.comparison-header-titles {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: 0.85rem;
+}
+
+.comparison-title-a,
+.comparison-title-b {
+  max-width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #e0e0e0;
+}
+
+.comparison-title-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.comparison-title-label.label-a {
+  background: rgba(76, 201, 240, 0.2);
+  color: #4cc9f0;
+}
+
+.comparison-title-label.label-b {
+  background: rgba(255, 165, 0, 0.2);
+  color: #ffa500;
+}
+
+.comparison-title-vs {
+  color: #666;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.comparison-header-center {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.comparison-mode-btn {
+  padding: 6px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.comparison-mode-btn:first-child {
+  border-radius: 6px 0 0 6px;
+}
+
+.comparison-mode-btn:last-child {
+  border-radius: 0 6px 6px 0;
+}
+
+.comparison-mode-btn.active {
+  background: rgba(76, 201, 240, 0.15);
+  color: #4cc9f0;
+  border-color: rgba(76, 201, 240, 0.3);
+}
+
+.comparison-mode-btn:hover:not(.active) {
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.comparison-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Viewport Area                                                              */
+/* -------------------------------------------------------------------------- */
+.comparison-viewport {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  background: #000;
+}
+
+/* --- Blink Mode --- */
+.comparison-blink-viewport {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  overflow: hidden;
+}
+
+.comparison-blink-viewport:active {
+  cursor: grabbing;
+}
+
+.comparison-blink-image {
+  image-rendering: pixelated;
+  transform-origin: center;
+  will-change: transform;
+  max-width: none;
+  max-height: none;
+  user-select: none;
+  pointer-events: none;
+}
+
+.comparison-blink-indicator {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  background: rgba(15, 15, 20, 0.85);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 100px;
+  z-index: 5;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.blink-indicator-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.blink-indicator-dot.dot-a {
+  background: #4cc9f0;
+}
+
+.blink-indicator-dot.dot-b {
+  background: #ffa500;
+}
+
+/* --- Side-by-Side Mode --- */
+.comparison-sidebyside-viewport {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  overflow: hidden;
+}
+
+.comparison-sidebyside-panel {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  cursor: grab;
+}
+
+.comparison-sidebyside-panel:active {
+  cursor: grabbing;
+}
+
+.comparison-sidebyside-divider {
+  width: 2px;
+  background: rgba(255, 255, 255, 0.15);
+  flex-shrink: 0;
+}
+
+.comparison-sidebyside-image {
+  image-rendering: pixelated;
+  transform-origin: center;
+  will-change: transform;
+  max-width: none;
+  max-height: none;
+  user-select: none;
+  pointer-events: none;
+}
+
+.comparison-panel-label {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 4px;
+  z-index: 5;
+}
+
+.comparison-panel-label.label-a {
+  background: rgba(76, 201, 240, 0.25);
+  color: #4cc9f0;
+}
+
+.comparison-panel-label.label-b {
+  background: rgba(255, 165, 0, 0.25);
+  color: #ffa500;
+}
+
+/* --- Overlay Mode --- */
+.comparison-overlay-viewport {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  overflow: hidden;
+}
+
+.comparison-overlay-viewport:active {
+  cursor: grabbing;
+}
+
+.comparison-overlay-stack {
+  position: relative;
+  display: inline-block;
+}
+
+.comparison-overlay-image {
+  image-rendering: pixelated;
+  max-width: none;
+  max-height: none;
+  user-select: none;
+  pointer-events: none;
+}
+
+.comparison-overlay-image.overlay-base {
+  display: block;
+}
+
+.comparison-overlay-image.overlay-top {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Floating Toolbar (Bottom)                                                  */
+/* -------------------------------------------------------------------------- */
+.comparison-floating-toolbar {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 20px;
+  z-index: 20;
+  background: rgba(15, 15, 20, 0.85);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  border-radius: 100px;
+}
+
+.comparison-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.comparison-toolbar-divider {
+  width: 1px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.comparison-toolbar-label {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+/* Blink controls */
+.blink-speed-slider {
+  width: 80px;
+  accent-color: #4cc9f0;
+}
+
+.blink-speed-value {
+  font-size: 0.75rem;
+  color: #4cc9f0;
+  min-width: 40px;
+  text-align: center;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.blink-toggle-btn {
+  background: rgba(76, 201, 240, 0.15);
+  border: 1px solid rgba(76, 201, 240, 0.3);
+  color: #4cc9f0;
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.blink-toggle-btn:hover {
+  background: rgba(76, 201, 240, 0.25);
+}
+
+.blink-auto-btn {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.6);
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.blink-auto-btn.active {
+  background: rgba(76, 201, 240, 0.15);
+  border-color: rgba(76, 201, 240, 0.3);
+  color: #4cc9f0;
+}
+
+.blink-auto-btn:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* Overlay controls */
+.overlay-opacity-slider {
+  width: 120px;
+  accent-color: #4cc9f0;
+}
+
+.overlay-opacity-value {
+  font-size: 0.75rem;
+  color: #4cc9f0;
+  min-width: 35px;
+  text-align: center;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.overlay-opacity-labels {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.7rem;
+}
+
+.overlay-label-a {
+  color: #4cc9f0;
+}
+
+.overlay-label-b {
+  color: #ffa500;
+}
+
+/* Zoom controls reuse */
+.comparison-zoom-btn {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  width: 30px;
+  height: 30px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.comparison-zoom-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.comparison-zoom-level {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.8);
+  min-width: 45px;
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 2px 6px;
+  background: transparent;
+  transition: all 0.2s;
+}
+
+.comparison-zoom-level:hover {
+  border-color: rgba(255, 255, 255, 0.3);
+  color: #fff;
+}
+
+/* Colormap select in toolbar */
+.comparison-cmap-select {
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 0.8rem;
+  cursor: pointer;
+  outline: none;
+  padding: 4px 8px;
+}
+
+.comparison-cmap-select option {
+  background: #15151a;
+  color: #fff;
+}
+
+/* Loading overlay */
+.comparison-loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 15;
+}
+
+.comparison-loading-overlay .spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(77, 184, 255, 0.2);
+  border-top-color: #4db8ff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+/* Status bar */
+.comparison-status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 6px 20px;
+  flex-shrink: 0;
+  min-height: 32px;
+  background: rgba(10, 10, 12, 0.95);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.comparison-status-hint {
+  font-style: italic;
+}

--- a/frontend/jwst-frontend/src/components/ImageComparisonViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageComparisonViewer.tsx
@@ -1,0 +1,573 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { API_BASE_URL } from '../config/api';
+import type { ImageSelection } from './ComparisonImagePicker';
+import './ImageComparisonViewer.css';
+
+type ComparisonMode = 'blink' | 'side-by-side' | 'overlay';
+
+interface ImageComparisonViewerProps {
+  imageA: ImageSelection;
+  imageB: ImageSelection;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const COLORMAPS = [
+  { value: 'inferno', label: 'Inferno' },
+  { value: 'magma', label: 'Magma' },
+  { value: 'viridis', label: 'Viridis' },
+  { value: 'plasma', label: 'Plasma' },
+  { value: 'grayscale', label: 'Grayscale' },
+  { value: 'hot', label: 'Hot' },
+  { value: 'cool', label: 'Cool' },
+  { value: 'rainbow', label: 'Rainbow' },
+];
+
+function buildPreviewUrl(dataId: string, colormap: string): string {
+  return (
+    `${API_BASE_URL}/api/jwstdata/${dataId}/preview?` +
+    `cmap=${colormap}&width=1200&height=1200&stretch=zscale`
+  );
+}
+
+async function fetchAuthBlob(url: string): Promise<string> {
+  const token = localStorage.getItem('jwst_auth_token');
+  const response = await fetch(url, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!response.ok) throw new Error(`Preview failed: ${response.status}`);
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
+}
+
+const ImageComparisonViewer: React.FC<ImageComparisonViewerProps> = ({
+  imageA,
+  imageB,
+  isOpen,
+  onClose,
+}) => {
+  const [mode, setMode] = useState<ComparisonMode>('blink');
+  const [colormap, setColormap] = useState('inferno');
+
+  // Image blob URLs
+  const [blobUrlA, setBlobUrlA] = useState<string | null>(null);
+  const [blobUrlB, setBlobUrlB] = useState<string | null>(null);
+  const [loadingA, setLoadingA] = useState(true);
+  const [loadingB, setLoadingB] = useState(true);
+
+  // Blink state
+  const [blinkShowA, setBlinkShowA] = useState(true);
+  const [isAutoBlinking, setIsAutoBlinking] = useState(false);
+  const [blinkInterval, setBlinkInterval] = useState(500);
+
+  // Overlay state
+  const [overlayOpacity, setOverlayOpacity] = useState(0.5);
+
+  // Shared zoom/pan
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+
+  const blinkTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Fetch previews
+  useEffect(() => {
+    if (!isOpen) return;
+    let revoked = false;
+
+    const fetchA = async () => {
+      setLoadingA(true);
+      try {
+        const url = buildPreviewUrl(imageA.dataId, colormap);
+        const blobUrl = await fetchAuthBlob(url);
+        if (!revoked) setBlobUrlA(blobUrl);
+      } catch {
+        // Silently fail - image will show loading state
+      } finally {
+        if (!revoked) setLoadingA(false);
+      }
+    };
+
+    const fetchB = async () => {
+      setLoadingB(true);
+      try {
+        const url = buildPreviewUrl(imageB.dataId, colormap);
+        const blobUrl = await fetchAuthBlob(url);
+        if (!revoked) setBlobUrlB(blobUrl);
+      } catch {
+        // Silently fail
+      } finally {
+        if (!revoked) setLoadingB(false);
+      }
+    };
+
+    fetchA();
+    fetchB();
+
+    return () => {
+      revoked = true;
+    };
+  }, [isOpen, imageA.dataId, imageB.dataId, colormap]);
+
+  // Cleanup blob URLs on unmount
+  useEffect(() => {
+    return () => {
+      setBlobUrlA((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return null;
+      });
+      setBlobUrlB((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return null;
+      });
+    };
+  }, []);
+
+  // Reset state when opened
+  useEffect(() => {
+    if (isOpen) {
+      setScale(1);
+      setOffset({ x: 0, y: 0 });
+      setBlinkShowA(true);
+      setIsAutoBlinking(false);
+      setOverlayOpacity(0.5);
+    }
+  }, [isOpen]);
+
+  // Auto-blink timer
+  useEffect(() => {
+    if (isAutoBlinking && mode === 'blink') {
+      blinkTimerRef.current = setInterval(() => {
+        setBlinkShowA((prev) => !prev);
+      }, blinkInterval);
+    }
+    return () => {
+      if (blinkTimerRef.current) {
+        clearInterval(blinkTimerRef.current);
+        blinkTimerRef.current = null;
+      }
+    };
+  }, [isAutoBlinking, blinkInterval, mode]);
+
+  // Stop auto-blink when leaving blink mode
+  useEffect(() => {
+    if (mode !== 'blink') {
+      setIsAutoBlinking(false);
+    }
+  }, [mode]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key === ' ' || e.key === 'b' || e.key === 'B') {
+        e.preventDefault();
+        if (mode === 'blink') {
+          setBlinkShowA((prev) => !prev);
+        }
+      }
+      if (e.key === '1') {
+        e.preventDefault();
+        setMode('blink');
+      }
+      if (e.key === '2') {
+        e.preventDefault();
+        setMode('side-by-side');
+      }
+      if (e.key === '3') {
+        e.preventDefault();
+        setMode('overlay');
+      }
+      if (e.key === 'p' || e.key === 'P') {
+        e.preventDefault();
+        if (mode === 'blink') {
+          setIsAutoBlinking((prev) => !prev);
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose, mode]);
+
+  // Zoom handlers
+  const handleZoomIn = () => setScale((s) => Math.min(s * 1.2, 10));
+  const handleZoomOut = () => setScale((s) => Math.max(s / 1.2, 0.1));
+  const handleResetZoom = () => {
+    setScale(1);
+    setOffset({ x: 0, y: 0 });
+  };
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    setScale((s) => Math.max(0.1, Math.min(10, s * delta)));
+  }, []);
+
+  // Pan handlers
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button === 0) {
+        setIsDragging(true);
+        setDragStart({ x: e.clientX - offset.x, y: e.clientY - offset.y });
+      }
+    },
+    [offset]
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isDragging) return;
+      e.preventDefault();
+      setOffset({
+        x: e.clientX - dragStart.x,
+        y: e.clientY - dragStart.y,
+      });
+    },
+    [isDragging, dragStart]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  const imageTransform = `translate(${offset.x}px, ${offset.y}px) scale(${scale})`;
+  const isLoading = loadingA || loadingB;
+
+  if (!isOpen) return null;
+
+  // ---- Blink Mode Viewport ----
+  const renderBlinkViewport = () => {
+    const currentUrl = blinkShowA ? blobUrlA : blobUrlB;
+    return (
+      <div
+        className="comparison-blink-viewport"
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onWheel={handleWheel}
+      >
+        {currentUrl && (
+          <img
+            src={currentUrl}
+            alt={blinkShowA ? imageA.title : imageB.title}
+            className="comparison-blink-image"
+            style={{ transform: imageTransform }}
+            draggable={false}
+          />
+        )}
+        <div className="comparison-blink-indicator">
+          <span className={`blink-indicator-dot ${blinkShowA ? 'dot-a' : 'dot-b'}`} />
+          <span style={{ color: blinkShowA ? '#4cc9f0' : '#ffa500' }}>
+            {blinkShowA ? 'A' : 'B'}
+          </span>
+        </div>
+      </div>
+    );
+  };
+
+  // ---- Side-by-Side Mode Viewport ----
+  const renderSideBySideViewport = () => (
+    <div className="comparison-sidebyside-viewport">
+      <div
+        className="comparison-sidebyside-panel"
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onWheel={handleWheel}
+      >
+        <span className="comparison-panel-label label-a">A</span>
+        {blobUrlA && (
+          <img
+            src={blobUrlA}
+            alt={imageA.title}
+            className="comparison-sidebyside-image"
+            style={{ transform: imageTransform }}
+            draggable={false}
+          />
+        )}
+      </div>
+      <div className="comparison-sidebyside-divider" />
+      <div
+        className="comparison-sidebyside-panel"
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onWheel={handleWheel}
+      >
+        <span className="comparison-panel-label label-b">B</span>
+        {blobUrlB && (
+          <img
+            src={blobUrlB}
+            alt={imageB.title}
+            className="comparison-sidebyside-image"
+            style={{ transform: imageTransform }}
+            draggable={false}
+          />
+        )}
+      </div>
+    </div>
+  );
+
+  // ---- Overlay Mode Viewport ----
+  const renderOverlayViewport = () => (
+    <div
+      className="comparison-overlay-viewport"
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      onWheel={handleWheel}
+    >
+      <div className="comparison-overlay-stack" style={{ transform: imageTransform }}>
+        {blobUrlA && (
+          <img
+            src={blobUrlA}
+            alt={imageA.title}
+            className="comparison-overlay-image overlay-base"
+            draggable={false}
+          />
+        )}
+        {blobUrlB && (
+          <img
+            src={blobUrlB}
+            alt={imageB.title}
+            className="comparison-overlay-image overlay-top"
+            style={{ opacity: overlayOpacity }}
+            draggable={false}
+          />
+        )}
+      </div>
+    </div>
+  );
+
+  // ---- Mode-specific toolbar controls ----
+  const renderModeControls = () => {
+    if (mode === 'blink') {
+      return (
+        <>
+          <div className="comparison-toolbar-divider" />
+          <div className="comparison-toolbar-group">
+            <button
+              className="blink-toggle-btn"
+              onClick={() => setBlinkShowA((prev) => !prev)}
+              title="Toggle image (Space/B)"
+            >
+              {blinkShowA ? 'A' : 'B'} &rarr; {blinkShowA ? 'B' : 'A'}
+            </button>
+          </div>
+          <div className="comparison-toolbar-divider" />
+          <div className="comparison-toolbar-group">
+            <button
+              className={`blink-auto-btn ${isAutoBlinking ? 'active' : ''}`}
+              onClick={() => setIsAutoBlinking((prev) => !prev)}
+              title="Auto-blink (P)"
+            >
+              {isAutoBlinking ? 'Stop' : 'Auto'}
+            </button>
+            <span className="comparison-toolbar-label">Speed</span>
+            <input
+              type="range"
+              className="blink-speed-slider"
+              min={100}
+              max={3000}
+              step={100}
+              value={blinkInterval}
+              onChange={(e) => setBlinkInterval(Number(e.target.value))}
+              title={`${blinkInterval}ms`}
+            />
+            <span className="blink-speed-value">{blinkInterval}ms</span>
+          </div>
+        </>
+      );
+    }
+
+    if (mode === 'overlay') {
+      return (
+        <>
+          <div className="comparison-toolbar-divider" />
+          <div className="comparison-toolbar-group">
+            <div className="overlay-opacity-labels">
+              <span className="overlay-label-a">A</span>
+            </div>
+            <input
+              type="range"
+              className="overlay-opacity-slider"
+              min={0}
+              max={1}
+              step={0.01}
+              value={overlayOpacity}
+              onChange={(e) => setOverlayOpacity(Number(e.target.value))}
+              title={`Opacity: ${Math.round(overlayOpacity * 100)}%`}
+            />
+            <div className="overlay-opacity-labels">
+              <span className="overlay-label-b">B</span>
+            </div>
+            <span className="overlay-opacity-value">{Math.round(overlayOpacity * 100)}%</span>
+          </div>
+        </>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <div className="comparison-viewer-overlay">
+      <div className="comparison-viewer-container">
+        {/* Header */}
+        <div className="comparison-header">
+          <div className="comparison-header-left">
+            <button
+              className="btn-icon"
+              onClick={onClose}
+              title="Close (Escape)"
+              style={{ color: 'rgba(255,255,255,0.6)' }}
+            >
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="19" y1="12" x2="5" y2="12" />
+                <polyline points="12 19 5 12 12 5" />
+              </svg>
+            </button>
+            <div className="comparison-header-titles">
+              <span className="comparison-title-label label-a">A</span>
+              <span className="comparison-title-a" title={imageA.title}>
+                {imageA.title}
+              </span>
+              <span className="comparison-title-vs">vs</span>
+              <span className="comparison-title-label label-b">B</span>
+              <span className="comparison-title-b" title={imageB.title}>
+                {imageB.title}
+              </span>
+            </div>
+          </div>
+
+          <div className="comparison-header-center">
+            <button
+              className={`comparison-mode-btn ${mode === 'blink' ? 'active' : ''}`}
+              onClick={() => setMode('blink')}
+              title="Blink mode (1)"
+            >
+              Blink
+            </button>
+            <button
+              className={`comparison-mode-btn ${mode === 'side-by-side' ? 'active' : ''}`}
+              onClick={() => setMode('side-by-side')}
+              title="Side by side (2)"
+            >
+              Side by Side
+            </button>
+            <button
+              className={`comparison-mode-btn ${mode === 'overlay' ? 'active' : ''}`}
+              onClick={() => setMode('overlay')}
+              title="Overlay mode (3)"
+            >
+              Overlay
+            </button>
+          </div>
+
+          <div className="comparison-header-right">
+            <select
+              className="comparison-cmap-select"
+              value={colormap}
+              onChange={(e) => setColormap(e.target.value)}
+              title="Colormap"
+            >
+              {COLORMAPS.map((cm) => (
+                <option key={cm.value} value={cm.value}>
+                  {cm.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Viewport */}
+        <div className="comparison-viewport">
+          {isLoading && (
+            <div className="comparison-loading-overlay">
+              <div className="spinner" />
+            </div>
+          )}
+
+          {mode === 'blink' && renderBlinkViewport()}
+          {mode === 'side-by-side' && renderSideBySideViewport()}
+          {mode === 'overlay' && renderOverlayViewport()}
+
+          {/* Floating Toolbar */}
+          <div className="comparison-floating-toolbar">
+            <div className="comparison-toolbar-group">
+              <button className="comparison-zoom-btn" onClick={handleZoomOut} title="Zoom Out">
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <circle cx="11" cy="11" r="8" />
+                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                  <line x1="8" y1="11" x2="14" y2="11" />
+                </svg>
+              </button>
+              <button
+                className="comparison-zoom-level"
+                onClick={handleResetZoom}
+                title="Reset Zoom"
+              >
+                {Math.round(scale * 100)}%
+              </button>
+              <button className="comparison-zoom-btn" onClick={handleZoomIn} title="Zoom In">
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <circle cx="11" cy="11" r="8" />
+                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                  <line x1="11" y1="8" x2="11" y2="14" />
+                  <line x1="8" y1="11" x2="14" y2="11" />
+                </svg>
+              </button>
+            </div>
+
+            {renderModeControls()}
+          </div>
+        </div>
+
+        {/* Status bar */}
+        <div className="comparison-status-bar">
+          <span className="comparison-status-hint">
+            {mode === 'blink' && 'Space/B: toggle | P: auto-blink | 1/2/3: switch mode'}
+            {mode === 'side-by-side' && 'Scroll to zoom | Drag to pan | 1/2/3: switch mode'}
+            {mode === 'overlay' && 'Slider blends A/B | Scroll to zoom | 1/2/3: switch mode'}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ImageComparisonViewer;

--- a/frontend/jwst-frontend/src/components/ImageViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageViewer.tsx
@@ -40,6 +40,7 @@ interface ImageViewerProps {
   onClose: () => void;
   isOpen: boolean;
   metadata?: Record<string, unknown>;
+  onCompare?: () => void;
 }
 
 // SVG Icons
@@ -190,7 +191,14 @@ const generateExportFilename = (
   return `${parts.join('_')}.${extension}`;
 };
 
-const ImageViewer: React.FC<ImageViewerProps> = ({ dataId, title, onClose, isOpen, metadata }) => {
+const ImageViewer: React.FC<ImageViewerProps> = ({
+  dataId,
+  title,
+  onClose,
+  isOpen,
+  metadata,
+  onCompare,
+}) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [colormap, setColormap] = useState<string>('inferno');
@@ -821,6 +829,27 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ dataId, title, onClose, isOpe
                 </div>
               </div>
               <div className="header-right">
+                {onCompare && (
+                  <button
+                    className="btn-icon"
+                    title="Compare with another image"
+                    onClick={onCompare}
+                  >
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <rect x="2" y="3" width="8" height="18" rx="1" />
+                      <rect x="14" y="3" width="8" height="18" rx="1" />
+                    </svg>
+                  </button>
+                )}
                 <div className="region-tools">
                   <button
                     className={`btn-icon btn-sm ${regionMode === 'rectangle' ? 'active' : ''}`}

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.css
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.css
@@ -1253,6 +1253,33 @@
   justify-content: center;
 }
 
+/* Compare button */
+.compare-open-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: linear-gradient(135deg, #4cc9f0 0%, #3a9fc0 100%);
+  color: #000;
+  border: 1px solid #4cc9f0;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.compare-open-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(76, 201, 240, 0.4);
+}
+
+.compare-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Composite selection button on cards */
 .composite-select-btn {
   display: flex;

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -11,6 +11,8 @@ import WhatsNewPanel from './WhatsNewPanel';
 import ImageViewer from './ImageViewer';
 import CompositeWizard from './CompositeWizard';
 import MosaicWizard from './MosaicWizard';
+import ComparisonImagePicker, { ImageSelection } from './ComparisonImagePicker';
+import ImageComparisonViewer from './ImageComparisonViewer';
 import { getFitsFileInfo } from '../utils/fitsUtils';
 import { jwstDataService, ApiError } from '../services';
 import './JwstDataDashboard.css';
@@ -48,6 +50,12 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
   const [selectedForComposite, setSelectedForComposite] = useState<Set<string>>(new Set());
   const [showCompositeWizard, setShowCompositeWizard] = useState<boolean>(false);
   const [showMosaicWizard, setShowMosaicWizard] = useState<boolean>(false);
+  const [showComparisonPicker, setShowComparisonPicker] = useState<boolean>(false);
+  const [comparisonPickerInitialA, setComparisonPickerInitialA] = useState<
+    ImageSelection | undefined
+  >(undefined);
+  const [comparisonImageA, setComparisonImageA] = useState<ImageSelection | null>(null);
+  const [comparisonImageB, setComparisonImageB] = useState<ImageSelection | null>(null);
 
   // Extract unique observation IDs that have been imported (for MAST search display)
   const importedObsIds = useMemo(() => {
@@ -547,6 +555,29 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
               </svg>
             </span>
             WCS Mosaic
+          </button>
+          <button
+            className="compare-open-btn"
+            onClick={() => {
+              setComparisonPickerInitialA(undefined);
+              setShowComparisonPicker(true);
+            }}
+            title="Compare two FITS images (blink, side-by-side, or overlay)"
+          >
+            <span className="compare-icon">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <rect x="2" y="3" width="8" height="18" rx="1" />
+                <rect x="14" y="3" width="8" height="18" rx="1" />
+              </svg>
+            </span>
+            Compare
           </button>
         </div>
       </div>
@@ -1089,6 +1120,16 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
         isOpen={!!viewingImageId}
         onClose={() => setViewingImageId(null)}
         metadata={viewingImageMetadata}
+        onCompare={() => {
+          if (viewingImageId) {
+            setComparisonPickerInitialA({
+              dataId: viewingImageId,
+              title: viewingImageTitle,
+              metadata: viewingImageMetadata,
+            });
+            setShowComparisonPicker(true);
+          }
+        }}
       />
 
       {deleteModalData && (
@@ -1215,6 +1256,31 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
 
       {showMosaicWizard && (
         <MosaicWizard allImages={viewableImages} onClose={() => setShowMosaicWizard(false)} />
+      )}
+
+      {showComparisonPicker && (
+        <ComparisonImagePicker
+          allImages={viewableImages}
+          initialImageA={comparisonPickerInitialA}
+          onSelect={(a, b) => {
+            setComparisonImageA(a);
+            setComparisonImageB(b);
+            setShowComparisonPicker(false);
+          }}
+          onClose={() => setShowComparisonPicker(false)}
+        />
+      )}
+
+      {comparisonImageA && comparisonImageB && (
+        <ImageComparisonViewer
+          imageA={comparisonImageA}
+          imageB={comparisonImageB}
+          isOpen={true}
+          onClose={() => {
+            setComparisonImageA(null);
+            setComparisonImageB(null);
+          }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds image comparison viewer with three modes: **blink** (toggle between two images), **side-by-side** (synchronized zoom/pan), and **opacity overlay** (slider to blend images)
- Adds image picker modal for selecting two viewable FITS images to compare
- Integrates into dashboard toolbar ("Compare" button) and ImageViewer header ("Compare with..." button)

## New Files

| File | Purpose |
|------|---------|
| `ComparisonImagePicker.tsx/.css` | Modal for selecting two images with search/filter, thumbnail previews |
| `ImageComparisonViewer.tsx/.css` | Full-screen comparison viewer with blink, side-by-side, and overlay modes |

## Modified Files

| File | Changes |
|------|---------|
| `JwstDataDashboard.tsx` | Added imports, comparison state, "Compare" button, picker/viewer rendering |
| `JwstDataDashboard.css` | Styles for the Compare button |
| `ImageViewer.tsx` | Added optional `onCompare` prop, compare button in header |

## Features

- **Blink mode**: Manual toggle (Space/B), auto-blink with adjustable speed (100ms-3000ms)
- **Side-by-side mode**: Two panels with synchronized zoom and pan
- **Overlay mode**: Opacity slider (0-100%) blending Image A and Image B
- Shared colormap selector (all 8 FITS colormaps)
- Zoom/pan controls shared across all modes
- Keyboard shortcuts: `Space`/`B` blink toggle, `1`/`2`/`3` mode switch, `P` auto-blink, `Escape` close
- Pre-selects current image as Image A when opened from single-image viewer

## Technical Notes

- Frontend-only feature -- no backend or processing engine changes
- Both images use existing `GET /jwstdata/{id}/preview` endpoint with auth token
- Preview images fetched as authenticated blobs (same pattern as ImageViewer)
- All state resets when viewer opens/closes

## Test Plan

1. Start Docker stack: `cd docker && docker compose up -d`
2. Ensure at least 2 viewable FITS images are imported (via MAST search or file import)
3. **Dashboard Compare button**:
   - Click "Compare" in the toolbar -- picker modal should open
   - Select Image A from left column, Image B from right column
   - Verify search filter works in both columns
   - Verify same image cannot be selected in both columns
   - Click "Compare" -- comparison viewer should open
4. **Blink mode** (default):
   - Verify one image displays at a time with A/B indicator
   - Press Space or B to toggle between images
   - Click "Auto" button -- images should alternate automatically
   - Adjust speed slider -- blink rate should change
   - Press P to stop auto-blink
5. **Side-by-side mode**:
   - Press 2 or click "Side by Side" -- two panels appear with divider
   - Scroll to zoom on either panel -- both panels zoom together
   - Drag to pan on either panel -- both panels pan together
   - Verify A and B labels appear in corners
6. **Overlay mode**:
   - Press 3 or click "Overlay" -- single viewport with opacity slider
   - Drag slider left -- Image A dominates
   - Drag slider right -- Image B dominates
   - Slider at 50% -- both images blended equally
7. **ImageViewer integration**:
   - Open any FITS image in the ImageViewer
   - Click the compare icon (two rectangles) in the header
   - Picker should open with current image pre-selected as Image A
   - Select Image B and compare
8. **General**:
   - Change colormap -- both images should update
   - Press Escape -- viewer should close
   - Verify no regressions in existing ImageViewer functionality

Generated with [Claude Code](https://claude.com/claude-code)