### PR TITLE
fix: add 127.0.0.1 to CORS allowed origins

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -28,9 +28,9 @@ MONGO_DATABASE=jwst_data_analysis
 ASPNETCORE_ENVIRONMENT=Development
 
 # CORS allowed origins (comma-separated)
-# For local development: http://localhost:3000,http://localhost:5173
+# For local development: localhost + 127.0.0.1 (browsers treat these as different origins)
 # For production: https://your-frontend-domain.com
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173
 
 # =============================================================================
 # Frontend Configuration (Vite)


### PR DESCRIPTION
## Summary

Add `http://127.0.0.1:3000` and `http://127.0.0.1:5173` to the default CORS allowed origins so login works when accessing the app via `127.0.0.1` instead of `localhost`.

## Why

Browsers treat `localhost` and `127.0.0.1` as different origins. When accessing the app at `http://127.0.0.1:3000`, the backend rejects the CORS preflight because only `localhost` origins were allowed. This caused login to silently fail.

## Type of Change
- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Add `http://127.0.0.1:3000` and `http://127.0.0.1:5173` to `CORS_ALLOWED_ORIGINS` in `.env.example`
- Updated comment to explain why both localhost and 127.0.0.1 are needed

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`) or documented why not
- [x] Verified behavior in browser at `http://localhost:3000` (if frontend touched)
- [x] API endpoints tested (if backend/API touched)
- [x] Relevant unit/integration tests pass

### Step-by-step verification:
1. Copy `.env.example` to `.env` (or update existing `.env`)
2. `docker compose up -d --force-recreate backend`
3. Open `http://127.0.0.1:3000` — login works
4. Open `http://localhost:3000` — login still works

## Documentation Checklist
- [x] No documentation updates needed
- [ ] Updated `docs/development-plan.md` for milestone/phase changes
- [ ] Updated `docs/desktop-requirements.md` for user-visible behavior changes
- [ ] Updated `docs/standards/*.md` for pattern/contract changes
- [ ] Updated other docs as needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: None — only adds additional allowed origins, does not remove existing ones
- Rollback: Revert commit

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All checks pass locally (build, lint, format, tests)