### PR TITLE
chore: enforce PR standards in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,43 @@
 ## Summary
-<!-- Brief description of what this PR does -->
+<!-- What changed and the user-visible outcome -->
 
+## Why
+<!-- Why this change is needed (bug, gap, risk, or goal) -->
 
 ## Type of Change
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation update
-- [ ] Refactoring
-- [ ] Tech debt resolution
+- [ ] feat (new capability)
+- [ ] fix (bug fix)
+- [ ] docs (documentation only)
+- [ ] refactor (no behavior change)
+- [ ] test (tests only)
+- [ ] chore (tooling/process)
 
 ## Changes Made
--
+- 
 
 ## Test Plan
-- [ ] Tested locally with Docker (`docker compose up -d --build`)
-- [ ] Verified in browser at http://localhost:3000
-- [ ] API endpoints tested (if applicable)
-- [ ] Unit tests pass (`dotnet test`)
+<!-- Check all items actually completed; add commands/results as needed -->
+- [ ] Tested locally with Docker (`docker compose up -d --build`) or documented why not
+- [ ] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
+- [ ] API endpoints tested (if backend/API touched)
+- [ ] Relevant unit/integration tests pass
 
 ## Documentation Checklist
-<!-- Check all that apply -->
 - [ ] No documentation updates needed
-- [ ] `CLAUDE.md` - API endpoints, features, or usage patterns
-- [ ] `docs/development-plan.md` - Completed milestones/features marked
-- [ ] `docs/tech-debt.md` - Resolved items moved to table
-- [ ] `docs/standards/*.md` - Model/API/frontend pattern changes
+- [ ] Updated `docs/development-plan.md` for milestone/phase changes
+- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
+- [ ] Updated `docs/standards/*.md` for pattern/contract changes
+- [ ] Updated other docs as needed
+
+## Risk & Rollback
+- Risk: 
+- Rollback: 
 
 ## Quality Checklist
+<!-- All items required before merge -->
+- [ ] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
+- [ ] Branch name follows `<type>/<short-description>` or `codex/...`
 - [ ] Code follows project coding standards
-- [ ] Linting passes (`npm run lint`, `dotnet format`, `ruff check`)
-- [ ] All CI checks pass
-- [ ] Created via feature branch and PR (not direct push to main)
+- [ ] Linting/formatting checks pass locally
+- [ ] Relevant tests pass locally
+- [ ] All CI checks are green

--- a/.github/scripts/validate-pr.js
+++ b/.github/scripts/validate-pr.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+/**
+ * Validate pull request standards from title/body metadata.
+ * This runs in CI and fails fast when required sections/checklists are incomplete.
+ */
+
+const prTitle = (process.env.PR_TITLE || "").trim();
+const prBody = (process.env.PR_BODY || "").replace(/\r\n/g, "\n");
+const prHeadRef = (process.env.PR_HEAD_REF || "").trim();
+
+const errors = [];
+
+const REQUIRED_SECTIONS = [
+  "Summary",
+  "Why",
+  "Type of Change",
+  "Changes Made",
+  "Test Plan",
+  "Documentation Checklist",
+  "Risk & Rollback",
+  "Quality Checklist",
+];
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripComments(text) {
+  return text.replace(/<!--[\s\S]*?-->/g, "").trim();
+}
+
+function extractSection(heading) {
+  const lines = prBody.split("\n");
+  const headingRegex = new RegExp(`^##\\s+${escapeRegExp(heading)}\\s*$`, "i");
+  const genericHeadingRegex = /^##\s+/;
+
+  let startIndex = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (headingRegex.test(lines[i])) {
+      startIndex = i;
+      break;
+    }
+  }
+
+  if (startIndex === -1) {
+    return "";
+  }
+
+  let endIndex = lines.length;
+  for (let i = startIndex + 1; i < lines.length; i += 1) {
+    if (genericHeadingRegex.test(lines[i])) {
+      endIndex = i;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex + 1, endIndex).join("\n").trim();
+}
+
+function checkedCount(section) {
+  return (section.match(/^- \[[xX]\]\s+/gm) || []).length;
+}
+
+function totalCheckboxCount(section) {
+  return (section.match(/^- \[[ xX]\]\s+/gm) || []).length;
+}
+
+function hasMeaningfulBullets(section) {
+  const content = stripComments(section);
+  const bulletLines = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "));
+
+  return bulletLines.some((line) => !/^-\s*$/.test(line));
+}
+
+if (!/^(feat|fix|docs|refactor|test|chore)(\([^)]+\))?: .+/i.test(prTitle)) {
+  errors.push(
+    "PR title must use conventional format, for example `feat: add X` or `fix(api): handle Y`.",
+  );
+}
+
+if (
+  !/^(codex\/|feature\/|fix\/|docs\/|refactor\/|test\/|chore\/|dependabot\/)/i.test(
+    prHeadRef,
+  )
+) {
+  errors.push(
+    "Branch name must start with `feature/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`, `dependabot/`, or `codex/`.",
+  );
+}
+
+for (const sectionName of REQUIRED_SECTIONS) {
+  if (!extractSection(sectionName)) {
+    errors.push(`Missing required section: \`## ${sectionName}\`.`);
+  }
+}
+
+const summarySection = extractSection("Summary");
+if (summarySection && stripComments(summarySection).length < 12) {
+  errors.push("`## Summary` must contain a meaningful description of the change.");
+}
+
+const whySection = extractSection("Why");
+if (whySection && stripComments(whySection).length < 12) {
+  errors.push("`## Why` must explain the reason for the change.");
+}
+
+const changesSection = extractSection("Changes Made");
+if (changesSection && !hasMeaningfulBullets(changesSection)) {
+  errors.push("`## Changes Made` must include at least one non-empty bullet item.");
+}
+
+const typeOfChangeSection = extractSection("Type of Change");
+if (typeOfChangeSection && checkedCount(typeOfChangeSection) < 1) {
+  errors.push("`## Type of Change` must have at least one checked checkbox.");
+}
+
+const testPlanSection = extractSection("Test Plan");
+if (testPlanSection && checkedCount(testPlanSection) < 1) {
+  errors.push("`## Test Plan` must have at least one checked checkbox.");
+}
+
+const docsChecklistSection = extractSection("Documentation Checklist");
+if (docsChecklistSection && checkedCount(docsChecklistSection) < 1) {
+  errors.push("`## Documentation Checklist` must have at least one checked checkbox.");
+}
+
+const riskSection = extractSection("Risk & Rollback");
+if (riskSection) {
+  const normalizedRiskSection = stripComments(riskSection);
+  if (!/Risk:\s*\S+/i.test(normalizedRiskSection)) {
+    errors.push("`## Risk & Rollback` must include a non-empty `Risk:` value.");
+  }
+  if (!/Rollback:\s*\S+/i.test(normalizedRiskSection)) {
+    errors.push("`## Risk & Rollback` must include a non-empty `Rollback:` value.");
+  }
+}
+
+const qualitySection = extractSection("Quality Checklist");
+if (qualitySection) {
+  const total = totalCheckboxCount(qualitySection);
+  const checked = checkedCount(qualitySection);
+
+  if (total < 1) {
+    errors.push("`## Quality Checklist` must include checkbox items.");
+  } else if (checked !== total) {
+    errors.push("All checkboxes in `## Quality Checklist` must be checked before merge.");
+  }
+}
+
+if (errors.length > 0) {
+  console.error("PR standards validation failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log("PR standards validation passed.");

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -1,0 +1,28 @@
+name: PR Standards
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+jobs:
+  validate-pr-standards:
+    name: Validate PR Standards
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Validate PR metadata and checklist
+        run: node .github/scripts/validate-pr.js
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,14 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 
 6. **PR checklist**:
    - [ ] Clear description of changes
+   - [ ] PR title uses conventional commit format (`feat:`, `fix:`, `docs:`, etc.)
+   - [ ] PR template sections are fully completed
    - [ ] CI checks passing
    - [ ] Documentation updated (if needed)
+
+7. **PR standards are enforced in CI**:
+   - Pull requests are validated for title format, branch naming, template completeness, and checklist status.
+   - Draft PRs are exempt until marked ready for review.
 
 ## Coding Standards
 


### PR DESCRIPTION
## Summary
- add a new PR standards workflow that validates PR metadata and checklist completion on non-draft pull requests
- add a dedicated PR validation script to enforce title format, branch naming, required sections, and checklist expectations
- tighten the pull request template with required sections for rationale, risks, and quality gates
- update contributing guidelines to reflect CI-enforced PR standards

## Why
- low-detail PRs can pass CI without sufficient review context today
- enforcing standards in CI makes expectations consistent and auditable before merge

## Type of Change
- [x] chore (tooling/process)

## Changes Made
- Added `.github/workflows/pr-standards.yml` for PR standards validation.
- Added `.github/scripts/validate-pr.js` to enforce PR title, branch name, template sections, and checklist rules.
- Updated `.github/PULL_REQUEST_TEMPLATE.md` with stronger required structure.
- Updated `CONTRIBUTING.md` to document the enforcement behavior.

## Test Plan
- [x] Ran validator with a valid PR payload (passes).
- [x] Ran validator with invalid payload (fails with actionable errors).

## Documentation Checklist
- [x] Updated other docs as needed

## Risk & Rollback
- Risk: contributors may initially hit validation failures until they adapt to the template/checklist requirements.
- Rollback: revert this PR to remove the workflow and validator.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green
