### PR TITLE
feat: add lineage view thumbnails and fix thumbnail path bug

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.Log.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.Log.cs
@@ -261,5 +261,14 @@ namespace JwstDataAnalysis.API.Controllers
         [LoggerMessage(EventId = 1942, Level = LogLevel.Error,
             Message = "Error during data type migration")]
         private partial void LogErrorDuringDataTypeMigration(Exception ex);
+
+        // Thumbnail operations (1E0x)
+        [LoggerMessage(EventId = 1950, Level = LogLevel.Error,
+            Message = "Error retrieving thumbnail for id: {Id}")]
+        private partial void LogErrorRetrievingThumbnail(Exception ex, string id);
+
+        [LoggerMessage(EventId = 1951, Level = LogLevel.Error,
+            Message = "Error starting thumbnail generation")]
+        private partial void LogErrorStartingThumbnailGeneration(Exception ex);
     }
 }

--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -2046,7 +2046,7 @@ namespace JwstDataAnalysis.API.Controllers
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error retrieving thumbnail for {Id}", id);
+                LogErrorRetrievingThumbnail(ex, id);
                 return StatusCode(500, "Failed to retrieve thumbnail");
             }
         }
@@ -2074,7 +2074,7 @@ namespace JwstDataAnalysis.API.Controllers
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error starting thumbnail generation");
+                LogErrorStartingThumbnailGeneration(ex);
                 return StatusCode(500, "Failed to start thumbnail generation");
             }
         }

--- a/backend/JwstDataAnalysis.API/Services/ThumbnailService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/ThumbnailService.Log.cs
@@ -1,0 +1,43 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+namespace JwstDataAnalysis.API.Services
+{
+    /// <summary>
+    /// High-performance logging methods for ThumbnailService.
+    /// </summary>
+    public partial class ThumbnailService
+    {
+        [LoggerMessage(EventId = 1, Level = LogLevel.Warning,
+            Message = "Thumbnail generation skipped: record {DataId} not found")]
+        private partial void LogRecordNotFound(string dataId);
+
+        [LoggerMessage(EventId = 2, Level = LogLevel.Debug,
+            Message = "Thumbnail generation skipped: record {DataId} is not viewable")]
+        private partial void LogRecordNotViewable(string dataId);
+
+        [LoggerMessage(EventId = 3, Level = LogLevel.Warning,
+            Message = "Thumbnail generation skipped: record {DataId} has no file path")]
+        private partial void LogNoFilePath(string dataId);
+
+        [LoggerMessage(EventId = 4, Level = LogLevel.Warning,
+            Message = "Thumbnail generation returned null for {DataId}")]
+        private partial void LogThumbnailReturnedNull(string dataId);
+
+        [LoggerMessage(EventId = 5, Level = LogLevel.Information,
+            Message = "Thumbnail generated for {DataId} ({Size} bytes)")]
+        private partial void LogThumbnailGenerated(string dataId, int size);
+
+        [LoggerMessage(EventId = 6, Level = LogLevel.Error,
+            Message = "Failed to generate thumbnail for {DataId}")]
+        private partial void LogThumbnailFailed(Exception ex, string dataId);
+
+        [LoggerMessage(EventId = 7, Level = LogLevel.Information,
+            Message = "Starting thumbnail generation for {Count} record(s)")]
+        private partial void LogBatchStarting(int count);
+
+        [LoggerMessage(EventId = 8, Level = LogLevel.Information,
+            Message = "Thumbnail generation complete: {Generated} generated, {Skipped} skipped, {Failed} failed")]
+        private partial void LogBatchComplete(int generated, int skipped, int failed);
+    }
+}

--- a/backend/JwstDataAnalysis.API/Services/ThumbnailService.cs
+++ b/backend/JwstDataAnalysis.API/Services/ThumbnailService.cs
@@ -12,7 +12,7 @@ namespace JwstDataAnalysis.API.Services
         Task GenerateThumbnailsForIdsAsync(List<string> dataIds);
     }
 
-    public class ThumbnailService(
+    public partial class ThumbnailService(
         IHttpClientFactory httpClientFactory,
         IMongoDBService mongoDBService,
         ILogger<ThumbnailService> logger) : IThumbnailService
@@ -26,24 +26,31 @@ namespace JwstDataAnalysis.API.Services
                 var record = await mongoDBService.GetAsync(dataId);
                 if (record == null)
                 {
-                    logger.LogWarning("Thumbnail generation skipped: record {DataId} not found", dataId);
+                    LogRecordNotFound(dataId);
                     return;
                 }
 
                 if (!record.IsViewable)
                 {
-                    logger.LogDebug("Thumbnail generation skipped: record {DataId} is not viewable", dataId);
+                    LogRecordNotViewable(dataId);
                     return;
                 }
 
                 if (string.IsNullOrEmpty(record.FilePath))
                 {
-                    logger.LogWarning("Thumbnail generation skipped: record {DataId} has no file path", dataId);
+                    LogNoFilePath(dataId);
                     return;
                 }
 
+                // Strip absolute prefix to get relative path — processing engine validates paths within /app/data
+                var filePath = record.FilePath;
+                if (filePath.StartsWith("/app/data/", StringComparison.Ordinal))
+                {
+                    filePath = filePath["/app/data/".Length..];
+                }
+
                 var client = httpClientFactory.CreateClient("ThumbnailEngine");
-                var requestBody = new { file_path = record.FilePath };
+                var requestBody = new { file_path = filePath };
                 var content = new StringContent(
                     JsonSerializer.Serialize(requestBody),
                     System.Text.Encoding.UTF8,
@@ -57,24 +64,24 @@ namespace JwstDataAnalysis.API.Services
 
                 if (result?.ThumbnailBase64 == null)
                 {
-                    logger.LogWarning("Thumbnail generation returned null for {DataId}", dataId);
+                    LogThumbnailReturnedNull(dataId);
                     return;
                 }
 
                 var thumbnailBytes = Convert.FromBase64String(result.ThumbnailBase64);
                 await mongoDBService.UpdateThumbnailAsync(dataId, thumbnailBytes);
 
-                logger.LogInformation("Thumbnail generated for {DataId} ({Size} bytes)", dataId, thumbnailBytes.Length);
+                LogThumbnailGenerated(dataId, thumbnailBytes.Length);
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Failed to generate thumbnail for {DataId}", dataId);
+                LogThumbnailFailed(ex, dataId);
             }
         }
 
         public async Task GenerateThumbnailsForIdsAsync(List<string> dataIds)
         {
-            logger.LogInformation("Starting thumbnail generation for {Count} record(s)", dataIds.Count);
+            LogBatchStarting(dataIds.Count);
 
             var generated = 0;
             var skipped = 0;
@@ -92,18 +99,26 @@ namespace JwstDataAnalysis.API.Services
                     }
 
                     await GenerateThumbnailAsync(dataId);
-                    generated++;
+
+                    // Verify thumbnail was actually stored (GenerateThumbnailAsync catches its own exceptions)
+                    var updated = await mongoDBService.GetThumbnailAsync(dataId);
+                    if (updated != null)
+                    {
+                        generated++;
+                    }
+                    else
+                    {
+                        failed++;
+                    }
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Failed to generate thumbnail for {DataId}", dataId);
+                    LogThumbnailFailed(ex, dataId);
                     failed++;
                 }
             }
 
-            logger.LogInformation(
-                "Thumbnail generation complete: {Generated} generated, {Skipped} skipped, {Failed} failed",
-                generated, skipped, failed);
+            LogBatchComplete(generated, skipped, failed);
         }
 
         private sealed class ThumbnailResponse

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.css
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.css
@@ -885,6 +885,37 @@
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   padding: 12px;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.lineage-file-card .lineage-file-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.lineage-thumbnail {
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-inset);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lineage-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.lineage-thumbnail-placeholder {
+  font-size: 20px;
+  opacity: 0.4;
 }
 
 .lineage-file-card .file-header {

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -1173,88 +1173,111 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
                                         key={item.id}
                                         className={`lineage-file-card ${isSelectedForComposite ? 'selected-composite' : ''}`}
                                       >
-                                        <div className="file-header">
-                                          {fitsInfo.viewable && (
-                                            <button
-                                              className={`composite-select-btn small ${isSelectedForComposite ? 'selected' : ''}`}
-                                              onClick={(e) => handleCompositeSelect(item.id, e)}
-                                              disabled={!canSelectForComposite}
-                                              title={
-                                                isSelectedForComposite
-                                                  ? 'Remove from composite selection'
-                                                  : 'Add to RGB composite'
-                                              }
-                                            >
-                                              {isSelectedForComposite ? '✓' : '+'}
-                                            </button>
-                                          )}
-                                          <span className="file-name" title={item.fileName}>
-                                            {item.fileName}
-                                          </span>
-                                          <div className="file-badges">
-                                            <span
-                                              className={`fits-type-badge small ${fitsInfo.type}`}
-                                              title={fitsInfo.description}
-                                            >
-                                              {fitsInfo.viewable ? '🖼️' : '📊'}
-                                            </span>
-                                            {item.imageInfo?.filter && (
-                                              <span
-                                                className="filter-badge small"
-                                                title={`Filter: ${item.imageInfo.filter}`}
-                                              >
-                                                {item.imageInfo.filter}
+                                        {fitsInfo.viewable && (
+                                          <div className="lineage-thumbnail">
+                                            {item.hasThumbnail ? (
+                                              <img
+                                                src={`${API_BASE_URL}/api/jwstdata/${item.id}/thumbnail`}
+                                                loading="lazy"
+                                                alt={item.fileName}
+                                                onError={(e) => {
+                                                  (e.target as HTMLImageElement).style.display =
+                                                    'none';
+                                                }}
+                                              />
+                                            ) : (
+                                              <span className="lineage-thumbnail-placeholder">
+                                                🔭
                                               </span>
                                             )}
-                                            <span
-                                              className={`status ${item.processingStatus}`}
-                                              style={{
-                                                color: getStatusColor(item.processingStatus),
-                                              }}
-                                            >
-                                              {item.processingStatus}
+                                          </div>
+                                        )}
+                                        <div className="lineage-file-content">
+                                          <div className="file-header">
+                                            {fitsInfo.viewable && (
+                                              <button
+                                                className={`composite-select-btn small ${isSelectedForComposite ? 'selected' : ''}`}
+                                                onClick={(e) => handleCompositeSelect(item.id, e)}
+                                                disabled={!canSelectForComposite}
+                                                title={
+                                                  isSelectedForComposite
+                                                    ? 'Remove from composite selection'
+                                                    : 'Add to RGB composite'
+                                                }
+                                              >
+                                                {isSelectedForComposite ? '✓' : '+'}
+                                              </button>
+                                            )}
+                                            <span className="file-name" title={item.fileName}>
+                                              {item.fileName}
+                                            </span>
+                                            <div className="file-badges">
+                                              <span
+                                                className={`fits-type-badge small ${fitsInfo.type}`}
+                                                title={fitsInfo.description}
+                                              >
+                                                {fitsInfo.viewable ? '🖼️' : '📊'}
+                                              </span>
+                                              {item.imageInfo?.filter && (
+                                                <span
+                                                  className="filter-badge small"
+                                                  title={`Filter: ${item.imageInfo.filter}`}
+                                                >
+                                                  {item.imageInfo.filter}
+                                                </span>
+                                              )}
+                                              <span
+                                                className={`status ${item.processingStatus}`}
+                                                style={{
+                                                  color: getStatusColor(item.processingStatus),
+                                                }}
+                                              >
+                                                {item.processingStatus}
+                                              </span>
+                                            </div>
+                                          </div>
+                                          <div className="file-meta">
+                                            <span>Type: {item.dataType}</span>
+                                            <span>
+                                              Size: {(item.fileSize / 1024 / 1024).toFixed(2)} MB
+                                            </span>
+                                            {item.imageInfo?.observationDate && (
+                                              <span>
+                                                Obs:{' '}
+                                                {new Date(
+                                                  item.imageInfo.observationDate
+                                                ).toLocaleDateString()}
+                                              </span>
+                                            )}
+                                            <span className="fits-type-label">
+                                              {fitsInfo.label}
                                             </span>
                                           </div>
-                                        </div>
-                                        <div className="file-meta">
-                                          <span>Type: {item.dataType}</span>
-                                          <span>
-                                            Size: {(item.fileSize / 1024 / 1024).toFixed(2)} MB
-                                          </span>
-                                          {item.imageInfo?.observationDate && (
-                                            <span>
-                                              Obs:{' '}
-                                              {new Date(
-                                                item.imageInfo.observationDate
-                                              ).toLocaleDateString()}
-                                            </span>
-                                          )}
-                                          <span className="fits-type-label">{fitsInfo.label}</span>
-                                        </div>
-                                        <div className="file-actions">
-                                          <button
-                                            onClick={() => {
-                                              setViewingImageId(item.id);
-                                              setViewingImageTitle(item.fileName);
-                                              setViewingImageMetadata(item.metadata);
-                                            }}
-                                            className={!fitsInfo.viewable ? 'disabled' : ''}
-                                            disabled={!fitsInfo.viewable}
-                                            title={
-                                              fitsInfo.viewable
-                                                ? 'View FITS image'
-                                                : fitsInfo.description
-                                            }
-                                          >
-                                            {fitsInfo.viewable ? 'View' : 'Table'}
-                                          </button>
-                                          <button
-                                            onClick={() =>
-                                              handleProcessData(item.id, 'basic_analysis')
-                                            }
-                                          >
-                                            Analyze
-                                          </button>
+                                          <div className="file-actions">
+                                            <button
+                                              onClick={() => {
+                                                setViewingImageId(item.id);
+                                                setViewingImageTitle(item.fileName);
+                                                setViewingImageMetadata(item.metadata);
+                                              }}
+                                              className={!fitsInfo.viewable ? 'disabled' : ''}
+                                              disabled={!fitsInfo.viewable}
+                                              title={
+                                                fitsInfo.viewable
+                                                  ? 'View FITS image'
+                                                  : fitsInfo.description
+                                              }
+                                            >
+                                              {fitsInfo.viewable ? 'View' : 'Table'}
+                                            </button>
+                                            <button
+                                              onClick={() =>
+                                                handleProcessData(item.id, 'basic_analysis')
+                                              }
+                                            >
+                                              Analyze
+                                            </button>
+                                          </div>
                                         </div>
                                       </div>
                                     );


### PR DESCRIPTION
## Summary
- Add inline 48x48 thumbnails to lineage file cards for viewable FITS items
- **Fix critical bug**: ThumbnailService was sending absolute paths (`/app/data/mast/...`) to the processing engine, which expects relative paths (`mast/...`). This caused all thumbnail generations to fail with 403 Forbidden
- Fix batch thumbnail counting — `generated` count was inflated when individual generations failed silently (exceptions caught internally)
- Add `LoggerMessage` delegates for `ThumbnailService` and `JwstDataController` thumbnail endpoints (resolves CA1848 warnings)

## Changes Made
- **`ThumbnailService.cs`**: Strip `/app/data/` prefix from file paths before sending to processing engine (matching pattern used by preview/histogram/pixeldata endpoints); verify thumbnail storage after generation for accurate batch counting; convert to `partial class` for `LoggerMessage` support
- **`ThumbnailService.Log.cs`** (new): High-performance logging delegates for thumbnail operations
- **`JwstDataController.cs`**: Replace direct `logger.LogError()` calls with `LoggerMessage` delegates
- **`JwstDataController.Log.cs`**: Add thumbnail error log delegates (EventId 1950-1951)
- **`JwstDataDashboard.tsx`**: Add `lineage-thumbnail` div with `<img>` (or placeholder) before file content in lineage file cards; wrap existing file-header/meta/actions in `lineage-file-content` div for flex layout
- **`JwstDataDashboard.css`**: Make `.lineage-file-card` a flex row; add `.lineage-thumbnail` (48x48), `.lineage-file-content`, and `.lineage-thumbnail-placeholder` styles

## Tech Debt Impact
- [x] Reduces tech debt — fixes CA1848 analyzer warnings in thumbnail code, fixes silent failure bug

## Risk & Rollback
Risk: Low — CSS layout change is scoped to lineage file cards; backend fix aligns with existing pattern used by all other processing engine calls
Rollback: Revert commit; thumbnails will stop appearing in lineage view, path bug returns

## Testing
- [ ] Backend builds with zero warnings (`dotnet build --warnaserror`)
- [ ] All 254 backend tests pass
- [ ] ESLint clean, Prettier formatted
- [ ] Docker rebuild succeeds
- [ ] Navigate to dashboard → switch to "Lineage" view → verify 48x48 thumbnails appear on viewable file cards
- [ ] Non-viewable items (tables, spectra) should NOT show a thumbnail
- [ ] Trigger `POST /api/jwstdata/generate-thumbnails` → verify backend logs show successful generations (no more 403 errors)
- [ ] Verify batch completion log shows accurate generated/skipped/failed counts

## Documentation Checklist
- [ ] No new endpoints added

Closes #298