### PR TITLE
fix: Reorder backend members per StyleCop SA1202/SA1204 (Tech Debt #77+#78)

### DIFF
--- a/backend/.editorconfig
+++ b/backend/.editorconfig
@@ -112,10 +112,6 @@ dotnet_naming_style.prefix_underscore.capitalization = camel_case
 dotnet_naming_style.prefix_underscore.required_prefix = _
 
 # StyleCop rule suppressions - tracked as tech debt (see docs/tech-debt.md)
-# SA1202: Public members should come before private members
-dotnet_diagnostic.SA1202.severity = none
-# SA1204: Static members should appear before non-static members
-dotnet_diagnostic.SA1204.severity = none
 # SA1402: File may only contain a single type (common to group related DTOs)
 dotnet_diagnostic.SA1402.severity = none
 # SA1649: File name should match first type name (related to SA1402)

--- a/backend/JwstDataAnalysis.API/Controllers/DataManagementController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/DataManagementController.cs
@@ -29,32 +29,6 @@ namespace JwstDataAnalysis.API.Controllers
         private readonly IMastService mastService = mastService;
         private readonly ILogger<DataManagementController> logger = logger;
 
-        private string? GetCurrentUserId()
-        {
-            return User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-                ?? User.FindFirst("sub")?.Value;
-        }
-
-        private bool IsCurrentUserAdmin() => User.IsInRole("Admin");
-
-        /// <summary>
-        /// Filters a list of data items to only those accessible to the current user.
-        /// Authenticated: own + public + shared. Admin: all.
-        /// </summary>
-        private List<JwstDataModel> FilterAccessibleData(List<JwstDataModel> data)
-        {
-            if (IsCurrentUserAdmin())
-            {
-                return data;
-            }
-
-            var userId = GetCurrentUserId();
-            return [.. data.Where(d =>
-                d.IsPublic
-                || d.UserId == userId
-                || (userId != null && d.SharedWith.Contains(userId)))];
-        }
-
         /// <summary>
         /// Advanced faceted search with filters and statistics.
         /// </summary>
@@ -829,6 +803,35 @@ namespace JwstDataAnalysis.API.Controllers
             return metadata;
         }
 
+        [GeneratedRegex(@"jw(\d{5})(\d{3})(\d{3})_(\d{5})_(\d{5})_([a-z0-9]+)", RegexOptions.IgnoreCase, "en-US")]
+        private static partial Regex MyRegex();
+
+        private string? GetCurrentUserId()
+        {
+            return User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                ?? User.FindFirst("sub")?.Value;
+        }
+
+        private bool IsCurrentUserAdmin() => User.IsInRole("Admin");
+
+        /// <summary>
+        /// Filters a list of data items to only those accessible to the current user.
+        /// Authenticated: own + public + shared. Admin: all.
+        /// </summary>
+        private List<JwstDataModel> FilterAccessibleData(List<JwstDataModel> data)
+        {
+            if (IsCurrentUserAdmin())
+            {
+                return data;
+            }
+
+            var userId = GetCurrentUserId();
+            return [.. data.Where(d =>
+                d.IsPublic
+                || d.UserId == userId
+                || (userId != null && d.SharedWith.Contains(userId)))];
+        }
+
         // Helper methods
         private DataResponse MapToDataResponse(JwstDataModel model)
         {
@@ -857,9 +860,6 @@ namespace JwstDataAnalysis.API.Controllers
                     model.ProcessingResults.Max(r => r.ProcessedDate) : null,
             };
         }
-
-        [GeneratedRegex(@"jw(\d{5})(\d{3})(\d{3})_(\d{5})_(\d{5})_([a-z0-9]+)", RegexOptions.IgnoreCase, "en-US")]
-        private static partial Regex MyRegex();
     }
 
     // Request models for bulk operations

--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -23,91 +23,6 @@ namespace JwstDataAnalysis.API.Controllers
         private readonly IConfiguration configuration = configuration;
 
         /// <summary>
-        /// Gets the current user ID from JWT claims.
-        /// </summary>
-        private string? GetCurrentUserId()
-        {
-            return User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-                ?? User.FindFirst("sub")?.Value;
-        }
-
-        /// <summary>
-        /// Checks if the current user has Admin role.
-        /// </summary>
-        private bool IsCurrentUserAdmin() => User.IsInRole("Admin");
-
-        /// <summary>
-        /// Checks if the current user can access a data item.
-        /// </summary>
-        private bool CanAccessData(JwstDataModel data)
-        {
-            if (IsCurrentUserAdmin())
-            {
-                return true;
-            }
-
-            var userId = GetCurrentUserId();
-            return data.IsPublic
-                || data.UserId == userId
-                || (userId != null && data.SharedWith.Contains(userId));
-        }
-
-        /// <summary>
-        /// Checks if the current user can modify a data item (owner or admin only).
-        /// </summary>
-        private bool CanModifyData(JwstDataModel data)
-        {
-            if (IsCurrentUserAdmin())
-            {
-                return true;
-            }
-
-            var userId = GetCurrentUserId();
-            return data.UserId == userId;
-        }
-
-        /// <summary>
-        /// Checks if the current user (authenticated or anonymous) can access a data item.
-        /// Anonymous users can only access public data.
-        /// Authenticated users can access their own, public, or shared data.
-        /// Admins can access all data.
-        /// </summary>
-        private bool IsDataAccessible(JwstDataModel data)
-        {
-            var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
-            if (!isAuthenticated)
-            {
-                return data.IsPublic;
-            }
-
-            return CanAccessData(data);
-        }
-
-        /// <summary>
-        /// Filters a list of data items to only those accessible to the current user.
-        /// Anonymous: public data only. Authenticated: own + public + shared. Admin: all.
-        /// </summary>
-        private List<JwstDataModel> FilterAccessibleData(List<JwstDataModel> data)
-        {
-            var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
-            if (!isAuthenticated)
-            {
-                return [.. data.Where(d => d.IsPublic)];
-            }
-
-            if (IsCurrentUserAdmin())
-            {
-                return data;
-            }
-
-            var userId = GetCurrentUserId();
-            return [.. data.Where(d =>
-                d.IsPublic
-                || d.UserId == userId
-                || (userId != null && d.SharedWith.Contains(userId)))];
-        }
-
-        /// <summary>
         /// Get all JWST data items accessible to the current user.
         /// </summary>
         /// <param name="includeArchived">Include archived items in the response.</param>
@@ -1750,26 +1665,6 @@ namespace JwstDataAnalysis.API.Controllers
             }
         }
 
-        private static string FormatFileSize(long bytes)
-        {
-            if (bytes >= 1073741824)
-            {
-                return $"{bytes / 1073741824.0:F2} GB";
-            }
-
-            if (bytes >= 1048576)
-            {
-                return $"{bytes / 1048576.0:F2} MB";
-            }
-
-            if (bytes >= 1024)
-            {
-                return $"{bytes / 1024.0:F2} KB";
-            }
-
-            return $"{bytes} bytes";
-        }
-
         /// <summary>
         /// Delete or preview deletion of all files at a specific processing level within an observation.
         /// </summary>
@@ -2108,6 +2003,114 @@ namespace JwstDataAnalysis.API.Controllers
             }
         }
 
+        private static string FormatFileSize(long bytes)
+        {
+            if (bytes >= 1073741824)
+            {
+                return $"{bytes / 1073741824.0:F2} GB";
+            }
+
+            if (bytes >= 1048576)
+            {
+                return $"{bytes / 1048576.0:F2} MB";
+            }
+
+            if (bytes >= 1024)
+            {
+                return $"{bytes / 1024.0:F2} KB";
+            }
+
+            return $"{bytes} bytes";
+        }
+
+        [System.Text.RegularExpressions.GeneratedRegex(@"(jw\d{5}-o\d+_t\d+_[a-z]+)", System.Text.RegularExpressions.RegexOptions.IgnoreCase, "en-US")]
+        private static partial System.Text.RegularExpressions.Regex MyRegex();
+
+        /// <summary>
+        /// Gets the current user ID from JWT claims.
+        /// </summary>
+        private string? GetCurrentUserId()
+        {
+            return User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                ?? User.FindFirst("sub")?.Value;
+        }
+
+        /// <summary>
+        /// Checks if the current user has Admin role.
+        /// </summary>
+        private bool IsCurrentUserAdmin() => User.IsInRole("Admin");
+
+        /// <summary>
+        /// Checks if the current user can access a data item.
+        /// </summary>
+        private bool CanAccessData(JwstDataModel data)
+        {
+            if (IsCurrentUserAdmin())
+            {
+                return true;
+            }
+
+            var userId = GetCurrentUserId();
+            return data.IsPublic
+                || data.UserId == userId
+                || (userId != null && data.SharedWith.Contains(userId));
+        }
+
+        /// <summary>
+        /// Checks if the current user can modify a data item (owner or admin only).
+        /// </summary>
+        private bool CanModifyData(JwstDataModel data)
+        {
+            if (IsCurrentUserAdmin())
+            {
+                return true;
+            }
+
+            var userId = GetCurrentUserId();
+            return data.UserId == userId;
+        }
+
+        /// <summary>
+        /// Checks if the current user (authenticated or anonymous) can access a data item.
+        /// Anonymous users can only access public data.
+        /// Authenticated users can access their own, public, or shared data.
+        /// Admins can access all data.
+        /// </summary>
+        private bool IsDataAccessible(JwstDataModel data)
+        {
+            var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+            if (!isAuthenticated)
+            {
+                return data.IsPublic;
+            }
+
+            return CanAccessData(data);
+        }
+
+        /// <summary>
+        /// Filters a list of data items to only those accessible to the current user.
+        /// Anonymous: public data only. Authenticated: own + public + shared. Admin: all.
+        /// </summary>
+        private List<JwstDataModel> FilterAccessibleData(List<JwstDataModel> data)
+        {
+            var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+            if (!isAuthenticated)
+            {
+                return [.. data.Where(d => d.IsPublic)];
+            }
+
+            if (IsCurrentUserAdmin())
+            {
+                return data;
+            }
+
+            var userId = GetCurrentUserId();
+            return [.. data.Where(d =>
+                d.IsPublic
+                || d.UserId == userId
+                || (userId != null && d.SharedWith.Contains(userId)))];
+        }
+
         // Helper method to map to response DTO
         private DataResponse MapToDataResponse(JwstDataModel model)
         {
@@ -2149,9 +2152,6 @@ namespace JwstDataAnalysis.API.Controllers
                 IsViewable = model.IsViewable,
             };
         }
-
-        [System.Text.RegularExpressions.GeneratedRegex(@"(jw\d{5}-o\d+_t\d+_[a-z]+)", System.Text.RegularExpressions.RegexOptions.IgnoreCase, "en-US")]
-        private static partial System.Text.RegularExpressions.Regex MyRegex();
     }
 
     public class ShareDataRequest


### PR DESCRIPTION
## Summary
- Re-enable SA1202 and SA1204 StyleCop analyzers in `.editorconfig` (previously suppressed)
- Reorder class members in all 4 backend files to comply with member ordering rules:
  - **SA1202**: Public members before private members
  - **SA1204**: Static members before non-static members
- Zero logic changes — pure member reordering (624 insertions, 624 deletions)

## Files Changed
| File | Change |
|------|--------|
| `backend/.editorconfig` | Remove SA1202/SA1204 suppressions |
| `MongoDBService.cs` | Move `BuildSearchFilter`, `MapToDataResponse`, `GetMaxVersionAsync` after public methods |
| `DataManagementController.cs` | Move `GetCurrentUserId`, `IsCurrentUserAdmin`, `FilterAccessibleData` after public methods; static before instance |
| `JwstDataController.cs` | Move 6 private helpers + `MyRegex` after public methods; static before instance |
| `MastController.cs` | Move all private methods after public endpoints; group static methods before instance methods |

## Test Plan
1. ✅ `dotnet build --warnaserror` — 0 warnings, 0 errors
2. ✅ `dotnet test` — 243 tests passed
3. ✅ Pre-commit hooks passed (build + tests)
4. Verify CI passes (Backend Tests, Frontend Tests, Lint, Python Setup, Docker Build)
5. Spot-check any reordered file in GitHub diff to confirm no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)