### PR TITLE
fix: replace instrument filter with wavelength filter, fix mosaic viewer and thumbnails

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -227,11 +227,7 @@ namespace JwstDataAnalysis.API.Controllers
 
                 // Get the relative path within the data directory for security
                 // The processing engine validates paths are within /app/data
-                var relativePath = data.FilePath;
-                if (data.FilePath.StartsWith("/app/data/", StringComparison.Ordinal))
-                {
-                    relativePath = data.FilePath["/app/data/".Length..];
-                }
+                var relativePath = ToProcessingEngineRelativePath(data.FilePath);
 
                 var client = httpClientFactory.CreateClient("ProcessingEngine");
                 client.Timeout = TimeSpan.FromMinutes(2); // Allow time for large file processing
@@ -2229,6 +2225,33 @@ namespace JwstDataAnalysis.API.Controllers
                 // Thumbnail
                 HasThumbnail = model.ThumbnailData != null,
             };
+        }
+
+        /// <summary>
+        /// Convert a stored file path to a relative path for the processing engine.
+        /// Handles both absolute (/app/data/...) and relative (./data/...) stored paths.
+        /// </summary>
+        private static string ToProcessingEngineRelativePath(string filePath)
+        {
+            // Absolute Docker path
+            if (filePath.StartsWith("/app/data/", StringComparison.Ordinal))
+            {
+                return filePath["/app/data/".Length..];
+            }
+
+            // Relative path from /app working directory (e.g. "./data/mosaic/...")
+            if (filePath.StartsWith("./data/", StringComparison.Ordinal))
+            {
+                return filePath["./data/".Length..];
+            }
+
+            // Relative without dot prefix (e.g. "data/mosaic/...")
+            if (filePath.StartsWith("data/", StringComparison.Ordinal))
+            {
+                return filePath["data/".Length..];
+            }
+
+            return filePath;
         }
     }
 


### PR DESCRIPTION
## Summary
Replace Instrument dropdown with Filter (wavelength) dropdown in the mosaic wizard, implement cascading filter logic, fix mosaic FITS viewer 404 errors, and add automatic thumbnail generation for saved mosaics.

## Why
- Users filter by wavelength (F1130W) far more often than by instrument when creating mosaics
- Cascading filters reduce clutter — downstream dropdowns only show relevant options
- Mosaic FITS files were unviewable due to relative path storage (`./data/mosaic/...` instead of `/app/data/mosaic/...`)
- Saved mosaics never triggered thumbnail generation, appearing without thumbnails on the dashboard

## Type of Change
- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made
- Replace Instrument dropdown with Filter (wavelength) dropdown in mosaic wizard step 1 — filters like F1130W, F444W are more practical for mosaic creation
- Make filter dropdowns cascade left to right: Target narrows Stage options, Stage narrows Filter options with auto-reset when a downstream value becomes invalid
- Fix mosaic FITS files not viewable in image viewer — `NormalizePathForStorage` now resolves relative paths to absolute via `Path.GetFullPath`
- Extract `ToProcessingEngineRelativePath` helper in controller to handle `/app/data/`, `./data/`, and `data/` path prefixes
- Fix missing thumbnails for saved mosaics — mosaic save flow now enqueues thumbnail generation via `IThumbnailQueue`

## Test Plan
- [x] Tested locally with Docker (`docker compose up -d --build`)
- [x] Verified behavior in browser at `http://localhost:3000`
- [x] API endpoints tested — mosaic viewer, thumbnail generation
- [x] Relevant unit/integration tests pass

### Steps to verify:
1. Open the Mosaic Creator wizard
2. Verify the third dropdown is now "Filter" (showing F1130W, F444W, etc.) instead of "Instrument"
3. Select a Target — verify Stage dropdown only shows stages present for that target
4. Select a Stage — verify Filter dropdown only shows filters present for that target+stage combination
5. Change Target to one that doesn't have the currently-selected Stage — verify Stage auto-resets to "All Stages"
6. Generate and save a mosaic FITS to library
7. Close the wizard and verify the mosaic appears on the dashboard with a thumbnail
8. Click the mosaic to open it in the image viewer — verify it loads and displays correctly

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low — filter UI change is cosmetic, path fix adds `Path.GetFullPath` call and broader prefix-stripping helper, thumbnail enqueue adds one line
- Rollback: Revert commit, existing DB records with correct `/app/data/` paths are unaffected

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All checks pass locally (build, lint, format, tests)