### PR TITLE
feat: dark theme, CSS design tokens, and cascading dashboard filters

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -302,6 +302,11 @@ These are the top 3 additions that most compress the distance to DS9/Jdaviz-leve
 
 Backend processing capabilities for scientific image analysis.
 
+#### **FITS Table + Spectral Viewer (Priority):**
+
+- [ ] Table data viewer for non-image FITS files
+- [ ] Spectral data visualization (1D spectrum plotting)
+
 #### **Image Processing:**
 
 - [ ] Image enhancement and filtering
@@ -325,7 +330,6 @@ Backend processing capabilities for scientific image analysis.
 
 - [ ] Processing job queue system
 - [ ] WebSocket support for real-time progress (replace polling)
-- [ ] Table data viewer for non-image FITS files
 
 #### **Viewer Features (require these algorithms):**
 

--- a/frontend/jwst-frontend/.interface-design/system.md
+++ b/frontend/jwst-frontend/.interface-design/system.md
@@ -1,0 +1,293 @@
+# JWST Data Analysis — Design System
+
+Extracted from the existing codebase. This is the source of truth for maintaining visual consistency.
+
+---
+
+## Architecture
+
+- **Styling**: Pure CSS (no Tailwind, no CSS-in-JS)
+- **Components**: Pure React, no UI library (no shadcn, no MUI)
+- **Icons**: Custom inline SVGs (24x24 grid, stroke-based, `strokeWidth: 2`)
+- **Theme**: Dark-first — no light mode toggle
+- **Design Language**: Scientific/astronomy, glassmorphism panels, technical typography
+
+---
+
+## Color System
+
+### Backgrounds (darkest → lightest)
+| Token | Value | Usage |
+|-------|-------|-------|
+| `bg-deepest` | `#000000` / `#050505` | App root, deep space |
+| `bg-base` | `#0a0a0c` / `#0d1117` | Main canvas |
+| `bg-elevated` | `#0f0f12` / `#15151a` | Panels, sidebars |
+| `bg-surface` | `#1a1a2e` / `#16213e` | Cards, containers |
+| `bg-overlay` | `rgba(20, 20, 25, 0.7)` – `rgba(26, 26, 46, 0.95)` | Glass panels |
+
+### Text
+| Token | Value | Usage |
+|-------|-------|-------|
+| `text-primary` | `#ffffff` | Headings, emphasis |
+| `text-secondary` | `rgba(255, 255, 255, 0.85)` – `#e0e0e0` | Body text |
+| `text-muted` | `rgba(255, 255, 255, 0.6)` | Labels, metadata keys |
+| `text-faint` | `rgba(255, 255, 255, 0.4)` | Placeholders, disabled |
+
+### Accents
+| Token | Value | Usage |
+|-------|-------|-------|
+| `accent-blue` | `#3b82f6` / `#4db8ff` | Primary actions, links |
+| `accent-cyan` | `#4ecdc4` / `#4cc9f0` | Status highlights, data values |
+| `accent-purple` | `#6f42c1` / `#8b5cf6` | Secondary accent, filter badges |
+| `accent-orange` | `#e67e22` / `#f59e0b` | Warnings, attention |
+| `accent-green` | `#10b981` / `#059669` | Success states |
+
+### Semantic
+| Token | Value | Usage |
+|-------|-------|-------|
+| `error` | `#dc2626` / `#ef4444` / `#ff6b6b` | Error states |
+| `error-bg` | `#fef2f2` / `#f8d7da` | Error backgrounds (light) |
+| `warning` | `#b45309` / `#fcd34d` | Warning states |
+| `warning-bg` | `#fff3cd` | Warning backgrounds (light) |
+| `success-bg` | `#d4edda` | Success backgrounds (light) |
+
+### Borders
+| Token | Value | Usage |
+|-------|-------|-------|
+| `border-subtle` | `rgba(255, 255, 255, 0.05)` – `0.08` | Glass panel edges |
+| `border-default` | `rgba(255, 255, 255, 0.1)` / `#ddd` | Standard separation |
+| `border-strong` | `rgba(255, 255, 255, 0.2)` | Hover states, emphasis |
+| `border-input` | `#cbd5e1` / `#e5e7eb` | Form field borders (light context) |
+
+### Interactive States
+| State | Pattern |
+|-------|---------|
+| Hover bg | `rgba(255, 255, 255, 0.05)` → `0.1` |
+| Active bg | `rgba(77, 184, 255, 0.2)` with `color: #4db8ff` |
+| Focus | `border-color: #3b82f6` + `box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15)` |
+| Disabled | `opacity: 0.5`, `cursor: not-allowed` |
+
+---
+
+## Typography
+
+### Font Stacks
+- **UI**: `-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif`
+- **Mono**: `'JetBrains Mono', 'Fira Code', Consolas, 'Courier New', monospace` — used for coordinates, metadata values, status readouts
+
+### Scale
+| Level | Size | Weight | Usage |
+|-------|------|--------|-------|
+| Display | `2rem` – `2.5rem` | 700 | Page titles, app header |
+| H2 | `1.5rem` | 600 | Section headings |
+| H3 | `1rem` – `1.1rem` | 600 | Subsection headings |
+| Body | `0.9rem` | 400 | Standard text |
+| Small | `0.8rem` – `0.85rem` | 400–500 | Metadata, controls |
+| Caption | `0.7rem` – `0.75rem` | 400 | Badges, hints |
+
+### Conventions
+- Monospace for all data readouts (coordinates, pixel values, WCS, status values)
+- `letter-spacing: 0.5px` on small labels/badges
+- Line height: `1.3`–`1.5` for body text
+
+---
+
+## Spacing
+
+### Scale
+`2 | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 20 | 24 | 30 | 32 | 40 | 60` (px)
+
+### Common Patterns
+| Context | Value |
+|---------|-------|
+| Button padding | `10px 20px` (standard), `8px 12px` (compact) |
+| Input padding | `10px 14px` – `12px 16px` |
+| Card padding | `20px` |
+| Panel header | `10px 12px` |
+| Panel body | `12px` |
+| Section gap | `12px` – `20px` |
+| Control group gap | `6px` – `14px` |
+| Row item gap | `8px` |
+
+---
+
+## Border Radius
+
+| Value | Usage |
+|-------|-------|
+| `3px` – `4px` | Badges, small controls, tags |
+| `5px` – `6px` | Buttons, filter dropdowns |
+| `8px` | **Default** — cards, inputs, panels |
+| `10px` – `12px` | Larger containers, modals |
+| `15px` – `16px` | Major sections, auth container |
+| `50%` | Circular avatars, spinner |
+| `100px` | Pill-shaped toolbar |
+
+---
+
+## Elevation / Shadows
+
+### Strategy
+Glassmorphism + shadows. Dark backgrounds reduce shadow visibility, so glass panels use `backdrop-filter: blur()` plus subtle borders for definition.
+
+### Levels
+| Level | Shadow | Usage |
+|-------|--------|-------|
+| Flat | none | Default surfaces |
+| Low | `0 2px 4px rgba(0,0,0,0.1)` | Cards resting |
+| Medium | `0 4px 12px rgba(0,0,0,0.15)` | Cards on hover |
+| High | `0 10px 30px rgba(0,0,0,0.2)` – `0.3` | Modals, dropdowns |
+| Extreme | `0 20px 60px rgba(0,0,0,0.3)` | Auth container, viewer |
+
+### Glass Panels
+```css
+background: rgba(20, 20, 25, 0.7);
+backdrop-filter: blur(10px);
+border: 1px solid rgba(255, 255, 255, 0.08);
+border-radius: 8px;
+```
+
+### Glow Effects
+- Channel indicators: `0 0 10px var(--channel-color)`
+- Selection: `0 0 0 2px rgba(78, 205, 196, 0.3)`
+
+---
+
+## Animation
+
+### Durations
+| Speed | Duration | Usage |
+|-------|----------|-------|
+| Fast | `0.15s` | Hover states, color changes |
+| Standard | `0.2s` | Panels, dropdowns, transforms |
+| Slow | `0.3s` | Opacity fades, larger transitions |
+
+### Easing
+- Default: `ease-out` (most interactions)
+- Continuous: `linear` (spinners only)
+
+### Keyframes
+| Name | Pattern | Duration |
+|------|---------|----------|
+| `spin` | `rotate(0deg) → rotate(360deg)` | `0.8s` – `1s linear infinite` |
+| `dropdownFadeIn` | `opacity: 0, translateY(-8px) → visible` | `0.15s ease-out` |
+| `slideDown` | `opacity: 0, translateY(-10px) → visible` | `0.2s ease-out` |
+
+### Interactive Patterns
+- Button hover: `translateY(-1px)` + shadow increase
+- Button active: `translateY(0)` (press in)
+- Icon hover: `scale(1.1)` – `scale(1.2)`
+- Dropdown toggle: `rotate(180deg)` on chevrons
+
+---
+
+## Layout
+
+### Dashboard Grid
+```css
+grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+gap: 20px;
+max-width: 1200px;
+margin: 0 auto;
+```
+
+### Viewer Layout
+```css
+grid-template-columns: 1fr 320px;  /* Content + sidebar */
+grid-template-columns: 1fr 42px;   /* Sidebar collapsed */
+```
+
+### Breakpoints
+| Name | Value | Target |
+|------|-------|--------|
+| Mobile | `640px` | Phones |
+| Tablet | `768px` | Tablets |
+| Compact | `900px` | Small laptops |
+| Desktop | `1024px` | Laptops+ |
+
+---
+
+## Component Patterns
+
+### Primary Button
+```css
+background: linear-gradient(135deg, #3b82f6, #2563eb);
+color: white;
+padding: 10px 20px;
+border: none;
+border-radius: 5px–8px;
+transition: all 0.2s ease;
+/* Hover: translateY(-1px), shadow with accent color at 0.4 alpha */
+```
+
+### Icon Button
+```css
+width: 36px; height: 36px;
+background: transparent;
+color: rgba(255, 255, 255, 0.6);
+border-radius: 6px;
+/* Hover: bg rgba(255,255,255,0.1), color #fff */
+/* Active: bg rgba(77,184,255,0.2), color #4db8ff */
+```
+
+### Card
+```css
+background: white;  /* or dark variant */
+border: 1px solid #ddd;
+border-radius: 8px;
+padding: 20px;
+/* Hover: translateY(-2px), box-shadow increase */
+```
+
+### Glass Panel
+```css
+background: rgba(20, 20, 25, 0.7);
+backdrop-filter: blur(10px);
+border: 1px solid rgba(255, 255, 255, 0.08);
+border-radius: 8px–12px;
+```
+
+### Input Field
+```css
+padding: 10px 14px;
+border: 1px solid #cbd5e1;
+border-radius: 5px–8px;
+background: #fff;  /* or rgba(30, 30, 45, 0.8) dark */
+/* Focus: border-color #3b82f6, box-shadow 0 0 0 3px rgba(59,130,246,0.15) */
+```
+
+### Status Badge
+```css
+padding: 4px 8px;
+border-radius: 12px;
+font-size: 0.75rem;
+font-weight: 600;
+/* Colors vary by status — see Semantic Colors */
+```
+
+---
+
+## Icons
+
+All custom SVGs. Standard attributes:
+```jsx
+width="24" height="24"
+viewBox="0 0 24 24"
+fill="none"
+stroke="currentColor"
+strokeWidth="2"
+strokeLinecap="round"
+strokeLinejoin="round"
+```
+
+No external icon library. Icons defined inline in component files.
+
+---
+
+## Notes
+
+- Status badges use **light backgrounds** even in the dark theme (Bootstrap-style alert colors)
+- Channel colors are dynamic via CSS custom properties (`--channel-color`)
+- Dashboard cards use white/light backgrounds — a visual break from the dark chrome
+- Sidebar panels use 280px width (floating) or 320px (fixed sidebar)
+- The app is desktop-primary with basic mobile responsiveness

--- a/frontend/jwst-frontend/src/App.css
+++ b/frontend/jwst-frontend/src/App.css
@@ -5,27 +5,17 @@
   background-size: cover;
   background-position: center;
   background-attachment: fixed;
-  color: white;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
+  color: var(--text-primary);
 }
 
 .App-header {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--bg-overlay);
   padding: 20px 30px;
-  color: white;
+  color: var(--text-primary);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
-  margin-bottom: 30px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 0;
 }
 
 .header-content {
@@ -41,44 +31,31 @@
 }
 
 .App-header h1 {
-  margin: 0 0 6px 0;
-  font-size: 2rem;
+  margin: 0 0 4px 0;
+  font-size: 1.75rem;
   font-weight: 700;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  letter-spacing: -0.02em;
 }
 
 .App-header p {
   margin: 0;
-  font-size: 1rem;
-  opacity: 0.9;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(360deg);
-  }
+  font-size: 0.9rem;
+  color: var(--text-secondary);
 }
 
 main {
-  background-color: white;
-  margin: 0 20px;
-  border-radius: 15px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  background-color: var(--bg-elevated);
+  margin: 16px 20px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
   overflow: hidden;
 }
 
+/* Loading state */
 .loading {
   text-align: center;
   padding: 60px 20px;
-  color: white;
+  color: var(--text-primary);
 }
 
 .loading h2 {
@@ -87,12 +64,12 @@ main {
 }
 
 .spinner {
-  border: 4px solid rgba(255, 255, 255, 0.3);
-  border-top: 4px solid white;
+  border: 3px solid var(--border-default);
+  border-top: 3px solid var(--accent-primary);
   border-radius: 50%;
-  width: 40px;
-  height: 40px;
-  animation: spin 1s linear infinite;
+  width: 36px;
+  height: 36px;
+  animation: spin 0.8s linear infinite;
   margin: 20px auto;
 }
 
@@ -100,16 +77,16 @@ main {
   0% {
     transform: rotate(0deg);
   }
-
   100% {
     transform: rotate(360deg);
   }
 }
 
+/* Error state */
 .error {
   text-align: center;
   padding: 60px 20px;
-  color: white;
+  color: var(--text-primary);
 }
 
 .error h2 {
@@ -119,40 +96,39 @@ main {
 
 .error p {
   margin-bottom: 20px;
-  opacity: 0.9;
+  color: var(--text-secondary);
 }
 
 .error button {
-  padding: 12px 24px;
-  background-color: rgba(255, 255, 255, 0.2);
+  padding: 10px 20px;
+  background-color: var(--accent-primary);
   color: white;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-radius: 8px;
+  border: none;
+  border-radius: var(--radius-md);
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 500;
-  transition: all 0.3s ease;
+  transition: background-color var(--transition-fast);
 }
 
 .error button:hover {
-  background-color: rgba(255, 255, 255, 0.3);
-  border-color: rgba(255, 255, 255, 0.5);
+  background-color: var(--accent-primary-hover);
 }
 
-/* Auth loading state */
+/* Auth loading */
 .auth-loading {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  color: white;
+  color: var(--text-primary);
 }
 
 .auth-loading p {
   margin-top: 16px;
   font-size: 1rem;
-  opacity: 0.9;
+  color: var(--text-secondary);
 }
 
 @media (max-width: 768px) {
@@ -161,11 +137,11 @@ main {
   }
 
   .App-header h1 {
-    font-size: 1.5rem;
+    font-size: 1.4rem;
   }
 
   .App-header p {
-    font-size: 0.9rem;
+    font-size: 0.85rem;
   }
 
   .header-content {
@@ -179,6 +155,6 @@ main {
   }
 
   main {
-    margin: 0 10px;
+    margin: 8px 10px;
   }
 }

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.css
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.css
@@ -1,3 +1,16 @@
+/* Screen-reader only utility */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .dashboard {
   max-width: 1200px;
   margin: 0 auto;
@@ -13,9 +26,9 @@
   flex-direction: column;
   gap: 12px;
   padding: 14px;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  background: #f8fafc;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
 }
 
 .controls-row {
@@ -33,12 +46,12 @@
 .controls-row-secondary-actions,
 .controls-row-analysis-actions {
   padding-top: 10px;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--border-subtle);
 }
 
 .controls-row-analysis-actions {
-  background: rgba(15, 23, 42, 0.03);
-  border-radius: 8px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
   padding: 10px;
   border-top: none;
 }
@@ -51,10 +64,15 @@
 .search-box input {
   width: 100%;
   padding: 10px 14px;
-  border: 1px solid #cbd5e1;
-  border-radius: 5px;
-  background: #fff;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
   font-size: 14px;
+}
+
+.search-box input::placeholder {
+  color: var(--text-muted);
 }
 
 .filter-box {
@@ -65,10 +83,26 @@
 .filter-box select {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid #cbd5e1;
-  border-radius: 5px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   font-size: 14px;
-  background-color: white;
+  background-color: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.filter-box select option {
+  background-color: var(--bg-surface);
+  color: var(--text-primary);
+}
+
+.filter-box select optgroup {
+  background-color: var(--bg-elevated);
+  color: var(--text-muted);
+  font-style: normal;
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 .controls .upload-btn,
@@ -82,63 +116,68 @@
   min-height: 38px;
 }
 
+/* Primary button — Upload (secondary per spec) */
 .upload-btn {
   padding: 10px 20px;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 5px;
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
+  transition: all var(--transition-fast);
 }
 
 .upload-btn:hover {
-  background-color: #0056b3;
+  background-color: var(--bg-surface-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
 }
 
+/* Primary button — MAST Search */
 .mast-search-btn {
   padding: 10px 20px;
-  background: linear-gradient(135deg, #6f42c1 0%, #5a32a3 100%);
+  background-color: var(--accent-primary);
   color: white;
   border: none;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .mast-search-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(111, 66, 193, 0.4);
+  background-color: var(--accent-primary-hover);
 }
 
 .mast-search-btn.active {
-  background: linear-gradient(135deg, #5a32a3 0%, #4a2683 100%);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+  background-color: var(--accent-primary-hover);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
+/* Ghost button — What's New */
 .whats-new-btn {
   padding: 10px 20px;
-  background: linear-gradient(135deg, #e67e22 0%, #d35400 100%);
-  color: white;
-  border: none;
-  border-radius: 5px;
+  background-color: transparent;
+  color: var(--text-muted);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .whats-new-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(230, 126, 34, 0.4);
+  color: var(--text-secondary);
+  background-color: var(--bg-surface-hover);
 }
 
 .whats-new-btn.active {
-  background: linear-gradient(135deg, #d35400 0%, #a84300 100%);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+  color: var(--accent-primary);
+  background-color: var(--accent-primary-subtle);
 }
 
 .upload-modal {
@@ -147,7 +186,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--bg-overlay);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -155,18 +194,19 @@
 }
 
 .upload-content {
-  background-color: white;
+  background-color: var(--bg-surface);
+  color: var(--text-primary);
   padding: 30px;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   width: 90%;
   max-width: 500px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-lg);
 }
 
 .upload-content h3 {
   margin-top: 0;
   margin-bottom: 20px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .form-group {
@@ -177,7 +217,7 @@
   display: block;
   margin-bottom: 5px;
   font-weight: 500;
-  color: #555;
+  color: var(--text-secondary);
 }
 
 .form-group input,
@@ -185,9 +225,16 @@
 .form-group textarea {
   width: 100%;
   padding: 10px;
-  border: 1px solid #ddd;
-  border-radius: 5px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   font-size: 14px;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.form-group input::placeholder,
+.form-group textarea::placeholder {
+  color: var(--text-muted);
 }
 
 .form-group textarea {
@@ -205,27 +252,30 @@
 .form-actions button {
   padding: 10px 20px;
   border: none;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
+  transition: all var(--transition-fast);
 }
 
 .form-actions button[type='submit'] {
-  background-color: #28a745;
+  background-color: var(--color-success);
   color: white;
 }
 
 .form-actions button[type='submit']:hover {
-  background-color: #218838;
+  background-color: #059669;
 }
 
 .form-actions button[type='button'] {
-  background-color: #6c757d;
-  color: white;
+  background-color: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
 }
 
 .form-actions button[type='button']:hover {
-  background-color: #545b62;
+  background-color: var(--bg-surface-hover);
+  color: var(--text-primary);
 }
 
 .data-grid {
@@ -235,19 +285,19 @@
 }
 
 .data-card {
-  border: 1px solid #ddd;
-  border-radius: 8px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   padding: 20px;
-  background-color: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background-color: var(--bg-surface);
+  box-shadow: var(--shadow-sm);
   transition:
-    transform 0.2s,
-    box-shadow 0.2s;
+    transform var(--transition-base),
+    box-shadow var(--transition-base);
 }
 
 .data-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
 }
 
 .card-header {
@@ -259,7 +309,7 @@
 
 .card-header h4 {
   margin: 0;
-  color: #333;
+  color: var(--text-primary);
   font-size: 16px;
   word-break: break-all;
   overflow-wrap: break-word;
@@ -275,28 +325,28 @@
 }
 
 .status.pending {
-  background-color: #f8f9fa;
-  color: #6c757d;
+  background-color: rgba(107, 114, 128, 0.15);
+  color: #9ca3af;
 }
 
 .status.processing {
-  background-color: #fff3cd;
-  color: #856404;
+  background-color: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
 }
 
 .status.completed {
-  background-color: #d4edda;
-  color: #155724;
+  background-color: rgba(16, 185, 129, 0.15);
+  color: #34d399;
 }
 
 .status.failed {
-  background-color: #f8d7da;
-  color: #721c24;
+  background-color: rgba(239, 68, 68, 0.15);
+  color: #f87171;
 }
 
 .card-content p {
   margin: 8px 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
@@ -308,25 +358,27 @@
 }
 
 .tag {
-  background-color: #e9ecef;
-  color: #495057;
+  background-color: var(--bg-elevated);
+  color: var(--text-secondary);
   padding: 2px 8px;
   border-radius: 12px;
   font-size: 12px;
-  border: none;
+  border: 1px solid var(--border-default);
   cursor: pointer;
   transition:
-    background-color 0.15s ease,
-    color 0.15s ease;
+    background-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .tag:hover {
-  background-color: #dce0e5;
+  background-color: var(--bg-surface-hover);
+  color: var(--text-primary);
 }
 
 .tag.active {
-  background-color: #007bff;
-  color: #fff;
+  background-color: var(--accent-primary);
+  color: white;
+  border-color: var(--accent-primary);
 }
 
 .card-actions {
@@ -338,99 +390,96 @@
 
 .card-actions button {
   padding: 8px 12px;
-  border: 1px solid #007bff;
-  background-color: white;
-  color: #007bff;
-  border-radius: 5px;
+  border: 1px solid var(--border-default);
+  background-color: transparent;
+  color: var(--accent-primary);
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 12px;
-  transition:
-    background-color 0.2s,
-    color 0.2s;
+  transition: all var(--transition-fast);
 }
 
 .card-actions button:hover {
-  background-color: #007bff;
-  color: white;
+  background-color: var(--accent-primary-subtle);
+  border-color: var(--accent-primary);
 }
 
 .card-actions .archive-btn {
-  border-color: #f59e0b;
-  color: #f59e0b;
-  background: linear-gradient(135deg, rgba(245, 158, 11, 0.1) 0%, rgba(245, 158, 11, 0.05) 100%);
+  border-color: var(--color-warning);
+  color: var(--color-warning);
+  background: transparent;
 }
 
 .card-actions .archive-btn:hover {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-  color: white;
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.4);
+  background: var(--color-warning-subtle);
 }
 
+/* Ghost button — Archive toggle */
 .archived-toggle {
   padding: 10px 20px;
-  background: linear-gradient(135deg, #6b7280 0%, #4b5563 100%);
-  color: white;
-  border: none;
-  border-radius: 5px;
+  background-color: transparent;
+  color: var(--text-muted);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .archived-toggle:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.4);
+  color: var(--text-secondary);
+  background-color: var(--bg-surface-hover);
 }
 
 .archived-toggle.active {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+  color: var(--accent-primary);
+  background-color: var(--accent-primary-subtle);
 }
 
+/* Primary button — Import MAST */
 .import-mast-btn {
   padding: 10px 20px;
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  background-color: var(--accent-primary);
   color: white;
   border: none;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .import-mast-btn:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.4);
+  background-color: var(--accent-primary-hover);
 }
 
 .import-mast-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-  transform: none;
 }
 
 .no-data {
   grid-column: 1 / -1;
   text-align: center;
   padding: 60px 20px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .no-data h3 {
   margin-bottom: 10px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .loading {
   text-align: center;
   padding: 60px 20px;
+  color: var(--text-secondary);
 }
 
 .spinner {
-  border: 4px solid #f3f3f3;
-  border-top: 4px solid #007bff;
+  border: 4px solid var(--border-default);
+  border-top: 4px solid var(--accent-primary);
   border-radius: 50%;
   width: 40px;
   height: 40px;
@@ -451,17 +500,18 @@
 .error {
   text-align: center;
   padding: 60px 20px;
-  color: #721c24;
+  color: var(--color-error);
 }
 
 .error button {
   margin-top: 15px;
   padding: 10px 20px;
-  background-color: #007bff;
+  background-color: var(--accent-primary);
   color: white;
   border: none;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   cursor: pointer;
+  transition: all var(--transition-fast);
 }
 
 @media (max-width: 768px) {
@@ -521,10 +571,10 @@
 /* View Toggle */
 .view-toggle {
   display: flex;
-  background-color: #f1f3f5;
-  border-radius: 5px;
+  background-color: var(--bg-elevated);
+  border-radius: var(--radius-md);
   padding: 2px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-default);
 }
 
 .view-btn {
@@ -535,22 +585,22 @@
   border: none;
   background: none;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-size: 14px;
-  color: #666;
+  color: var(--text-muted);
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .view-btn:hover {
-  background-color: rgba(0, 0, 0, 0.05);
-  color: #333;
+  background-color: var(--bg-surface-hover);
+  color: var(--text-secondary);
 }
 
 .view-btn.active {
-  background-color: white;
-  color: #007bff;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background-color: var(--bg-surface);
+  color: var(--accent-primary);
+  box-shadow: var(--shadow-sm);
 }
 
 .view-btn .icon {
@@ -561,10 +611,10 @@
 /* Grouped View */
 .data-group {
   margin-bottom: 30px;
-  background-color: #f8f9fa;
-  border-radius: 8px;
+  background-color: var(--bg-surface);
+  border-radius: var(--radius-md);
   padding: 15px;
-  border: 1px solid #e9ecef;
+  border: 1px solid var(--border-default);
 }
 
 .group-header {
@@ -573,21 +623,21 @@
   justify-content: space-between;
   margin-bottom: 15px;
   padding-bottom: 10px;
-  border-bottom: 1px solid #dee2e6;
+  border-bottom: 1px solid var(--border-subtle);
   cursor: pointer;
   user-select: none;
-  transition: background-color 0.2s ease;
-  border-radius: 4px;
+  transition: background-color var(--transition-fast);
+  border-radius: var(--radius-sm);
   padding: 10px;
   margin: -10px -10px 15px -10px;
 }
 
 .group-header:hover {
-  background-color: rgba(0, 0, 0, 0.03);
+  background-color: var(--bg-surface-hover);
 }
 
 .group-header:focus {
-  outline: 2px solid #007bff;
+  outline: 2px solid var(--accent-primary);
   outline-offset: 2px;
 }
 
@@ -599,15 +649,15 @@
 
 .collapse-icon {
   font-size: 12px;
-  color: #6c757d;
-  transition: transform 0.2s ease;
+  color: var(--text-muted);
+  transition: transform var(--transition-fast);
   width: 16px;
   text-align: center;
 }
 
 .group-header h3 {
   margin: 0;
-  color: #495057;
+  color: var(--text-primary);
   font-size: 18px;
 }
 
@@ -622,11 +672,11 @@
 }
 
 .group-count {
-  background-color: #e9ecef;
+  background-color: var(--bg-elevated);
   padding: 4px 10px;
   border-radius: 12px;
   font-size: 12px;
-  color: #6c757d;
+  color: var(--text-muted);
   font-weight: 600;
 }
 
@@ -638,10 +688,10 @@
 }
 
 .lineage-group {
-  background-color: #f8f9fa;
-  border-radius: 8px;
+  background-color: var(--bg-surface);
+  border-radius: var(--radius-md);
   padding: 15px;
-  border: 1px solid #e9ecef;
+  border: 1px solid var(--border-default);
 }
 
 .lineage-group.collapsed {
@@ -655,12 +705,12 @@
   cursor: pointer;
   padding: 10px;
   margin: -10px -10px 15px -10px;
-  border-radius: 4px;
-  transition: background-color 0.2s ease;
+  border-radius: var(--radius-sm);
+  transition: background-color var(--transition-fast);
 }
 
 .lineage-header:hover {
-  background-color: rgba(0, 0, 0, 0.03);
+  background-color: var(--bg-surface-hover);
 }
 
 .lineage-group.collapsed .lineage-header {
@@ -676,7 +726,7 @@
 .lineage-header-left h3 {
   margin: 0;
   font-size: 16px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .lineage-header-right {
@@ -714,7 +764,7 @@
   top: 0;
   bottom: 20px;
   width: 2px;
-  background: linear-gradient(to bottom, #e5e7eb 0%, #e5e7eb 100%);
+  background: var(--border-default);
 }
 
 .lineage-level {
@@ -727,16 +777,16 @@
   align-items: center;
   gap: 10px;
   padding: 8px 12px;
-  background: white;
-  border: 1px solid #e5e7eb;
-  border-radius: 6px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
+  color: var(--text-primary);
 }
 
 .level-header:hover {
-  background: #f9fafb;
-  border-color: #d1d5db;
+  background: var(--bg-surface-hover);
 }
 
 .level-connector {
@@ -749,31 +799,31 @@
 .connector-line {
   width: 20px;
   height: 2px;
-  background: #e5e7eb;
+  background: var(--border-default);
 }
 
 .level-dot {
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  border: 2px solid white;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  border: 2px solid var(--bg-surface);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
 .level-label {
   font-weight: 500;
-  color: #374151;
+  color: var(--text-primary);
   flex: 1;
 }
 
 .level-count {
-  color: #6b7280;
+  color: var(--text-muted);
   font-size: 13px;
 }
 
 .expand-icon {
   font-size: 18px;
-  color: #9ca3af;
+  color: var(--text-muted);
   font-weight: bold;
 }
 
@@ -787,9 +837,9 @@
 }
 
 .lineage-file-card {
-  background: white;
-  border: 1px solid #e5e7eb;
-  border-radius: 6px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   padding: 12px;
 }
 
@@ -802,7 +852,7 @@
 
 .lineage-file-card .file-name {
   font-weight: 500;
-  color: #111827;
+  color: var(--text-primary);
   font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -814,7 +864,7 @@
   display: flex;
   gap: 15px;
   font-size: 12px;
-  color: #6b7280;
+  color: var(--text-muted);
   margin-bottom: 10px;
 }
 
@@ -826,17 +876,17 @@
 .lineage-file-card .file-actions button {
   padding: 4px 10px;
   font-size: 11px;
-  border: 1px solid #007bff;
-  background: white;
-  color: #007bff;
-  border-radius: 4px;
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--accent-primary);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--transition-fast);
 }
 
 .lineage-file-card .file-actions button:hover {
-  background: #007bff;
-  color: white;
+  background: var(--accent-primary-subtle);
+  border-color: var(--accent-primary);
 }
 
 /* Responsive adjustments */
@@ -877,28 +927,28 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-size: 11px;
   font-weight: 500;
   white-space: nowrap;
 }
 
 .fits-type-badge.image {
-  background-color: #dbeafe;
-  color: #1d4ed8;
-  border: 1px solid #93c5fd;
+  background-color: rgba(59, 130, 246, 0.12);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.25);
 }
 
 .fits-type-badge.table {
-  background-color: #fef3c7;
-  color: #92400e;
-  border: 1px solid #fcd34d;
+  background-color: rgba(245, 158, 11, 0.12);
+  color: #fbbf24;
+  border: 1px solid rgba(245, 158, 11, 0.25);
 }
 
 .fits-type-badge.unknown {
-  background-color: #f3f4f6;
-  color: #6b7280;
-  border: 1px solid #d1d5db;
+  background-color: rgba(107, 114, 128, 0.12);
+  color: #9ca3af;
+  border: 1px solid rgba(107, 114, 128, 0.25);
 }
 
 .fits-type-badge.small {
@@ -911,14 +961,14 @@
   display: inline-flex;
   align-items: center;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-size: 11px;
   font-weight: 600;
   font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;
   white-space: nowrap;
-  background-color: #ede9fe;
-  color: #6d28d9;
-  border: 1px solid #c4b5fd;
+  background-color: rgba(139, 92, 246, 0.12);
+  color: #a78bfa;
+  border: 1px solid rgba(139, 92, 246, 0.25);
 }
 
 .filter-badge.small {
@@ -927,40 +977,40 @@
 }
 
 .fits-type-label {
-  background-color: #f3f4f6;
-  color: #6b7280;
+  background-color: var(--bg-elevated);
+  color: var(--text-muted);
   padding: 1px 6px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   font-size: 11px;
 }
 
 /* View button states */
 .view-file-btn {
   padding: 6px 12px;
-  background-color: #007bff;
+  background-color: var(--accent-primary);
   color: white;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 12px;
-  transition: all 0.2s;
+  transition: all var(--transition-fast);
 }
 
 .view-file-btn:hover:not(.disabled) {
-  background-color: #0056b3;
+  background-color: var(--accent-primary-hover);
 }
 
 .view-file-btn.disabled,
 .lineage-file-card .file-actions button.disabled {
-  background-color: #f3f4f6;
-  color: #9ca3af;
-  border-color: #d1d5db;
+  background-color: var(--bg-elevated);
+  color: var(--text-faint);
+  border-color: var(--border-subtle);
   cursor: not-allowed;
 }
 
 .lineage-file-card .file-actions button.disabled:hover {
-  background-color: #f3f4f6;
-  color: #9ca3af;
+  background-color: var(--bg-elevated);
+  color: var(--text-faint);
 }
 
 /* Card header adjustments for badges */
@@ -998,27 +1048,27 @@
   row-gap: 4px;
   gap: 8px;
   font-size: 13px;
-  color: #6b7280;
+  color: var(--text-muted);
 }
 
 .obs-title {
-  color: #0f766e;
+  color: #2dd4bf;
   font-weight: 500;
   font-style: italic;
 }
 
 .target-name {
-  color: #4f46e5;
+  color: #818cf8;
   font-weight: 500;
 }
 
 .instrument-name {
-  color: #059669;
+  color: #34d399;
   font-weight: 500;
 }
 
 .meta-separator {
-  color: #d1d5db;
+  color: var(--text-faint);
 }
 
 /* Grouped View Title and Meta */
@@ -1039,7 +1089,7 @@
   row-gap: 4px;
   gap: 8px;
   font-size: 13px;
-  color: #6b7280;
+  color: var(--text-muted);
 }
 
 /* Delete Observation Button */
@@ -1047,20 +1097,20 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: #fff5f5;
-  border: 1px solid #ef4444;
-  color: #ef4444;
+  background: var(--color-error-subtle);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: var(--color-error);
   padding: 5px 10px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 12px;
   font-weight: 600;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
   margin-left: 10px;
 }
 
 .delete-observation-btn:hover {
-  background-color: #ef4444;
+  background-color: var(--color-error);
   color: white;
 }
 
@@ -1075,7 +1125,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: var(--bg-overlay);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -1084,19 +1134,20 @@
 
 /* Delete Modal */
 .delete-modal {
-  background-color: white;
+  background-color: var(--bg-surface);
+  color: var(--text-primary);
   padding: 24px;
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   width: 90%;
   max-width: 500px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-lg);
   max-height: 80vh;
   overflow-y: auto;
 }
 
 .delete-modal h3 {
   margin: 0 0 20px 0;
-  color: #dc2626;
+  color: var(--color-error);
   font-size: 20px;
   display: flex;
   align-items: center;
@@ -1104,7 +1155,7 @@
 }
 
 .delete-modal h3::before {
-  content: '⚠️';
+  content: '\26A0\FE0F';
 }
 
 .delete-modal-content {
@@ -1113,19 +1164,19 @@
 
 .delete-observation-id {
   font-size: 14px;
-  color: #374151;
+  color: var(--text-secondary);
   margin-bottom: 8px;
   word-break: break-all;
 }
 
 .delete-summary {
   font-size: 16px;
-  color: #111827;
+  color: var(--text-primary);
   margin-bottom: 16px;
   padding: 10px;
-  background-color: #fef2f2;
-  border-radius: 6px;
-  border-left: 4px solid #ef4444;
+  background-color: var(--color-error-subtle);
+  border-radius: var(--radius-md);
+  border-left: 4px solid var(--color-error);
 }
 
 /* File List */
@@ -1137,7 +1188,7 @@
 .delete-file-list strong {
   display: block;
   margin-bottom: 8px;
-  color: #374151;
+  color: var(--text-secondary);
 }
 
 .delete-file-list ul {
@@ -1145,27 +1196,27 @@
   overflow-y: auto;
   margin: 0;
   padding-left: 20px;
-  background-color: #f9fafb;
-  border: 1px solid #e5e7eb;
-  border-radius: 6px;
+  background-color: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   padding: 10px 10px 10px 30px;
 }
 
 .delete-file-list li {
-  color: #6b7280;
+  color: var(--text-muted);
   padding: 2px 0;
   word-break: break-all;
 }
 
 /* Warning Message */
 .delete-warning {
-  color: #dc2626;
+  color: #f87171;
   font-size: 14px;
   font-weight: 500;
   padding: 12px;
-  background-color: #fef2f2;
-  border: 1px solid #fecaca;
-  border-radius: 6px;
+  background-color: var(--color-error-subtle);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-md);
   margin-top: 16px;
 }
 
@@ -1178,18 +1229,18 @@
 
 .delete-cancel-btn {
   padding: 10px 20px;
-  background-color: #f3f4f6;
-  color: #374151;
-  border: 1px solid #d1d5db;
-  border-radius: 6px;
+  background-color: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .delete-cancel-btn:hover:not(:disabled) {
-  background-color: #e5e7eb;
+  background-color: var(--bg-surface-hover);
 }
 
 .delete-cancel-btn:disabled {
@@ -1199,14 +1250,14 @@
 
 .delete-confirm-btn {
   padding: 10px 20px;
-  background-color: #dc2626;
+  background-color: var(--color-error);
   color: white;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .delete-confirm-btn:hover:not(:disabled) {
@@ -1231,48 +1282,44 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  background: #f8fafc;
-  border: 1px solid #dbe4ef;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
   padding: 5px 9px;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 12px;
   font-weight: 600;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .level-action-btn:hover {
-  transform: translateY(-1px);
+  background: var(--bg-surface-hover);
 }
 
 .level-action-btn.archive-btn {
-  color: #a16207;
-  background: #fffbeb;
-  border-color: #fcd34d;
+  color: var(--color-warning);
+  background: var(--color-warning-subtle);
+  border-color: rgba(245, 158, 11, 0.3);
 }
 
 .level-action-btn.archive-btn:hover {
-  background-color: #f59e0b;
-  color: #fff;
-  border-color: #f59e0b;
+  background-color: rgba(245, 158, 11, 0.25);
 }
 
 .level-action-btn.delete-btn {
-  color: #dc2626;
-  background: #fef2f2;
-  border-color: #fecaca;
+  color: var(--color-error);
+  background: var(--color-error-subtle);
+  border-color: rgba(239, 68, 68, 0.3);
 }
 
 .level-action-btn.delete-btn:hover {
-  background-color: #ef4444;
-  color: #fff;
-  border-color: #ef4444;
+  background-color: rgba(239, 68, 68, 0.25);
 }
 
 .level-action-btn:disabled {
   opacity: 0.3;
   cursor: not-allowed;
-  transform: none;
 }
 
 .level-action-btn .action-label {
@@ -1282,7 +1329,7 @@
 /* Delete Level Modal specific styles */
 .delete-level-id {
   font-size: 14px;
-  color: #374151;
+  color: var(--text-secondary);
   margin-bottom: 12px;
   display: flex;
   align-items: center;
@@ -1302,32 +1349,33 @@
    RGB Composite Selection Styles
    ============================================ */
 
-/* Composite toolbar button */
+/* Secondary button — Composite */
 .composite-btn {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 10px 16px;
-  background: linear-gradient(135deg, #374151 0%, #1f2937 100%);
-  color: #9ca3af;
-  border: 1px solid #4b5563;
-  border-radius: 5px;
+  background-color: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   cursor: not-allowed;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .composite-btn.ready {
-  background: linear-gradient(135deg, #4a90d9 0%, #357abd 100%);
-  color: white;
-  border-color: #4a90d9;
+  background-color: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-default);
   cursor: pointer;
 }
 
 .composite-btn.ready:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(74, 144, 217, 0.4);
+  background-color: var(--bg-surface-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
 }
 
 .composite-btn:disabled {
@@ -1340,25 +1388,26 @@
   justify-content: center;
 }
 
-/* WCS Mosaic button */
+/* Secondary button — WCS Mosaic */
 .mosaic-open-btn {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 10px 16px;
-  background: linear-gradient(135deg, #8844ff 0%, #6633cc 100%);
-  color: white;
-  border: 1px solid #8844ff;
-  border-radius: 5px;
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .mosaic-open-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(136, 68, 255, 0.4);
+  background-color: var(--bg-surface-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
 }
 
 .mosaic-icon {
@@ -1367,25 +1416,26 @@
   justify-content: center;
 }
 
-/* Compare button */
+/* Secondary button — Compare */
 .compare-open-btn {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 10px 16px;
-  background: linear-gradient(135deg, #4cc9f0 0%, #3a9fc0 100%);
-  color: #000;
-  border: 1px solid #4cc9f0;
-  border-radius: 5px;
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .compare-open-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(76, 201, 240, 0.4);
+  background-color: var(--bg-surface-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
 }
 
 .compare-icon {
@@ -1410,7 +1460,7 @@
   font-size: 16px;
   font-weight: 700;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
   flex-shrink: 0;
   margin-right: 8px;
 }
@@ -1444,10 +1494,20 @@
 .data-card.selected-composite,
 .lineage-file-card.selected-composite {
   border-color: #4ecdc4;
-  box-shadow: 0 0 0 2px rgba(78, 205, 196, 0.3);
+  box-shadow: 0 0 0 2px rgba(78, 205, 196, 0.2);
 }
 
 .data-card.selected-composite .card-header,
 .lineage-file-card.selected-composite .file-header {
-  background: linear-gradient(135deg, rgba(78, 205, 196, 0.1) 0%, transparent 50%);
+  background: linear-gradient(135deg, rgba(78, 205, 196, 0.08) 0%, transparent 50%);
+}
+
+/* Focus States */
+.tag:focus-visible,
+.view-btn:focus-visible,
+.level-header:focus-visible,
+.composite-select-btn:focus-visible,
+.group-header:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }

--- a/frontend/jwst-frontend/src/components/UserMenu.css
+++ b/frontend/jwst-frontend/src/components/UserMenu.css
@@ -10,30 +10,36 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  background: rgba(255, 255, 255, 0.15);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
-  color: white;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
   cursor: pointer;
   padding: 6px 12px;
   font-size: 0.9rem;
-  transition: background 0.2s;
+  transition: background var(--transition-fast);
 }
 
 .user-menu-trigger:hover {
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.user-menu-trigger:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }
 
 .user-avatar {
   width: 28px;
   height: 28px;
-  background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+  background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-secondary) 100%);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 0.75rem;
   font-weight: 600;
+  color: white;
 }
 
 .user-name {
@@ -46,7 +52,7 @@
 .dropdown-arrow {
   display: flex;
   align-items: center;
-  transition: transform 0.2s;
+  transition: transform var(--transition-fast);
 }
 
 .dropdown-arrow.open {
@@ -57,9 +63,10 @@
   position: absolute;
   top: calc(100% + 8px);
   right: 0;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
   min-width: 260px;
   overflow: hidden;
   z-index: 1000;
@@ -87,7 +94,7 @@
 .user-menu-avatar {
   width: 40px;
   height: 40px;
-  background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+  background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-secondary) 100%);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -104,7 +111,7 @@
 }
 
 .user-menu-name {
-  color: #1f2937;
+  color: var(--text-primary);
   font-size: 0.95rem;
   font-weight: 600;
   overflow: hidden;
@@ -113,7 +120,7 @@
 }
 
 .user-menu-email {
-  color: #6b7280;
+  color: var(--text-muted);
   font-size: 0.85rem;
   margin-top: 2px;
   overflow: hidden;
@@ -122,7 +129,7 @@
 }
 
 .user-menu-org {
-  color: #9ca3af;
+  color: var(--text-faint);
   font-size: 0.8rem;
   margin-top: 4px;
   overflow: hidden;
@@ -132,7 +139,7 @@
 
 .user-menu-divider {
   height: 1px;
-  background: #e5e7eb;
+  background: var(--border-subtle);
 }
 
 .user-menu-item {
@@ -143,23 +150,29 @@
   padding: 12px 16px;
   background: none;
   border: none;
-  color: #374151;
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 0.9rem;
   text-align: left;
-  transition: background 0.15s;
+  transition: background var(--transition-fast);
 }
 
 .user-menu-item:hover {
-  background: #f3f4f6;
+  background: var(--bg-surface-hover);
+  color: var(--text-primary);
+}
+
+.user-menu-item:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
 }
 
 .user-menu-item.logout {
-  color: #dc2626;
+  color: var(--color-error);
 }
 
 .user-menu-item.logout:hover {
-  background: #fef2f2;
+  background: var(--color-error-subtle);
 }
 
 /* Hide on small screens, show only avatar */

--- a/frontend/jwst-frontend/src/index.css
+++ b/frontend/jwst-frontend/src/index.css
@@ -1,12 +1,77 @@
-body {
-  margin: 0;
-  font-family:
+/* ============================================
+   Design Tokens — Dark Theme
+   Future: add [data-theme="light"] overrides
+   ============================================ */
+:root {
+  /* Surfaces */
+  --bg-base: #0c0d10;
+  --bg-elevated: #141519;
+  --bg-surface: #1a1d24;
+  --bg-surface-hover: #21252e;
+  --bg-overlay: rgba(18, 19, 23, 0.9);
+
+  /* Text */
+  --text-primary: #e8eaed;
+  --text-secondary: #9ca3af;
+  --text-muted: #6b7280;
+  --text-faint: #4b5563;
+
+  /* Borders */
+  --border-subtle: rgba(255, 255, 255, 0.06);
+  --border-default: rgba(255, 255, 255, 0.1);
+  --border-strong: rgba(255, 255, 255, 0.18);
+
+  /* Primary accent */
+  --accent-primary: #3b82f6;
+  --accent-primary-hover: #2563eb;
+  --accent-primary-subtle: rgba(59, 130, 246, 0.12);
+
+  /* Secondary accent */
+  --accent-secondary: #8b5cf6;
+  --accent-secondary-hover: #7c3aed;
+  --accent-secondary-subtle: rgba(139, 92, 246, 0.12);
+
+  /* Semantic */
+  --color-success: #10b981;
+  --color-success-subtle: rgba(16, 185, 129, 0.12);
+  --color-warning: #f59e0b;
+  --color-warning-subtle: rgba(245, 158, 11, 0.12);
+  --color-error: #ef4444;
+  --color-error-subtle: rgba(239, 68, 68, 0.12);
+  --color-info: #3b82f6;
+
+  /* Border radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+
+  /* Shadows (dark theme — heavier) */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.6);
+
+  /* Transitions */
+  --transition-fast: 0.15s ease-out;
+  --transition-base: 0.2s ease-out;
+
+  /* Font stacks */
+  --font-sans:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
     'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  --font-mono:
+    'JetBrains Mono', 'Fira Code', source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-family: var(--font-mono);
 }


### PR DESCRIPTION
## Summary
- Introduces a CSS custom property (design token) system as the theming foundation with ~30 tokens for surfaces, text, borders, accents, semantic colors, radius, shadows, transitions, and fonts
- Converts the entire dashboard UI to a cohesive dark theme — App shell, data dashboard, and user menu
- Replaces rainbow gradient toolbar buttons with a 3-tier button hierarchy (primary/secondary/ghost)
- Merges the separate "File Type" dropdown into the "Data Type" dropdown using `<optgroup>` elements, and removes unused filter options (Metadata, Processed)
- Implements cascading filter dropdowns: Type → Level → Tag — each dropdown dynamically shows only options present in the upstream-filtered data, with item counts
- Bumps FITS table viewer to early Phase 5 in the development plan

## Why
The dashboard had inconsistent styling (rainbow gradient buttons, mixed light/dark elements, hardcoded colors), redundant filter dropdowns, and static filter options that showed irrelevant choices. This PR establishes a proper design token system, applies a cohesive dark theme, simplifies the filter UI, and makes filter dropdowns context-aware so users only see relevant options.

## Type of Change
- [x] New feature (non-breaking change adding functionality)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe below)

## Changes Made
- **`frontend/jwst-frontend/src/index.css`** — Added CSS custom properties (design tokens) for dark theme: surfaces, text hierarchy, borders, accent colors, semantic colors, radius, shadows, transitions, font stacks
- **`frontend/jwst-frontend/src/App.css`** — Rewrote to use design tokens: dark main content area, token-based header/spinner/error/auth states
- **`frontend/jwst-frontend/src/components/JwstDataDashboard.css`** — Full dark theme rewrite: token-based colors, standardized border radius (sm/md/lg), button hierarchy, dark-friendly status/FITS badges, `optgroup` styling, `.visually-hidden` utility, focus-visible states
- **`frontend/jwst-frontend/src/components/UserMenu.css`** — Dark theme conversion using tokens
- **`frontend/jwst-frontend/src/components/JwstDataDashboard.tsx`** — Merged File Type into Data Type dropdown with `<optgroup>`; removed Metadata/Processed options; implemented cascading filter chain (`baseFiltered` → `availableTypes` → `afterTypeFilter` → `availableLevels` → `afterLevelFilter` → `availableTags` → `filteredData`) with `useEffect` auto-reset for invalid downstream selections; dynamic option rendering with counts
- **`frontend/jwst-frontend/.interface-design/system.md`** — New design system documentation extracted from the codebase
- **`docs/development-plan.md`** — Bumped FITS table viewer to early Phase 5

## Tech Debt Impact
- [x] Reduces tech debt — establishes CSS token system, eliminates inconsistent inline colors and one-off gradients
- [ ] No change
- [ ] Increases tech debt

## Risk & Rollback
Risk: Low — purely frontend CSS/JSX changes. No backend or API modifications. Design tokens are additive.
Rollback: Revert the merge commit.

## Quality Checklist
- [x] I have performed a self-review of my code
- [x] New code follows the project's coding standards
- [x] I have added/updated tests as needed
- [x] All new and existing tests pass locally

## Documentation Checklist
- [ ] CLAUDE.md updated (if architectural patterns changed)
- [x] Development plan updated (if roadmap items affected)
- [ ] API documentation updated (if endpoints changed)
- [ ] Tech debt log updated (if tech debt items addressed/created)

## Test Plan
- [x] Start the application stack
- [x] Navigate to the dashboard in a browser
- [ ] **Dark theme**: Verify all surfaces are dark (no white backgrounds), text is readable against dark surfaces, header/cards/modals/badges all use the dark palette
- [ ] **Button hierarchy**: Verify toolbar buttons follow the hierarchy — "Search MAST" is primary (blue fill), "Upload Data"/"RGB Composite"/"WCS Mosaic"/"Compare" are secondary (outlined), "Show Archived"/"Sync MAST Files" are ghost (minimal)
- [ ] **Type dropdown**: Verify a single "All Types" dropdown with optgroup sections for "FITS Content" (Viewable/Tables) and "Data Category" (Images/Spectral/Calibration/Sensor/Raw). Confirm "Metadata" and "Processed" are gone
- [ ] **Cascading filters**: Select a type (e.g., "Images") → verify the Processing Level dropdown updates to show only levels that contain image files, with counts. Select a level → verify the Tag dropdown updates similarly
- [ ] **Auto-reset**: Select "Level 1" in the level dropdown, then change the type to something that has no L1 files → verify the level dropdown auto-resets to "All Levels"
- [ ] **Counts**: Each dropdown option should show a count in parentheses (e.g., "Level 2b (Calibrated) (15)")
- [ ] **User menu**: Click the user menu → verify dropdown uses dark theme
- [ ] **Lineage and target views**: Switch between Lineage and By Target views, verify both render correctly with dark theme