### PR TITLE
fix: use CSS ::after for required field asterisks in register form

### DIFF
--- a/frontend/jwst-frontend/src/pages/AuthPages.css
+++ b/frontend/jwst-frontend/src/pages/AuthPages.css
@@ -70,7 +70,8 @@
   font-weight: 500;
 }
 
-.form-group .required {
+.form-group label.required::after {
+  content: ' *';
   color: #dc2626;
 }
 

--- a/frontend/jwst-frontend/src/pages/RegisterPage.tsx
+++ b/frontend/jwst-frontend/src/pages/RegisterPage.tsx
@@ -103,11 +103,8 @@ export function RegisterPage() {
           {error && <div className="auth-error">{error}</div>}
 
           <div className="form-group">
-            <label htmlFor="username">
-              Username{' '}
-              <span className="required" aria-hidden="true">
-                *
-              </span>
+            <label htmlFor="username" className="required">
+              Username
             </label>
             <input
               id="username"
@@ -122,11 +119,8 @@ export function RegisterPage() {
           </div>
 
           <div className="form-group">
-            <label htmlFor="email">
-              Email{' '}
-              <span className="required" aria-hidden="true">
-                *
-              </span>
+            <label htmlFor="email" className="required">
+              Email
             </label>
             <input
               id="email"
@@ -140,11 +134,8 @@ export function RegisterPage() {
           </div>
 
           <div className="form-group">
-            <label htmlFor="password">
-              Password{' '}
-              <span className="required" aria-hidden="true">
-                *
-              </span>
+            <label htmlFor="password" className="required">
+              Password
             </label>
             <input
               id="password"
@@ -158,11 +149,8 @@ export function RegisterPage() {
           </div>
 
           <div className="form-group">
-            <label htmlFor="confirmPassword">
-              Confirm Password{' '}
-              <span className="required" aria-hidden="true">
-                *
-              </span>
+            <label htmlFor="confirmPassword" className="required">
+              Confirm Password
             </label>
             <input
               id="confirmPassword"


### PR DESCRIPTION
## Summary
- Replace DOM `<span>` asterisks with CSS `::after` pseudo-element for required field indicators on the register page

## Why
PR #238's `aria-hidden="true"` approach didn't work — Playwright's `getByLabel` still includes `aria-hidden` span text content in the computed label name. This caused 9 e2e tests to fail because `getByLabel('Password', { exact: true })` matched "Password *" instead of "Password".

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Removed `<span className="required" aria-hidden="true">*</span>` from all 4 required field labels in `RegisterPage.tsx`
- Added `className="required"` to the label elements instead
- Changed CSS from `.form-group .required` (span color) to `.form-group label.required::after` (pseudo-element with `content: ' *'`)
- The asterisk is now purely visual via CSS — not in the DOM text at all

## Test Plan
- [x] Run `npm test` locally — 24 unit tests pass
- [x] Run `npm run lint` — clean
- [x] Run `npm run format:check` — clean
- [ ] CI e2e tests — 9 register page tests should now pass

## Documentation Checklist
- [x] No documentation changes needed

## Tech Debt Impact
- [x] No new tech debt introduced and no tech debt resolved

## Risk & Rollback
- Risk: Low — visual-only change to how asterisks render, no logic changes
- Rollback: Revert the single commit

## Quality Checklist
- [x] Changes are minimal and focused on the specific issue
- [x] No unnecessary refactoring or scope creep
- [x] Error handling is appropriate
- [x] No new warnings or errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)