### PR TITLE
docs: Update tracking docs for session 2026-02-07

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -780,6 +780,6 @@ See [`docs/mast-usage.md`](docs/mast-usage.md) for detailed API examples, metada
 
 See [`docs/tech-debt.md`](docs/tech-debt.md) for the authoritative list of tech debt items, security issues, and their resolution status.
 
-**Quick stats**: 42 resolved | 39 remaining (as of 2026-02-06)
+**Quick stats**: 49 resolved | 32 remaining (as of 2026-02-07)
 
 Run `/tasks` to see current status and dependencies.

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -6,28 +6,12 @@ This document tracks known bugs and their resolution status.
 
 | Status | Count |
 |--------|-------|
-| **Open** | 1 |
-| **Resolved** | 2 |
+| **Open** | 0 |
+| **Resolved** | 3 |
 
 ## Open Bugs
 
-### 66. Race Condition in Download Resume
-**Priority**: Medium
-**Location**: `processing-engine/app/mast/routes.py:422-439`
-
-**Issue**: No check for duplicate resume requests - two clients could resume the same download job simultaneously, corrupting state.
-
-**Reproduction Steps**:
-1. Start a MAST download that gets interrupted
-2. Send two concurrent resume requests for the same job ID
-3. Both proceed without conflict detection
-
-**Expected Behavior**: Second resume request should return 409 Conflict while first is in progress.
-
-**Fix Approach**:
-1. Track in-progress resumes in a set with async lock
-2. Return 409 Conflict if job already being resumed
-3. Clean up tracking on completion/failure
+(None currently open)
 
 ---
 
@@ -51,3 +35,4 @@ This document tracks known bugs and their resolution status.
 |--------|-------------|----|
 | 60 | Unsafe URL Construction in Frontend | #158 |
 | 65 | Information Disclosure in Error Messages | TBD |
+| 66 | Race Condition in Download Resume | PR #177 |

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -243,9 +243,9 @@ Complete React frontend application with advanced FITS visualization capabilitie
 
 #### **Image Analysis (C-series):**
 
-- [ ] C2: Region selection and statistics (mean, median, std, min, max, sum, pixel count)
-- [ ] C3: Image comparison/blink mode (toggle, side-by-side, opacity overlay)
-- [ ] C4: Color balance and curves adjustment
+- [x] C2: Region selection and statistics (mean, median, std, min, max, sum, pixel count)
+- [x] C3: Image comparison/blink mode (toggle, side-by-side, opacity overlay)
+- [x] C4: Color balance and curves adjustment
 
 *Note: C1 (Smoothing/Noise Reduction) moved to Phase 5 (requires backend algorithms)*
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -6,8 +6,8 @@ This document tracks tech debt items and their resolution status.
 
 | Status | Count |
 |--------|-------|
-| **Resolved** | 46 |
-| **Remaining** | 35 |
+| **Resolved** | 49 |
+| **Remaining** | 32 |
 
 > **Code Style Suppressions (2026-02-03)**: Added 11 tech debt items (#77-#87) for StyleCop/CodeAnalysis rule suppressions in `.editorconfig`. These are lower priority but tracked for future cleanup.
 
@@ -551,7 +551,7 @@ These security issues were addressed in earlier PRs but may warrant re-review gi
 
 
 
-## Resolved Tasks (25)
+## Resolved Tasks (28)
 
 | Task | Description | PR |
 |------|-------------|-----|
@@ -591,6 +591,9 @@ These security issues were addressed in earlier PRs but may warrant re-review gi
 | #51 | Path Traversal via obsId Parameter | PR #108 |
 | #52 | SSRF Risk in MAST URL Construction | PR #110 |
 | #53 | Path Traversal in Chunked Downloader | PR #112 |
+| #90 | Disable Seed Users in Production | PR #176 |
+| #91 | Incomplete Downloads Panel Not Visible After Cancel | PR #176 |
+| #92 | Mosaic Wizard Export Button Cut Off | PR #176 |
 | #54 | Missing HTTPS/TLS Enforcement | PR #113 |
 | #55 | Missing Authentication on All API Endpoints | PR #117 |
 | #58 | Docker Containers Run as Root | PR #TBD |
@@ -1060,42 +1063,21 @@ The following StyleCop and CodeAnalysis rules are suppressed in `backend/.editor
 
 ---
 
-### 90. Disable Seed Users in Production
-**Priority**: MEDIUM
-**Location**: `backend/JwstDataAnalysis.API/Services/SeedDataService.cs`, `appsettings.json`
-**Category**: Security
-
-**Issue**: The `SeedDataService` creates default users on every startup if they don't exist. This is useful for development and testing (fresh databases always have a working admin), but must be disabled before any production deployment to prevent unauthorized default accounts.
-
-**Fix Approach**:
-1. Add `"Seeding": { "Enabled": false }` to `appsettings.Production.json`
-2. Check `Enabled` flag in `SeedDataService.SeedUsersAsync()` before creating users
-3. Log a warning if seeding is enabled in non-Development environments
-
-**Estimated Effort**: 30 minutes
+### ~~90. Disable Seed Users in Production~~ ✅ RESOLVED (PR #176)
+**Status**: Fixed in PR #176
+**Fix**: Created `SeedDataService` with `SeedingSettings` config POCO. Enabled by default in dev (`appsettings.json`), disabled in production (`appsettings.Production.json`). Logs warning if seeding enabled in non-Development environment.
 
 ---
 
-### 91. Incomplete Downloads Panel Not Visible After Cancel
-**Priority**: LOW
-**Location**: `frontend/jwst-frontend/src/components/MastSearch.tsx`
-**Category**: UX Bug
-
-**Issue**: After cancelling an active download, the Incomplete Downloads panel doesn't appear until the user hides and re-shows the MAST Search panel. The `resumableJobs` state is only fetched on component mount (`useEffect`), so a newly-cancelled download doesn't trigger a refresh.
-
-**Fix Approach**: After a cancel completes, re-fetch the resumable jobs list (`/mast/download/resumable`) to refresh the panel immediately.
-
-**Estimated Effort**: 15 minutes
+### ~~91. Incomplete Downloads Panel Not Visible After Cancel~~ ✅ RESOLVED (PR #176)
+**Status**: Fixed in PR #176
+**Fix**: Extracted `refreshResumableJobs()` helper, called from `closeProgressModal()` so panel refreshes after cancel/error/close.
 
 ---
 
-### 92. Mosaic Wizard Export Button Cut Off on Generate Step
-
-- **Priority**: Low
-- **Location**: `frontend/jwst-frontend/src/components/MosaicWizard.css`
-- **Issue**: On the Generate step (step 3), after generating a mosaic, the "Download PNG/FITS" export button is partially cut off at the bottom of the content area. The image container expands to fill all available space, pushing the action buttons below the visible area.
-- **Impact**: Users have to scroll or may not notice the export button exists after generating a mosaic.
-- **Fix Approach**: Rework the generate step flex layout so the image container properly shrinks to leave room for the actions row. Consider a max-height constraint on the image container or moving the export button into the footer bar.
+### ~~92. Mosaic Wizard Export Button Cut Off on Generate Step~~ ✅ RESOLVED (PR #176)
+**Status**: Fixed in PR #176
+**Fix**: Merged duplicate `.mosaic-result-actions` CSS rules, preserving `flex-shrink: 0` so the export button isn't pushed below the visible area.
 
 ## Adding New Tech Debt
 


### PR DESCRIPTION
## Summary

- Mark C2, C3, C4 complete in `docs/development-plan.md` (all C-series image analysis done)
- Mark #90, #91, #92 resolved in `docs/tech-debt.md` (PR #176)
- Move bug #66 to resolved in `docs/bugs.md` (PR #177)
- Update summary counts: 49 resolved / 32 remaining tech debt, 0 open bugs
- Update CLAUDE.md quick stats

## Test plan

1. Verify markdown renders correctly on GitHub
2. Confirm counts match resolved items in tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)