### PR TITLE
docs: Update tracking docs for session 2026-02-07

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,6 +577,6 @@ Stick to documentation edits, idea capture, and planning work.
 
 See [`docs/tech-debt.md`](docs/tech-debt.md) for the authoritative list of tech debt items, security issues, and their resolution status.
 
-**Quick stats**: 50 resolved | 31 remaining (as of 2026-02-07)
+**Quick stats**: 53 resolved | 35 remaining (as of 2026-02-07)
 
 Run `/tasks` to see current status and dependencies.

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -254,7 +254,7 @@ Complete React frontend application with advanced FITS visualization capabilitie
 - [x] D3: WCS grid overlay *(PR #180)*
 - [x] D4: Scale bar *(PR #183)*
 - [x] D5: Annotation tools (text, arrows, circles) *(PR #181)*
-- [ ] D6: AVM metadata embedding on export
+- [x] D6: AVM metadata embedding on export *(PR #208)*
 
 *Note: D1 (Batch Processing), D2 (Source Detection) moved to Phase 5 (require backend algorithms)*
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -6,9 +6,9 @@ This document tracks tech debt items and their resolution status.
 
 | Status | Count |
 |--------|-------|
-| **Resolved** | 51 |
+| **Resolved** | 53 |
 | **Moved to bugs.md** | 3 |
-| **Remaining** | 37 |
+| **Remaining** | 35 |
 
 > **Code Style Suppressions (2026-02-03)**: Items #77-#87 track StyleCop/CodeAnalysis rule suppressions in `.editorconfig`. Lower priority but tracked for future cleanup.
 
@@ -16,7 +16,7 @@ This document tracks tech debt items and their resolution status.
 
 ---
 
-## Remaining Tasks (38)
+## Remaining Tasks (36)
 
 ### 13. Proper Job Queue for Background Tasks
 **Priority**: Nice to Have
@@ -435,30 +435,6 @@ This document tracks tech debt items and their resolution status.
 
 ---
 
-### 77. SA1202 - Public Members Before Private Members
-**Priority**: Medium
-**Location**: `backend/.editorconfig`
-**Category**: Code Organization
-
-**Issue**: Public members should come before private members in class declarations. Suppressed because large controller/service files organize methods by functionality rather than visibility.
-
-**Fix Approach**: Reorder methods in `MongoDBService.cs`, `MastController.cs`, `JwstDataController.cs`, `DataManagementController.cs`. Remove suppression from `.editorconfig`.
-
-**Estimated Effort**: 4-6 hours
-
----
-
-### 78. SA1204 - Static Members Before Non-Static Members
-**Priority**: Medium
-**Location**: `backend/.editorconfig`
-**Category**: Code Organization
-
-**Issue**: Static members should appear before non-static members. Suppressed because static helper methods are placed near the instance methods that use them.
-
-**Fix Approach**: Move all private static methods before private instance methods in affected controllers. Remove suppression.
-
-**Estimated Effort**: 2-3 hours
-
 ---
 
 ### 79. SA1402 - File May Only Contain Single Type
@@ -596,7 +572,7 @@ This document tracks tech debt items and their resolution status.
 
 ---
 
-## Resolved Tasks (51)
+## Resolved Tasks (53)
 
 ### Quick Reference
 
@@ -653,6 +629,8 @@ This document tracks tech debt items and their resolution status.
 | 90 | Disable Seed Users in Production | PR #176 | SeedDataService with SeedingSettings config |
 | 91 | Incomplete Downloads Panel Not Visible After Cancel | PR #176 | refreshResumableJobs() on modal close |
 | 92 | Mosaic Wizard Export Button Cut Off | PR #176 | Merged duplicate CSS rules |
+| 77 | SA1202 - Public Members Before Private Members | PR #209 | Reordered all backend files |
+| 78 | SA1204 - Static Members Before Non-Static Members | PR #209 | Reordered all backend files |
 
 ### Moved to bugs.md
 


### PR DESCRIPTION
## Summary
- Mark D6 (AVM metadata embedding) complete in development plan (PR #208)
- Move tech debt #77 (SA1202) and #78 (SA1204) to resolved (PR #209)
- Update stats: 53 resolved, 35 remaining

## Test Plan
1. Docs-only change — no code changes
2. Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)