### PR TITLE
feat: add automatic FITS thumbnail generation for dashboard cards

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
@@ -54,11 +54,14 @@ public class JwstDataControllerTests
             .AddInMemoryCollection(configValues)
             .Build();
 
+        var mockThumbnailService = new Mock<IThumbnailService>();
+
         sut = new JwstDataController(
             mockMongoService.Object,
             mockLogger.Object,
             mockHttpClientFactory.Object,
-            configuration);
+            configuration,
+            mockThumbnailService.Object);
 
         // Set up a mock HttpContext with an authenticated user
         SetupAuthenticatedUser(TestUserId, isAdmin: false);

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerViewerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerViewerTests.cs
@@ -45,11 +45,14 @@ public class JwstDataControllerViewerTests
             .AddInMemoryCollection(configValues)
             .Build();
 
+        var mockThumbnailService = new Mock<IThumbnailService>();
+
         sut = new JwstDataController(
             mockMongoService.Object,
             mockLogger.Object,
             mockHttpClientFactory.Object,
-            configuration);
+            configuration,
+            mockThumbnailService.Object);
 
         SetupAuthenticatedUser(TestUserId);
     }

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
@@ -53,10 +53,13 @@ public class MastControllerTests
             .AddInMemoryCollection(configValues)
             .Build();
 
+        var mockThumbnailService = new Mock<IThumbnailService>();
+
         sut = new MastController(
             mockMastService.Object,
             mockMongoService.Object,
             mockJobTracker.Object,
+            mockThumbnailService.Object,
             mockLogger.Object,
             configuration);
 

--- a/backend/JwstDataAnalysis.API/Controllers/DataManagementController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/DataManagementController.cs
@@ -858,6 +858,9 @@ namespace JwstDataAnalysis.API.Controllers
                 ProcessingResultsCount = model.ProcessingResults.Count,
                 LastProcessed = model.ProcessingResults.Count > 0 ?
                     model.ProcessingResults.Max(r => r.ProcessedDate) : null,
+
+                // Thumbnail
+                HasThumbnail = model.ThumbnailData != null,
             };
         }
     }

--- a/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
@@ -126,6 +126,9 @@ namespace JwstDataAnalysis.API.Models
 
         // File viewability
         public bool IsViewable { get; set; } = true;
+
+        // Thumbnail availability
+        public bool HasThumbnail { get; set; }
     }
 
     public class ProcessingRequest

--- a/backend/JwstDataAnalysis.API/Models/JwstDataModel.cs
+++ b/backend/JwstDataAnalysis.API/Models/JwstDataModel.cs
@@ -143,6 +143,11 @@ namespace JwstDataAnalysis.API.Models
 
         // File viewability (image vs table/catalog)
         public bool IsViewable { get; set; } = true; // true for image files, false for tables/catalogs
+
+        // Thumbnail (auto-generated PNG preview)
+        public byte[]? ThumbnailData { get; set; }
+
+        public DateTime? ThumbnailGeneratedAt { get; set; }
     }
 
     public class ImageMetadata

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -87,6 +87,15 @@ builder.Services.AddHttpClient("ProcessingEngine", client =>
     client.BaseAddress = new Uri(baseUrl);
 });
 
+// Configure HttpClient for ThumbnailService with 60-second timeout for thumbnail generation
+builder.Services.AddHttpClient("ThumbnailEngine", client =>
+{
+    var baseUrl = builder.Configuration.GetValue<string>("ProcessingEngine:BaseUrl") ?? "http://localhost:8000";
+    client.BaseAddress = new Uri(baseUrl);
+    client.Timeout = TimeSpan.FromSeconds(60);
+});
+builder.Services.AddSingleton<IThumbnailService, ThumbnailService>();
+
 builder.Services.AddControllers();
 builder.Services.AddHealthChecks();
 

--- a/backend/JwstDataAnalysis.API/Services/IMongoDBService.cs
+++ b/backend/JwstDataAnalysis.API/Services/IMongoDBService.cs
@@ -145,5 +145,12 @@ namespace JwstDataAnalysis.API.Services
         /// <param name="userId">The user ID to assign as owner.</param>
         /// <returns>The number of items claimed.</returns>
         Task<long> ClaimOrphanedDataAsync(string userId);
+
+        // Thumbnail methods
+        Task UpdateThumbnailAsync(string id, byte[] thumbnailData);
+
+        Task<byte[]?> GetThumbnailAsync(string id);
+
+        Task<List<string>> GetViewableWithoutThumbnailIdsAsync();
     }
 }

--- a/backend/JwstDataAnalysis.API/Services/ThumbnailService.cs
+++ b/backend/JwstDataAnalysis.API/Services/ThumbnailService.cs
@@ -1,0 +1,114 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace JwstDataAnalysis.API.Services
+{
+    public interface IThumbnailService
+    {
+        Task GenerateThumbnailAsync(string dataId);
+
+        Task GenerateThumbnailsForIdsAsync(List<string> dataIds);
+    }
+
+    public class ThumbnailService(
+        IHttpClientFactory httpClientFactory,
+        IMongoDBService mongoDBService,
+        ILogger<ThumbnailService> logger) : IThumbnailService
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+        public async Task GenerateThumbnailAsync(string dataId)
+        {
+            try
+            {
+                var record = await mongoDBService.GetAsync(dataId);
+                if (record == null)
+                {
+                    logger.LogWarning("Thumbnail generation skipped: record {DataId} not found", dataId);
+                    return;
+                }
+
+                if (!record.IsViewable)
+                {
+                    logger.LogDebug("Thumbnail generation skipped: record {DataId} is not viewable", dataId);
+                    return;
+                }
+
+                if (string.IsNullOrEmpty(record.FilePath))
+                {
+                    logger.LogWarning("Thumbnail generation skipped: record {DataId} has no file path", dataId);
+                    return;
+                }
+
+                var client = httpClientFactory.CreateClient("ThumbnailEngine");
+                var requestBody = new { file_path = record.FilePath };
+                var content = new StringContent(
+                    JsonSerializer.Serialize(requestBody),
+                    System.Text.Encoding.UTF8,
+                    "application/json");
+
+                var response = await client.PostAsync("/thumbnail", content);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<ThumbnailResponse>(json, JsonOptions);
+
+                if (result?.ThumbnailBase64 == null)
+                {
+                    logger.LogWarning("Thumbnail generation returned null for {DataId}", dataId);
+                    return;
+                }
+
+                var thumbnailBytes = Convert.FromBase64String(result.ThumbnailBase64);
+                await mongoDBService.UpdateThumbnailAsync(dataId, thumbnailBytes);
+
+                logger.LogInformation("Thumbnail generated for {DataId} ({Size} bytes)", dataId, thumbnailBytes.Length);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to generate thumbnail for {DataId}", dataId);
+            }
+        }
+
+        public async Task GenerateThumbnailsForIdsAsync(List<string> dataIds)
+        {
+            logger.LogInformation("Starting thumbnail generation for {Count} record(s)", dataIds.Count);
+
+            var generated = 0;
+            var skipped = 0;
+            var failed = 0;
+
+            foreach (var dataId in dataIds)
+            {
+                try
+                {
+                    var record = await mongoDBService.GetAsync(dataId);
+                    if (record == null || !record.IsViewable || record.ThumbnailData != null)
+                    {
+                        skipped++;
+                        continue;
+                    }
+
+                    await GenerateThumbnailAsync(dataId);
+                    generated++;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to generate thumbnail for {DataId}", dataId);
+                    failed++;
+                }
+            }
+
+            logger.LogInformation(
+                "Thumbnail generation complete: {Generated} generated, {Skipped} skipped, {Failed} failed",
+                generated, skipped, failed);
+        }
+
+        private sealed class ThumbnailResponse
+        {
+            public string? ThumbnailBase64 { get; set; }
+        }
+    }
+}

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -261,6 +261,7 @@ Complete React frontend application with advanced FITS visualization capabilitie
 #### **Dashboard & UX (E-series):**
 
 - [ ] E1: Search by target name in top search bar (filter local observations by `targetName`)
+- [x] E2: Automatic FITS thumbnail generation for dashboard cards
 
 #### **Phase 4 Deliverables:**
 

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.css
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.css
@@ -287,17 +287,61 @@
 .data-card {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
-  padding: 20px;
+  padding: 0;
   background-color: var(--bg-surface);
   box-shadow: var(--shadow-sm);
   transition:
     transform var(--transition-base),
     box-shadow var(--transition-base);
+  overflow: hidden;
 }
 
 .data-card:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-md);
+}
+
+.data-card .card-thumbnail {
+  width: 100%;
+  aspect-ratio: 1;
+  background-color: #0a0a0f;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.data-card .card-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+.data-card .card-thumbnail .thumbnail-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: var(--text-muted, #666);
+  font-size: 2rem;
+  opacity: 0.3;
+}
+
+.data-card .card-header,
+.data-card .card-content,
+.data-card .card-actions {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.data-card .card-header {
+  padding-top: 15px;
+}
+
+.data-card .card-actions {
+  padding-bottom: 20px;
 }
 
 .card-header {

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -15,6 +15,7 @@ import ComparisonImagePicker, { ImageSelection } from './ComparisonImagePicker';
 import ImageComparisonViewer from './ImageComparisonViewer';
 import { getFitsFileInfo } from '../utils/fitsUtils';
 import { jwstDataService, ApiError } from '../services';
+import { API_BASE_URL } from '../config/api';
 import './JwstDataDashboard.css';
 
 interface JwstDataDashboardProps {
@@ -854,6 +855,24 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                               key={item.id}
                               className={`data-card ${isSelectedForComposite ? 'selected-composite' : ''}`}
                             >
+                              {fitsInfo.viewable && (
+                                <div className="card-thumbnail">
+                                  {item.hasThumbnail ? (
+                                    <img
+                                      src={`${API_BASE_URL}/api/jwstdata/${item.id}/thumbnail`}
+                                      loading="lazy"
+                                      alt={item.fileName}
+                                      onError={(e) => {
+                                        (e.target as HTMLImageElement).style.display = 'none';
+                                      }}
+                                    />
+                                  ) : (
+                                    <div className="thumbnail-placeholder">
+                                      <span>🔭</span>
+                                    </div>
+                                  )}
+                                </div>
+                              )}
                               <div className="card-header">
                                 {fitsInfo.viewable && (
                                   <button

--- a/frontend/jwst-frontend/src/types/JwstDataTypes.ts
+++ b/frontend/jwst-frontend/src/types/JwstDataTypes.ts
@@ -23,6 +23,8 @@ export interface JwstDataModel {
   derivedFrom?: string[];
   // Viewability
   isViewable?: boolean;
+  // Thumbnail
+  hasThumbnail?: boolean;
 }
 
 export interface ImageMetadata {

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import logging
 import os
@@ -178,6 +179,10 @@ async def startup_cleanup():
         )
 
 
+class ThumbnailRequest(BaseModel):
+    file_path: str
+
+
 class ProcessingRequest(BaseModel):
     data_id: str
     algorithm: str
@@ -199,6 +204,82 @@ async def root():
 @app.get("/health")
 async def health_check():
     return {"status": "healthy", "service": "jwst-processing-engine"}
+
+
+@app.post("/thumbnail")
+async def generate_thumbnail(request: ThumbnailRequest):
+    """
+    Generate a 256x256 PNG thumbnail from a FITS file.
+
+    Uses zscale stretch with inferno colormap - fixed parameters for consistent thumbnails.
+
+    Args:
+        request: ThumbnailRequest with file_path to the FITS file
+
+    Returns:
+        JSON with thumbnail_base64 (raw base64 PNG, no data URI prefix)
+    """
+    try:
+        # Security: Validate file path is within allowed directory
+        validated_path = validate_file_path(request.file_path)
+        # Security: Validate file size to prevent memory exhaustion
+        validate_fits_file_size(validated_path)
+        logger.info(f"Generating thumbnail for: {validated_path}")
+
+        # Read FITS file
+        with fits.open(validated_path) as hdul:
+            # Find the first image extension with 2D data
+            data = None
+            for _i, hdu in enumerate(hdul):
+                if hdu.data is not None and len(hdu.data.shape) >= 2:
+                    validate_fits_array_size(hdu.data.shape)
+                    data = hdu.data.astype(np.float64)
+                    break
+
+            if data is None:
+                raise HTTPException(status_code=400, detail="No image data found in FITS file")
+
+            # Handle 3D+ data cubes - use middle slice
+            while len(data.shape) > 2:
+                mid_idx = data.shape[0] // 2
+                data = data[mid_idx]
+
+            # Handle NaN values
+            data = np.nan_to_num(data, nan=0.0, posinf=0.0, neginf=0.0)
+
+            # Apply zscale stretch
+            try:
+                stretched, _, _ = zscale_stretch(data)
+            except Exception as stretch_error:
+                logger.warning(
+                    f"Zscale failed for thumbnail: {stretch_error}, falling back to linear"
+                )
+                stretched = normalize_to_range(data)
+
+            # Ensure data is in 0-1 range
+            stretched = np.clip(stretched, 0, 1)
+
+            # Create 256x256 thumbnail
+            fig = plt.figure(figsize=(2.56, 2.56), dpi=100)
+            plt.imshow(stretched, origin="lower", cmap="inferno", vmin=0, vmax=1)
+            plt.axis("off")
+
+            buf = io.BytesIO()
+            plt.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
+            plt.close(fig)
+            buf.seek(0)
+
+            thumbnail_base64 = base64.b64encode(buf.getvalue()).decode("ascii")
+
+            logger.info(f"Thumbnail generated successfully, base64 length: {len(thumbnail_base64)}")
+
+            return {"thumbnail_base64": thumbnail_base64}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error generating thumbnail: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Thumbnail generation failed: {str(e)}") from e
 
 
 @app.post("/process", response_model=ProcessingResponse)

--- a/processing-engine/tests/test_thumbnail.py
+++ b/processing-engine/tests/test_thumbnail.py
@@ -1,0 +1,58 @@
+"""Tests for /thumbnail endpoint validation and functionality."""
+
+import base64
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+class TestThumbnailValidation:
+    """Tests for POST /thumbnail input validation."""
+
+    def test_missing_file_path_returns_422(self):
+        resp = client.post("/thumbnail", json={})
+        assert resp.status_code == 422
+
+    def test_path_traversal_returns_403(self):
+        resp = client.post("/thumbnail", json={"file_path": "../../etc/passwd"})
+        assert resp.status_code == 403
+
+    def test_absolute_path_returns_403(self):
+        resp = client.post("/thumbnail", json={"file_path": "/etc/passwd"})
+        assert resp.status_code == 403
+
+    def test_nonexistent_file_returns_404(self):
+        resp = client.post("/thumbnail", json={"file_path": "nonexistent.fits"})
+        assert resp.status_code == 404
+
+
+class TestThumbnailGeneration:
+    """Tests for /thumbnail endpoint with real FITS files (requires test fixtures)."""
+
+    @pytest.fixture
+    def fits_path(self):
+        """Return relative path to test FITS file if available."""
+        import os
+
+        # Check for e2e test fixture
+        test_file = "mast/e2e-test-obs/test_mirimage_i2d.fits"
+        data_dir = os.environ.get("DATA_DIR", "/app/data")
+        full_path = os.path.join(data_dir, test_file)
+        if os.path.exists(full_path):
+            return test_file
+        pytest.skip("Test FITS file not available")
+
+    def test_generates_valid_png_base64(self, fits_path):
+        resp = client.post("/thumbnail", json={"file_path": fits_path})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "thumbnail_base64" in data
+
+        # Verify it's valid base64 that decodes to a PNG
+        decoded = base64.b64decode(data["thumbnail_base64"])
+        assert decoded[:8] == b"\x89PNG\r\n\x1a\n"  # PNG magic bytes


### PR DESCRIPTION
## Summary
Dashboard cards now show visual previews of FITS images. 256x256 PNG thumbnails are auto-generated after MAST import and displayed on cards with lazy loading.

## Why
Dashboard cards only showed metadata (filename, type, badges) with no visual preview. Users had to click "View" to see what an image looked like. Thumbnail previews make the dashboard feel like a real data browser.

## Type of Change
- [x] feat (new capability)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Added `POST /thumbnail` endpoint to processing engine — generates 256x256 PNG with zscale stretch + inferno colormap
- Added `ThumbnailData` (byte[]) and `ThumbnailGeneratedAt` (DateTime?) fields to `JwstDataModel`
- Added `HasThumbnail` (bool) to `DataResponse` DTO — computed from `ThumbnailData != null`
- Updated all 3 `MapToDataResponse()` copies (MongoDBService, JwstDataController, DataManagementController)
- Created `ThumbnailService` with `GenerateThumbnailAsync` and `GenerateThumbnailsForIdsAsync`
- Added MongoDB methods: `UpdateThumbnailAsync`, `GetThumbnailAsync`, `GetViewableWithoutThumbnailIdsAsync`
- Added `GET /api/jwstdata/{id}/thumbnail` — returns raw PNG with 24hr cache headers
- Added `POST /api/jwstdata/generate-thumbnails` — backfill endpoint (admin only)
- Added fire-and-forget thumbnail generation after MAST import (both fresh and resumed imports)
- Added thumbnail generation hook to `refresh-metadata-all` flow
- Added thumbnail `<img>` to dashboard cards with lazy loading, error handling, and placeholder
- Added CSS for card thumbnails with dark background, `object-fit: contain`, and 1:1 aspect ratio
- Added processing engine tests for `/thumbnail` endpoint
- Updated development plan with E2 entry

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [x] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [x] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

### Step-by-step verification:
1. **Processing engine tests**: `docker exec jwst-processing python -m pytest tests/test_thumbnail.py -x -q` — 4 passed, 1 skipped
2. **Full processing engine suite**: `docker exec jwst-processing python -m pytest tests/ -x -q` — 206 passed, 1 skipped
3. **Backend tests**: `dotnet test backend/JwstDataAnalysis.API.Tests` — 254 passed
4. **Backfill test**: Start app, call `POST /api/jwstdata/generate-thumbnails` (with admin auth), then reload dashboard — thumbnails should appear on viewable cards
5. **Import test**: Import a new observation from MAST → verify thumbnail appears on card after import completes
6. **Fallback**: Records without thumbnails show a subtle telescope emoji placeholder — no broken images
7. **Caching**: Inspect Network tab — thumbnail requests return PNG with `Cache-Control: public, max-age=86400`

## Documentation Checklist
- [ ] No documentation updates needed
- [x] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
Risk: Low — thumbnail generation is fire-and-forget and doesn't block import. Thumbnail data stored alongside existing documents.
Rollback: Remove `ThumbnailData`/`ThumbnailGeneratedAt` fields from MongoDB documents. Frontend gracefully handles missing thumbnails.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All CI checks are green