### PR TITLE
fix: resolve analyzer warnings in MosaicService

### DIFF
--- a/backend/JwstDataAnalysis.API/Services/MosaicService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/MosaicService.Log.cs
@@ -69,5 +69,11 @@ namespace JwstDataAnalysis.API.Services
             Level = LogLevel.Debug,
             Message = "Resolved {DataId}: {AbsolutePath} -> {RelativePath}")]
         private partial void LogResolvedPath(string dataId, string absolutePath, string relativePath);
+
+        [LoggerMessage(
+            EventId = 11,
+            Level = LogLevel.Information,
+            Message = "Saved generated mosaic FITS dataId={DataId} file={FileName} size={SizeBytes}")]
+        private partial void LogSavedMosaicFits(string dataId, string fileName, long sizeBytes);
     }
 }

--- a/backend/JwstDataAnalysis.API/Services/MosaicService.cs
+++ b/backend/JwstDataAnalysis.API/Services/MosaicService.cs
@@ -212,11 +212,7 @@ namespace JwstDataAnalysis.API.Services
 
             await mongoDBService.CreateAsync(model);
 
-            logger.LogInformation(
-                "Saved generated mosaic FITS dataId={DataId} file={FileName} size={SizeBytes}",
-                model.Id,
-                model.FileName,
-                model.FileSize);
+            LogSavedMosaicFits(model.Id, model.FileName, model.FileSize);
 
             return new SavedMosaicResponseDto
             {
@@ -595,7 +591,7 @@ namespace JwstDataAnalysis.API.Services
         }
 
         private static void AddMetadataValues(
-            IDictionary<string, object> metadata,
+            Dictionary<string, object> metadata,
             string key,
             List<string> values)
         {
@@ -690,7 +686,7 @@ namespace JwstDataAnalysis.API.Services
         }
 
         private static bool TryGetWcsValue(
-            IReadOnlyDictionary<string, double>? wcs,
+            Dictionary<string, double>? wcs,
             string key,
             out double value)
         {
@@ -715,12 +711,14 @@ namespace JwstDataAnalysis.API.Services
             return false;
         }
 
-        private string BuildGeneratedMosaicFileName()
+        private static string BuildGeneratedMosaicFileName()
         {
             var timestamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmss", CultureInfo.InvariantCulture);
             var suffix = Guid.NewGuid().ToString("N")[..8];
             return $"jwst-mosaic-{timestamp}-{suffix}_i2d.fits";
         }
+
+        private static string NormalizePathForStorage(string path) => path.Replace('\\', '/');
 
         private string GetMosaicOutputDirectory()
         {
@@ -732,8 +730,6 @@ namespace JwstDataAnalysis.API.Services
             outputRoot ??= "/app/data";
             return Path.Combine(outputRoot, "mosaic");
         }
-
-        private string NormalizePathForStorage(string path) => path.Replace('\\', '/');
 
         private async Task<JwstDataModel> ResolveDataIdToRecordAsync(string dataId)
         {


### PR DESCRIPTION
## Summary
- Fixes 5 C# analyzer warnings in MosaicService that cause `--warnaserror` build failures

## Why
The compliance check (`dotnet build --warnaserror`) was failing with CA1859, CA1822, CA1848, and SA1204 warnings treated as errors. These were pre-existing issues in MosaicService that surfaced during a routine compliance run.

## Type of Change
- [ ] New feature (non-breaking change adding functionality)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe below)

## Changes Made
- **CA1859**: Changed `IReadOnlyDictionary<string, double>?` to `Dictionary<string, double>?` in `TryGetWcsValue` parameter and `IDictionary<string, object>` to `Dictionary<string, object>` in `AddMetadataValues` parameter — callers always pass concrete types
- **CA1822**: Marked `BuildGeneratedMosaicFileName` and `NormalizePathForStorage` as `static` since they don't access instance data
- **CA1848**: Replaced inline `logger.LogInformation(...)` with a `LoggerMessage` delegate (`LogSavedMosaicFits`) in the Log partial class for high-performance structured logging
- **SA1204**: Reordered `NormalizePathForStorage` (static) before `GetMosaicOutputDirectory` (non-static) to satisfy StyleCop member ordering rules

## Tech Debt Impact
- [x] Reduces tech debt — eliminates analyzer warnings that block warnaserror builds
- [ ] No change
- [ ] Increases tech debt

## Risk & Rollback
Risk: Low — parameter type narrowing and static marking are non-breaking for private methods. LoggerMessage delegate produces identical log output.
Rollback: Revert the merge commit.

## Quality Checklist
- [x] I have performed a self-review of my code
- [x] New code follows the project's coding standards
- [x] I have added/updated tests as needed
- [x] All new and existing tests pass locally

## Documentation Checklist
- [x] CLAUDE.md updated (if architectural patterns changed)
- [ ] API documentation updated (if endpoints changed)
- [ ] Tech debt log updated (if tech debt items addressed/created)

## Test Plan
- [x] `dotnet build JwstDataAnalysis.sln --warnaserror --verbosity quiet` — 0 warnings, 0 errors
- [x] `dotnet test JwstDataAnalysis.API.Tests` — 254/254 passing
- [ ] Verify mosaic generation still works end-to-end (no behavioral change expected)