### PR TITLE
feat: support multiple images per RGB composite channel

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.Log.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.Log.cs
@@ -11,8 +11,8 @@ namespace JwstDataAnalysis.API.Controllers
         [LoggerMessage(
             EventId = 1,
             Level = LogLevel.Information,
-            Message = "Generating composite: Red={RedId}, Green={GreenId}, Blue={BlueId}")]
-        private partial void LogGeneratingComposite(string redId, string greenId, string blueId);
+            Message = "Generating composite: Red={RedCount} file(s), Green={GreenCount} file(s), Blue={BlueCount} file(s)")]
+        private partial void LogGeneratingComposite(int redCount, int greenCount, int blueCount);
 
         [LoggerMessage(
             EventId = 2,

--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
@@ -49,14 +49,14 @@ namespace JwstDataAnalysis.API.Controllers
                     return BadRequest(new { error = "Red, green, and blue channel configurations are required" });
                 }
 
-                if (string.IsNullOrEmpty(request.Red.DataId) ||
-                    string.IsNullOrEmpty(request.Green.DataId) ||
-                    string.IsNullOrEmpty(request.Blue.DataId))
+                if (request.Red.DataIds == null || request.Red.DataIds.Count == 0 ||
+                    request.Green.DataIds == null || request.Green.DataIds.Count == 0 ||
+                    request.Blue.DataIds == null || request.Blue.DataIds.Count == 0)
                 {
-                    return BadRequest(new { error = "DataId is required for all channels" });
+                    return BadRequest(new { error = "At least one DataId is required for each channel" });
                 }
 
-                LogGeneratingComposite(request.Red.DataId, request.Green.DataId, request.Blue.DataId);
+                LogGeneratingComposite(request.Red.DataIds.Count, request.Green.DataIds.Count, request.Blue.DataIds.Count);
 
                 var userId = GetCurrentUserId();
                 var isAuthenticated = User.Identity?.IsAuthenticated ?? false;

--- a/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
@@ -12,10 +12,11 @@ namespace JwstDataAnalysis.API.Models
     public class ChannelConfigDto
     {
         /// <summary>
-        /// Gets or sets mongoDB ID of the data record (will be resolved to file path).
+        /// Gets or sets mongoDB IDs of the data records (will be resolved to file paths).
         /// </summary>
         [Required]
-        public string DataId { get; set; } = string.Empty;
+        [MinLength(1)]
+        public List<string> DataIds { get; set; } = new();
 
         /// <summary>
         /// Gets or sets stretch method: zscale, asinh, log, sqrt, power, histeq, linear.
@@ -146,8 +147,8 @@ namespace JwstDataAnalysis.API.Models
     /// </summary>
     internal class ProcessingChannelConfig
     {
-        [JsonPropertyName("file_path")]
-        public string FilePath { get; set; } = string.Empty;
+        [JsonPropertyName("file_paths")]
+        public List<string> FilePaths { get; set; } = new();
 
         [JsonPropertyName("stretch")]
         public string Stretch { get; set; } = "zscale";

--- a/backend/JwstDataAnalysis.API/Services/CompositeService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.Log.cs
@@ -13,8 +13,8 @@ namespace JwstDataAnalysis.API.Services
         [LoggerMessage(
             EventId = 1,
             Level = LogLevel.Information,
-            Message = "Generating composite: Red={RedId}, Green={GreenId}, Blue={BlueId}")]
-        private partial void LogGeneratingComposite(string redId, string greenId, string blueId);
+            Message = "Generating composite: Red={RedCount} file(s), Green={GreenCount} file(s), Blue={BlueCount} file(s)")]
+        private partial void LogGeneratingComposite(int redCount, int greenCount, int blueCount);
 
         [LoggerMessage(
             EventId = 2,

--- a/frontend/jwst-frontend/src/components/CompositeWizard.tsx
+++ b/frontend/jwst-frontend/src/components/CompositeWizard.tsx
@@ -40,7 +40,7 @@ export const CompositeWizard: React.FC<CompositeWizardProps> = ({
     blue: { ...DEFAULT_CHANNEL_PARAMS_BY_CHANNEL.blue },
   });
 
-  const [currentStep, setCurrentStep] = useState<WizardStep>(initialSelection.length === 3 ? 2 : 1);
+  const [currentStep, setCurrentStep] = useState<WizardStep>(initialSelection.length >= 3 ? 2 : 1);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set(initialSelection));
   const [channelAssignment, setChannelAssignment] = useState<ChannelAssignment>({
     ...DEFAULT_CHANNEL_ASSIGNMENT,
@@ -58,7 +58,7 @@ export const CompositeWizard: React.FC<CompositeWizardProps> = ({
       setSelectedIds(ids);
 
       // If we have exactly 3 images, auto-sort them
-      if (ids.size === 3) {
+      if (ids.size >= 3) {
         const images = Array.from(ids)
           .map((id) => allImages.find((img) => img.id === id))
           .filter((img): img is JwstDataModel => img !== undefined);
@@ -73,11 +73,11 @@ export const CompositeWizard: React.FC<CompositeWizardProps> = ({
     [allImages]
   );
 
-  const canProceedToStep2 = selectedIds.size === 3;
+  const canProceedToStep2 = selectedIds.size >= 3;
   const canProceedToStep3 =
-    channelAssignment.red !== null &&
-    channelAssignment.green !== null &&
-    channelAssignment.blue !== null;
+    channelAssignment.red.length > 0 &&
+    channelAssignment.green.length > 0 &&
+    channelAssignment.blue.length > 0;
 
   const handleNext = () => {
     if (currentStep === 1 && canProceedToStep2) {

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -423,7 +423,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
       const newSet = new Set(prev);
       if (newSet.has(dataId)) {
         newSet.delete(dataId);
-      } else if (newSet.size < 3) {
+      } else {
         newSet.add(dataId);
       }
       return newSet;
@@ -580,13 +580,13 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
 
           <div className="controls-row controls-row-analysis-actions">
             <button
-              className={`composite-btn ${selectedForComposite.size === 3 ? 'ready' : ''}`}
+              className={`composite-btn ${selectedForComposite.size >= 3 ? 'ready' : ''}`}
               onClick={handleOpenCompositeWizard}
-              disabled={selectedForComposite.size !== 3}
+              disabled={selectedForComposite.size < 3}
               title={
-                selectedForComposite.size === 3
+                selectedForComposite.size >= 3
                   ? 'Create RGB composite from selected images'
-                  : `Select 3 images for RGB composite (${selectedForComposite.size}/3 selected)`
+                  : `Select 3+ images for RGB composite (${selectedForComposite.size} selected)`
               }
             >
               <span className="composite-icon">
@@ -596,7 +596,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                   <circle cx="12" cy="14" r="4" fill="#4488ff" opacity="0.8" />
                 </svg>
               </span>
-              RGB Composite ({selectedForComposite.size}/3)
+              RGB Composite ({selectedForComposite.size} selected)
             </button>
             <button
               className="mosaic-open-btn"
@@ -761,9 +761,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                         {items.map((item) => {
                           const fitsInfo = getFitsFileInfo(item.fileName);
                           const isSelectedForComposite = selectedForComposite.has(item.id);
-                          const canSelectForComposite =
-                            fitsInfo.viewable &&
-                            (selectedForComposite.size < 3 || isSelectedForComposite);
+                          const canSelectForComposite = fitsInfo.viewable;
                           return (
                             <div
                               key={item.id}
@@ -778,9 +776,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                                     title={
                                       isSelectedForComposite
                                         ? 'Remove from composite selection'
-                                        : canSelectForComposite
-                                          ? 'Add to RGB composite'
-                                          : 'Maximum 3 images for composite'
+                                        : 'Add to RGB composite'
                                     }
                                   >
                                     {isSelectedForComposite ? '✓' : '+'}
@@ -1065,9 +1061,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                                     const isSelectedForComposite = selectedForComposite.has(
                                       item.id
                                     );
-                                    const canSelectForComposite =
-                                      fitsInfo.viewable &&
-                                      (selectedForComposite.size < 3 || isSelectedForComposite);
+                                    const canSelectForComposite = fitsInfo.viewable;
                                     return (
                                       <div
                                         key={item.id}
@@ -1082,9 +1076,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                                               title={
                                                 isSelectedForComposite
                                                   ? 'Remove from composite selection'
-                                                  : canSelectForComposite
-                                                    ? 'Add to RGB composite'
-                                                    : 'Maximum 3 images for composite'
+                                                  : 'Add to RGB composite'
                                               }
                                             >
                                               {isSelectedForComposite ? '✓' : '+'}

--- a/frontend/jwst-frontend/src/components/wizard/ChannelCard.css
+++ b/frontend/jwst-frontend/src/components/wizard/ChannelCard.css
@@ -144,6 +144,67 @@
   padding: 0.5rem;
 }
 
+/* Image chips */
+.channel-image-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.image-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.5rem;
+  background: rgba(74, 144, 217, 0.15);
+  border: 1px solid rgba(74, 144, 217, 0.3);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: #e5e7eb;
+  max-width: 100%;
+}
+
+.image-chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+}
+
+.image-chip-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  color: #9ca3af;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all 0.15s ease;
+}
+
+.image-chip-remove:hover {
+  background: rgba(255, 68, 68, 0.3);
+  color: #ff4444;
+}
+
+/* Add image dropdown */
+.channel-add-image {
+  margin-top: 0.25rem;
+}
+
+/* Channel count badge */
+.channel-count {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  font-weight: 400;
+}
+
 /* Responsive */
 @media (max-width: 1024px) {
   .channel-card {

--- a/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.tsx
@@ -27,16 +27,15 @@ export const ImageSelectionStep: React.FC<ImageSelectionStepProps> = ({
     const newSelection = new Set(selectedIds);
     if (newSelection.has(id)) {
       newSelection.delete(id);
-    } else if (newSelection.size < 3) {
+    } else {
       newSelection.add(id);
     }
     onSelectionChange(newSelection);
   };
 
   const handleSelectAll = () => {
-    // Select first 3 images
-    const first3 = imageFiles.slice(0, 3).map((img) => img.id);
-    onSelectionChange(new Set(first3));
+    const allIds = imageFiles.map((img) => img.id);
+    onSelectionChange(new Set(allIds));
   };
 
   const handleClearAll = () => {
@@ -46,14 +45,14 @@ export const ImageSelectionStep: React.FC<ImageSelectionStepProps> = ({
   return (
     <div className="image-selection-step">
       <div className="step-instructions">
-        <h3>Select 3 Images</h3>
+        <h3>Select Images</h3>
         <p>
-          Choose 3 FITS images to combine into an RGB composite. Images will be automatically sorted
-          by wavelength (shortest to Blue, middle to Green, longest to Red).
+          Choose 3 or more FITS images to combine into an RGB composite. Images will be
+          automatically sorted by wavelength (shortest to Blue, middle to Green, longest to Red).
         </p>
         <div className="selection-actions">
           <button className="btn-action" onClick={handleSelectAll} disabled={imageFiles.length < 3}>
-            Select First 3
+            Select All
           </button>
           <button
             className="btn-action btn-secondary"
@@ -62,7 +61,7 @@ export const ImageSelectionStep: React.FC<ImageSelectionStepProps> = ({
           >
             Clear Selection
           </button>
-          <span className="selection-count">{selectedIds.size} / 3 selected</span>
+          <span className="selection-count">{selectedIds.size} selected (min 3)</span>
         </div>
       </div>
 
@@ -76,7 +75,7 @@ export const ImageSelectionStep: React.FC<ImageSelectionStepProps> = ({
           imageFiles.map((img) => {
             const isSelected = selectedIds.has(img.id);
             const wavelength = getWavelengthFromData(img);
-            const canSelect = selectedIds.size < 3 || isSelected;
+            const canSelect = true;
 
             return (
               <button

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -10,7 +10,7 @@ export type StretchMethod = 'zscale' | 'asinh' | 'log' | 'sqrt' | 'power' | 'his
  * Configuration for a single color channel (R, G, or B)
  */
 export interface ChannelConfig {
-  dataId: string;
+  dataIds: string[];
   stretch: StretchMethod;
   blackPoint: number; // 0.0-1.0
   whitePoint: number; // 0.0-1.0
@@ -36,7 +36,7 @@ export interface CompositeRequest {
 /**
  * Channel assignment state for the wizard
  */
-export type ChannelAssignment = Record<ChannelName, string | null>; // dataId
+export type ChannelAssignment = Record<ChannelName, string[]>; // dataIds
 
 /**
  * Per-channel stretch parameters
@@ -91,9 +91,9 @@ export const DEFAULT_CHANNEL_PARAMS = {
 } satisfies ChannelStretchParams;
 
 export const DEFAULT_CHANNEL_ASSIGNMENT: ChannelAssignment = {
-  red: null,
-  green: null,
-  blue: null,
+  red: [],
+  green: [],
+  blue: [],
 };
 
 export const DEFAULT_CHANNEL_PARAMS_BY_CHANNEL: ChannelParams = {

--- a/processing-engine/app/composite/models.py
+++ b/processing-engine/app/composite/models.py
@@ -13,7 +13,7 @@ CurveType = Literal["linear", "s_curve", "inverse_s", "shadows", "highlights"]
 class ChannelConfig(BaseModel):
     """Configuration for a single RGB channel."""
 
-    file_path: str = Field(..., description="Path to FITS file (relative to data directory)")
+    file_paths: list[str] = Field(..., min_length=1, description="Paths to FITS files (relative to data directory)")
     stretch: str = Field(
         default="zscale",
         description="Stretch method: zscale, asinh, log, sqrt, power, histeq, linear",


### PR DESCRIPTION
## Summary
- Allow assigning multiple FITS files to each RGB channel in the composite wizard, with files mean-combined via the mosaic engine before RGB stacking
- Remove the 3-image selection cap — users can now select 3+ images, auto-sorted into channel groups by wavelength (divided into thirds)
- Rewrite ChannelCard UI to use chip/tag-based multi-image display with add/remove controls per channel

## Changes Made
- **Processing engine** (`models.py`, `routes.py`): Change `file_path: str` to `file_paths: list[str]` in `ChannelConfig`; load and mean-combine multiple files per channel using existing `generate_mosaic()` before reprojection
- **Backend C#** (`CompositeModels.cs`, `CompositeService.cs`, `CompositeController.cs`, log files): Change `DataId` to `DataIds` (list), add `ResolveDataIdsToFilePathsAsync`, update validation and logging
- **Frontend types** (`CompositeTypes.ts`): Change `dataId: string` to `dataIds: string[]`, `ChannelAssignment` values from `string | null` to `string[]`
- **Frontend utils** (`wavelengthUtils.ts`): Rewrite `autoSortByWavelength` to handle N≥3 images, dividing into 3 groups with remainder distributed starting from blue
- **Frontend components** (`ImageSelectionStep`, `JwstDataDashboard`, `CompositeWizard`): Remove 3-image cap, update button states and text for `>= 3` logic
- **Frontend ChannelCard** (`ChannelCard.tsx`, `ChannelCard.css`): Complete rewrite — chip-based multi-image display with removable tags and add-image dropdown
- **Frontend wizard steps** (`ChannelAssignmentStep`, `CompositePreviewStep`): Array-based channel assignment, unassigned image tracking, updated preview generation and channel summaries

## Tech Debt Impact
- [ ] Increases tech debt
- [x] Neutral
- [ ] Reduces tech debt

## Testing
- TypeScript compiles cleanly (0 errors)
- ESLint passes on all changed files
- 24 frontend unit tests pass
- 254 C# backend tests pass
- 191 Python processing engine tests pass

## Risk & Rollback
Risk: Medium — significant UI changes to the composite wizard, but the underlying mosaic engine is proven and existing tests pass.
Rollback: Revert this commit. No database or API contract changes that would require migration.

## Test Plan
1. Start the application stack
2. Navigate to a dataset with 6+ images (e.g., NGC-3324 with various filters)
3. Select exactly 3 images → verify wizard opens, auto-sorts 1 per channel, works as before
4. Close wizard, select 6-8 images → verify button shows "(N selected)" and enables at ≥3
5. Open wizard → verify auto-sort distributes images across R/G/B by wavelength
6. In channel assignment step:
   - Verify each channel shows image chips with filter labels and X remove buttons
   - Remove an image from a channel → verify it appears in "Add image..." dropdown
   - Add an image to a different channel → verify chip appears
   - Swap two channels → verify arrays swap correctly
7. Verify live preview renders correctly with multiple images per channel
8. Proceed to export step → verify channel summary shows filter counts
9. Export composite → verify output image generates successfully
10. Edge cases: 4 images (uneven distribution), moving all images to one channel

## Documentation Checklist
- [ ] Updated user-facing documentation
- [ ] Updated API documentation
- [ ] Updated `docs/tech-debt.md`
- [x] No documentation updates needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)