### PR TITLE
fix: show metadata for mosaic-generated FITS files in ImageViewer

### DIFF
--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -3,6 +3,7 @@ import {
   JwstDataModel,
   DeleteObservationResponse,
   DeleteLevelResponse,
+  ImageMetadata,
 } from '../types/JwstDataTypes';
 import MastSearch from './MastSearch';
 import WhatsNewPanel from './WhatsNewPanel';
@@ -41,6 +42,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
   const [viewingImageMetadata, setViewingImageMetadata] = useState<
     Record<string, unknown> | undefined
   >(undefined);
+  const [viewingImageInfo, setViewingImageInfo] = useState<ImageMetadata | undefined>(undefined);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [collapsedLineages, setCollapsedLineages] = useState<Set<string>>(new Set());
   const [expandedLevels, setExpandedLevels] = useState<Set<string>>(new Set());
@@ -421,6 +423,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     setViewingImageId(item.id);
     setViewingImageTitle(item.fileName);
     setViewingImageMetadata(item.metadata);
+    setViewingImageInfo(item.imageInfo);
   };
 
   // Get only viewable images for composite selection
@@ -517,6 +520,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
         isOpen={!!viewingImageId}
         onClose={() => setViewingImageId(null)}
         metadata={viewingImageMetadata}
+        imageInfo={viewingImageInfo}
         onCompare={() => {
           if (viewingImageId) {
             setComparisonPickerInitialA({


### PR DESCRIPTION
Closes #301

## Summary
ImageViewer now displays metadata for mosaic-generated FITS files by falling back to `imageInfo` fields when `mast_*` metadata keys are absent.

## Why
Mosaic-generated files store their astronomical metadata in the structured `imageInfo` object (`ImageMetadata`) rather than `mast_*`-prefixed keys in the `metadata` dictionary. The ImageViewer only read `mast_*` keys, so mosaic files showed no metadata, "Unknown Target / JWST" in the header breadcrumb, and generic export filenames.

## Type of Change
- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Added `imageInfo?: ImageMetadata` prop to `ImageViewerProps` in `ImageViewer.tsx`
- Updated `getDisplayMetadata()` to fall back to `imageInfo` fields (targetName, instrument, filter, exposureTime, calibrationLevel, proposalId, observationTitle) when no `mast_*` keys are present
- Updated header breadcrumb variables (targetName, instrument, filter, obsTitle) to fall back to `imageInfo` fields
- Updated `generateExportFilename()` to use `imageInfo.instrument` and `imageInfo.filter` as fallbacks for meaningful export filenames
- Added `viewingImageInfo` state in `JwstDataDashboard.tsx`, populated from `item.imageInfo` in `handleViewItem()`, and passed as `imageInfo` prop to `<ImageViewer>`

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [x] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [ ] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

**Steps to verify:**
1. `docker compose up -d --build`
2. Open dashboard, click a MAST-imported file → metadata sidebar should display as before (mast_* keys)
3. Click a mosaic-generated file → metadata panel should now show target name, instrument, filter, etc. from `imageInfo`
4. Check header breadcrumb shows actual target/instrument instead of "Unknown Target / JWST"
5. Export image and verify the filename includes instrument/filter info
6. Run frontend lint: `docker exec jwst-frontend npm run lint` → passes clean

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low — additive fallback only; existing MAST metadata path is unchanged
- Rollback: Revert this PR; MAST-imported files are unaffected either way

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All checks pass locally (build, lint, format, tests)