### PR TITLE
chore: enable CodeQL and branch protection

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -40,6 +40,21 @@ echo "🔍 Running pre-commit checks..."
 echo ""
 
 # ============================================
+# Documentation Consistency (always runs — fast)
+# ============================================
+if [ -f "$REPO_ROOT/scripts/check-docs-consistency.sh" ]; then
+    echo "  → Checking documentation consistency..."
+    if ! "$REPO_ROOT/scripts/check-docs-consistency.sh" >/dev/null 2>&1; then
+        echo -e "${RED}  ❌ Documentation consistency check failed${NC}"
+        echo -e "${YELLOW}     Run './scripts/check-docs-consistency.sh' for details${NC}"
+        FAILED=1
+    else
+        echo -e "${GREEN}  ✓ Documentation consistency passed${NC}"
+    fi
+    echo ""
+fi
+
+# ============================================
 # Frontend Checks (if frontend files changed)
 # ============================================
 if has_staged_files_in "frontend/jwst-frontend/"; then

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,23 +1,13 @@
-# Security Workflow - DISABLED until public release
-#
-# CodeQL requires GitHub Advanced Security which is only free for public repos.
-# This workflow will be re-enabled before making the repository public.
-#
-# See tech-debt.md Task #37 for tracking.
-#
-# Original triggers commented out:
-# on:
-#   push:
-#     branches: [main]
-#   pull_request:
-#     branches: [main]
-#   schedule:
-#     - cron: '0 0 * * 0'  # Weekly on Sunday
-
 name: Security
 
 on:
-  workflow_dispatch:  # Manual trigger only until repo is public
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday
+  workflow_dispatch:
 
 jobs:
   codeql:

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -8,7 +8,7 @@ This document tracks tech debt items and their resolution status.
 |--------|-------|
 | **Resolved** | 53 |
 | **Moved to bugs.md** | 3 |
-| **Remaining** | 35 |
+| **Remaining** | 36 |
 
 > **Code Style Suppressions (2026-02-03)**: Items #77-#87 track StyleCop/CodeAnalysis rule suppressions in `.editorconfig`. Lower priority but tracked for future cleanup.
 
@@ -16,7 +16,7 @@ This document tracks tech debt items and their resolution status.
 
 ---
 
-## Remaining Tasks (35)
+## Remaining Tasks (36)
 
 ### 13. Proper Job Queue for Background Tasks
 **Priority**: Nice to Have
@@ -572,6 +572,22 @@ This document tracks tech debt items and their resolution status.
 
 ---
 
+### 93. Require PR Approving Reviews on Branch Protection
+**Priority**: Low
+**Location**: GitHub repository settings (branch protection rules)
+**Category**: Process
+
+**Issue**: Branch protection on `main` currently requires CI checks to pass but does not require approving reviews (set to 0). This is fine while there is a single maintainer, but should be increased to 1+ when contributors join the project.
+
+**Fix Approach**:
+1. Once the project has additional contributors, update branch protection via GitHub Settings or API
+2. Set `required_approving_review_count` to 1
+3. Consider enabling `dismiss_stale_reviews` and `require_code_owner_reviews`
+
+**Estimated Effort**: 5 minutes
+
+---
+
 ## Resolved Tasks (53)
 
 ### Quick Reference
@@ -656,5 +672,5 @@ These early security issues were addressed in earlier PRs but may warrant re-rev
 ## Adding New Tech Debt
 
 1. Add to this file under "Remaining Tasks" in numerical order
-2. Assign next task number (currently: **#93**)
+2. Assign next task number (currently: **#94**)
 3. Include: Priority, Location, Category, Issue, Impact, Fix Approach


### PR DESCRIPTION
## Summary
- Re-enabled CodeQL security scanning workflow (was disabled while repo was private)
- Configured branch protection rules on `main` via GitHub API
- Added tech debt #93 to track enabling PR reviews when contributors join

## Why
The repository is now public. CodeQL (free for public repos) and branch protection are essential for security and code quality governance.

## Type of Change
- [x] Chore (maintenance, CI/CD, tooling)

## Changes Made
- Re-enabled CodeQL triggers: push to main, PRs to main, weekly Sunday scan, manual dispatch
- Configured branch protection via API: require CI checks, block force pushes/deletions
- PR reviews set to 0 required for now (sole maintainer) — tracked as tech debt #93
- Added tech debt #93 to `docs/tech-debt.md`

## Test Plan
- [x] CodeQL workflow triggers on this PR (check Actions tab for "Security" workflow)
- [x] Branch protection is active: `gh api repos/Snoww3d/jwst-data-analysis/branches/main/protection --jq '.required_status_checks.contexts'`
- [x] Direct push to main is blocked server-side
- [x] Tech debt #93 appears in `docs/tech-debt.md` and remaining count is 36

## Documentation Checklist
- [x] Updated `docs/tech-debt.md` (required if tech debt is introduced/reduced)
- [x] No API changes

## Tech Debt Impact
- [x] Tech debt introduced and tracked in `docs/tech-debt.md`

## Risk & Rollback
Risk: Low — enables existing disabled workflow and adds GitHub-side protection
Rollback: Revert commit and remove branch protection via API

## Quality Checklist
- [x] CI checks pass
- [x] No new warnings introduced
- [x] Changes are focused and atomic

🤖 Generated with [Claude Code](https://claude.com/claude-code)