### PR TITLE
refactor: replace fire-and-forget Task.Run with background task queue

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
@@ -54,14 +54,14 @@ public class JwstDataControllerTests
             .AddInMemoryCollection(configValues)
             .Build();
 
-        var mockThumbnailService = new Mock<IThumbnailService>();
+        var mockThumbnailQueue = new Mock<IThumbnailQueue>();
 
         sut = new JwstDataController(
             mockMongoService.Object,
             mockLogger.Object,
             mockHttpClientFactory.Object,
             configuration,
-            mockThumbnailService.Object);
+            mockThumbnailQueue.Object);
 
         // Set up a mock HttpContext with an authenticated user
         SetupAuthenticatedUser(TestUserId, isAdmin: false);

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerViewerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerViewerTests.cs
@@ -45,14 +45,14 @@ public class JwstDataControllerViewerTests
             .AddInMemoryCollection(configValues)
             .Build();
 
-        var mockThumbnailService = new Mock<IThumbnailService>();
+        var mockThumbnailQueue = new Mock<IThumbnailQueue>();
 
         sut = new JwstDataController(
             mockMongoService.Object,
             mockLogger.Object,
             mockHttpClientFactory.Object,
             configuration,
-            mockThumbnailService.Object);
+            mockThumbnailQueue.Object);
 
         SetupAuthenticatedUser(TestUserId);
     }

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
@@ -53,13 +53,13 @@ public class MastControllerTests
             .AddInMemoryCollection(configValues)
             .Build();
 
-        var mockThumbnailService = new Mock<IThumbnailService>();
+        var mockThumbnailQueue = new Mock<IThumbnailQueue>();
 
         sut = new MastController(
             mockMastService.Object,
             mockMongoService.Object,
             mockJobTracker.Object,
-            mockThumbnailService.Object,
+            mockThumbnailQueue.Object,
             mockLogger.Object,
             configuration);
 

--- a/backend/JwstDataAnalysis.API.Tests/Services/ThumbnailBackgroundServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/ThumbnailBackgroundServiceTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+
+using JwstDataAnalysis.API.Services;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace JwstDataAnalysis.API.Tests.Services;
+
+/// <summary>
+/// Unit tests for ThumbnailQueue and ThumbnailBackgroundService.
+/// Verifies queue behavior, batch processing, and failure resilience.
+/// </summary>
+public class ThumbnailBackgroundServiceTests
+{
+    private readonly ThumbnailQueue queue;
+    private readonly Mock<IThumbnailService> mockThumbnailService;
+    private readonly Mock<ILogger<ThumbnailBackgroundService>> mockLogger;
+    private readonly ThumbnailBackgroundService sut;
+
+    public ThumbnailBackgroundServiceTests()
+    {
+        queue = new ThumbnailQueue();
+        mockThumbnailService = new Mock<IThumbnailService>();
+        mockLogger = new Mock<ILogger<ThumbnailBackgroundService>>();
+
+        sut = new ThumbnailBackgroundService(queue, mockThumbnailService.Object, mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task ProcessesBatchFromQueue()
+    {
+        // Arrange
+        var ids = new List<string> { "id-1", "id-2", "id-3" };
+        mockThumbnailService
+            .Setup(s => s.GenerateThumbnailsForIdsAsync(ids))
+            .Returns(Task.CompletedTask);
+
+        queue.EnqueueBatch(ids);
+
+        using var cts = new CancellationTokenSource();
+
+        // Act — start the service, let it process one batch, then cancel
+        var serviceTask = sut.StartAsync(cts.Token);
+        await Task.Delay(200);
+        cts.Cancel();
+
+        try { await sut.StopAsync(CancellationToken.None); }
+        catch (OperationCanceledException) { /* expected */ }
+
+        // Assert
+        mockThumbnailService.Verify(
+            s => s.GenerateThumbnailsForIdsAsync(ids),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ContinuesAfterBatchFailure()
+    {
+        // Arrange — first batch throws, second batch should still be processed
+        var failBatch = new List<string> { "fail-1" };
+        var okBatch = new List<string> { "ok-1" };
+
+        mockThumbnailService
+            .Setup(s => s.GenerateThumbnailsForIdsAsync(failBatch))
+            .ThrowsAsync(new InvalidOperationException("test error"));
+        mockThumbnailService
+            .Setup(s => s.GenerateThumbnailsForIdsAsync(okBatch))
+            .Returns(Task.CompletedTask);
+
+        queue.EnqueueBatch(failBatch);
+        queue.EnqueueBatch(okBatch);
+
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        var serviceTask = sut.StartAsync(cts.Token);
+        await Task.Delay(300);
+        cts.Cancel();
+
+        try { await sut.StopAsync(CancellationToken.None); }
+        catch (OperationCanceledException) { /* expected */ }
+
+        // Assert — both batches were attempted
+        mockThumbnailService.Verify(
+            s => s.GenerateThumbnailsForIdsAsync(failBatch),
+            Times.Once);
+        mockThumbnailService.Verify(
+            s => s.GenerateThumbnailsForIdsAsync(okBatch),
+            Times.Once);
+    }
+
+    [Fact]
+    public void EmptyListIsNotEnqueued()
+    {
+        // Act
+        queue.EnqueueBatch([]);
+
+        // Assert
+        queue.PendingCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void PendingCountReflectsBatches()
+    {
+        // Act
+        queue.EnqueueBatch(new List<string> { "a" });
+        queue.EnqueueBatch(new List<string> { "b", "c" });
+
+        // Assert — each EnqueueBatch call is one item in the channel
+        queue.PendingCount.Should().Be(2);
+    }
+}

--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -15,7 +15,7 @@ namespace JwstDataAnalysis.API.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    public partial class JwstDataController(IMongoDBService mongoDBService, ILogger<JwstDataController> logger, IHttpClientFactory httpClientFactory, IConfiguration configuration, IThumbnailService thumbnailService) : ControllerBase
+    public partial class JwstDataController(IMongoDBService mongoDBService, ILogger<JwstDataController> logger, IHttpClientFactory httpClientFactory, IConfiguration configuration, IThumbnailQueue thumbnailQueue) : ControllerBase
     {
         private static readonly Regex ObsBaseIdPattern = new(@"^[a-zA-Z0-9._-]+$", RegexOptions.Compiled);
 
@@ -24,7 +24,7 @@ namespace JwstDataAnalysis.API.Controllers
 
         private readonly IHttpClientFactory httpClientFactory = httpClientFactory;
         private readonly IConfiguration configuration = configuration;
-        private readonly IThumbnailService thumbnailService = thumbnailService;
+        private readonly IThumbnailQueue thumbnailQueue = thumbnailQueue;
 
         /// <summary>
         /// Get all JWST data items accessible to the current user.
@@ -2067,8 +2067,7 @@ namespace JwstDataAnalysis.API.Controllers
                     return Ok(new { queued = 0, message = "All viewable records already have thumbnails" });
                 }
 
-                // Fire-and-forget background generation
-                _ = Task.Run(() => thumbnailService.GenerateThumbnailsForIdsAsync(ids));
+                thumbnailQueue.EnqueueBatch(ids);
 
                 return Ok(new { queued = ids.Count });
             }

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -96,6 +96,11 @@ builder.Services.AddHttpClient("ThumbnailEngine", client =>
 });
 builder.Services.AddSingleton<IThumbnailService, ThumbnailService>();
 
+// Background queue for thumbnail generation (replaces fire-and-forget Task.Run)
+builder.Services.AddSingleton<ThumbnailQueue>();
+builder.Services.AddSingleton<IThumbnailQueue>(sp => sp.GetRequiredService<ThumbnailQueue>());
+builder.Services.AddHostedService<ThumbnailBackgroundService>();
+
 builder.Services.AddControllers();
 builder.Services.AddHealthChecks();
 

--- a/backend/JwstDataAnalysis.API/Services/IThumbnailQueue.cs
+++ b/backend/JwstDataAnalysis.API/Services/IThumbnailQueue.cs
@@ -1,0 +1,12 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+namespace JwstDataAnalysis.API.Services
+{
+    public interface IThumbnailQueue
+    {
+        void EnqueueBatch(List<string> dataIds);
+
+        int PendingCount { get; }
+    }
+}

--- a/backend/JwstDataAnalysis.API/Services/ThumbnailBackgroundService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/ThumbnailBackgroundService.Log.cs
@@ -1,0 +1,24 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+namespace JwstDataAnalysis.API.Services
+{
+    public sealed partial class ThumbnailBackgroundService
+    {
+        [LoggerMessage(EventId = 8001, Level = LogLevel.Information,
+            Message = "Thumbnail background service started")]
+        private partial void LogServiceStarted();
+
+        [LoggerMessage(EventId = 8002, Level = LogLevel.Information,
+            Message = "Thumbnail batch received: {Count} ID(s) queued for processing")]
+        private partial void LogBatchReceived(int count);
+
+        [LoggerMessage(EventId = 8003, Level = LogLevel.Error,
+            Message = "Thumbnail batch failed ({Count} IDs). Service will continue processing.")]
+        private partial void LogBatchFailed(Exception ex, int count);
+
+        [LoggerMessage(EventId = 8004, Level = LogLevel.Information,
+            Message = "Thumbnail background service stopping")]
+        private partial void LogServiceStopping();
+    }
+}

--- a/backend/JwstDataAnalysis.API/Services/ThumbnailBackgroundService.cs
+++ b/backend/JwstDataAnalysis.API/Services/ThumbnailBackgroundService.cs
@@ -1,0 +1,36 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+namespace JwstDataAnalysis.API.Services
+{
+    public sealed partial class ThumbnailBackgroundService(
+        ThumbnailQueue queue,
+        IThumbnailService thumbnailService,
+        ILogger<ThumbnailBackgroundService> logger) : BackgroundService
+    {
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            LogServiceStarted();
+
+            await foreach (var batch in queue.Reader.ReadAllAsync(stoppingToken))
+            {
+                LogBatchReceived(batch.Count);
+
+                try
+                {
+                    await thumbnailService.GenerateThumbnailsForIdsAsync(batch);
+                }
+                catch (Exception ex)
+                {
+                    LogBatchFailed(ex, batch.Count);
+                }
+                finally
+                {
+                    queue.DecrementPending();
+                }
+            }
+
+            LogServiceStopping();
+        }
+    }
+}

--- a/backend/JwstDataAnalysis.API/Services/ThumbnailQueue.cs
+++ b/backend/JwstDataAnalysis.API/Services/ThumbnailQueue.cs
@@ -1,0 +1,35 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Channels;
+
+namespace JwstDataAnalysis.API.Services
+{
+    public sealed class ThumbnailQueue : IThumbnailQueue
+    {
+        private readonly Channel<List<string>> channel = Channel.CreateUnbounded<List<string>>(
+            new UnboundedChannelOptions { SingleReader = true });
+
+        private int pendingCount;
+
+        public ChannelReader<List<string>> Reader => channel.Reader;
+
+        public int PendingCount => Volatile.Read(ref pendingCount);
+
+        public void EnqueueBatch(List<string> dataIds)
+        {
+            if (dataIds.Count == 0)
+            {
+                return;
+            }
+
+            channel.Writer.TryWrite(dataIds);
+            Interlocked.Increment(ref pendingCount);
+        }
+
+        public void DecrementPending()
+        {
+            Interlocked.Decrement(ref pendingCount);
+        }
+    }
+}


### PR DESCRIPTION
Closes #306

## Summary
Replace 4 fire-and-forget `Task.Run` thumbnail generation calls with a `BackgroundService` + `Channel<T>` queue that provides proper error logging, graceful shutdown, and sequential processing.

## Why
The existing `_ = Task.Run(...)` pattern silently swallows exceptions, has no cancellation support, and loses in-flight work on app restart. This is a known tech debt item (#306).

## Type of Change
- [ ] feat (new capability)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [x] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Added `IThumbnailQueue` interface with `EnqueueBatch(List<string>)` and `PendingCount`
- Added `ThumbnailQueue` implementation using `Channel.CreateUnbounded<List<string>>` with `SingleReader = true`
- Added `ThumbnailBackgroundService` (`BackgroundService`) that reads batches from the channel and delegates to `IThumbnailService.GenerateThumbnailsForIdsAsync`
- Added source-generated logging partial (`ThumbnailBackgroundService.Log.cs`) with event IDs 8001-8004
- Registered `ThumbnailQueue` (concrete singleton) + `IThumbnailQueue` (forwarding interface) + `ThumbnailBackgroundService` (hosted service) in `Program.cs`
- Replaced `_ = Task.Run(...)` with `thumbnailQueue.EnqueueBatch(...)` in `JwstDataController` (1 call) and `MastController` (3 calls)
- Updated constructor injection in both controllers from `IThumbnailService` to `IThumbnailQueue`
- Updated 3 test files to mock `IThumbnailQueue` instead of `IThumbnailService`
- Added 4 unit tests for the background service (batch processing, failure resilience, empty list no-op, PendingCount)

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [ ] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [x] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

### Steps to verify:
1. `docker compose up -d --build` — confirm app starts
2. Check `docker logs jwst-backend` for `Thumbnail background service started` log (event 8001)
3. Run .NET tests: all 258 pass (including 4 new `ThumbnailBackgroundServiceTests`)
4. Run Python tests: all 212 pass (no changes, sanity check)
5. Import an observation via MAST — thumbnails should generate via the queue (check logs for `Thumbnail batch received` event 8002)
6. Trigger `/api/jwstdata/thumbnails/generate` — should queue IDs and return immediately

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [ ] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [x] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
Risk: Low — behavioral change is internal only (queue vs direct fire-and-forget). Sequential processing matches existing behavior. No API surface changes.
Rollback: Revert PR commit. No database or config changes needed.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All checks pass locally (build, lint, format, tests)