### PR TITLE
chore: enforce tech debt handling in PR standards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,8 +26,14 @@
 - [ ] No documentation updates needed
 - [ ] Updated `docs/development-plan.md` for milestone/phase changes
 - [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
+- [ ] Updated `docs/tech-debt.md` (required if tech debt is introduced/reduced)
 - [ ] Updated `docs/standards/*.md` for pattern/contract changes
 - [ ] Updated other docs as needed
+
+## Tech Debt Impact
+- [ ] No new tech debt introduced
+- [ ] Tech debt introduced and tracked in `docs/tech-debt.md`
+- [ ] Existing tech debt reduced and `docs/tech-debt.md` updated
 
 ## Risk & Rollback
 - Risk: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,11 +79,12 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
    - [ ] Clear description of changes
    - [ ] PR title uses conventional commit format (`feat:`, `fix:`, `docs:`, etc.)
    - [ ] PR template sections are fully completed
+   - [ ] Tech debt impact is classified and `docs/tech-debt.md` is updated when debt changes
    - [ ] CI checks passing
    - [ ] Documentation updated (if needed)
 
 7. **PR standards are enforced in CI**:
-   - Pull requests are validated for title format, branch naming, template completeness, and checklist status.
+   - Pull requests are validated for title format, branch naming, template completeness, checklist status, and tech debt handling.
    - Draft PRs are exempt until marked ready for review.
 
 ## Coding Standards


### PR DESCRIPTION
## Summary
- add explicit tech debt impact classification to the PR template
- enforce tech debt handling in the PR validation script
- require documentation checkbox alignment when debt is introduced/reduced
- update contributing guidance to reflect the new requirement

## Why
- before making the repo public, we need consistent visibility into whether changes add, reduce, or avoid tech debt
- this keeps debt tracking intentional and ensures `docs/tech-debt.md` stays current

## Type of Change
- [x] chore (tooling/process)

## Changes Made
- Updated `.github/PULL_REQUEST_TEMPLATE.md` with a required `Tech Debt Impact` section.
- Updated `.github/scripts/validate-pr.js` to enforce exactly one tech debt impact option.
- Added cross-check: if debt is introduced/reduced, `Updated docs/tech-debt.md` must be checked in docs checklist.
- Updated `CONTRIBUTING.md` to include tech debt requirements.

## Test Plan
- [x] Ran validator with a passing payload where tech debt is introduced and docs checkbox is checked.
- [x] Ran validator with a failing payload where tech debt is introduced but docs checkbox is not checked.
- [x] Ran validator with a passing payload for no-new-tech-debt path.

## Documentation Checklist
- [x] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced and tracked in `docs/tech-debt.md`
- [ ] Existing tech debt reduced and `docs/tech-debt.md` updated

## Risk & Rollback
- Risk: low; stricter PR validation may initially require contributors to adjust template completion habits.
- Rollback: revert this PR to remove the additional tech debt checks.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green
