### PR TITLE
fix: resolve remaining 12 CodeQL py/path-injection alerts

### DIFF
--- a/processing-engine/app/analysis/routes.py
+++ b/processing-engine/app/analysis/routes.py
@@ -28,23 +28,26 @@ def validate_file_path(file_path: str) -> Path:
         raise HTTPException(status_code=403, detail="Access denied: invalid path")
 
     try:
-        requested_path = (ALLOWED_DATA_DIR / file_path).resolve()
+        # Resolve using string ops so CodeQL tracks the sanitizer
+        safe_dir = os.path.realpath(str(ALLOWED_DATA_DIR))
+        full_path = os.path.realpath(os.path.join(safe_dir, file_path))
 
-        # Uses str startswith on normalized paths (recognized by CodeQL as a sanitizer)
-        allowed_prefix = str(ALLOWED_DATA_DIR) + os.sep
-        if not (str(requested_path) + os.sep).startswith(allowed_prefix):
+        # startswith on the same variable that flows to sinks (CodeQL sanitizer)
+        if not full_path.startswith(safe_dir + os.sep):
             logger.warning(f"Path traversal attempt blocked: {file_path}")
             raise HTTPException(
                 status_code=403, detail="Access denied: path outside allowed directory"
             )
 
-        if not requested_path.exists():
-            raise HTTPException(status_code=404, detail=f"File not found: {requested_path.name}")
+        if not os.path.exists(full_path):
+            raise HTTPException(
+                status_code=404, detail=f"File not found: {os.path.basename(full_path)}"
+            )
 
-        if not requested_path.is_file():
+        if not os.path.isfile(full_path):
             raise HTTPException(status_code=400, detail="Path is not a file")
 
-        return requested_path
+        return Path(full_path)
 
     except HTTPException:
         raise

--- a/processing-engine/app/mast/routes.py
+++ b/processing-engine/app/mast/routes.py
@@ -721,9 +721,9 @@ async def _run_chunked_download_job(
         download_tracker.set_resumable(job_id, True)
 
         # Create observation-specific download directory
-        obs_dir = os.path.join(download_dir, obs_id)
-        # Verify path stays within download_dir (CodeQL-recognized sanitizer pattern)
-        if not os.path.normpath(obs_dir).startswith(os.path.normpath(download_dir) + os.sep):
+        # Normalize so startswith is on the same variable flowing to makedirs
+        obs_dir = os.path.normpath(os.path.join(download_dir, obs_id))
+        if not obs_dir.startswith(os.path.normpath(download_dir) + os.sep):
             raise ValueError(f"Invalid obs_id for path: {obs_id}")
         os.makedirs(obs_dir, exist_ok=True)
 

--- a/processing-engine/app/mosaic/routes.py
+++ b/processing-engine/app/mosaic/routes.py
@@ -298,23 +298,26 @@ def validate_file_path(file_path: str) -> Path:
         raise HTTPException(status_code=403, detail="Access denied: invalid path")
 
     try:
-        requested_path = (ALLOWED_DATA_DIR / file_path).resolve()
+        # Resolve using string ops so CodeQL tracks the sanitizer
+        safe_dir = os.path.realpath(str(ALLOWED_DATA_DIR))
+        full_path = os.path.realpath(os.path.join(safe_dir, file_path))
 
-        # Uses str startswith on normalized paths (recognized by CodeQL as a sanitizer)
-        allowed_prefix = str(ALLOWED_DATA_DIR) + os.sep
-        if not (str(requested_path) + os.sep).startswith(allowed_prefix):
+        # startswith on the same variable that flows to sinks (CodeQL sanitizer)
+        if not full_path.startswith(safe_dir + os.sep):
             logger.warning(f"Path traversal attempt blocked: {file_path}")
             raise HTTPException(
                 status_code=403, detail="Access denied: path outside allowed directory"
             )
 
-        if not requested_path.exists():
-            raise HTTPException(status_code=404, detail=f"File not found: {requested_path.name}")
+        if not os.path.exists(full_path):
+            raise HTTPException(
+                status_code=404, detail=f"File not found: {os.path.basename(full_path)}"
+            )
 
-        if not requested_path.is_file():
+        if not os.path.isfile(full_path):
             raise HTTPException(status_code=400, detail="Path is not a file")
 
-        return requested_path
+        return Path(full_path)
 
     except HTTPException:
         raise
@@ -333,7 +336,7 @@ def validate_fits_file_size(file_path: Path) -> None:
     Raises:
         HTTPException: 413 if file exceeds maximum size
     """
-    file_size = file_path.stat().st_size
+    file_size = os.stat(str(file_path)).st_size
     if file_size > MAX_FITS_FILE_SIZE_BYTES:
         max_mb = MAX_FITS_FILE_SIZE_BYTES / (1024 * 1024)
         file_mb = file_size / (1024 * 1024)

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -65,27 +65,29 @@ def validate_file_path(file_path: str) -> Path:
         raise HTTPException(status_code=403, detail="Access denied: invalid path")
 
     try:
-        # Resolve the path (handles .., symlinks, etc.)
-        requested_path = (ALLOWED_DATA_DIR / file_path).resolve()
+        # Resolve the path using string ops so CodeQL tracks the sanitizer
+        safe_dir = os.path.realpath(str(ALLOWED_DATA_DIR))
+        full_path = os.path.realpath(os.path.join(safe_dir, file_path))
 
         # Security check: ensure path is within allowed directory
-        # Uses str startswith on normalized paths (recognized by CodeQL as a sanitizer)
-        allowed_prefix = str(ALLOWED_DATA_DIR) + os.sep
-        if not (str(requested_path) + os.sep).startswith(allowed_prefix):
+        # startswith on the same variable that flows to sinks (CodeQL sanitizer)
+        if not full_path.startswith(safe_dir + os.sep):
             logger.warning(f"Path traversal attempt blocked: {file_path}")
             raise HTTPException(
                 status_code=403, detail="Access denied: path outside allowed directory"
             )
 
         # Check file exists
-        if not requested_path.exists():
-            raise HTTPException(status_code=404, detail=f"File not found: {requested_path.name}")
+        if not os.path.exists(full_path):
+            raise HTTPException(
+                status_code=404, detail=f"File not found: {os.path.basename(full_path)}"
+            )
 
         # Check it's a file, not a directory
-        if not requested_path.is_file():
+        if not os.path.isfile(full_path):
             raise HTTPException(status_code=400, detail="Path is not a file")
 
-        return requested_path
+        return Path(full_path)
 
     except HTTPException:
         raise
@@ -105,7 +107,7 @@ def validate_fits_file_size(file_path: Path) -> None:
     Raises:
         HTTPException: 413 if file exceeds maximum size
     """
-    file_size = file_path.stat().st_size
+    file_size = os.stat(str(file_path)).st_size
     if file_size > MAX_FITS_FILE_SIZE_BYTES:
         max_mb = MAX_FITS_FILE_SIZE_BYTES / (1024 * 1024)
         file_mb = file_size / (1024 * 1024)


### PR DESCRIPTION
## Summary
Resolves the remaining 12 py/path-injection CodeQL alerts by refactoring path validation to use os.path string operations throughout.

## Why
The previous fix (PR #291) used str(Path_object).startswith() but CodeQL could not connect the string check back to the Path object used in sinks (.exists(), .is_file(), .stat()). By using os.path.realpath() + os.path.exists() etc. with startswith on the same string variable, CodeQL can properly track the taint sanitization.

## Type of Change
- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Refactored validate_file_path() in main.py, analysis/routes.py, and mosaic/routes.py to use os.path.realpath() + os.path.join() instead of Path.resolve()
- Changed validate_fits_file_size() in main.py and mosaic/routes.py to use os.stat(str(file_path)) instead of file_path.stat()
- Fixed mast/routes.py obs_dir to normalize before the startswith check so the checked variable flows to os.makedirs()
- All pre-checks (isabs, .. rejection) and security semantics remain identical

## Test Plan
- [x] Tested locally with Docker
- [ ] Verified behavior in browser at http://localhost:3000 (if frontend touched)
- [ ] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

1. Pull branch and run tests: all 202 should pass
2. Wait for CodeQL CI scan to confirm the 12 remaining alerts are resolved
3. After merge, check GitHub Security > Code scanning to confirm alert count dropped

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated docs/development-plan.md for milestone/phase changes
- [ ] Updated docs/desktop-requirements.md for user-visible behavior changes
- [ ] Updated docs/standards/*.md for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [ ] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [x] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low — pure refactor of path validation logic with identical security semantics. All 202 backend tests pass.
- Rollback: Revert this commit to restore the previous startswith pattern.

## Quality Checklist
- [x] PR title uses conventional format
- [x] Branch name follows type/short-description
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green