### PR TITLE
fix: Equal left/right margins on auth page form inputs

### DIFF
--- a/frontend/jwst-frontend/src/pages/AuthPages.css
+++ b/frontend/jwst-frontend/src/pages/AuthPages.css
@@ -74,9 +74,11 @@
   background: #f9fafb;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
+  box-sizing: border-box;
   color: #1f2937;
   font-size: 1rem;
   padding: 12px 16px;
+  width: 100%;
   transition:
     border-color 0.2s,
     box-shadow 0.2s;


### PR DESCRIPTION
## Summary
- Add `box-sizing: border-box` and `width: 100%` to auth page form inputs so padding/border don't cause the inputs to overflow past the container's right padding

## Test plan
1. Navigate to `/login`
2. Verify the left and right margins between the card edge and the form inputs are equal
3. Check the registration page (`/register`) — same styles apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)