### PR TITLE
docs: make challenge-first collaboration the default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,14 @@ This file is the primary guidance for all coding agents working in this reposito
 - Tool-specific files (for example `CLAUDE.md`) may add tool-specific tips.
 - If a tool-specific file conflicts with this file on shared process rules, `AGENTS.md` wins.
 
+## Default Collaboration Style (All Agents)
+
+- Default to constructive challenge, not agreement-first responses.
+- Before endorsing an idea, surface the strongest practical reasons it could fail (risk, cost, maintenance, security, or complexity).
+- Offer at least one lower-cost alternative when the proposed approach is heavy or premature.
+- State clear go/no-go criteria when giving recommendations so decisions are testable.
+- If evidence is weak, say so directly and recommend validation steps instead of optimistic assumptions.
+
 ## Core Workflow Rules
 
 - Never push directly to `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,11 @@ This file provides Claude-specific guidance for Claude Code (claude.ai/code) whe
 > Shared process and workflow rules live in `AGENTS.md` and are authoritative for all agents.
 > If guidance here conflicts with `AGENTS.md`, follow `AGENTS.md`.
 
+## Interaction Default
+
+- Follow the challenge-first collaboration style defined in `AGENTS.md`.
+- Do not use agreement-first framing for project decisions.
+
 ## Project Overview
 
 JWST Data Analysis Application - A microservices-based platform for analyzing James Webb Space Telescope data with advanced scientific computing capabilities.


### PR DESCRIPTION
## Summary
Adds a default challenge-first collaboration policy to shared agent instructions so models critique proposals before endorsing them.

## Why
Current agent behavior can skew toward agreement-first responses. This change makes constructive pushback and decision criteria the explicit default for repository collaboration.

## Type of Change
- [ ] feat (new capability)
- [ ] fix (bug fix)
- [x] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Added `Default Collaboration Style (All Agents)` section to `AGENTS.md` with challenge-first requirements.
- Added an `Interaction Default` reminder in `CLAUDE.md` to follow the `AGENTS.md` rule.

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [ ] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [ ] API endpoints tested (if backend/API touched)
- [ ] Relevant unit/integration tests pass

Documentation-only change. No runtime behavior changes, so Docker/browser/API/unit test execution was not applicable.

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/tech-debt.md` (required if tech debt is introduced/reduced)
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced and tracked in `docs/tech-debt.md`
- [ ] Existing tech debt reduced and `docs/tech-debt.md` updated

## Risk & Rollback
- Risk: Low. Changes affect assistant guidance text only.
- Rollback: Revert commit `4a139ee`.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green

Note: Current GitHub Actions jobs are not starting due repository billing/spending-limit status, not code-level test failures.
