### PR TITLE
fix: cache playwright browsers in e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,11 +221,26 @@ jobs:
         cache: 'npm'
         cache-dependency-path: frontend/jwst-frontend/package-lock.json
 
+    - name: Resolve Playwright version
+      id: playwright-version
+      run: |
+        VERSION=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      working-directory: frontend/jwst-frontend
+
+    - name: Cache Playwright Browsers
+      id: playwright-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
     - name: Install Frontend Dependencies
       run: npm ci
       working-directory: frontend/jwst-frontend
 
     - name: Install Playwright Browsers (Chromium only)
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: npx playwright install --with-deps chromium
       working-directory: frontend/jwst-frontend
 


### PR DESCRIPTION
## Summary
Cache Playwright browser binaries in CI so the E2E workflow avoids re-installing Chromium on every run.

## Why
The E2E job currently runs `npx playwright install --with-deps chromium` on each execution, which adds several minutes to repeat runs.

## Type of Change
- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Added a Playwright version resolution step in CI using `package-lock.json`.
- Added `actions/cache` for `~/.cache/ms-playwright`, keyed by OS + Playwright version.
- Updated the Playwright install step to run only on cache miss.

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [ ] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [ ] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

Workflow/config-only change. Local validation:
- `node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version"` in `frontend/jwst-frontend`.

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/tech-debt.md` (required if tech debt is introduced/reduced)
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced and tracked in `docs/tech-debt.md`
- [ ] Existing tech debt reduced and `docs/tech-debt.md` updated

## Risk & Rollback
- Risk: Low. Change is isolated to CI workflow behavior for browser install/caching.
- Rollback: Revert this PR to restore unconditional Playwright installation behavior.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green
