### PR TITLE
feat: add server-side reprojection cache for composite previews

### DIFF
--- a/processing-engine/app/composite/cache.py
+++ b/processing-engine/app/composite/cache.py
@@ -1,0 +1,122 @@
+"""
+In-memory cache for reprojected composite channel arrays.
+
+Caches the expensive load → downscale → mosaic → reproject results so that
+stretch-only parameter changes (the most common user interaction) can skip
+those steps and return in ~100ms instead of seconds.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from collections import OrderedDict
+
+import numpy as np
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 600  # 10 minutes
+DEFAULT_MAX_ENTRIES = 3
+DEFAULT_MAX_BYTES = 512 * 1024 * 1024  # 512 MB
+
+
+class CompositeCache:
+    """LRU cache for reprojected RGB channel arrays with TTL and memory limits."""
+
+    def __init__(self) -> None:
+        self._ttl = int(os.environ.get("COMPOSITE_CACHE_TTL_SECONDS", DEFAULT_TTL_SECONDS))
+        self._max_entries = int(os.environ.get("COMPOSITE_CACHE_MAX_ENTRIES", DEFAULT_MAX_ENTRIES))
+        self._max_bytes = int(os.environ.get("COMPOSITE_CACHE_MAX_BYTES", DEFAULT_MAX_BYTES))
+        self._lock = threading.Lock()
+        # OrderedDict preserves insertion order; we move accessed keys to the
+        # end so the *first* key is the least-recently-used.
+        self._store: OrderedDict[str, tuple[dict[str, np.ndarray], float]] = OrderedDict()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def make_key(
+        red_paths: list[str],
+        green_paths: list[str],
+        blue_paths: list[str],
+        input_budget: int,
+    ) -> str:
+        """Deterministic cache key from channel file paths + input budget."""
+        payload = json.dumps(
+            {
+                "red": sorted(red_paths),
+                "green": sorted(green_paths),
+                "blue": sorted(blue_paths),
+                "budget": input_budget,
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def get(self, key: str) -> dict[str, np.ndarray] | None:
+        """Return cached channel arrays or ``None`` on miss / expiry."""
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+
+            channels, ts = entry
+            if time.monotonic() - ts > self._ttl:
+                del self._store[key]
+                logger.debug("Composite cache entry expired for key=%s…", key[:12])
+                return None
+
+            # Mark as recently used
+            self._store.move_to_end(key)
+            return channels
+
+    def put(self, key: str, channels: dict[str, np.ndarray]) -> None:
+        """Store reprojected channels if within the memory budget."""
+        entry_bytes = sum(arr.nbytes for arr in channels.values())
+
+        if entry_bytes > self._max_bytes:
+            logger.info(
+                "Composite cache SKIP — entry too large (%s MB, limit %s MB)",
+                entry_bytes // (1024 * 1024),
+                self._max_bytes // (1024 * 1024),
+            )
+            return
+
+        with self._lock:
+            # Evict expired entries first
+            self._evict_expired()
+
+            # Evict LRU entries until we're under the memory cap
+            current_bytes = self._total_bytes()
+            while current_bytes + entry_bytes > self._max_bytes and self._store:
+                evicted_key, _ = self._store.popitem(last=False)
+                current_bytes = self._total_bytes()
+                logger.debug("Composite cache evicted (memory) key=%s…", evicted_key[:12])
+
+            # Evict LRU entries until we're under the max-entries cap
+            while len(self._store) >= self._max_entries and self._store:
+                evicted_key, _ = self._store.popitem(last=False)
+                logger.debug("Composite cache evicted (count) key=%s…", evicted_key[:12])
+
+            self._store[key] = (channels, time.monotonic())
+
+    # ------------------------------------------------------------------
+    # Internal helpers (caller must hold self._lock)
+    # ------------------------------------------------------------------
+
+    def _evict_expired(self) -> None:
+        now = time.monotonic()
+        expired = [k for k, (_, ts) in self._store.items() if now - ts > self._ttl]
+        for k in expired:
+            del self._store[k]
+
+    def _total_bytes(self) -> int:
+        return sum(
+            sum(arr.nbytes for arr in channels.values()) for channels, _ in self._store.values()
+        )


### PR DESCRIPTION
Closes #288

## Summary

Adds an in-memory LRU cache for reprojected composite channel arrays so that stretch/levels slider changes skip the expensive load → downscale → mosaic → reproject pipeline and return much faster.

## Why

Composite preview generation re-runs the full pipeline on every request. When users adjust stretch/levels/gamma sliders (the most frequent interaction), the expensive steps re-run unnecessarily — those results only change when channel file assignments change. This cache makes slider adjustments return in ~100ms instead of seconds.

## Type of Change
- [x] feat (new capability)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Added `processing-engine/app/composite/cache.py` — `CompositeCache` class with LRU eviction, TTL expiry, and memory guard (configurable via env vars `COMPOSITE_CACHE_TTL_SECONDS`, `COMPOSITE_CACHE_MAX_ENTRIES`, `COMPOSITE_CACHE_MAX_BYTES`)
- Modified `processing-engine/app/composite/routes.py` — cache lookup before the heavy pipeline, cache storage after reprojection completes; logs HIT/MISS for observability

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [ ] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [x] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

### Steps to verify
1. `cd docker && docker compose up -d --build`
2. Open dashboard → Composite Wizard → assign channels → generate preview
3. Adjust a stretch slider — second preview should return noticeably faster
4. Check processing engine logs: `docker logs jwst-processing --tail 50` — look for "cache HIT" / "cache MISS"
5. Change a channel file assignment → should see "cache MISS" (full pipeline)
6. Adjust stretch again → "cache HIT" (fast path)
7. Run tests: `docker exec jwst-processing python -m pytest` — 214 pass
8. Run lint: `docker exec jwst-frontend npm run lint` — clean

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low — backend-only change, no API contract changes; cache is additive (miss = full pipeline as before)
- Rollback: Revert this PR; composite generation returns to always running the full pipeline

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All checks pass locally (build, lint, format, tests)