### PR TITLE
feat: Add interactive curves/levels adjustment to FITS viewer (C4)

### DIFF
--- a/frontend/jwst-frontend/src/components/CurvesEditor.css
+++ b/frontend/jwst-frontend/src/components/CurvesEditor.css
@@ -1,0 +1,111 @@
+.curves-editor {
+  background: rgba(20, 20, 30, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  overflow: hidden;
+  min-width: 220px;
+  backdrop-filter: blur(10px);
+}
+
+.curves-editor.collapsed {
+  min-width: auto;
+}
+
+.curves-editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 12px;
+  background: rgba(30, 30, 45, 0.8);
+  cursor: pointer;
+  user-select: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.curves-editor-header:hover {
+  background: rgba(40, 40, 60, 0.8);
+}
+
+.curves-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.curves-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.curves-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.curves-editor-body {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  animation: curvesSlideDown 0.2s ease-out;
+}
+
+@keyframes curvesSlideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.curves-canvas {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 4px;
+  cursor: crosshair;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.curves-presets {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.curves-preset-btn {
+  background: rgba(30, 30, 45, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.7);
+  padding: 4px 8px;
+  font-size: 10px;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.curves-preset-btn:hover {
+  border-color: rgba(255, 255, 255, 0.3);
+  color: #fff;
+}
+
+.curves-preset-btn.active {
+  background: rgba(77, 184, 255, 0.2);
+  border-color: #4db8ff;
+  color: #4db8ff;
+}
+
+.curves-hint {
+  text-align: center;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+}

--- a/frontend/jwst-frontend/src/components/CurvesEditor.tsx
+++ b/frontend/jwst-frontend/src/components/CurvesEditor.tsx
@@ -1,0 +1,394 @@
+import React, { useRef, useEffect, useCallback, useState } from 'react';
+import './CurvesEditor.css';
+import type { CurveControlPoint, CurvePresetName } from '../types/CurvesTypes';
+import { generateLUT, CURVE_PRESETS } from '../utils/curvesUtils';
+
+interface CurvesEditorProps {
+  controlPoints: CurveControlPoint[];
+  onChange: (points: CurveControlPoint[]) => void;
+  activePreset: CurvePresetName | null;
+  onPresetChange: (preset: CurvePresetName) => void;
+  onReset: () => void;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
+}
+
+// Canvas layout constants
+const CANVAS_SIZE = 200;
+const MARGIN = 8;
+const PLOT_SIZE = CANVAS_SIZE - 2 * MARGIN;
+const POINT_RADIUS = 6;
+const POINT_HIT_RADIUS = 12;
+
+// Convert curve-space (0-1) to canvas pixel coordinates
+function toCanvasX(input: number): number {
+  return MARGIN + input * PLOT_SIZE;
+}
+function toCanvasY(output: number): number {
+  return MARGIN + (1 - output) * PLOT_SIZE;
+}
+// Convert canvas pixel coordinates to curve-space (0-1)
+function fromCanvasX(px: number): number {
+  return Math.max(0, Math.min(1, (px - MARGIN) / PLOT_SIZE));
+}
+function fromCanvasY(py: number): number {
+  return Math.max(0, Math.min(1, 1 - (py - MARGIN) / PLOT_SIZE));
+}
+
+// SVG Icons
+const Icons = {
+  Curves: () => (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 20 Q 8 4, 12 12 T 21 4" />
+    </svg>
+  ),
+  ChevronDown: () => (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="6 9 12 15 18 9"></polyline>
+    </svg>
+  ),
+  ChevronUp: () => (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="18 15 12 9 6 15"></polyline>
+    </svg>
+  ),
+  Reset: () => (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="1 4 1 10 7 10"></polyline>
+      <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+    </svg>
+  ),
+};
+
+const PRESET_LIST: CurvePresetName[] = ['linear', 'auto_contrast', 'high_contrast', 'invert'];
+
+const CurvesEditor: React.FC<CurvesEditorProps> = ({
+  controlPoints,
+  onChange,
+  activePreset,
+  onPresetChange,
+  onReset,
+  collapsed,
+  onToggleCollapse,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+
+  // Get sorted points for rendering
+  const sortedPoints = [...controlPoints].sort((a, b) => a.input - b.input);
+
+  // Draw the curves editor canvas
+  const drawCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Set actual pixel dimensions (CSS handles display size via aspect-ratio)
+    canvas.width = CANVAS_SIZE;
+    canvas.height = CANVAS_SIZE;
+
+    ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+
+    // Background
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
+    ctx.fillRect(MARGIN, MARGIN, PLOT_SIZE, PLOT_SIZE);
+
+    // Grid lines (25%, 50%, 75%)
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
+    ctx.lineWidth = 1;
+    for (const frac of [0.25, 0.5, 0.75]) {
+      const x = toCanvasX(frac);
+      const y = toCanvasY(frac);
+      ctx.beginPath();
+      ctx.moveTo(x, MARGIN);
+      ctx.lineTo(x, MARGIN + PLOT_SIZE);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(MARGIN, y);
+      ctx.lineTo(MARGIN + PLOT_SIZE, y);
+      ctx.stroke();
+    }
+
+    // Identity diagonal (reference line)
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    ctx.moveTo(toCanvasX(0), toCanvasY(0));
+    ctx.lineTo(toCanvasX(1), toCanvasY(1));
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Draw the interpolated curve using the LUT for accuracy
+    const lut = generateLUT(sortedPoints);
+    ctx.strokeStyle = '#4cc9f0';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    for (let i = 0; i < 256; i++) {
+      const x = toCanvasX(i / 255);
+      const y = toCanvasY(lut[i] / 255);
+      if (i === 0) {
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+    }
+    ctx.stroke();
+
+    // Draw control points
+    for (let i = 0; i < sortedPoints.length; i++) {
+      const p = sortedPoints[i];
+      const cx = toCanvasX(p.input);
+      const cy = toCanvasY(p.output);
+      const isActive = i === draggingIndex;
+      const radius = isActive ? POINT_RADIUS + 2 : POINT_RADIUS;
+
+      // Glow for active point
+      if (isActive) {
+        ctx.shadowColor = '#4db8ff';
+        ctx.shadowBlur = 8;
+      }
+
+      ctx.fillStyle = '#4db8ff';
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+
+      ctx.shadowColor = 'transparent';
+      ctx.shadowBlur = 0;
+    }
+  }, [sortedPoints, draggingIndex]);
+
+  useEffect(() => {
+    if (!collapsed) {
+      drawCanvas();
+    }
+  }, [collapsed, drawCanvas]);
+
+  // Get mouse position in canvas coordinates, accounting for CSS scaling
+  const getCanvasPos = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>): { x: number; y: number } => {
+      const canvas = canvasRef.current;
+      if (!canvas) return { x: 0, y: 0 };
+      const rect = canvas.getBoundingClientRect();
+      const scaleX = CANVAS_SIZE / rect.width;
+      const scaleY = CANVAS_SIZE / rect.height;
+      return {
+        x: (e.clientX - rect.left) * scaleX,
+        y: (e.clientY - rect.top) * scaleY,
+      };
+    },
+    []
+  );
+
+  // Find the control point index nearest to a canvas position (within hit radius)
+  const findNearestPoint = useCallback(
+    (canvasX: number, canvasY: number): number | null => {
+      let bestIdx: number | null = null;
+      let bestDist = POINT_HIT_RADIUS;
+      for (let i = 0; i < sortedPoints.length; i++) {
+        const px = toCanvasX(sortedPoints[i].input);
+        const py = toCanvasY(sortedPoints[i].output);
+        const dist = Math.sqrt((canvasX - px) ** 2 + (canvasY - py) ** 2);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestIdx = i;
+        }
+      }
+      return bestIdx;
+    },
+    [sortedPoints]
+  );
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (e.button !== 0) return; // Left click only
+      const pos = getCanvasPos(e);
+      const idx = findNearestPoint(pos.x, pos.y);
+      if (idx !== null) {
+        setDraggingIndex(idx);
+      }
+    },
+    [getCanvasPos, findNearestPoint]
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (draggingIndex === null) return;
+
+      const pos = getCanvasPos(e);
+      const newInput = fromCanvasX(pos.x);
+      const newOutput = fromCanvasY(pos.y);
+
+      const newPoints = sortedPoints.map((p, i) => {
+        if (i !== draggingIndex) return { ...p };
+
+        // Endpoints: lock input at 0 or 1, only allow output change
+        if (i === 0) {
+          return { input: sortedPoints[0].input, output: newOutput };
+        }
+        if (i === sortedPoints.length - 1) {
+          return { input: sortedPoints[sortedPoints.length - 1].input, output: newOutput };
+        }
+
+        // Interior points: constrain input between neighbors
+        const minInput = sortedPoints[i - 1].input + 0.01;
+        const maxInput = sortedPoints[i + 1].input - 0.01;
+        return {
+          input: Math.max(minInput, Math.min(maxInput, newInput)),
+          output: newOutput,
+        };
+      });
+
+      onChange(newPoints);
+    },
+    [draggingIndex, sortedPoints, getCanvasPos, onChange]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setDraggingIndex(null);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    setDraggingIndex(null);
+  }, []);
+
+  // Double-click: add a new control point
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const pos = getCanvasPos(e);
+
+      // Don't add if too close to an existing point
+      if (findNearestPoint(pos.x, pos.y) !== null) return;
+
+      const newInput = fromCanvasX(pos.x);
+      const newOutput = fromCanvasY(pos.y);
+
+      const newPoints = [...sortedPoints, { input: newInput, output: newOutput }];
+      newPoints.sort((a, b) => a.input - b.input);
+      onChange(newPoints);
+    },
+    [getCanvasPos, findNearestPoint, sortedPoints, onChange]
+  );
+
+  // Right-click: remove a control point (min 2 points enforced)
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+      if (sortedPoints.length <= 2) return;
+
+      const pos = getCanvasPos(e);
+      const idx = findNearestPoint(pos.x, pos.y);
+      if (idx === null) return;
+
+      // Don't remove the first or last endpoint
+      if (idx === 0 || idx === sortedPoints.length - 1) return;
+
+      const newPoints = sortedPoints.filter((_, i) => i !== idx);
+      onChange(newPoints);
+    },
+    [sortedPoints, getCanvasPos, findNearestPoint, onChange]
+  );
+
+  return (
+    <div className={`curves-editor ${collapsed ? 'collapsed' : ''}`}>
+      <div className="curves-editor-header" onClick={onToggleCollapse}>
+        <div className="curves-header-left">
+          <Icons.Curves />
+          <span className="curves-title">Curves</span>
+        </div>
+        <div className="curves-header-right">
+          {!collapsed && (
+            <button
+              className="btn-reset"
+              onClick={(e) => {
+                e.stopPropagation();
+                onReset();
+              }}
+              title="Reset to linear"
+            >
+              <Icons.Reset />
+            </button>
+          )}
+          <span className="collapse-icon">
+            {collapsed ? <Icons.ChevronDown /> : <Icons.ChevronUp />}
+          </span>
+        </div>
+      </div>
+
+      {!collapsed && (
+        <div className="curves-editor-body">
+          <canvas
+            ref={canvasRef}
+            className="curves-canvas"
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseLeave}
+            onDoubleClick={handleDoubleClick}
+            onContextMenu={handleContextMenu}
+          />
+
+          <div className="curves-presets">
+            {PRESET_LIST.map((preset) => (
+              <button
+                key={preset}
+                className={`curves-preset-btn ${activePreset === preset ? 'active' : ''}`}
+                onClick={() => onPresetChange(preset)}
+                title={CURVE_PRESETS[preset].description}
+              >
+                {CURVE_PRESETS[preset].label}
+              </button>
+            ))}
+          </div>
+
+          <div className="curves-hint">
+            Drag points. Double-click to add. Right-click to remove.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CurvesEditor;

--- a/frontend/jwst-frontend/src/types/CurvesTypes.ts
+++ b/frontend/jwst-frontend/src/types/CurvesTypes.ts
@@ -1,0 +1,21 @@
+/** A single control point on the curves editor canvas */
+export interface CurveControlPoint {
+  /** Input brightness 0.0-1.0 (x-axis) */
+  input: number;
+  /** Output brightness 0.0-1.0 (y-axis) */
+  output: number;
+}
+
+/** Named preset for common curve adjustments */
+export type CurvePresetName = 'linear' | 'auto_contrast' | 'high_contrast' | 'invert';
+
+/** Definition of a preset curve */
+export interface CurvePreset {
+  name: CurvePresetName;
+  label: string;
+  description: string;
+  points: CurveControlPoint[];
+}
+
+/** A 256-entry lookup table mapping input [0..255] to output [0..255] */
+export type LookupTable = Uint8Array;

--- a/frontend/jwst-frontend/src/utils/curvesUtils.ts
+++ b/frontend/jwst-frontend/src/utils/curvesUtils.ts
@@ -1,0 +1,208 @@
+import type {
+  CurveControlPoint,
+  CurvePreset,
+  CurvePresetName,
+  LookupTable,
+} from '../types/CurvesTypes';
+
+/** Spline segment coefficients: S(x) = a + b*(x-xi) + c*(x-xi)^2 + d*(x-xi)^3 */
+interface SplineCoefficients {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+}
+
+/**
+ * Compute natural cubic spline coefficients using the Thomas algorithm.
+ * Natural boundary: second derivative = 0 at both endpoints.
+ */
+function computeSplineCoefficients(xs: number[], ys: number[]): SplineCoefficients[] {
+  const n = xs.length - 1;
+  if (n < 1) return [];
+
+  // For two points, return a simple linear segment
+  if (n === 1) {
+    const slope = (ys[1] - ys[0]) / (xs[1] - xs[0]);
+    return [{ a: ys[0], b: slope, c: 0, d: 0 }];
+  }
+
+  // Compute interval widths
+  const h = new Array<number>(n);
+  for (let i = 0; i < n; i++) {
+    h[i] = xs[i + 1] - xs[i];
+  }
+
+  // Build tridiagonal system for second derivatives (sigma)
+  const alpha = new Array<number>(n - 1);
+  for (let i = 0; i < n - 1; i++) {
+    alpha[i] = (3 / h[i + 1]) * (ys[i + 2] - ys[i + 1]) - (3 / h[i]) * (ys[i + 1] - ys[i]);
+  }
+
+  // Solve tridiagonal system via Thomas algorithm
+  const l = new Array<number>(n - 1);
+  const mu = new Array<number>(n - 1);
+  const z = new Array<number>(n - 1);
+
+  l[0] = 2 * (h[0] + h[1]);
+  mu[0] = h[1] / l[0];
+  z[0] = alpha[0] / l[0];
+
+  for (let i = 1; i < n - 1; i++) {
+    l[i] = 2 * (h[i] + h[i + 1]) - h[i] * mu[i - 1];
+    mu[i] = i < n - 2 ? h[i + 1] / l[i] : 0;
+    z[i] = (alpha[i] - h[i] * z[i - 1]) / l[i];
+  }
+
+  // Back-substitution for second derivatives
+  const sigma = new Array<number>(n + 1).fill(0); // Natural BCs: sigma[0] = sigma[n] = 0
+  for (let i = n - 2; i >= 0; i--) {
+    sigma[i + 1] = z[i] - mu[i] * sigma[i + 2];
+  }
+
+  // Compute polynomial coefficients for each segment
+  const coeffs: SplineCoefficients[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    coeffs[i] = {
+      a: ys[i],
+      b: (ys[i + 1] - ys[i]) / h[i] - (h[i] * (sigma[i + 1] + 2 * sigma[i])) / 3,
+      c: sigma[i],
+      d: (sigma[i + 1] - sigma[i]) / (3 * h[i]),
+    };
+  }
+
+  return coeffs;
+}
+
+/**
+ * Evaluate the cubic spline at a given x value.
+ * Clamps result to [0, 1].
+ */
+function evaluateSpline(x: number, xs: number[], coeffs: SplineCoefficients[]): number {
+  const n = coeffs.length;
+  if (n === 0) return x; // Identity fallback
+
+  // Find the correct segment (binary search would be overkill for <10 points)
+  let seg = n - 1;
+  for (let i = 0; i < n; i++) {
+    if (x < xs[i + 1]) {
+      seg = i;
+      break;
+    }
+  }
+
+  const dx = x - xs[seg];
+  const { a, b, c, d } = coeffs[seg];
+  const y = a + b * dx + c * dx * dx + d * dx * dx * dx;
+
+  return Math.max(0, Math.min(1, y));
+}
+
+/**
+ * Generate a 256-entry lookup table from control points using cubic spline interpolation.
+ */
+export function generateLUT(controlPoints: CurveControlPoint[]): LookupTable {
+  const sorted = [...controlPoints].sort((a, b) => a.input - b.input);
+  const xs = sorted.map((p) => p.input);
+  const ys = sorted.map((p) => p.output);
+
+  const coeffs = computeSplineCoefficients(xs, ys);
+  const lut = new Uint8Array(256);
+
+  for (let i = 0; i < 256; i++) {
+    const x = i / 255;
+    const y = evaluateSpline(x, xs, coeffs);
+    lut[i] = Math.round(y * 255);
+  }
+
+  return lut;
+}
+
+/**
+ * Check if control points represent the identity (linear) curve.
+ * Returns true when the LUT would be a no-op.
+ */
+export function isIdentityCurve(controlPoints: CurveControlPoint[]): boolean {
+  if (controlPoints.length !== 2) return false;
+  const sorted = [...controlPoints].sort((a, b) => a.input - b.input);
+  const EPSILON = 0.001;
+  return (
+    Math.abs(sorted[0].input) < EPSILON &&
+    Math.abs(sorted[0].output) < EPSILON &&
+    Math.abs(sorted[1].input - 1) < EPSILON &&
+    Math.abs(sorted[1].output - 1) < EPSILON
+  );
+}
+
+/**
+ * Apply a LUT to ImageData in-place. Remaps R, G, B channels; alpha is untouched.
+ */
+export function applyLUT(imageData: ImageData, lut: LookupTable): void {
+  const data = imageData.data;
+  const len = data.length;
+  for (let i = 0; i < len; i += 4) {
+    data[i] = lut[data[i]]; // R
+    data[i + 1] = lut[data[i + 1]]; // G
+    data[i + 2] = lut[data[i + 2]]; // B
+    // alpha unchanged
+  }
+}
+
+/** Get the default (identity) control points. */
+export function getDefaultControlPoints(): CurveControlPoint[] {
+  return [
+    { input: 0, output: 0 },
+    { input: 1, output: 1 },
+  ];
+}
+
+/** All available curve presets. */
+export const CURVE_PRESETS: Record<CurvePresetName, CurvePreset> = {
+  linear: {
+    name: 'linear',
+    label: 'Linear',
+    description: 'No adjustment (reset)',
+    points: [
+      { input: 0, output: 0 },
+      { input: 1, output: 1 },
+    ],
+  },
+  auto_contrast: {
+    name: 'auto_contrast',
+    label: 'Auto Contrast',
+    description: 'Gentle S-curve for improved contrast',
+    points: [
+      { input: 0, output: 0 },
+      { input: 0.25, output: 0.15 },
+      { input: 0.5, output: 0.5 },
+      { input: 0.75, output: 0.85 },
+      { input: 1, output: 1 },
+    ],
+  },
+  high_contrast: {
+    name: 'high_contrast',
+    label: 'High Contrast',
+    description: 'Aggressive S-curve for maximum contrast',
+    points: [
+      { input: 0, output: 0 },
+      { input: 0.25, output: 0.05 },
+      { input: 0.5, output: 0.5 },
+      { input: 0.75, output: 0.95 },
+      { input: 1, output: 1 },
+    ],
+  },
+  invert: {
+    name: 'invert',
+    label: 'Invert',
+    description: 'Negative image',
+    points: [
+      { input: 0, output: 1 },
+      { input: 1, output: 0 },
+    ],
+  },
+};
+
+/** Get control points for a named preset. */
+export function getPresetControlPoints(name: CurvePresetName): CurveControlPoint[] {
+  return CURVE_PRESETS[name].points.map((p) => ({ ...p }));
+}


### PR DESCRIPTION
## Summary

- Adds a Photoshop/GIMP-style interactive curves editor to the FITS ImageViewer
- Natural cubic spline interpolation (Thomas algorithm) for smooth curve shaping
- 256-entry LUT applied via offscreen canvas overlay — zero cost when at default
- 4 built-in presets: Linear, Auto Contrast, High Contrast, Invert
- Interactive canvas: drag control points, double-click to add, right-click to remove
- Works alongside existing stretch + colormap pipeline (curves apply on top)
- Pan/zoom, cursor tracking, and region selection all work with curves active

## Files Changed

| File | Status | Description |
|------|--------|-------------|
| `types/CurvesTypes.ts` | NEW | TypeScript types for curves |
| `utils/curvesUtils.ts` | NEW | Spline math, LUT generation/application, presets |
| `components/CurvesEditor.tsx` | NEW | Interactive canvas-based curves panel |
| `components/CurvesEditor.css` | NEW | Panel styling |
| `components/ImageViewer.tsx` | MODIFIED | State, canvas overlay, panel integration |

## Test plan

1. **Start Docker stack**: `cd docker && docker compose up -d --build`
2. **Open any FITS image** in the ImageViewer
3. **Curves panel**: Verify it appears in floating panels (left side, below histograms), collapsible
4. **Drag control points**: Image should update in real-time with tonal adjustment
5. **Double-click canvas**: Adds a new control point
6. **Right-click a middle point**: Removes it (endpoint removal blocked, min 2 points enforced)
7. **Presets**: Click Auto Contrast, High Contrast, Invert — verify visible changes
8. **Reset**: Click reset icon — image returns to original
9. **Pan/zoom**: Works normally with curves active
10. **Change colormap/stretch**: Curves reapply correctly on top
11. **Cursor coordinates**: Still display when hovering with curves active
12. **Region selection**: Still works with curves active
13. **Open new image**: Curves reset to default automatically
14. **Performance**: No lag when dragging points (LUT application <5ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)