### PR TITLE
fix: trim leading/trailing spaces from search input

### DIFF
--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -119,7 +119,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
   // --- Cascading filter chain ---
 
   const baseFiltered = useMemo(() => {
-    const term = searchTerm.toLowerCase();
+    const term = searchTerm.trim().toLowerCase();
     return data.filter((item) => {
       const matchesArchived = showArchived ? item.isArchived : !item.isArchived;
       const matchesSearch =

--- a/frontend/jwst-frontend/src/components/wizard/MosaicSelectStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/MosaicSelectStep.tsx
@@ -151,8 +151,8 @@ export const MosaicSelectStep: React.FC<MosaicSelectStepProps> = ({
           if (wavelengthFilter !== ALL_FILTER_VALUE && imageFilter !== wavelengthFilter)
             return false;
 
-          if (searchTerm) {
-            const term = searchTerm.toLowerCase();
+          if (searchTerm.trim()) {
+            const term = searchTerm.trim().toLowerCase();
             return (
               img.fileName.toLowerCase().includes(term) ||
               img.imageInfo?.targetName?.toLowerCase().includes(term) ||


### PR DESCRIPTION
## Summary
Fixes search bars not handling leading/trailing whitespace — e.g. searching `" hubble "` returned no results instead of matching `"hubble"`.

## Why
Users who accidentally type spaces before/after their search query get zero results. This is a common UX annoyance — trimming whitespace is standard practice for search inputs.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Changes Made
- Added `.trim()` to the search term in the dashboard filter logic (`JwstDataDashboard.tsx`)
- Added `.trim()` to both the truthiness check and the lowercased comparison in the mosaic select step (`MosaicSelectStep.tsx`)

## Test Plan
- [x] Type a search query with leading/trailing spaces on the dashboard — results match as if spaces were absent
- [x] Type a search query with leading/trailing spaces on the mosaic select step — results match as if spaces were absent
- [x] Normal search without extra spaces still works identically

### Steps to reproduce
1. Start the app and navigate to the dashboard
2. Upload or have at least one file with a known filename (e.g. `hubble`)
3. Type `" hubble "` (with leading/trailing spaces) in the search bar
4. **Expected**: The file appears in results, same as typing `"hubble"` without spaces
5. Navigate to the mosaic wizard select step
6. Repeat the same search with leading/trailing spaces
7. **Expected**: Images filter correctly despite extra whitespace

## Quality Checklist
- [x] Code follows project conventions
- [x] TypeScript types are properly defined
- [x] No ESLint warnings introduced
- [x] Error states handled appropriately
- [x] Loading states handled appropriately

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt added (explain below)
- [ ] Tech debt reduced (explain below)

## Risk & Rollback
Risk: Minimal — only adds `.trim()` to search filtering, no behavior change for inputs without whitespace.
Rollback: Revert this PR.

## Documentation Checklist
- [x] No documentation updates needed