### PR TITLE
fix: remove default credentials from docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     container_name: jwst-mongodb
     restart: unless-stopped
     environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME:-admin}
-      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-changeme}
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME:?Set MONGO_ROOT_USERNAME in .env (see .env.example)}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:?Set MONGO_ROOT_PASSWORD in .env (see .env.example)}
     volumes:
       - mongodb_data:/data/db
     networks:
@@ -29,7 +29,7 @@ services:
     ports:
       - "127.0.0.1:5001:8080"
     environment:
-      - MongoDB__ConnectionString=mongodb://${MONGO_ROOT_USERNAME:-admin}:${MONGO_ROOT_PASSWORD:-changeme}@mongodb:27017
+      - MongoDB__ConnectionString=mongodb://${MONGO_ROOT_USERNAME:?Set MONGO_ROOT_USERNAME in .env}:${MONGO_ROOT_PASSWORD:?Set MONGO_ROOT_PASSWORD in .env}@mongodb:27017
       - MongoDB__DatabaseName=${MONGO_DATABASE:-jwst_data_analysis}
       - ProcessingEngine__BaseUrl=http://processing-engine:8000
     volumes:


### PR DESCRIPTION
## Summary
Remove hardcoded fallback credentials from docker-compose.yml so the app fails fast if .env isn't configured, preventing accidental deployment with weak defaults.

## Why
The compose file used `:-changeme` fallbacks for MongoDB credentials, meaning `docker compose up` would succeed without a `.env` file — running MongoDB with `admin/changeme`. This is a security risk, especially for public release. Closes #280.

## Type of Change
- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Replaced `${MONGO_ROOT_USERNAME:-admin}` with `${MONGO_ROOT_USERNAME:?Set MONGO_ROOT_USERNAME in .env (see .env.example)}` in mongodb service
- Replaced `${MONGO_ROOT_PASSWORD:-changeme}` with `${MONGO_ROOT_PASSWORD:?Set MONGO_ROOT_PASSWORD in .env}` in mongodb and backend services
- Docker compose now errors with a helpful message if credentials aren't set

## Test Plan
- [x] Tested locally with Docker
- [ ] Verified behavior in browser at http://localhost:3000 (if frontend touched)
- [ ] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

1. Verify `docker compose config` still works with existing `.env`
2. Verify `docker compose --env-file /dev/null config` fails with a clear error message pointing to `.env.example`
3. Run `docker compose up -d --build` and confirm the app starts normally

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated docs/development-plan.md for milestone/phase changes
- [ ] Updated docs/desktop-requirements.md for user-visible behavior changes
- [ ] Updated docs/standards/*.md for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [ ] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [x] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low — anyone who already has `.env` configured is unaffected. New clones need to copy `.env.example` to `.env` first (already documented).
- Rollback: Revert this commit to restore the `:-changeme` defaults.

## Quality Checklist
- [x] PR title uses conventional format
- [x] Branch name follows type/short-description
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green