### PR TITLE
docs: add challenge-first collaboration style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,14 @@ Primary guidance for all coding agents working in this repository.
 - Tool-specific config files (gitignored) may add tips specific to individual tool capabilities.
 - If a tool-specific file conflicts with this file on shared process rules, **this file wins**.
 
+## Default Collaboration Style (All Agents)
+
+- Default to constructive challenge, not agreement-first responses.
+- Before endorsing an idea, surface the strongest practical reasons it could fail (risk, cost, maintenance, security, or complexity).
+- Offer at least one lower-cost alternative when the proposed approach is heavy or premature.
+- State clear go/no-go criteria when giving recommendations so decisions are testable.
+- If evidence is weak, say so directly and recommend validation steps instead of optimistic assumptions.
+
 ## Project Overview
 
 JWST Data Analysis Application — a microservices-based platform for analyzing James Webb Space Telescope data with advanced scientific computing capabilities.


### PR DESCRIPTION
## Summary
Adds a default collaboration policy to `AGENTS.md` requiring agents to constructively challenge proposals before endorsing them.

## Why
Agent behavior can skew toward agreement-first responses. Making constructive pushback the explicit default improves decision quality across all agents.

## Type of Change
- [x] docs (documentation only)

## Changes Made
- Added `Default Collaboration Style (All Agents)` section to `AGENTS.md`
- Requires surfacing risks, offering alternatives, and stating testable criteria

Originally proposed by Codex in PR #228 (closed due to merge conflicts from CLAUDE.md untracking). CLAUDE.md portion dropped since that file is now gitignored.

## Test Plan
- [x] Documentation-only change — no runtime behavior to test

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — documentation-only change affecting agent guidance text
Rollback: Revert commit

## Quality Checklist
- [x] PR title uses conventional format
- [x] Branch name follows naming convention
- [x] Linting/formatting checks pass locally
- [x] All CI checks are green

🤖 Generated with [Claude Code](https://claude.com/claude-code)