### PR TITLE
chore: add issue link prompt to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Link related issue (auto-closes on merge): Closes #000 -->
+
 ## Summary
 <!-- What changed and the user-visible outcome -->
 


### PR DESCRIPTION
<!-- No related issue — this is the process fix itself -->

## Summary
Add a comment at the top of the PR template prompting authors to link the related GitHub issue with `Closes #N`.

## Why
PR #294 had `Closes #286` in the initial body, but it was lost when the body was rewritten to match the template. Issue #286 stayed open after merge. A visible prompt in the template prevents this.

## Type of Change
- [ ] feat (new capability)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [x] chore (tooling/process)

## Changes Made
- Added `<!-- Link related issue (auto-closes on merge): Closes #000 -->` comment to the top of `.github/PULL_REQUEST_TEMPLATE.md`

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [ ] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [ ] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

Verification: Create a new PR and confirm the issue link prompt appears at the top of the body.

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
Risk: None — template comment only, no functional impact.
Rollback: Revert this PR to remove the comment.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green