### PR TITLE
fix: Disable seed users in production, refresh downloads panel, fix mosaic export button (#90, #91, #92)

### DIFF
--- a/backend/JwstDataAnalysis.API/Configuration/SeedingSettings.cs
+++ b/backend/JwstDataAnalysis.API/Configuration/SeedingSettings.cs
@@ -1,0 +1,17 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+namespace JwstDataAnalysis.API.Configuration
+{
+    /// <summary>
+    /// Configuration settings for database seeding.
+    /// </summary>
+    public class SeedingSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether seed data (default users) should be created on startup.
+        /// Defaults to true for development; should be false in production.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+    }
+}

--- a/backend/JwstDataAnalysis.API/Services/SeedDataService.cs
+++ b/backend/JwstDataAnalysis.API/Services/SeedDataService.cs
@@ -1,0 +1,87 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using JwstDataAnalysis.API.Configuration;
+using JwstDataAnalysis.API.Models;
+
+using Microsoft.Extensions.Options;
+
+namespace JwstDataAnalysis.API.Services
+{
+    /// <summary>
+    /// Seeds default users into the database on application startup.
+    /// Controlled by the Seeding:Enabled configuration flag.
+    /// </summary>
+    public class SeedDataService(
+        IMongoDBService mongoDBService,
+        IAuthService authService,
+        IOptions<SeedingSettings> seedingSettings,
+        IWebHostEnvironment environment,
+        ILogger<SeedDataService> logger)
+    {
+        private readonly IMongoDBService mongoDBService = mongoDBService;
+        private readonly IAuthService authService = authService;
+        private readonly SeedingSettings settings = seedingSettings.Value;
+        private readonly IWebHostEnvironment environment = environment;
+        private readonly ILogger<SeedDataService> logger = logger;
+
+        /// <summary>
+        /// Seeds default users if seeding is enabled in configuration.
+        /// </summary>
+        public async Task SeedUsersAsync()
+        {
+            if (!settings.Enabled)
+            {
+                logger.LogInformation("Database seeding is disabled via configuration");
+                return;
+            }
+
+            if (!environment.IsDevelopment())
+            {
+                logger.LogWarning(
+                    "Database seeding is enabled in {Environment} environment. " +
+                    "Set Seeding:Enabled to false in production configuration",
+                    environment.EnvironmentName);
+            }
+
+            await SeedUserAsync(
+                username: "admin",
+                email: "admin@jwst.local",
+                password: "Admin123!",
+                displayName: "Administrator");
+
+            await SeedUserAsync(
+                username: "demo",
+                email: "demo@jwst.local",
+                password: "Demo1234!",
+                displayName: "Demo User");
+        }
+
+        private async Task SeedUserAsync(string username, string email, string password, string displayName)
+        {
+            var existingUser = await mongoDBService.GetUserByUsernameAsync(username);
+            if (existingUser != null)
+            {
+                logger.LogDebug("Seed user '{Username}' already exists, skipping", username);
+                return;
+            }
+
+            try
+            {
+                await authService.RegisterAsync(new RegisterRequest
+                {
+                    Username = username,
+                    Email = email,
+                    Password = password,
+                    DisplayName = displayName,
+                });
+
+                logger.LogInformation("Created seed user '{Username}'", username);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to create seed user '{Username}'", username);
+            }
+        }
+    }
+}

--- a/backend/JwstDataAnalysis.API/appsettings.Production.json
+++ b/backend/JwstDataAnalysis.API/appsettings.Production.json
@@ -1,0 +1,5 @@
+{
+  "Seeding": {
+    "Enabled": false
+  }
+}

--- a/backend/JwstDataAnalysis.API/appsettings.json
+++ b/backend/JwstDataAnalysis.API/appsettings.json
@@ -34,6 +34,9 @@
     "PollIntervalMs": 500,
     "BasePath": "/app/data/mast"
   },
+  "Seeding": {
+    "Enabled": true
+  },
   "IpRateLimiting": {
     "EnableEndpointRateLimiting": true,
     "StackBlockedRequests": false,

--- a/frontend/jwst-frontend/src/components/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/MastSearch.tsx
@@ -79,12 +79,16 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete, importedObsId
   const endIndex = startIndex + itemsPerPage;
   const paginatedResults = searchResults.slice(startIndex, endIndex);
 
-  // Fetch resumable (incomplete) downloads on mount
-  useEffect(() => {
+  const refreshResumableJobs = () => {
     mastService
       .getResumableImports()
       .then((res) => setResumableJobs(Array.isArray(res.jobs) ? res.jobs : []))
       .catch(() => {}); // Silently fail - section just won't show
+  };
+
+  // Fetch resumable (incomplete) downloads on mount
+  useEffect(() => {
+    refreshResumableJobs();
   }, []);
 
   const handleResumeFromPanel = (job: ResumableJobSummary) => {
@@ -312,6 +316,7 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete, importedObsId
     shouldPollRef.current = false; // Stop any ongoing polling
     setImportProgress(null);
     setCancelling(false);
+    refreshResumableJobs(); // Refresh incomplete downloads panel after cancel/error/close
   };
 
   const handleCancelImport = async () => {

--- a/frontend/jwst-frontend/src/components/MosaicWizard.css
+++ b/frontend/jwst-frontend/src/components/MosaicWizard.css
@@ -563,6 +563,9 @@
 }
 
 .mosaic-result-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
   flex-shrink: 0;
 }
 
@@ -571,12 +574,6 @@
   max-height: 100%;
   object-fit: contain;
   min-height: 0;
-}
-
-.mosaic-result-actions {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
 }
 
 .mosaic-btn-export {


### PR DESCRIPTION
## Summary

Three independent quick fixes bundled into a single PR:

- **#90: Disable Seed Users in Production** — New `SeedDataService` creates default admin + demo users on startup, controlled by `Seeding:Enabled` config flag. Enabled by default in dev, disabled in `appsettings.Production.json`. Logs a warning if seeding is enabled in non-Development environments.
- **#91: Incomplete Downloads Panel Not Visible After Cancel** — Extracted `refreshResumableJobs()` helper and call it from `closeProgressModal()` so the "Incomplete Downloads" panel refreshes after cancel/error/close.
- **#92: Mosaic Wizard Export Button Cut Off** — Merged duplicate `.mosaic-result-actions` CSS rules, preserving `flex-shrink: 0` so the export button isn't pushed below the visible area.

## Files Changed

**#90 (Backend):**
- `Configuration/SeedingSettings.cs` — NEW config POCO
- `Services/SeedDataService.cs` — NEW seeding service
- `appsettings.json` — Added `Seeding.Enabled = true`
- `appsettings.Production.json` — NEW, `Seeding.Enabled = false`
- `Program.cs` — Register config + call seeding at startup

**#91 (Frontend):**
- `MastSearch.tsx` — Extract `refreshResumableJobs()`, call on modal close

**#92 (Frontend):**
- `MosaicWizard.css` — Merge duplicate CSS rule

## Test plan

1. **#90 — Seed users in dev mode:**
   - Start the Docker stack: `cd docker && docker compose up -d --build`
   - Check backend logs: `docker compose logs backend | grep -i seed`
   - Verify logs show "Created seed user 'admin'" and "Created seed user 'demo'" on first boot
   - Restart: `docker compose restart backend`
   - Verify logs show "already exists, skipping" on second boot

2. **#90 — Seed users disabled in prod:**
   - Set `ASPNETCORE_ENVIRONMENT=Production` in docker-compose override
   - Restart backend and verify logs show "Database seeding is disabled via configuration"

3. **#91 — Downloads panel refresh after cancel:**
   - Open MAST Search, start importing an observation
   - Cancel the import mid-download
   - Close the progress modal
   - Verify the "Incomplete Downloads" panel appears immediately (without hiding/re-showing MAST Search)

4. **#92 — Mosaic export button visible:**
   - Open Mosaic Wizard, select 2+ FITS files
   - Generate a mosaic
   - Verify the "Download PNG/FITS" export button is fully visible below the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)