### PR TITLE
feat: multi-image composite channels with fast preview downscaling

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -258,6 +258,10 @@ Complete React frontend application with advanced FITS visualization capabilitie
 
 *Note: D1 (Batch Processing), D2 (Source Detection) moved to Phase 5 (require backend algorithms)*
 
+#### **Dashboard & UX (E-series):**
+
+- [ ] E1: Search by target name in top search bar (filter local observations by `targetName`)
+
 #### **Phase 4 Deliverables:**
 
 - [x] Centralized API service layer with type-safe error handling

--- a/frontend/jwst-frontend/src/components/wizard/ChannelAssignmentStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/ChannelAssignmentStep.tsx
@@ -133,7 +133,8 @@ export const ChannelAssignmentStep: React.FC<ChannelAssignmentStepProps> = ({
     setPreviewError(null);
 
     // Create new abort controller
-    abortControllerRef.current = new AbortController();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
 
     try {
       const redParams = channelParams.red || DEFAULT_CHANNEL_PARAMS;
@@ -146,7 +147,7 @@ export const ChannelAssignmentStep: React.FC<ChannelAssignmentStepProps> = ({
         { dataIds: blue, ...blueParams },
         600,
         undefined,
-        abortControllerRef.current.signal
+        controller.signal
       );
 
       // Cleanup old URL
@@ -161,7 +162,10 @@ export const ChannelAssignmentStep: React.FC<ChannelAssignmentStepProps> = ({
         console.error('Preview generation error:', err);
       }
     } finally {
-      setPreviewLoading(false);
+      // Only clear loading if this is still the active request
+      if (abortControllerRef.current === controller) {
+        setPreviewLoading(false);
+      }
     }
   };
 

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -98,7 +98,8 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
-    abortControllerRef.current = new AbortController();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
 
     try {
       const redParams = channelParams.red || DEFAULT_CHANNEL_PARAMS;
@@ -111,7 +112,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         { dataIds: blue, ...blueParams },
         1000, // Larger preview for final step
         overallAdjustments,
-        abortControllerRef.current.signal
+        controller.signal
       );
 
       if (previewUrlRef.current) {
@@ -127,7 +128,11 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         console.error('Preview generation error:', err);
       }
     } finally {
-      setPreviewLoading(false);
+      // Only clear loading if this is still the active request.
+      // If another request superseded us (via abort), it owns the loading state.
+      if (abortControllerRef.current === controller) {
+        setPreviewLoading(false);
+      }
     }
   };
 

--- a/processing-engine/tests/test_composite_downscale.py
+++ b/processing-engine/tests/test_composite_downscale.py
@@ -1,0 +1,154 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Unit tests for output-aware downscaling in the composite pipeline.
+
+Tests verify that the input pixel budget is derived from the requested
+output dimensions, so previews process much faster while exports retain
+full quality.
+"""
+
+import numpy as np
+from astropy.wcs import WCS
+
+from app.composite.routes import (
+    MAX_INPUT_PIXELS,
+    MIN_PREVIEW_PIXELS,
+    PREVIEW_OVERSAMPLE,
+    downscale_for_composite,
+)
+
+
+def _make_wcs(naxis1: int = 100, naxis2: int = 100, cdelt: float = -0.001) -> WCS:
+    """Create a minimal celestial WCS for testing."""
+    header = {
+        "NAXIS": 2,
+        "NAXIS1": naxis1,
+        "NAXIS2": naxis2,
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CRPIX1": naxis1 / 2.0,
+        "CRPIX2": naxis2 / 2.0,
+        "CRVAL1": 180.0,
+        "CRVAL2": 45.0,
+        "CDELT1": cdelt,
+        "CDELT2": abs(cdelt),
+    }
+    return WCS(header, naxis=2)
+
+
+class TestDownscaleMaxPixels:
+    """Tests for the max_pixels parameter on downscale_for_composite."""
+
+    def test_no_downscale_when_below_budget(self):
+        """Image smaller than budget is returned unchanged."""
+        data = np.ones((100, 100), dtype=np.float64)
+        wcs = _make_wcs(100, 100)
+
+        result_data, result_wcs = downscale_for_composite(data, wcs, max_pixels=20_000)
+
+        assert result_data.shape == (100, 100)
+        np.testing.assert_array_equal(result_data, data)
+
+    def test_downscale_when_above_budget(self):
+        """Image larger than budget is downscaled."""
+        data = np.ones((1000, 1000), dtype=np.float64)  # 1M pixels
+        wcs = _make_wcs(1000, 1000)
+
+        result_data, result_wcs = downscale_for_composite(data, wcs, max_pixels=250_000)
+
+        # Should be roughly 500x500 (sqrt(250k/1M) = 0.5)
+        assert result_data.shape[0] * result_data.shape[1] <= 260_000
+        assert result_data.shape[0] < 1000
+
+    def test_default_uses_max_input_pixels(self):
+        """Without max_pixels arg, uses the global MAX_INPUT_PIXELS."""
+        # Create data smaller than MAX_INPUT_PIXELS — should not downscale
+        data = np.ones((100, 100), dtype=np.float64)
+        wcs = _make_wcs(100, 100)
+
+        result_data, _ = downscale_for_composite(data, wcs)
+
+        assert result_data.shape == (100, 100)
+
+    def test_small_budget_produces_small_output(self):
+        """A preview-sized budget (1.44M) downscales a 16M-pixel image aggressively."""
+        data = np.ones((4000, 4000), dtype=np.float64)  # 16M pixels
+        wcs = _make_wcs(4000, 4000)
+
+        # Simulate 600x600 preview budget: 360k * 4 = 1.44M
+        budget = 1_440_000
+        result_data, _ = downscale_for_composite(data, wcs, max_pixels=budget)
+
+        result_pixels = result_data.shape[0] * result_data.shape[1]
+        assert result_pixels <= budget * 1.05  # allow small rounding margin
+        assert result_pixels < 2_000_000  # significantly smaller than 16M
+
+    def test_wcs_adjusted_on_downscale(self):
+        """WCS CDELT and CRPIX are adjusted when downscaling."""
+        data = np.ones((2000, 2000), dtype=np.float64)
+        cdelt = -0.001
+        wcs = _make_wcs(2000, 2000, cdelt=cdelt)
+
+        result_data, result_wcs = downscale_for_composite(data, wcs, max_pixels=1_000_000)
+
+        # CDELT should be larger in magnitude (coarser pixels)
+        result_header = result_wcs.to_header()
+        assert abs(result_header["CDELT1"]) > abs(cdelt)
+
+
+class TestBudgetFormula:
+    """Tests for the budget formula used in generate_composite."""
+
+    def test_preview_budget_is_small(self):
+        """600x600 preview should get ~1.44M budget, not 16M."""
+        output_pixels = 600 * 600  # 360K
+        input_budget = min(
+            MAX_INPUT_PIXELS,
+            max(output_pixels * PREVIEW_OVERSAMPLE, MIN_PREVIEW_PIXELS),
+        )
+        assert input_budget == 1_440_000
+        assert input_budget < MAX_INPUT_PIXELS
+
+    def test_large_export_hits_cap(self):
+        """4096x4096 export should hit the MAX_INPUT_PIXELS cap."""
+        output_pixels = 4096 * 4096  # ~16.8M
+        input_budget = min(
+            MAX_INPUT_PIXELS,
+            max(output_pixels * PREVIEW_OVERSAMPLE, MIN_PREVIEW_PIXELS),
+        )
+        assert input_budget == MAX_INPUT_PIXELS
+
+    def test_medium_export_scales_proportionally(self):
+        """2048x2048 export: 4.2M * 4 = 16.8M, capped at 16M."""
+        output_pixels = 2048 * 2048
+        input_budget = min(
+            MAX_INPUT_PIXELS,
+            max(output_pixels * PREVIEW_OVERSAMPLE, MIN_PREVIEW_PIXELS),
+        )
+        assert input_budget == MAX_INPUT_PIXELS
+
+    def test_tiny_preview_uses_floor(self):
+        """Very small output (100x100 = 10K) should use MIN_PREVIEW_PIXELS floor."""
+        output_pixels = 100 * 100  # 10K
+        input_budget = min(
+            MAX_INPUT_PIXELS,
+            max(output_pixels * PREVIEW_OVERSAMPLE, MIN_PREVIEW_PIXELS),
+        )
+        assert input_budget == MIN_PREVIEW_PIXELS
+
+    def test_1000x1000_preview_budget(self):
+        """1000x1000 preview: 1M * 4 = 4M budget."""
+        output_pixels = 1000 * 1000
+        input_budget = min(
+            MAX_INPUT_PIXELS,
+            max(output_pixels * PREVIEW_OVERSAMPLE, MIN_PREVIEW_PIXELS),
+        )
+        assert input_budget == 4_000_000
+
+    def test_constants_have_expected_values(self):
+        """Verify the constants are configured as designed."""
+        assert PREVIEW_OVERSAMPLE == 4
+        assert MIN_PREVIEW_PIXELS == 500_000
+        assert MAX_INPUT_PIXELS == 16_000_000


### PR DESCRIPTION
## Summary
Add support for assigning multiple FITS images per RGB channel in the composite wizard with mean-combination, and implement output-aware downscaling so preview requests process significantly less data than full exports.

## Why
With multi-image channels (5-8 FITS files), composite previews take minutes because the pipeline processes all requests identically — a 600x600 preview goes through the same 16M-pixel intermediate processing as a 4096x4096 export. Previews should feel faster while exports retain full quality.

## Type of Change
- [x] feat (new capability)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- **Backend (C#):** Update `CompositeModels` to accept `file_paths[]` per channel instead of single `file_path`, update `CompositeService` and controller to pass arrays through
- **Processing Engine (Python):** Add `max_pixels` parameter to `downscale_for_composite()` and `max_reproject_pixels` to `reproject_channels_to_common_wcs()` so pixel budgets scale with requested output size. Mean-combine multiple files per channel via `generate_mosaic()`. Add constants `PREVIEW_OVERSAMPLE=4` and `MIN_PREVIEW_PIXELS=500K`
- **Frontend (React):** Update `ChannelCard`, `ChannelAssignmentStep`, `CompositePreviewStep`, and `ImageSelectionStep` to support multi-image channels. Fix preview abort race condition — only clear loading state if the request is still the active one
- **Tests:** Add 11 unit tests for downscale budget formula and `downscale_for_composite()` with custom `max_pixels`
- **Docs:** Add tech debt #97 (composite preview architecture rework) and E1 (search by target) to Phase 4 feature list
- **Pre-commit hook:** Improve ruff detection and import sorting

## Test Plan
- [x] Tested locally with Docker (`docker exec jwst-processing python -m pytest tests/ -v`) — all 202 tests pass
- [x] Relevant unit/integration tests pass — 11 new downscale tests added

Manual verification steps:
1. Open the composite wizard with 5+ FITS images loaded
2. Assign multiple images to a single channel (e.g., two F090W images to red)
3. Verify preview generates successfully (still slow — tracked as tech debt #97)
4. Adjust sliders mid-preview — verify no "Failed to generate preview" error (abort race fix)
5. Export at 4096x4096 — verify full-quality output (will be slower, expected)
6. Check Docker logs for budget logging: `input_budget=1,440,000 px` for 600x600 preview

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [x] Updated `docs/tech-debt.md` (required if tech debt is introduced/reduced)
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [ ] No new tech debt introduced
- [x] Tech debt introduced and tracked in `docs/tech-debt.md`
- [ ] Reduces existing tech debt

## Risk & Rollback
Risk: Low — the output-aware downscaling uses the same code path with a smaller pixel budget; exports are completely unchanged (budget caps at existing 16M). All 202 existing tests pass.

Rollback: Revert this PR. The `max_pixels` parameter defaults to the previous hardcoded value, so reverting has no side effects.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)