### PR TITLE
fix: agent-stack.sh bugs and review.sh improvements

### DIFF
--- a/docker/docker-compose.agent.yml
+++ b/docker/docker-compose.agent.yml
@@ -59,9 +59,12 @@ services:
       - VITE_API_URL=http://localhost:${BACKEND_PORT}
     volumes:
       - ${SOURCE_ROOT}/frontend/jwst-frontend:/app
-      - /app/node_modules
+      - frontend_node_modules:/app/node_modules
     networks:
       - default
+
+volumes:
+  frontend_node_modules:
 
 networks:
   jwst-shared:

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -14,8 +14,11 @@ services:
   frontend:
     volumes:
       - ../frontend/jwst-frontend:/app
-      - /app/node_modules
+      - frontend_node_modules:/app/node_modules
 
   processing-engine:
     ports:
       - "127.0.0.1:8000:8000"  # Expose processing engine for debugging (localhost only)
+
+volumes:
+  frontend_node_modules:

--- a/scripts/agent-stack.sh
+++ b/scripts/agent-stack.sh
@@ -141,18 +141,18 @@ create_worktree() {
   local worktree_path="$PROJECT_ROOT-${name}"
 
   if [[ -d "$worktree_path" ]]; then
-    warn "Directory $worktree_path already exists"
+    warn "Directory $worktree_path already exists" >&2
     echo "$worktree_path"
     return
   fi
 
-  info "Creating worktree at $worktree_path from branch $branch..."
+  info "Creating worktree at $worktree_path from branch $branch..." >&2
   # Fetch the branch if it's remote
-  git -C "$PROJECT_ROOT" fetch origin "$branch" 2>/dev/null || true
-  git -C "$PROJECT_ROOT" worktree add "$worktree_path" "$branch" 2>/dev/null \
-    || git -C "$PROJECT_ROOT" worktree add "$worktree_path" "origin/$branch" 2>/dev/null \
+  git -C "$PROJECT_ROOT" fetch origin "$branch" &>/dev/null || true
+  git -C "$PROJECT_ROOT" worktree add "$worktree_path" "$branch" &>/dev/null \
+    || git -C "$PROJECT_ROOT" worktree add "$worktree_path" "origin/$branch" &>/dev/null \
     || die "Failed to create worktree from branch '$branch'"
-  ok "Worktree created at $worktree_path"
+  ok "Worktree created at $worktree_path" >&2
   echo "$worktree_path"
 }
 

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -98,9 +98,9 @@ show_status() {
 # ─── Main ──────────────────────────────────────────────────────────────────
 
 case "${1:-}" in
-  --stop)   stop_all ;;
-  --status) show_status ;;
-  --help|-h)
+  --stop|-stop)     stop_all ;;
+  --status|-status) show_status ;;
+  --help|-h|-help)
     echo "Usage: review.sh [<pr-number>|--stop|--status]"
     echo ""
     echo "  review.sh              Interactive: pick from open PRs"


### PR DESCRIPTION
Closes #

## Summary

Fixes bugs discovered during live testing of the multi-agent Docker stack infrastructure (PR #330) and adds the `--pr` flag and `review.sh` script.

## Why

Three issues found during end-to-end testing after #330 merged:
1. `create_worktree()` stdout pollution corrupted `SOURCE_ROOT`, causing Docker Compose to fail with "invalid compose project"
2. Anonymous volumes (`/app/node_modules`) caused "undefined volume" errors in Docker Compose
3. `review.sh` rejected single-dash flags (`-status`) which is a common user pattern

## Type of Change
- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Fix `create_worktree()` by redirecting status messages to stderr and using `&>/dev/null` on git commands to prevent stdout pollution
- Declare `frontend_node_modules` as a named volume in both `docker-compose.agent.yml` and `docker-compose.override.yml` (replaces anonymous volume syntax)
- Add `--pr <number>` flag to `agent-stack.sh` that resolves PR branch via `gh pr view` and auto-names the stack `pr-N`
- Add `scripts/review.sh` interactive PR preview script (pick from open PRs, spin up stack, open browser)
- Accept single-dash flags in `review.sh` (`-status`, `-stop`, `-help`)

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [x] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [ ] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

### Step-by-step verification:
1. `docker compose up -d` — main stack starts normally (no volume errors)
2. `./scripts/review.sh 330` — resolves PR branch, creates worktree, starts agent stack at `:3001`
3. `./scripts/review.sh --status` — shows main + agent stacks
4. `./scripts/review.sh -status` — single-dash also works
5. `./scripts/agent-stack.sh down pr-330 --cleanup` — stops stack, removes worktree
6. `./scripts/review.sh --stop` — stops all agent stacks

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low — fixes bugs in new infrastructure scripts only, no impact on application code
- Rollback: Revert commit, agent-stack.sh reverts to pre-fix state (--pr flag removed, volume bug returns)

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All checks pass locally (build, lint, format, tests)