### PR TITLE
fix: resolve analyzer warnings in thumbnail queue files

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/ThumbnailBackgroundServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/ThumbnailBackgroundServiceTests.cs
@@ -15,7 +15,7 @@ namespace JwstDataAnalysis.API.Tests.Services;
 /// Unit tests for ThumbnailQueue and ThumbnailBackgroundService.
 /// Verifies queue behavior, batch processing, and failure resilience.
 /// </summary>
-public class ThumbnailBackgroundServiceTests
+public class ThumbnailBackgroundServiceTests : IDisposable
 {
     private readonly ThumbnailQueue queue;
     private readonly Mock<IThumbnailService> mockThumbnailService;
@@ -29,6 +29,12 @@ public class ThumbnailBackgroundServiceTests
         mockLogger = new Mock<ILogger<ThumbnailBackgroundService>>();
 
         sut = new ThumbnailBackgroundService(queue, mockThumbnailService.Object, mockLogger.Object);
+    }
+
+    public void Dispose()
+    {
+        sut.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     [Fact]
@@ -49,8 +55,14 @@ public class ThumbnailBackgroundServiceTests
         await Task.Delay(200);
         cts.Cancel();
 
-        try { await sut.StopAsync(CancellationToken.None); }
-        catch (OperationCanceledException) { /* expected */ }
+        try
+        {
+            await sut.StopAsync(CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
 
         // Assert
         mockThumbnailService.Verify(
@@ -82,8 +94,14 @@ public class ThumbnailBackgroundServiceTests
         await Task.Delay(300);
         cts.Cancel();
 
-        try { await sut.StopAsync(CancellationToken.None); }
-        catch (OperationCanceledException) { /* expected */ }
+        try
+        {
+            await sut.StopAsync(CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
 
         // Assert — both batches were attempted
         mockThumbnailService.Verify(

--- a/backend/JwstDataAnalysis.API/Services/IThumbnailQueue.cs
+++ b/backend/JwstDataAnalysis.API/Services/IThumbnailQueue.cs
@@ -3,10 +3,12 @@
 
 namespace JwstDataAnalysis.API.Services
 {
+#pragma warning disable CA1711 // Type name intentionally ends in 'Queue' — it is a queue
     public interface IThumbnailQueue
+#pragma warning restore CA1711
     {
-        void EnqueueBatch(List<string> dataIds);
-
         int PendingCount { get; }
+
+        void EnqueueBatch(List<string> dataIds);
     }
 }

--- a/backend/JwstDataAnalysis.API/Services/ThumbnailQueue.cs
+++ b/backend/JwstDataAnalysis.API/Services/ThumbnailQueue.cs
@@ -5,7 +5,9 @@ using System.Threading.Channels;
 
 namespace JwstDataAnalysis.API.Services
 {
+#pragma warning disable CA1711 // Type name intentionally ends in 'Queue' — it is a queue
     public sealed class ThumbnailQueue : IThumbnailQueue
+#pragma warning restore CA1711
     {
         private readonly Channel<List<string>> channel = Channel.CreateUnbounded<List<string>>(
             new UnboundedChannelOptions { SingleReader = true });


### PR DESCRIPTION
## Summary
Fix 8 analyzer warnings (promoted to errors with `--warnaserror`) introduced in #314.

## Why
The `dotnet build` in the Docker container doesn't use `--warnaserror`, so these passed CI but fail the local compliance check.

## Type of Change
- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Suppressed CA1711 on `IThumbnailQueue` and `ThumbnailQueue` (naming is intentional — they are queues)
- Reordered `IThumbnailQueue` members: property before method (SA1201)
- Expanded single-line `try/catch` blocks to multi-line in tests (SA1501)
- Implemented `IDisposable` on `ThumbnailBackgroundServiceTests` for owned `BackgroundService` field (CA1001)

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [ ] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [ ] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

### Steps to verify:
1. `dotnet build JwstDataAnalysis.sln --warnaserror` — 0 warnings, 0 errors
2. `dotnet test` — 258/258 pass

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
Risk: None — analyzer suppressions and style-only changes, no behavioral impact.
Rollback: Revert commit.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All checks pass locally (build, lint, format, tests)