### PR TITLE
feat: Add AVM metadata embedding on export (D6)

### DIFF
--- a/frontend/jwst-frontend/src/components/ExportOptionsPanel.css
+++ b/frontend/jwst-frontend/src/components/ExportOptionsPanel.css
@@ -285,6 +285,61 @@
   margin-top: 4px;
 }
 
+/* AVM Toggle */
+.export-avm-toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.export-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.export-toggle-checkbox {
+  display: none;
+}
+
+.export-toggle-switch {
+  position: relative;
+  width: 32px;
+  height: 18px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 9px;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+.export-toggle-switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.export-toggle-checkbox:checked + .export-toggle-switch {
+  background: rgba(77, 184, 255, 0.5);
+}
+
+.export-toggle-checkbox:checked + .export-toggle-switch::after {
+  left: 16px;
+  background: #4db8ff;
+}
+
+.export-toggle-text {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
 /* Footer */
 .export-options-footer {
   padding: 12px;

--- a/frontend/jwst-frontend/src/components/ExportOptionsPanel.tsx
+++ b/frontend/jwst-frontend/src/components/ExportOptionsPanel.tsx
@@ -60,6 +60,7 @@ const ExportOptionsPanel: React.FC<ExportOptionsPanelProps> = ({
   const [resolution, setResolution] = useState<ExportResolutionPreset>('standard');
   const [customWidth, setCustomWidth] = useState<number>(1200);
   const [customHeight, setCustomHeight] = useState<number>(1200);
+  const [embedAvm, setEmbedAvm] = useState<boolean>(true);
 
   const handleExport = () => {
     const preset = ExportResolutionPresets[resolution];
@@ -71,6 +72,7 @@ const ExportOptionsPanel: React.FC<ExportOptionsPanelProps> = ({
       quality,
       width,
       height,
+      embedAvm,
     });
   };
 
@@ -198,6 +200,25 @@ const ExportOptionsPanel: React.FC<ExportOptionsPanelProps> = ({
             <span className="export-dimension-hint">10-8000 pixels</span>
           </div>
         )}
+        {/* AVM Metadata Toggle */}
+        <div className="export-control-group">
+          <div className="export-avm-toggle">
+            <label className="export-toggle-label" htmlFor="avm-toggle">
+              <input
+                id="avm-toggle"
+                type="checkbox"
+                checked={embedAvm}
+                onChange={(e) => setEmbedAvm(e.target.checked)}
+                className="export-toggle-checkbox"
+              />
+              <span className="export-toggle-switch" />
+              <span className="export-toggle-text">Embed AVM metadata</span>
+            </label>
+            <span className="export-format-hint">
+              Embeds coordinates and observation info (AVM 1.2 standard)
+            </span>
+          </div>
+        </div>
       </div>
 
       <div className="export-options-footer">

--- a/frontend/jwst-frontend/src/components/ImageViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageViewer.tsx
@@ -964,7 +964,8 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
         `&whitePoint=${stretchParams.whitePoint}` +
         `&asinhA=${stretchParams.asinhA}` +
         `&format=${options.format}` +
-        `&quality=${options.quality}`;
+        `&quality=${options.quality}` +
+        `&embedAvm=${options.embedAvm}`;
 
       const token = localStorage.getItem('jwst_auth_token');
       const response = await fetch(exportUrl, {

--- a/frontend/jwst-frontend/src/types/JwstDataTypes.ts
+++ b/frontend/jwst-frontend/src/types/JwstDataTypes.ts
@@ -228,6 +228,7 @@ export interface ExportOptions {
   quality: number; // 1-100 (only used for JPEG)
   width: number; // 10-8000 pixels
   height: number; // 10-8000 pixels
+  embedAvm: boolean; // Embed AVM XMP metadata in exported image
 }
 
 // Resolution presets for export

--- a/processing-engine/app/processing/avm.py
+++ b/processing-engine/app/processing/avm.py
@@ -1,0 +1,324 @@
+"""AVM (Astronomy Visualization Metadata) XMP embedding for exported images.
+
+Implements the AVM 1.2 standard for embedding astronomical metadata into
+PNG and JPEG images. This allows exported images to carry WCS coordinates,
+observation details, and instrument information that tools like
+WorldWide Telescope and Aladin can read.
+
+Reference: https://www.virtualastronomy.org/avm_metadata.php
+"""
+
+import io
+import json
+import logging
+import math
+import xml.etree.ElementTree as ET
+
+from PIL import Image, PngImagePlugin
+
+
+logger = logging.getLogger(__name__)
+
+# AVM 1.2 XMP namespace URIs
+NS_X = "adobe:ns:meta/"
+NS_RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+NS_DC = "http://purl.org/dc/elements/1.1/"
+NS_AVM = "http://www.communicatingastronomy.org/avm/1.0/"
+NS_PHOTOSHOP = "http://ns.adobe.com/photoshop/1.0/"
+
+
+def _build_xmp_packet(metadata: dict) -> str:
+    """Build an XMP packet string conforming to AVM 1.2.
+
+    Args:
+        metadata: Dictionary with optional keys:
+            - ra: float, reference RA in degrees
+            - dec: float, reference Dec in degrees
+            - scale_x: float, pixel scale in degrees/pixel (axis 1)
+            - scale_y: float, pixel scale in degrees/pixel (axis 2)
+            - rotation: float, image rotation in degrees
+            - coordinate_frame: str, e.g. "ICRS", "FK5"
+            - target_name: str, astronomical object name
+            - instrument: str, instrument name
+            - filter: str, filter name
+            - facility: str, telescope/facility name
+            - description: str, image description
+            - publisher: str, publisher/creator name
+            - spectral_band: str, e.g. "Infrared", "Optical"
+
+    Returns:
+        XMP packet as a string ready for embedding.
+    """
+    # Register namespaces to avoid ns0/ns1 prefixes
+    ET.register_namespace("x", NS_X)
+    ET.register_namespace("rdf", NS_RDF)
+    ET.register_namespace("dc", NS_DC)
+    ET.register_namespace("avm", NS_AVM)
+    ET.register_namespace("photoshop", NS_PHOTOSHOP)
+
+    # Root xpacket wrapper
+    xmpmeta = ET.Element(f"{{{NS_X}}}xmpmeta")
+    rdf = ET.SubElement(xmpmeta, f"{{{NS_RDF}}}RDF")
+    desc = ET.SubElement(rdf, f"{{{NS_RDF}}}Description")
+
+    # Dublin Core: title / description
+    if metadata.get("target_name"):
+        title_elem = ET.SubElement(desc, f"{{{NS_DC}}}title")
+        alt = ET.SubElement(title_elem, f"{{{NS_RDF}}}Alt")
+        li = ET.SubElement(alt, f"{{{NS_RDF}}}li")
+        li.set("xml:lang", "x-default")
+        li.text = metadata["target_name"]
+
+    if metadata.get("description"):
+        desc_elem = ET.SubElement(desc, f"{{{NS_DC}}}description")
+        alt = ET.SubElement(desc_elem, f"{{{NS_RDF}}}Alt")
+        li = ET.SubElement(alt, f"{{{NS_RDF}}}li")
+        li.set("xml:lang", "x-default")
+        li.text = metadata["description"]
+
+    if metadata.get("publisher"):
+        creator = ET.SubElement(desc, f"{{{NS_DC}}}creator")
+        seq = ET.SubElement(creator, f"{{{NS_RDF}}}Seq")
+        li = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li.text = metadata["publisher"]
+
+    # AVM Spatial fields
+    coord_frame = metadata.get("coordinate_frame", "ICRS")
+    ET.SubElement(desc, f"{{{NS_AVM}}}Spatial.CoordinateFrame").text = coord_frame
+    ET.SubElement(desc, f"{{{NS_AVM}}}Spatial.Equinox").text = "J2000"
+    ET.SubElement(desc, f"{{{NS_AVM}}}Spatial.CoordsystemProjection").text = "TAN"
+
+    if metadata.get("ra") is not None and metadata.get("dec") is not None:
+        ref_val = ET.SubElement(desc, f"{{{NS_AVM}}}Spatial.ReferenceValue")
+        seq = ET.SubElement(ref_val, f"{{{NS_RDF}}}Seq")
+        li_ra = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li_ra.text = str(float(metadata["ra"]))
+        li_dec = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li_dec.text = str(float(metadata["dec"]))
+
+    if metadata.get("scale_x") is not None and metadata.get("scale_y") is not None:
+        scale = ET.SubElement(desc, f"{{{NS_AVM}}}Spatial.Scale")
+        seq = ET.SubElement(scale, f"{{{NS_RDF}}}Seq")
+        li_x = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li_x.text = str(float(metadata["scale_x"]))
+        li_y = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li_y.text = str(float(metadata["scale_y"]))
+
+    if metadata.get("rotation") is not None:
+        ET.SubElement(desc, f"{{{NS_AVM}}}Spatial.Rotation").text = str(float(metadata["rotation"]))
+
+    # AVM Subject fields
+    if metadata.get("target_name"):
+        subj_name = ET.SubElement(desc, f"{{{NS_AVM}}}Subject.Name")
+        seq = ET.SubElement(subj_name, f"{{{NS_RDF}}}Seq")
+        li = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li.text = metadata["target_name"]
+
+    # AVM Observation fields
+    if metadata.get("facility"):
+        fac = ET.SubElement(desc, f"{{{NS_AVM}}}Facility")
+        seq = ET.SubElement(fac, f"{{{NS_RDF}}}Seq")
+        li = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li.text = metadata["facility"]
+
+    if metadata.get("instrument"):
+        inst = ET.SubElement(desc, f"{{{NS_AVM}}}Instrument")
+        seq = ET.SubElement(inst, f"{{{NS_RDF}}}Seq")
+        li = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li.text = metadata["instrument"]
+
+    if metadata.get("filter"):
+        filt = ET.SubElement(desc, f"{{{NS_AVM}}}Spectral.CentralWavelength")
+        seq = ET.SubElement(filt, f"{{{NS_RDF}}}Seq")
+        li = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li.text = metadata["filter"]
+
+    if metadata.get("spectral_band"):
+        band = ET.SubElement(desc, f"{{{NS_AVM}}}Spectral.Band")
+        seq = ET.SubElement(band, f"{{{NS_RDF}}}Seq")
+        li = ET.SubElement(seq, f"{{{NS_RDF}}}li")
+        li.text = metadata["spectral_band"]
+
+    # Photoshop: credit / source
+    if metadata.get("publisher"):
+        ET.SubElement(desc, f"{{{NS_PHOTOSHOP}}}Credit").text = metadata["publisher"]
+    ET.SubElement(desc, f"{{{NS_PHOTOSHOP}}}Source").text = "James Webb Space Telescope"
+
+    # Serialize to string
+    xml_bytes = ET.tostring(xmpmeta, encoding="unicode", xml_declaration=False)
+
+    # Wrap in standard XMP packet processing instructions
+    xmp_packet = (
+        '<?xpacket begin="\xef\xbb\xbf" id="W5M0MpCehiHzreSzNTczkc9d"?>\n'
+        + xml_bytes
+        + "\n<?xpacket end='w'?>"
+    )
+    return xmp_packet
+
+
+def embed_avm_xmp(
+    image_bytes: bytes,
+    image_format: str,
+    metadata: dict,
+) -> bytes:
+    """Embed AVM XMP metadata into a PNG or JPEG image.
+
+    Args:
+        image_bytes: The raw image bytes (PNG or JPEG).
+        image_format: "png" or "jpeg".
+        metadata: AVM metadata dictionary (see _build_xmp_packet for keys).
+
+    Returns:
+        New image bytes with AVM XMP metadata embedded.
+    """
+    xmp_packet = _build_xmp_packet(metadata)
+    logger.info(f"Embedding AVM metadata: {list(metadata.keys())}")
+
+    img = Image.open(io.BytesIO(image_bytes))
+
+    output = io.BytesIO()
+
+    if image_format == "png":
+        # For PNG, add XMP as a tEXt chunk with key "XML:com.adobe.xmp"
+        png_info = PngImagePlugin.PngInfo()
+        png_info.add_text("XML:com.adobe.xmp", xmp_packet)
+        # Preserve existing PNG metadata if present
+        if hasattr(img, "info"):
+            for key, value in img.info.items():
+                if key != "XML:com.adobe.xmp" and isinstance(value, str):
+                    png_info.add_text(key, value)
+        img.save(output, format="PNG", pnginfo=png_info)
+    elif image_format == "jpeg":
+        # For JPEG, embed XMP via the xmp keyword argument
+        xmp_bytes = xmp_packet.encode("utf-8")
+        # Ensure RGB mode for JPEG
+        if img.mode == "RGBA":
+            background = Image.new("RGB", img.size, (0, 0, 0))
+            background.paste(img, mask=img.split()[3])
+            img = background
+        elif img.mode != "RGB":
+            img = img.convert("RGB")
+        img.save(output, format="JPEG", quality=95, xmp=xmp_bytes)
+    else:
+        logger.warning(f"AVM embedding not supported for format: {image_format}")
+        return image_bytes
+
+    result = output.getvalue()
+    logger.info(f"AVM embedded: {len(image_bytes)} -> {len(result)} bytes ({image_format})")
+    return result
+
+
+def extract_wcs_for_avm(
+    header: dict,
+    original_width: int,
+    original_height: int,
+    output_width: int,
+    output_height: int,
+) -> dict:
+    """Extract and scale WCS parameters from a FITS header for AVM embedding.
+
+    The preview image is typically resized from the original FITS dimensions,
+    so we need to adjust CRPIX and CDELT/CD matrix values accordingly.
+
+    Args:
+        header: FITS header (dict-like).
+        original_width: Original FITS image width in pixels.
+        original_height: Original FITS image height in pixels.
+        output_width: Output preview image width in pixels.
+        output_height: Output preview image height in pixels.
+
+    Returns:
+        Dictionary with AVM-ready WCS fields, or empty dict if WCS not available.
+    """
+    try:
+        crpix1 = float(header.get("CRPIX1", 0))
+        crval1 = float(header.get("CRVAL1", 0))
+        crval2 = float(header.get("CRVAL2", 0))
+
+        # Check we have meaningful WCS
+        if crpix1 == 0 and crval1 == 0:
+            return {}
+
+        # Get pixel scale from CD matrix or CDELT
+        cd1_1 = float(header.get("CD1_1", header.get("CDELT1", 0)))
+        cd2_1 = float(header.get("CD2_1", 0))
+        cd2_2 = float(header.get("CD2_2", header.get("CDELT2", 0)))
+
+        if cd1_1 == 0 and cd2_2 == 0:
+            return {}
+
+        # Compute scale ratios for the resize
+        scale_x = original_width / output_width if output_width > 0 else 1.0
+        scale_y = original_height / output_height if output_height > 0 else 1.0
+
+        # Adjust pixel scale (degrees/pixel becomes larger when image is smaller)
+        scaled_cd1_1 = cd1_1 * scale_x
+        scaled_cd2_1 = cd2_1 * scale_x
+        scaled_cd2_2 = cd2_2 * scale_y
+
+        # Compute rotation from CD matrix (degrees, measured N through E)
+        rotation = math.degrees(math.atan2(-scaled_cd2_1, scaled_cd2_2))
+
+        # Coordinate frame from CTYPE
+        ctype1 = str(header.get("CTYPE1", ""))
+        coord_frame = "ICRS"
+        if "FK5" in ctype1.upper():
+            coord_frame = "FK5"
+        elif "FK4" in ctype1.upper():
+            coord_frame = "FK4"
+        elif "GAL" in ctype1.upper():
+            coord_frame = "GAL"
+
+        return {
+            "ra": crval1,
+            "dec": crval2,
+            "scale_x": scaled_cd1_1,
+            "scale_y": scaled_cd2_2,
+            "rotation": rotation,
+            "coordinate_frame": coord_frame,
+        }
+
+    except (ValueError, KeyError, TypeError) as e:
+        logger.warning(f"Could not extract WCS for AVM: {e}")
+        return {}
+
+
+def parse_avm_metadata_json(avm_metadata_json: str) -> dict:
+    """Parse AVM metadata from JSON string passed via query parameter.
+
+    Args:
+        avm_metadata_json: JSON string with observation metadata from the backend.
+
+    Returns:
+        Dictionary with AVM-compatible keys.
+    """
+    if not avm_metadata_json:
+        return {}
+
+    try:
+        raw = json.loads(avm_metadata_json)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Could not parse avm_metadata JSON")
+        return {}
+
+    result = {}
+
+    # Map backend metadata fields to AVM keys
+    if raw.get("target_name"):
+        result["target_name"] = raw["target_name"]
+    if raw.get("instrument"):
+        result["instrument"] = raw["instrument"]
+    if raw.get("filter"):
+        result["filter"] = raw["filter"]
+    if raw.get("description"):
+        result["description"] = raw["description"]
+    if raw.get("facility"):
+        result["facility"] = raw["facility"]
+    else:
+        result["facility"] = "JWST"
+    if raw.get("spectral_band"):
+        result["spectral_band"] = raw["spectral_band"]
+    if raw.get("publisher"):
+        result["publisher"] = raw["publisher"]
+
+    return result

--- a/processing-engine/tests/test_avm_embedding.py
+++ b/processing-engine/tests/test_avm_embedding.py
@@ -1,0 +1,295 @@
+"""Tests for AVM XMP metadata embedding."""
+
+import io
+import json
+import xml.etree.ElementTree as ET
+
+import pytest
+from PIL import Image
+
+from app.processing.avm import (
+    _build_xmp_packet,
+    embed_avm_xmp,
+    extract_wcs_for_avm,
+    parse_avm_metadata_json,
+)
+
+
+def _create_test_png(width: int = 100, height: int = 100) -> bytes:
+    """Create a minimal test PNG image."""
+    img = Image.new("RGB", (width, height), color=(128, 64, 32))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _create_test_jpeg(width: int = 100, height: int = 100) -> bytes:
+    """Create a minimal test JPEG image."""
+    img = Image.new("RGB", (width, height), color=(128, 64, 32))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=90)
+    return buf.getvalue()
+
+
+class TestBuildXmpPacket:
+    """Tests for _build_xmp_packet."""
+
+    def test_basic_packet_structure(self):
+        xmp = _build_xmp_packet({"target_name": "NGC-6804"})
+        assert "<?xpacket begin=" in xmp
+        assert "<?xpacket end='w'?>" in xmp
+        assert "NGC-6804" in xmp
+
+    def test_spatial_fields(self):
+        metadata = {
+            "ra": 295.123,
+            "dec": -10.456,
+            "scale_x": -0.001,
+            "scale_y": 0.001,
+            "rotation": 45.0,
+            "coordinate_frame": "ICRS",
+        }
+        xmp = _build_xmp_packet(metadata)
+        assert "295.123" in xmp
+        assert "-10.456" in xmp
+        assert "ICRS" in xmp
+        assert "45.0" in xmp
+        assert "TAN" in xmp  # projection
+
+    def test_observation_fields(self):
+        metadata = {
+            "target_name": "Carina Nebula",
+            "instrument": "NIRCam",
+            "filter": "F200W",
+            "facility": "JWST",
+            "spectral_band": "Infrared",
+        }
+        xmp = _build_xmp_packet(metadata)
+        assert "Carina Nebula" in xmp
+        assert "NIRCam" in xmp
+        assert "F200W" in xmp
+        assert "JWST" in xmp
+        assert "Infrared" in xmp
+
+    def test_publisher_and_description(self):
+        metadata = {
+            "publisher": "JWST Data Analysis App",
+            "description": "Preview of NGC-6804 taken with NIRCam",
+        }
+        xmp = _build_xmp_packet(metadata)
+        assert "JWST Data Analysis App" in xmp
+        assert "Preview of NGC-6804" in xmp
+
+    def test_empty_metadata(self):
+        xmp = _build_xmp_packet({})
+        assert "<?xpacket begin=" in xmp
+        # Should still have the default spatial fields
+        assert "ICRS" in xmp
+        assert "J2000" in xmp
+
+    def test_xmp_is_valid_xml(self):
+        metadata = {"target_name": "Test", "ra": 180.0, "dec": 45.0}
+        xmp = _build_xmp_packet(metadata)
+        # Extract just the XML part (between xpacket markers)
+        xml_start = xmp.index("<")
+        # Find the end of the actual XML element (before the xpacket end)
+        xpacket_end = xmp.index("<?xpacket end")
+        xml_content = xmp[xml_start:xpacket_end].strip()
+        # Should parse as valid XML
+        ET.fromstring(xml_content)
+
+
+class TestEmbedAvmXmp:
+    """Tests for embed_avm_xmp."""
+
+    def test_embed_png(self):
+        png_bytes = _create_test_png()
+        metadata = {
+            "target_name": "NGC-1234",
+            "ra": 50.0,
+            "dec": -30.0,
+        }
+        result = embed_avm_xmp(png_bytes, "png", metadata)
+        assert len(result) > len(png_bytes)
+
+        # Verify the PNG can be opened and has XMP metadata
+        img = Image.open(io.BytesIO(result))
+        assert img.format == "PNG"
+        assert "XML:com.adobe.xmp" in img.info
+        xmp_text = img.info["XML:com.adobe.xmp"]
+        assert "NGC-1234" in xmp_text
+
+    def test_embed_jpeg(self):
+        jpeg_bytes = _create_test_jpeg()
+        metadata = {
+            "target_name": "M31",
+            "instrument": "MIRI",
+        }
+        result = embed_avm_xmp(jpeg_bytes, "jpeg", metadata)
+        assert len(result) > 0
+
+        # Verify the JPEG can be opened
+        img = Image.open(io.BytesIO(result))
+        assert img.format == "JPEG"
+
+    def test_embed_unsupported_format_returns_original(self):
+        png_bytes = _create_test_png()
+        result = embed_avm_xmp(png_bytes, "tiff", {"target_name": "Test"})
+        assert result == png_bytes
+
+    def test_embed_empty_metadata(self):
+        png_bytes = _create_test_png()
+        result = embed_avm_xmp(png_bytes, "png", {})
+        assert len(result) > 0
+        # Should still be a valid PNG
+        img = Image.open(io.BytesIO(result))
+        assert img.format == "PNG"
+
+    def test_embed_preserves_image_dimensions(self):
+        png_bytes = _create_test_png(200, 150)
+        result = embed_avm_xmp(png_bytes, "png", {"target_name": "Test"})
+        img = Image.open(io.BytesIO(result))
+        assert img.size == (200, 150)
+
+    def test_embed_rgba_jpeg_conversion(self):
+        """JPEG doesn't support alpha; ensure RGBA images convert correctly."""
+        img = Image.new("RGBA", (50, 50), color=(100, 150, 200, 128))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")  # Save as PNG first (supports RGBA)
+        png_bytes = buf.getvalue()
+
+        result = embed_avm_xmp(png_bytes, "jpeg", {"target_name": "Test"})
+        img_out = Image.open(io.BytesIO(result))
+        assert img_out.mode == "RGB"
+
+
+class TestExtractWcsForAvm:
+    """Tests for extract_wcs_for_avm."""
+
+    def test_basic_wcs_extraction(self):
+        header = {
+            "CRPIX1": 512.0,
+            "CRPIX2": 512.0,
+            "CRVAL1": 180.5,
+            "CRVAL2": -45.2,
+            "CD1_1": -1e-5,
+            "CD1_2": 0.0,
+            "CD2_1": 0.0,
+            "CD2_2": 1e-5,
+            "CTYPE1": "RA---TAN",
+            "CTYPE2": "DEC--TAN",
+        }
+        result = extract_wcs_for_avm(header, 1024, 1024, 512, 512)
+        assert result["ra"] == 180.5
+        assert result["dec"] == -45.2
+        assert result["coordinate_frame"] == "ICRS"
+        # CRPIX should be scaled down by 2
+        assert abs(result["scale_x"] - (-1e-5 * 2)) < 1e-10
+        assert abs(result["scale_y"] - (1e-5 * 2)) < 1e-10
+
+    def test_no_wcs_returns_empty(self):
+        header = {"CRPIX1": 0, "CRVAL1": 0}
+        result = extract_wcs_for_avm(header, 1024, 1024, 512, 512)
+        assert result == {}
+
+    def test_missing_cd_matrix_returns_empty(self):
+        header = {
+            "CRPIX1": 512.0,
+            "CRPIX2": 512.0,
+            "CRVAL1": 180.0,
+            "CRVAL2": -45.0,
+        }
+        result = extract_wcs_for_avm(header, 1024, 1024, 512, 512)
+        assert result == {}
+
+    def test_cdelt_fallback(self):
+        header = {
+            "CRPIX1": 100.0,
+            "CRPIX2": 100.0,
+            "CRVAL1": 90.0,
+            "CRVAL2": 20.0,
+            "CDELT1": -0.001,
+            "CDELT2": 0.001,
+            "CTYPE1": "RA---TAN",
+        }
+        result = extract_wcs_for_avm(header, 200, 200, 100, 100)
+        assert result["ra"] == 90.0
+        assert result["scale_x"] == pytest.approx(-0.002, abs=1e-8)
+        assert result["scale_y"] == pytest.approx(0.002, abs=1e-8)
+
+    def test_fk5_coordinate_frame(self):
+        header = {
+            "CRPIX1": 256.0,
+            "CRPIX2": 256.0,
+            "CRVAL1": 45.0,
+            "CRVAL2": 60.0,
+            "CD1_1": -1e-4,
+            "CD2_2": 1e-4,
+            "CTYPE1": "RA---TAN-FK5",
+        }
+        result = extract_wcs_for_avm(header, 512, 512, 512, 512)
+        assert result["coordinate_frame"] == "FK5"
+
+    def test_same_size_no_scaling(self):
+        header = {
+            "CRPIX1": 256.0,
+            "CRPIX2": 256.0,
+            "CRVAL1": 100.0,
+            "CRVAL2": -20.0,
+            "CD1_1": -3e-5,
+            "CD1_2": 0.0,
+            "CD2_1": 0.0,
+            "CD2_2": 3e-5,
+            "CTYPE1": "RA---TAN",
+        }
+        result = extract_wcs_for_avm(header, 512, 512, 512, 512)
+        assert result["scale_x"] == pytest.approx(-3e-5, abs=1e-12)
+        assert result["scale_y"] == pytest.approx(3e-5, abs=1e-12)
+
+
+class TestParseAvmMetadataJson:
+    """Tests for parse_avm_metadata_json."""
+
+    def test_valid_json(self):
+        data = {
+            "target_name": "NGC-6804",
+            "instrument": "NIRCam",
+            "filter": "F200W",
+        }
+        result = parse_avm_metadata_json(json.dumps(data))
+        assert result["target_name"] == "NGC-6804"
+        assert result["instrument"] == "NIRCam"
+        assert result["filter"] == "F200W"
+        assert result["facility"] == "JWST"  # Default
+
+    def test_empty_string(self):
+        result = parse_avm_metadata_json("")
+        assert result == {}
+
+    def test_invalid_json(self):
+        result = parse_avm_metadata_json("not-json{")
+        assert result == {}
+
+    def test_none_input(self):
+        result = parse_avm_metadata_json(None)
+        assert result == {}
+
+    def test_custom_facility(self):
+        data = {"facility": "HST", "target_name": "Test"}
+        result = parse_avm_metadata_json(json.dumps(data))
+        assert result["facility"] == "HST"
+
+    def test_all_fields(self):
+        data = {
+            "target_name": "Carina",
+            "instrument": "MIRI",
+            "filter": "F770W",
+            "description": "Mid-infrared view",
+            "facility": "JWST",
+            "spectral_band": "Infrared",
+            "publisher": "Test User",
+        }
+        result = parse_avm_metadata_json(json.dumps(data))
+        assert len(result) == 7
+        assert result["spectral_band"] == "Infrared"
+        assert result["publisher"] == "Test User"


### PR DESCRIPTION
## Summary
- Implements D6: AVM (Astronomy Visualization Metadata) embedding in exported PNG/JPEG images
- AVM is an XMP-based standard that embeds astronomical provenance info (WCS coordinates, telescope, instrument, filter) into image metadata
- Completes the last remaining Phase 4 feature item

### Changes across all 3 layers:
- **Processing engine**: New `avm.py` module with XMP packet builder, WCS extractor, and Pillow-based embedder for PNG/JPEG. No new dependencies — uses Pillow's built-in XMP support
- **Backend**: Added `embedAvm` query param to `GetPreview()`, serializes MongoDB observation metadata (target, instrument, filter, facility, wavelength) as JSON and forwards to processing engine
- **Frontend**: Added AVM toggle checkbox in export options panel (default: enabled), passes `embedAvm` param in export URL

### Key design decisions:
- No `pyavm` dependency — manual XMP generation using AVM 1.2 namespace
- WCS extracted directly from FITS header for accuracy, observation metadata from MongoDB
- Graceful degradation — embeds whatever metadata is available, skips silently if none
- 22 unit tests covering XMP embedding, WCS extraction, metadata parsing, edge cases

## Test plan
1. Start Docker stack: `docker compose up -d --build`
2. Import a FITS observation from MAST (or use existing data)
3. Open an observation in the FITS viewer
4. Click the export button — verify AVM toggle is visible and ON by default
5. Export as PNG — verify the file contains XMP metadata:
   ```bash
   python3 -c "from PIL import Image; img = Image.open('export.png'); print(img.info.get('XML:com.adobe.xmp', 'No XMP found'))"
   ```
6. Export as JPEG — verify XMP is present
7. Toggle AVM OFF and export — verify no XMP metadata embedded
8. Run processing engine tests: `docker exec jwst-processing python -m pytest tests/test_avm_embedding.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)