### PR TITLE
feat: client-side caching for What's New panel

### DIFF
--- a/frontend/jwst-frontend/src/utils/cacheUtils.ts
+++ b/frontend/jwst-frontend/src/utils/cacheUtils.ts
@@ -1,0 +1,62 @@
+const CACHE_PREFIX = 'jwst_cache_';
+const CACHE_VERSION = 1;
+
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+  version: number;
+}
+
+export function getCached<T>(key: string, ttlMs: number): T | null {
+  try {
+    const raw = localStorage.getItem(CACHE_PREFIX + key);
+    if (!raw) return null;
+    const entry: CacheEntry<T> = JSON.parse(raw);
+    if (entry.version !== CACHE_VERSION) return null;
+    if (Date.now() - entry.timestamp > ttlMs) return null;
+    return entry.data;
+  } catch {
+    return null;
+  }
+}
+
+export function getStale<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(CACHE_PREFIX + key);
+    if (!raw) return null;
+    const entry: CacheEntry<T> = JSON.parse(raw);
+    if (entry.version !== CACHE_VERSION) return null;
+    return entry.data;
+  } catch {
+    return null;
+  }
+}
+
+export function setCache<T>(key: string, data: T): void {
+  try {
+    const entry: CacheEntry<T> = {
+      data,
+      timestamp: Date.now(),
+      version: CACHE_VERSION,
+    };
+    localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(entry));
+  } catch {
+    // localStorage full or disabled — silent no-op
+  }
+}
+
+export function clearCacheByPrefix(prefix: string): void {
+  try {
+    const fullPrefix = CACHE_PREFIX + prefix;
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(fullPrefix)) {
+        keysToRemove.push(key);
+      }
+    }
+    keysToRemove.forEach((k) => localStorage.removeItem(k));
+  } catch {
+    // silent no-op
+  }
+}


### PR DESCRIPTION
## Summary

Add localStorage-based caching (15-min TTL) with stale-while-revalidate to the What's New panel. Re-opening the panel now shows results instantly instead of a multi-second round-trip through .NET → Python → MAST.

## Why

The What's New panel fetches from MAST on every open/toggle, taking several seconds each time. MAST releases change at most daily, so aggressive client-side caching is safe and eliminates redundant round-trips.

## Type of Change

- [x] feat (new capability)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made

- Created `cacheUtils.ts` with reusable localStorage utilities (`getCached`, `getStale`, `setCache`, `clearCacheByPrefix`) with versioned entries for deploy-safe invalidation
- Modified `mastService.ts` to accept optional `RecentReleasesOptions` with `skipCache` and `onStaleData` callback; checks cache before making API calls
- Modified `WhatsNewPanel.tsx` to wire `skipCache` (Refresh bypasses cache), `onStaleData` (shows stale data instantly), and `isMountedRef` guard for unmount safety

## Test Plan

- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [x] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [ ] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

Steps to verify:
1. Open the app, click "What's New" — normal loading spinner, then results
2. Close the panel, re-open — results appear instantly (no spinner)
3. DevTools → Application → Local Storage → verify `jwst_cache_whats_new:*` entries exist
4. Click "Refresh" — shows spinner and fetches fresh data (bypasses cache)
5. Change filter (e.g., 7d → 30d) — first time fetches, switch back to 7d shows cached results instantly
6. "Load More" for page 2 — close and re-open, page 1 is cached
7. `cd frontend/jwst-frontend && npx vitest run` — all 24 tests pass

## Documentation Checklist

- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/tech-debt.md` (required if tech debt is introduced/reduced)
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt introduced and tracked in `docs/tech-debt.md`
- [ ] Existing tech debt reduced and `docs/tech-debt.md` updated

## Risk & Rollback

Risk: Low — additive change, all cache operations wrapped in try/catch with silent fallback to current behavior if localStorage is full or disabled.

Rollback: Revert this PR. No backend changes, no data migrations, no config changes.

## Quality Checklist

- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green