### PR TITLE
refactor: replace emoji indicators with SVG icons

### DIFF
--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { LineageIcon, TargetIcon } from '../icons/DashboardIcons';
 import './DashboardToolbar.css';
 
 interface DashboardToolbarProps {
@@ -219,14 +220,14 @@ const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
               onClick={() => onViewModeChange('lineage')}
               title="Lineage Tree View"
             >
-              <span className="icon">⌲</span> Lineage
+              <LineageIcon size={14} /> Lineage
             </button>
             <button
               className={`view-btn ${viewMode === 'target' ? 'active' : ''}`}
               onClick={() => onViewModeChange('target')}
               title="Group by Target Name"
             >
-              <span className="icon">🎯</span> By Target
+              <TargetIcon size={14} /> By Target
             </button>
           </div>
           <button

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -3,6 +3,7 @@ import { JwstDataModel } from '../../types/JwstDataTypes';
 import { getFitsFileInfo } from '../../utils/fitsUtils';
 import { getStatusColor } from '../../utils/statusUtils';
 import { API_BASE_URL } from '../../config/api';
+import { TelescopeIcon, ImageIcon, TableIcon, CheckIcon, PlusIcon } from '../icons/DashboardIcons';
 import './DataCard.css';
 
 interface DataCardProps {
@@ -44,7 +45,7 @@ const DataCard: React.FC<DataCardProps> = ({
             />
           ) : (
             <div className="thumbnail-placeholder">
-              <span>🔭</span>
+              <TelescopeIcon size={32} />
             </div>
           )}
         </div>
@@ -59,13 +60,13 @@ const DataCard: React.FC<DataCardProps> = ({
               isSelectedForComposite ? 'Remove from composite selection' : 'Add to RGB composite'
             }
           >
-            {isSelectedForComposite ? '✓' : '+'}
+            {isSelectedForComposite ? <CheckIcon /> : <PlusIcon />}
           </button>
         )}
         <h4>{item.fileName}</h4>
         <div className="card-badges">
           <span className={`fits-type-badge ${fitsInfo.type}`} title={fitsInfo.description}>
-            {fitsInfo.viewable ? '🖼️' : '📊'} {fitsInfo.label}
+            {fitsInfo.viewable ? <ImageIcon /> : <TableIcon />} {fitsInfo.label}
           </span>
           {item.imageInfo?.filter && (
             <span className="filter-badge" title={`Filter: ${item.imageInfo.filter}`}>

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
@@ -3,6 +3,7 @@ import { JwstDataModel } from '../../types/JwstDataTypes';
 import { getFitsFileInfo } from '../../utils/fitsUtils';
 import { getStatusColor } from '../../utils/statusUtils';
 import { API_BASE_URL } from '../../config/api';
+import { TelescopeIcon, ImageIcon, TableIcon, CheckIcon, PlusIcon } from '../icons/DashboardIcons';
 import './LineageFileCard.css';
 
 interface LineageFileCardProps {
@@ -37,7 +38,9 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
               }}
             />
           ) : (
-            <span className="lineage-thumbnail-placeholder">🔭</span>
+            <span className="lineage-thumbnail-placeholder">
+              <TelescopeIcon size={24} />
+            </span>
           )}
         </div>
       )}
@@ -52,7 +55,7 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
                 isSelectedForComposite ? 'Remove from composite selection' : 'Add to RGB composite'
               }
             >
-              {isSelectedForComposite ? '✓' : '+'}
+              {isSelectedForComposite ? <CheckIcon /> : <PlusIcon />}
             </button>
           )}
           <span className="file-name" title={item.fileName}>
@@ -60,7 +63,7 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
           </span>
           <div className="file-badges">
             <span className={`fits-type-badge small ${fitsInfo.type}`} title={fitsInfo.description}>
-              {fitsInfo.viewable ? '🖼️' : '📊'}
+              {fitsInfo.viewable ? <ImageIcon /> : <TableIcon />}
             </span>
             {item.imageInfo?.filter && (
               <span className="filter-badge small" title={`Filter: ${item.imageInfo.filter}`}>

--- a/frontend/jwst-frontend/src/components/dashboard/LineageView.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageView.tsx
@@ -5,6 +5,7 @@ import {
   ProcessingLevelLabels,
 } from '../../types/JwstDataTypes';
 import { formatFileSize } from '../../utils/formatUtils';
+import { TrashIcon, ArchiveIcon } from '../icons/DashboardIcons';
 import LineageFileCard from './LineageFileCard';
 import './LineageView.css';
 
@@ -160,7 +161,7 @@ const LineageView: React.FC<LineageViewProps> = ({
                     onClick={(e) => onDeleteObservation(obsId, e)}
                     title="Delete this observation"
                   >
-                    <span aria-hidden="true">🗑️</span>
+                    <TrashIcon size={14} />
                     <span className="action-label">Delete</span>
                   </button>
                 )}
@@ -205,7 +206,7 @@ const LineageView: React.FC<LineageViewProps> = ({
                               disabled={isArchivingLevel}
                               title={`Archive all ${level} files`}
                             >
-                              <span aria-hidden="true">📦</span>
+                              <ArchiveIcon size={14} />
                               <span className="action-label">Archive</span>
                             </button>
                             <button
@@ -213,7 +214,7 @@ const LineageView: React.FC<LineageViewProps> = ({
                               onClick={(e) => onDeleteLevel(obsId, level, e)}
                               title={`Delete all ${level} files`}
                             >
-                              <span aria-hidden="true">🗑️</span>
+                              <TrashIcon size={14} />
                               <span className="action-label">Delete</span>
                             </button>
                           </div>

--- a/frontend/jwst-frontend/src/components/icons/DashboardIcons.tsx
+++ b/frontend/jwst-frontend/src/components/icons/DashboardIcons.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+interface IconProps {
+  size?: number;
+  className?: string;
+}
+
+const defaultProps = (size: number) => ({
+  width: size,
+  height: size,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+});
+
+export const TelescopeIcon: React.FC<IconProps> = ({ size = 18, className }) => (
+  <svg {...defaultProps(size)} className={className}>
+    <circle cx="12" cy="5" r="3" />
+    <line x1="12" y1="8" x2="12" y2="14" />
+    <line x1="12" y1="14" x2="6" y2="22" />
+    <line x1="12" y1="14" x2="18" y2="22" />
+    <line x1="8" y1="19" x2="16" y2="19" />
+  </svg>
+);
+
+export const ImageIcon: React.FC<IconProps> = ({ size = 14, className }) => (
+  <svg {...defaultProps(size)} className={className}>
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+    <circle cx="8.5" cy="8.5" r="1.5" />
+    <polyline points="21 15 16 10 5 21" />
+  </svg>
+);
+
+export const TableIcon: React.FC<IconProps> = ({ size = 14, className }) => (
+  <svg {...defaultProps(size)} className={className}>
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+    <line x1="3" y1="9" x2="21" y2="9" />
+    <line x1="3" y1="15" x2="21" y2="15" />
+    <line x1="9" y1="3" x2="9" y2="21" />
+  </svg>
+);
+
+export const CheckIcon: React.FC<IconProps> = ({ size = 14, className }) => (
+  <svg {...defaultProps(size)} className={className}>
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+export const PlusIcon: React.FC<IconProps> = ({ size = 14, className }) => (
+  <svg {...defaultProps(size)} className={className}>
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+export const TargetIcon: React.FC<IconProps> = ({ size = 16, className }) => (
+  <svg {...defaultProps(size)} className={className}>
+    <circle cx="12" cy="12" r="10" />
+    <circle cx="12" cy="12" r="6" />
+    <circle cx="12" cy="12" r="2" />
+  </svg>
+);
+
+export const TrashIcon: React.FC<IconProps> = ({ size = 14, className }) => (
+  <svg {...defaultProps(size)} className={className}>
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  </svg>
+);
+
+export const ArchiveIcon: React.FC<IconProps> = ({ size = 14, className }) => (
+  <svg {...defaultProps(size)} className={className}>
+    <polyline points="21 8 21 21 3 21 3 8" />
+    <rect x="1" y="3" width="22" height="5" />
+    <line x1="10" y1="12" x2="14" y2="12" />
+  </svg>
+);
+
+export const LineageIcon: React.FC<IconProps> = ({ size = 16, className }) => (
+  <svg {...defaultProps(size)} className={className}>
+    <line x1="6" y1="3" x2="6" y2="15" />
+    <circle cx="18" cy="6" r="3" />
+    <circle cx="6" cy="18" r="3" />
+    <path d="M6 6a9 9 0 0 0 9 9" strokeWidth="2" fill="none" />
+  </svg>
+);


### PR DESCRIPTION
Closes #305

## Summary

Replace emoji characters in dashboard components with consistent SVG icons from a new shared DashboardIcons module.

## Why

Emoji rendering varies across OS/browser and looks inconsistent. The project already uses SVG icons in ImageViewer — this extends that pattern to the dashboard.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Chore (CI/CD, tooling, docs)
- [ ] Documentation only

## Changes Made

- Created `src/components/icons/DashboardIcons.tsx` — shared module with 9 stroke-based SVG icon components (TelescopeIcon, ImageIcon, TableIcon, CheckIcon, PlusIcon, TargetIcon, TrashIcon, ArchiveIcon, LineageIcon)
- Replaced emoji in `DataCard.tsx` — telescope placeholder, FITS type badges, composite selection buttons
- Replaced emoji in `LineageFileCard.tsx` — same replacements as DataCard
- Replaced emoji in `DashboardToolbar.tsx` — lineage view icon (⌲) and target view icon (🎯)
- Replaced emoji in `LineageView.tsx` — delete (🗑️) and archive (📦) button icons

## Test Plan

- [x] Frontend build passes (`npm run build`)
- [x] ESLint passes on all changed files
- [x] Verify dashboard cards render icons instead of emoji (telescope placeholder, type badges, composite buttons)
- [x] Verify lineage view renders SVG delete/archive icons
- [x] Verify toolbar view-mode buttons render SVG lineage/target icons

## Documentation Checklist

- [x] N/A — no doc updates needed

## Tech Debt Impact

- [x] Reduces existing tech debt — eliminates cross-platform emoji rendering inconsistency
- [ ] No impact on tech debt
- [ ] Adds new tech debt (justified because: N/A)
- [ ] Neutral refactor

## Risk & Rollback

Risk: Low — visual-only change, no logic changes. Icons use `currentColor` so they inherit text color automatically.

Rollback: Revert this commit to restore emoji characters.

## Quality Checklist

- [x] Changes are focused and atomic
- [x] No unrelated modifications included
- [x] Commit messages follow conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)