### PR TITLE
chore: remove stale CLAUDE.md references from public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 A modern web application for analyzing James Webb Space Telescope (JWST) data, featuring direct integration with the MAST (Mikulski Archive for Space Telescopes) portal.
 
+<!-- TODO: Add screenshot — replace with actual path after capturing -->
+<!-- ![JWST Data Analysis Screenshot](docs/images/screenshot-viewer.png) -->
+
 ## Features
 
 - **MAST Portal Integration** - Search and import JWST observations by target name, coordinates, or program ID

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -541,7 +541,6 @@ flowchart TB
 ## See Also
 
 - [AGENTS.md](../AGENTS.md) - Shared agent workflow and process rules
-- [CLAUDE.md](https://github.com/Snoww3d/jwst-data-analysis/blob/main/CLAUDE.md) - Claude-specific addendum
 - [Development Plan](development-plan.md) - Project roadmap
 - [Backend Development Standards](standards/backend-development.md)
 - [Frontend Development Standards](standards/frontend-development.md)

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -210,7 +210,7 @@ This document tracks tech debt items and their resolution status.
 **Fix Approach**:
 1. Add `mongodb-mcp-server` configuration for direct DB inspection
 2. Add `github-mcp-server` for issue/PR management
-3. Document usage in `CLAUDE.md`
+3. Document usage in `AGENTS.md`
 
 ---
 
@@ -289,7 +289,7 @@ This document tracks tech debt items and their resolution status.
 1. Enable branch protection on `main` via GitHub Settings > Branches
 2. Configure rules: require PR, require status checks, optionally require review approval
 3. Test that direct pushes are rejected server-side
-4. Update CLAUDE.md to note server-side protection is active
+4. Update `AGENTS.md` to note server-side protection is active
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -124,7 +124,7 @@ When adding new scripts:
    - Use colors for output (GREEN, BLUE, YELLOW, NC)
    - Include error handling
 4. **Test thoroughly**: Try edge cases
-5. **Update docs**: Update `AGENTS.md` for shared workflow-impacting scripts and `CLAUDE.md` only for Claude-specific usage notes
+5. **Update docs**: Update `AGENTS.md` for shared workflow-impacting scripts
 
 ---
 


### PR DESCRIPTION
## Summary
Removes dead references to `CLAUDE.md` across public documentation now that the file is gitignored and untracked.

## Why
`CLAUDE.md` was untracked in PR #231 as part of going public. Four references in public docs now point to a non-existent file, which would confuse visitors.

## Type of Change
- [x] docs (documentation only)

## Changes Made
- Removed dead `CLAUDE.md` link from `docs/architecture.md` See Also section
- Removed `CLAUDE.md` mention from `scripts/README.md` contributing guidelines
- Updated two `docs/tech-debt.md` references to point to `AGENTS.md` instead
- Added screenshot placeholder comment to `README.md` (will be replaced with actual images)

## Test Plan
- [x] Documentation-only change — no runtime behavior to test
- [x] Verified no remaining CLAUDE.md references in tracked `.md` files

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — documentation text changes only
Rollback: Revert commit

## Quality Checklist
- [x] PR title uses conventional format
- [x] Branch name follows naming convention
- [x] Linting/formatting checks pass locally
- [x] All CI checks are green

🤖 Generated with [Claude Code](https://claude.com/claude-code)