### PR TITLE
feat: Add angular scale bar to FITS viewer (D4)

### DIFF
--- a/frontend/jwst-frontend/src/components/FitsViewer.css
+++ b/frontend/jwst-frontend/src/components/FitsViewer.css
@@ -296,6 +296,17 @@
   color: #fff;
 }
 
+.viewer-floating-toolbar .btn-icon.active {
+  background: rgba(0, 229, 204, 0.15);
+  color: #00e5cc;
+}
+
+.btn-icon:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 .btn-text {
   background: transparent;
   border: 1px solid rgba(255, 255, 255, 0.1);

--- a/frontend/jwst-frontend/src/components/ImageViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageViewer.tsx
@@ -1238,6 +1238,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
                 scaleFactor={pixelData?.scale_factor ?? 1}
                 imageElement={imageRef.current}
                 visible={showWcsGrid}
+                zoomScale={scale}
               />
 
               {/* Region Selection Overlay */}

--- a/frontend/jwst-frontend/src/components/WcsGridOverlay.css
+++ b/frontend/jwst-frontend/src/components/WcsGridOverlay.css
@@ -29,3 +29,53 @@
   font-weight: 500;
   dominant-baseline: middle;
 }
+
+/* --- Angular Scale Bar --- */
+
+.wcs-scale-bar {
+  position: absolute;
+  bottom: 72px;
+  right: 20px;
+  z-index: 6;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.wcs-scale-bar-label {
+  color: #00e5cc;
+  font-family: 'JetBrains Mono', 'SF Mono', Monaco, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  text-shadow:
+    0 0 4px rgba(0, 0, 0, 0.9),
+    0 0 8px rgba(0, 0, 0, 0.7);
+  white-space: nowrap;
+}
+
+.wcs-scale-bar-line {
+  height: 2px;
+  background: #00e5cc;
+  opacity: 0.8;
+  position: relative;
+  min-width: 20px;
+}
+
+.wcs-scale-bar-tick {
+  position: absolute;
+  width: 2px;
+  height: 8px;
+  background: #00e5cc;
+  opacity: 0.8;
+  top: -3px;
+}
+
+.wcs-scale-bar-tick-left {
+  left: 0;
+}
+
+.wcs-scale-bar-tick-right {
+  right: 0;
+}


### PR DESCRIPTION
## Summary
- Add dynamic angular scale bar to the FITS viewer, positioned in the lower-right corner
- Scale bar automatically appears when WCS grid overlay is enabled
- Computes pixel scale from WCS CD matrix or CDELT values
- Snaps to "nice" angular values (0.1" to 10° range)
- Dynamically resizes based on current zoom level
- Formatted labels: arcsec, arcmin, or degrees depending on scale
- Styling matches WCS grid overlay (cyan color, monospace font, text shadows)
- Added active toggle state and disabled state for toolbar buttons

## Files Changed
- `wcsGridUtils.ts` — Added `computeScaleBar()`, `getPixelScaleArcsec()`, `ScaleBarData` interface
- `WcsGridOverlay.tsx` — Added `zoomScale` prop, scale bar rendering with Fragment wrapper
- `WcsGridOverlay.css` — Scale bar styles (positioned bottom-right, tick marks)
- `ImageViewer.tsx` — Pass `zoomScale={scale}` prop to WcsGridOverlay
- `FitsViewer.css` — Active/disabled toolbar button styles

## Test Plan
1. Open a FITS image with WCS data in the viewer
2. Toggle the WCS Grid button — grid and scale bar should both appear
3. Zoom in/out — scale bar should dynamically adjust its length and label
4. Scale bar should show sensible values (e.g. "30 arcsec" for typical JWST images)
5. Verify scale bar appears in lower-right corner, above the floating toolbar
6. Toggle WCS Grid off — both grid and scale bar should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)