### PR TITLE
feat: normalize MAST target search variants

### DIFF
--- a/docs/desktop-requirements.md
+++ b/docs/desktop-requirements.md
@@ -158,6 +158,7 @@ A desktop application for astronomers and researchers to browse, import, analyze
 | FR-4.1.2.13 | Persist download state to allow resume after app restart | Must       |
 | FR-4.1.2.14 | Filter search results by instrument                      | Should     |
 | FR-4.1.2.15 | Filter search results by calibration level               | Should     |
+| FR-4.1.2.16 | Normalize target-name query variants (space/hyphen/compact) for equivalent object lookup | Should     |
 
 **MAST Search Response Fields to Capture:**
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -97,7 +97,7 @@ Common patterns, API endpoints, troubleshooting, and MAST usage tips.
 **MAST Search Issues**:
 - Ensure processing engine is running: `docker compose logs processing-engine`
 - Check internet connectivity (MAST requires external access)
-- Target name searches are case-insensitive but must match MAST naming
+- Target-name search normalizes common variants (for example: `NGC 3132`, `NGC-3132`, `NGC3132`)
 - If JSON serialization errors occur, NaN values from MAST are being handled
 - Large downloads may timeout; increase `HttpClient.Timeout` if needed
 - Downloaded files stored in `data/mast/{obs_id}/` directory

--- a/processing-engine/tests/test_mast_target_search_variants.py
+++ b/processing-engine/tests/test_mast_target_search_variants.py
@@ -1,0 +1,94 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Tests for target-name normalization and variant-aware MAST target search.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.mast.mast_service import MastService
+
+
+def _mock_coord(ra_deg: float, dec_deg: float) -> SimpleNamespace:
+    return SimpleNamespace(
+        ra=SimpleNamespace(deg=ra_deg),
+        dec=SimpleNamespace(deg=dec_deg),
+    )
+
+
+class TestTargetVariantNormalization:
+    @pytest.mark.parametrize(
+        ("target_name", "expected"),
+        [
+            ("NGC-3132", ["NGC-3132", "NGC 3132", "NGC3132"]),
+            ("NGC 3132", ["NGC 3132", "NGC-3132", "NGC3132"]),
+            ("NGC3132", ["NGC3132", "NGC 3132"]),
+            ("Crab Nebula", ["Crab Nebula", "Crab-Nebula", "CrabNebula"]),
+        ],
+    )
+    def test_generate_target_candidates(self, target_name: str, expected: list[str]):
+        candidates = MastService._generate_target_candidates(target_name)
+        assert candidates == expected
+
+
+class TestTargetVariantSearch:
+    @pytest.mark.parametrize(
+        "target_query",
+        ["NGC 3132", "NGC-3132", "NGC3132", "ngc_3132"],
+    )
+    def test_search_by_target_resolves_common_variants(self, target_query: str, tmp_path):
+        service = MastService(download_dir=str(tmp_path))
+        resolved_coord = _mock_coord(151.1, -40.5)
+        attempted_variants: list[str] = []
+
+        def from_name_with_variant_support(candidate: str):
+            attempted_variants.append(candidate)
+            if candidate.casefold() == "ngc 3132":
+                return resolved_coord
+            raise ValueError("not found")
+
+        with (
+            patch(
+                "app.mast.mast_service.SkyCoord.from_name",
+                side_effect=from_name_with_variant_support,
+            ),
+            patch(
+                "app.mast.mast_service.Observations.query_criteria",
+                return_value=[{"obs_id": "raw"}],
+            ) as query_mock,
+            patch.object(service, "_table_to_dict_list", return_value=[{"obs_id": "jw-test"}]),
+        ):
+            results = service.search_by_target(
+                target_name=target_query, radius=0.2, calib_level=[1, 2, 3]
+            )
+
+        assert results == [{"obs_id": "jw-test"}]
+        assert any(variant.casefold() == "ngc 3132" for variant in attempted_variants)
+
+        kwargs = query_mock.call_args.kwargs
+        assert kwargs["obs_collection"] == "JWST"
+        assert kwargs["calib_level"] == [1, 2, 3]
+        assert kwargs["s_ra"] == pytest.approx([150.9, 151.3])
+        assert kwargs["s_dec"] == pytest.approx([-40.7, -40.3])
+
+    def test_search_by_target_raises_when_all_variants_fail(self, tmp_path):
+        service = MastService(download_dir=str(tmp_path))
+        attempted_variants: list[str] = []
+
+        def always_fail(candidate: str):
+            attempted_variants.append(candidate)
+            raise ValueError("not found")
+
+        with (
+            patch("app.mast.mast_service.SkyCoord.from_name", side_effect=always_fail),
+            pytest.raises(ValueError, match="Could not resolve target name 'NGC-3132'"),
+        ):
+            service.search_by_target(target_name="NGC-3132")
+
+        assert attempted_variants == ["NGC-3132", "NGC 3132", "NGC3132"]


### PR DESCRIPTION
## Summary
Target search now normalizes common name-format variants so equivalent queries (space, hyphen, compact forms) resolve consistently.

## Why
Users searching for the same object with different separators (for example `NGC 3132`, `NGC-3132`, `NGC3132`) can get inconsistent results. This update makes target lookup resilient to those formatting differences.

Closes #326.

## Type of Change
- [x] Feature (non-breaking enhancement)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation update

## Changes Made
- Added target normalization/candidate generation helpers in `MastService`.
- Updated target-coordinate resolution to retry normalized candidates before failing.
- Added processing-engine tests covering candidate generation and variant-aware resolution paths.
- Updated docs for behavior and requirement alignment.

## Test Plan
- [x] `docker exec jwst-processing python -m ruff check /app/app/mast/mast_service.py /app/tests/test_mast_target_search_variants.py`
- [x] `docker exec jwst-processing python -m pytest /app/tests/test_mast_target_search_variants.py /app/tests/test_mast_service_security.py`

## Documentation Checklist
- [x] Updated `docs/quick-reference.md`.
- [x] Updated `docs/desktop-requirements.md` with `FR-4.1.2.16`.
- [x] No endpoint contract changes required in API docs.

## Tech Debt Impact
- [x] No new tech debt introduced.
- [ ] Introduces temporary tech debt with follow-up issue.
- [ ] Introduces an accepted long-term tradeoff.

## Risk & Rollback
Risk: Low, scoped to target-name resolution behavior in processing-engine MAST search.
Rollback: Revert commit `e098911` to restore prior exact-resolution behavior.

## Quality Checklist
- [x] Pre-commit checks passed.
- [x] Lint/tests above executed successfully.
- [x] Manual validation steps provided.

## Manual Validation
1. Start stack: `docker compose up -d`.
2. Open MAST Search and choose `Target`.
3. Query `Crab Nebula`, `NGC 3132`, `NGC-3132`, and `NGC3132`.
4. Confirm equivalent target variants resolve consistently.
