### PR TITLE
fix: Separate collapse state for Stretched and Raw Data histogram panels

### DIFF
--- a/frontend/jwst-frontend/src/components/ImageViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageViewer.tsx
@@ -320,7 +320,8 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   const [histogramPercentiles, setHistogramPercentiles] = useState<PercentileData | null>(null);
   const [histogramStats, setHistogramStats] = useState<HistogramStats | null>(null);
   const [histogramLoading, setHistogramLoading] = useState<boolean>(false);
-  const [histogramCollapsed, setHistogramCollapsed] = useState<boolean>(false);
+  const [stretchedHistogramCollapsed, setStretchedHistogramCollapsed] = useState<boolean>(false);
+  const [rawHistogramCollapsed, setRawHistogramCollapsed] = useState<boolean>(false);
 
   // Pixel data state for hover coordinate display
   const [pixelData, setPixelData] = useState<PixelDataResponse | null>(null);
@@ -1438,8 +1439,10 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
                     onWhitePointChange={handleStretchedWhitePointChange}
                     onDragEnd={handleStretchedDragEnd}
                     loading={histogramLoading}
-                    collapsed={histogramCollapsed}
-                    onToggleCollapse={() => setHistogramCollapsed(!histogramCollapsed)}
+                    collapsed={stretchedHistogramCollapsed}
+                    onToggleCollapse={() =>
+                      setStretchedHistogramCollapsed(!stretchedHistogramCollapsed)
+                    }
                     title="Stretched (Zoomed View)"
                     showControls={true}
                     barColor="#4cc9f0"
@@ -1461,8 +1464,8 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
                     onBlackPointChange={handleHistogramBlackPointChange}
                     onWhitePointChange={handleHistogramWhitePointChange}
                     loading={histogramLoading}
-                    collapsed={histogramCollapsed}
-                    onToggleCollapse={() => setHistogramCollapsed(!histogramCollapsed)}
+                    collapsed={rawHistogramCollapsed}
+                    onToggleCollapse={() => setRawHistogramCollapsed(!rawHistogramCollapsed)}
                     title="Raw Data"
                     showControls={true}
                     barColor="rgba(255, 255, 255, 0.5)"


### PR DESCRIPTION
## Summary

- Both the Stretched (Zoomed View) and Raw Data histogram panels shared a single `histogramCollapsed` state variable
- Clicking either panel's collapse toggle would open/close both panels simultaneously
- Split into two independent state variables: `stretchedHistogramCollapsed` and `rawHistogramCollapsed`

## Test plan

1. Open the image viewer with a FITS file loaded
2. Click the collapse toggle on the **Stretched (Zoomed View)** panel — only that panel should collapse/expand
3. Click the collapse toggle on the **Raw Data** panel — only that panel should collapse/expand
4. Verify both can be independently open, independently closed, or one open while the other is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)