### PR TITLE
fix: Resolve all backend build warnings (SA1516, CA1848)

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/MastController.Log.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.Log.cs
@@ -36,6 +36,10 @@ namespace JwstDataAnalysis.API.Controllers
             Message = "MAST download failed for: {ObsId}")]
         private partial void LogDownloadFailed(Exception ex, string obsId);
 
+        [LoggerMessage(EventId = 2108, Level = LogLevel.Error,
+            Message = "Failed to dismiss download {JobId}")]
+        private partial void LogFailedToDismissDownload(Exception ex, string jobId);
+
         // Import job operations (22xx)
         [LoggerMessage(EventId = 2201, Level = LogLevel.Information,
             Message = "Starting MAST import job {JobId} for observation: {ObsId}")]

--- a/backend/JwstDataAnalysis.API/Controllers/MastController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.cs
@@ -679,7 +679,7 @@ namespace JwstDataAnalysis.API.Controllers
             }
             catch (HttpRequestException ex)
             {
-                logger.LogError(ex, "Failed to dismiss download {JobId}", jobId);
+                LogFailedToDismissDownload(ex, jobId);
                 return StatusCode(503, new { error = "Processing engine unavailable" });
             }
         }

--- a/backend/JwstDataAnalysis.API/Models/AnalysisModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/AnalysisModels.cs
@@ -11,25 +11,35 @@ namespace JwstDataAnalysis.API.Models
     public class RegionStatisticsRequestDto
     {
         public string DataId { get; set; } = string.Empty;
+
         public string RegionType { get; set; } = string.Empty;
+
         public RectangleRegionDto? Rectangle { get; set; }
+
         public EllipseRegionDto? Ellipse { get; set; }
+
         public int HduIndex { get; set; } = -1;
     }
 
     public class RectangleRegionDto
     {
         public int X { get; set; }
+
         public int Y { get; set; }
+
         public int Width { get; set; }
+
         public int Height { get; set; }
     }
 
     public class EllipseRegionDto
     {
         public double CenterX { get; set; }
+
         public double CenterY { get; set; }
+
         public double RadiusX { get; set; }
+
         public double RadiusY { get; set; }
     }
 
@@ -39,11 +49,17 @@ namespace JwstDataAnalysis.API.Models
     public class RegionStatisticsResponseDto
     {
         public double Mean { get; set; }
+
         public double Median { get; set; }
+
         public double Std { get; set; }
+
         public double Min { get; set; }
+
         public double Max { get; set; }
+
         public double Sum { get; set; }
+
         public int PixelCount { get; set; }
     }
 

--- a/backend/JwstDataAnalysis.API/Services/MastService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/MastService.Log.cs
@@ -85,6 +85,10 @@ namespace JwstDataAnalysis.API.Services
             Message = "Error getting resumable downloads")]
         private partial void LogErrorGettingResumableDownloads(Exception ex);
 
+        [LoggerMessage(EventId = 4214, Level = LogLevel.Error,
+            Message = "Failed to dismiss download {JobId}")]
+        private partial void LogFailedToDismissDownload(Exception ex, string jobId);
+
         // Processing engine communication (43xx)
         [LoggerMessage(EventId = 4301, Level = LogLevel.Debug,
             Message = "Calling processing engine: {Endpoint} with body: {Body}")]

--- a/backend/JwstDataAnalysis.API/Services/MastService.cs
+++ b/backend/JwstDataAnalysis.API/Services/MastService.cs
@@ -265,7 +265,7 @@ namespace JwstDataAnalysis.API.Services
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Failed to dismiss download {JobId}", jobId);
+                LogFailedToDismissDownload(ex, jobId);
                 return false;
             }
         }

--- a/backend/JwstDataAnalysis.API/Services/SeedDataService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/SeedDataService.Log.cs
@@ -1,0 +1,29 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+namespace JwstDataAnalysis.API.Services
+{
+    public partial class SeedDataService
+    {
+        // Event IDs: 7xxx for seed data operations
+        [LoggerMessage(EventId = 7001, Level = LogLevel.Information,
+            Message = "Database seeding is disabled via configuration")]
+        private partial void LogSeedingDisabled();
+
+        [LoggerMessage(EventId = 7002, Level = LogLevel.Warning,
+            Message = "Database seeding is enabled in {Environment} environment. Set Seeding:Enabled to false in production configuration")]
+        private partial void LogSeedingEnabledInNonDev(string environment);
+
+        [LoggerMessage(EventId = 7003, Level = LogLevel.Debug,
+            Message = "Seed user '{Username}' already exists, skipping")]
+        private partial void LogSeedUserExists(string username);
+
+        [LoggerMessage(EventId = 7004, Level = LogLevel.Information,
+            Message = "Created seed user '{Username}'")]
+        private partial void LogSeedUserCreated(string username);
+
+        [LoggerMessage(EventId = 7005, Level = LogLevel.Warning,
+            Message = "Failed to create seed user '{Username}'")]
+        private partial void LogSeedUserFailed(Exception ex, string username);
+    }
+}

--- a/backend/JwstDataAnalysis.API/Services/SeedDataService.cs
+++ b/backend/JwstDataAnalysis.API/Services/SeedDataService.cs
@@ -12,7 +12,7 @@ namespace JwstDataAnalysis.API.Services
     /// Seeds default users into the database on application startup.
     /// Controlled by the Seeding:Enabled configuration flag.
     /// </summary>
-    public class SeedDataService(
+    public partial class SeedDataService(
         IMongoDBService mongoDBService,
         IAuthService authService,
         IOptions<SeedingSettings> seedingSettings,
@@ -32,16 +32,13 @@ namespace JwstDataAnalysis.API.Services
         {
             if (!settings.Enabled)
             {
-                logger.LogInformation("Database seeding is disabled via configuration");
+                LogSeedingDisabled();
                 return;
             }
 
             if (!environment.IsDevelopment())
             {
-                logger.LogWarning(
-                    "Database seeding is enabled in {Environment} environment. " +
-                    "Set Seeding:Enabled to false in production configuration",
-                    environment.EnvironmentName);
+                LogSeedingEnabledInNonDev(environment.EnvironmentName);
             }
 
             await SeedUserAsync(
@@ -62,7 +59,7 @@ namespace JwstDataAnalysis.API.Services
             var existingUser = await mongoDBService.GetUserByUsernameAsync(username);
             if (existingUser != null)
             {
-                logger.LogDebug("Seed user '{Username}' already exists, skipping", username);
+                LogSeedUserExists(username);
                 return;
             }
 
@@ -76,11 +73,11 @@ namespace JwstDataAnalysis.API.Services
                     DisplayName = displayName,
                 });
 
-                logger.LogInformation("Created seed user '{Username}'", username);
+                LogSeedUserCreated(username);
             }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "Failed to create seed user '{Username}'", username);
+                LogSeedUserFailed(ex, username);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixed all backend build warnings so `dotnet build --warnaserror` passes cleanly
- SA1516: Added blank lines between properties in `AnalysisModels.cs` DTOs
- CA1848: Replaced 7 direct `logger.Log*()` calls with `[LoggerMessage]` source generators in `SeedDataService`, `MastService`, and `MastController`
- Also updated `/compliance-check` skill to include backend lint (`--warnaserror`) as a check

## Test plan
- [ ] `dotnet build backend/JwstDataAnalysis.sln --warnaserror` — 0 warnings, 0 errors
- [ ] `dotnet test backend/JwstDataAnalysis.API.Tests` — 243/243 passing
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)