### PR TITLE
feat: add target stage and instrument filters to mosaic selection

### DIFF
--- a/docs/desktop-requirements.md
+++ b/docs/desktop-requirements.md
@@ -355,7 +355,7 @@ jpegURL             - Preview image URL
 | FR-4.4.2.4 | Background Subtraction | Remove sky background | Should |
 | FR-4.4.2.5 | Source Detection | Find and catalog point sources | Could |
 | FR-4.4.2.6 | Aperture Photometry | Measure source brightness | Could |
-| FR-4.4.2.7 | WCS Mosaic / Image Stacking | Combine 2+ FITS images via WCS reprojection with footprint preview, stretch/colormap controls, and configurable export dimensions | Could |
+| FR-4.4.2.7 | WCS Mosaic / Image Stacking | Combine 2+ FITS images via WCS reprojection with footprint preview, target/stage/instrument filtering, stretch/colormap controls, and configurable export dimensions | Could |
 | FR-4.4.2.8 | Cosmic Ray Removal | Identify and mask cosmic rays | Could |
 
 **Algorithm Parameter Schema Example (Basic Analysis):**

--- a/frontend/jwst-frontend/src/components/MosaicWizard.css
+++ b/frontend/jwst-frontend/src/components/MosaicWizard.css
@@ -228,6 +228,45 @@
   cursor: not-allowed;
 }
 
+.mosaic-filter-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.mosaic-filter-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mosaic-filter-control label {
+  color: #9ca3af;
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+
+.mosaic-filter-control select {
+  width: 100%;
+  padding: 0.55rem 0.6rem;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(74, 144, 217, 0.2);
+  border-radius: 6px;
+  color: #e5e7eb;
+  font-size: 0.83rem;
+  outline: none;
+}
+
+.mosaic-filter-control select:focus {
+  border-color: rgba(74, 144, 217, 0.5);
+}
+
+.mosaic-filter-control select option {
+  background: #1a1a2e;
+  color: #e5e7eb;
+}
+
 .mosaic-file-list {
   flex: 1;
   overflow-y: auto;
@@ -819,6 +858,10 @@
   .mosaic-selection-actions {
     width: 100%;
     justify-content: flex-end;
+  }
+
+  .mosaic-filter-row {
+    grid-template-columns: 1fr;
   }
 
   .mosaic-setting-dimensions {


### PR DESCRIPTION
## Summary
Adds quick dropdown filters to Mosaic Wizard Step 1 so users can narrow files by target, processing stage, and instrument before selecting files.

## Why
The file list gets large quickly. Adding dedicated filters (with Stage defaulted to L3) makes it much faster to build a useful selection for mosaic generation.

## Type of Change
- [x] feat (new capability)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Added Step 1 filter dropdowns in `MosaicWizard`: `Target`, `Stage`, and `Instrument`.
- Defaulted `Stage` filter to `L3 (Combined)` for faster common-case selection.
- Integrated dropdown filters into the existing file filtering logic alongside text search.
- Added dynamic target/instrument option lists from available images.
- Updated Step 1 UI count to show selected and currently shown rows.
- Added responsive styling for the new filter row in Mosaic wizard CSS.
- Updated desktop requirements text to capture target/stage/instrument filtering for mosaic workflow.

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [x] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [x] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

## Documentation Checklist
- [ ] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [x] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/tech-debt.md` (required if tech debt is introduced/reduced)
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced and tracked in `docs/tech-debt.md`
- [ ] Existing tech debt reduced and `docs/tech-debt.md` updated

## Risk & Rollback
- Risk: low; filter defaults (L3) may hide non-L3 rows until users switch stage to All.
- Rollback: revert this PR to restore the previous search-only selection behavior.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green
