### PR TITLE
feat: per-channel RGB params and composite access control

### DIFF
--- a/backend/JwstDataAnalysis.API/Services/CompositeService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.Log.cs
@@ -51,5 +51,11 @@ namespace JwstDataAnalysis.API.Services
             Level = LogLevel.Debug,
             Message = "Resolved {DataId}: {AbsolutePath} -> {RelativePath}")]
         private partial void LogResolvedPath(string dataId, string absolutePath, string relativePath);
+
+        [LoggerMessage(
+            EventId = 8,
+            Level = LogLevel.Warning,
+            Message = "Access denied for composite source data {DataId}. Authenticated={IsAuthenticated}, UserId={UserId}, IsAdmin={IsAdmin}")]
+        private partial void LogAccessDenied(string dataId, bool isAuthenticated, string? userId, bool isAdmin);
     }
 }

--- a/backend/JwstDataAnalysis.API/Services/ICompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/ICompositeService.cs
@@ -14,7 +14,14 @@ namespace JwstDataAnalysis.API.Services
         /// Generate an RGB composite image from 3 FITS files.
         /// </summary>
         /// <param name="request">Composite request with channel configurations.</param>
+        /// <param name="userId">Current user ID when authenticated, otherwise null.</param>
+        /// <param name="isAuthenticated">Whether the request is authenticated.</param>
+        /// <param name="isAdmin">Whether the current user has Admin role.</param>
         /// <returns>Binary image data (PNG or JPEG).</returns>
-        Task<byte[]> GenerateCompositeAsync(CompositeRequestDto request);
+        Task<byte[]> GenerateCompositeAsync(
+            CompositeRequestDto request,
+            string? userId,
+            bool isAuthenticated,
+            bool isAdmin);
     }
 }

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -55,7 +55,7 @@ Common patterns, API endpoints, troubleshooting, and MAST usage tips.
 **Other Endpoints** (see Swagger for details):
 - **Lineage**: `GET /jwstdata/lineage` - Groups by observation
 - **Data Management**: `/datamanagement/search`, `/statistics`, `/export`, `/bulk/tags`, `/bulk/status`
-- **Composite**: `POST /composite/generate` - RGB from 3 FITS files
+- **Composite**: `POST /composite/generate` - RGB from 3 FITS files (anonymous for public data, auth for private/shared access)
 - **Mosaic**: `POST /mosaic/generate` - WCS-aware mosaic from 2+ FITS files, `POST /mosaic/footprint` - WCS footprint polygons
 - **Analysis**: `POST /analysis/region-statistics` - Compute statistics for rectangle/ellipse regions (mean, median, std, min, max, sum, pixel count)
 - **MAST Search**: `/mast/search/target`, `/coordinates`, `/observation`, `/program`

--- a/frontend/jwst-frontend/src/components/CompositeWizard.tsx
+++ b/frontend/jwst-frontend/src/components/CompositeWizard.tsx
@@ -4,7 +4,8 @@ import {
   WizardStep,
   ChannelAssignment,
   ChannelParams,
-  DEFAULT_CHANNEL_PARAMS,
+  DEFAULT_CHANNEL_ASSIGNMENT,
+  DEFAULT_CHANNEL_PARAMS_BY_CHANNEL,
 } from '../types/CompositeTypes';
 import { autoSortByWavelength } from '../utils/wavelengthUtils';
 import WizardStepper from './wizard/WizardStepper';
@@ -33,14 +34,18 @@ export const CompositeWizard: React.FC<CompositeWizardProps> = ({
   initialSelection = [],
   onClose,
 }) => {
+  const createDefaultChannelParams = (): ChannelParams => ({
+    red: { ...DEFAULT_CHANNEL_PARAMS_BY_CHANNEL.red },
+    green: { ...DEFAULT_CHANNEL_PARAMS_BY_CHANNEL.green },
+    blue: { ...DEFAULT_CHANNEL_PARAMS_BY_CHANNEL.blue },
+  });
+
   const [currentStep, setCurrentStep] = useState<WizardStep>(initialSelection.length === 3 ? 2 : 1);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set(initialSelection));
   const [channelAssignment, setChannelAssignment] = useState<ChannelAssignment>({
-    red: null,
-    green: null,
-    blue: null,
+    ...DEFAULT_CHANNEL_ASSIGNMENT,
   });
-  const [channelParams, setChannelParams] = useState<ChannelParams>({});
+  const [channelParams, setChannelParams] = useState<ChannelParams>(createDefaultChannelParams);
 
   // Get selected images as array
   const selectedImages = Array.from(selectedIds)
@@ -61,12 +66,8 @@ export const CompositeWizard: React.FC<CompositeWizardProps> = ({
         const sorted = autoSortByWavelength(images);
         setChannelAssignment(sorted);
 
-        // Initialize params for each image
-        const newParams: ChannelParams = {};
-        images.forEach((img) => {
-          newParams[img.id] = { ...DEFAULT_CHANNEL_PARAMS };
-        });
-        setChannelParams(newParams);
+        // Initialize per-channel params to defaults (channels can share the same image).
+        setChannelParams(createDefaultChannelParams());
       }
     },
     [allImages]

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -67,9 +67,9 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     abortControllerRef.current = new AbortController();
 
     try {
-      const redParams = channelParams[red] || DEFAULT_CHANNEL_PARAMS;
-      const greenParams = channelParams[green] || DEFAULT_CHANNEL_PARAMS;
-      const blueParams = channelParams[blue] || DEFAULT_CHANNEL_PARAMS;
+      const redParams = channelParams.red || DEFAULT_CHANNEL_PARAMS;
+      const greenParams = channelParams.green || DEFAULT_CHANNEL_PARAMS;
+      const blueParams = channelParams.blue || DEFAULT_CHANNEL_PARAMS;
 
       const blob = await compositeService.generatePreview(
         { dataId: red, ...redParams },
@@ -101,9 +101,9 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     setExporting(true);
 
     try {
-      const redParams = channelParams[red] || DEFAULT_CHANNEL_PARAMS;
-      const greenParams = channelParams[green] || DEFAULT_CHANNEL_PARAMS;
-      const blueParams = channelParams[blue] || DEFAULT_CHANNEL_PARAMS;
+      const redParams = channelParams.red || DEFAULT_CHANNEL_PARAMS;
+      const greenParams = channelParams.green || DEFAULT_CHANNEL_PARAMS;
+      const blueParams = channelParams.blue || DEFAULT_CHANNEL_PARAMS;
 
       const blob = await compositeService.exportComposite(
         { dataId: red, ...redParams },

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -2,6 +2,8 @@
  * TypeScript types for RGB Composite Creator wizard
  */
 
+export type ChannelName = 'red' | 'green' | 'blue';
+
 /**
  * Configuration for a single color channel (R, G, or B)
  */
@@ -30,24 +32,20 @@ export interface CompositeRequest {
 /**
  * Channel assignment state for the wizard
  */
-export interface ChannelAssignment {
-  red: string | null; // dataId
-  green: string | null; // dataId
-  blue: string | null; // dataId
-}
+export type ChannelAssignment = Record<ChannelName, string | null>; // dataId
 
 /**
  * Per-channel stretch parameters
  */
-export interface ChannelParams {
-  [dataId: string]: {
-    stretch: string;
-    blackPoint: number;
-    whitePoint: number;
-    gamma: number;
-    asinhA: number;
-  };
+export interface ChannelStretchParams {
+  stretch: string;
+  blackPoint: number;
+  whitePoint: number;
+  gamma: number;
+  asinhA: number;
 }
+
+export type ChannelParams = Record<ChannelName, ChannelStretchParams>;
 
 /**
  * Export options for the final composite
@@ -73,6 +71,18 @@ export const DEFAULT_CHANNEL_PARAMS = {
   whitePoint: 1.0,
   gamma: 1.0,
   asinhA: 0.1,
+} satisfies ChannelStretchParams;
+
+export const DEFAULT_CHANNEL_ASSIGNMENT: ChannelAssignment = {
+  red: null,
+  green: null,
+  blue: null,
+};
+
+export const DEFAULT_CHANNEL_PARAMS_BY_CHANNEL: ChannelParams = {
+  red: { ...DEFAULT_CHANNEL_PARAMS },
+  green: { ...DEFAULT_CHANNEL_PARAMS },
+  blue: { ...DEFAULT_CHANNEL_PARAMS },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Switch RGB wizard stretch state from data-id keyed params to per-channel params so duplicate image assignments stay independent.
- Keep preview/export payloads unchanged while mapping each channel's dataId plus its own stretch values.
- Allow anonymous composite generation for public data and enforce per-data access checks (public, owner, shared, admin) before resolving file paths.
- Return 403 for authenticated forbidden access and 404 for anonymous forbidden access.
- Update quick reference docs for composite endpoint access behavior.

## Verification
- npm run build (frontend/jwst-frontend)
- dotnet build backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj
- pre-commit checks:
  - frontend ESLint + Prettier + unit tests
  - backend build + tests (254 passed)
