### PR TITLE
fix: resolve SA1204 static member ordering warning

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -2098,6 +2098,33 @@ namespace JwstDataAnalysis.API.Controllers
         private static partial System.Text.RegularExpressions.Regex MyRegex();
 
         /// <summary>
+        /// Convert a stored file path to a relative path for the processing engine.
+        /// Handles both absolute (/app/data/...) and relative (./data/...) stored paths.
+        /// </summary>
+        private static string ToProcessingEngineRelativePath(string filePath)
+        {
+            // Absolute Docker path
+            if (filePath.StartsWith("/app/data/", StringComparison.Ordinal))
+            {
+                return filePath["/app/data/".Length..];
+            }
+
+            // Relative path from /app working directory (e.g. "./data/mosaic/...")
+            if (filePath.StartsWith("./data/", StringComparison.Ordinal))
+            {
+                return filePath["./data/".Length..];
+            }
+
+            // Relative without dot prefix (e.g. "data/mosaic/...")
+            if (filePath.StartsWith("data/", StringComparison.Ordinal))
+            {
+                return filePath["data/".Length..];
+            }
+
+            return filePath;
+        }
+
+        /// <summary>
         /// Gets the current user ID from JWT claims.
         /// </summary>
         private string? GetCurrentUserId()
@@ -2225,33 +2252,6 @@ namespace JwstDataAnalysis.API.Controllers
                 // Thumbnail
                 HasThumbnail = model.ThumbnailData != null,
             };
-        }
-
-        /// <summary>
-        /// Convert a stored file path to a relative path for the processing engine.
-        /// Handles both absolute (/app/data/...) and relative (./data/...) stored paths.
-        /// </summary>
-        private static string ToProcessingEngineRelativePath(string filePath)
-        {
-            // Absolute Docker path
-            if (filePath.StartsWith("/app/data/", StringComparison.Ordinal))
-            {
-                return filePath["/app/data/".Length..];
-            }
-
-            // Relative path from /app working directory (e.g. "./data/mosaic/...")
-            if (filePath.StartsWith("./data/", StringComparison.Ordinal))
-            {
-                return filePath["./data/".Length..];
-            }
-
-            // Relative without dot prefix (e.g. "data/mosaic/...")
-            if (filePath.StartsWith("data/", StringComparison.Ordinal))
-            {
-                return filePath["data/".Length..];
-            }
-
-            return filePath;
         }
     }
 


### PR DESCRIPTION
## Summary
- Move `ToProcessingEngineRelativePath()` static method above non-static private methods in `JwstDataController.cs`

## Why
StyleCop SA1204 requires static members to appear before non-static members. This was the only remaining warning in the backend build with `--warnaserror`, causing the compliance check to fail.

## Type of Change
- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe):

## Changes Made
- Moved `private static string ToProcessingEngineRelativePath()` from line 2234 (after non-static methods) to line 2100 (grouped with other static methods `FormatFileSize` and `MyRegex`)

## Test Plan
- [x] Backend builds with `--warnaserror` and 0 warnings
- [x] All 258 backend tests pass
- [ ] No functional changes — method just moved within the same class

## Documentation Checklist
- [ ] Updated `docs/key-files.md`
- [ ] Updated `docs/standards/backend-development.md`
- [ ] Updated `docs/architecture.md`
- [ ] Updated `docs/quick-reference.md`
- [ ] Updated `docs/development-plan.md`
- [x] No documentation updates needed

## Tech Debt Impact
- [ ] No new tech debt introduced
- [ ] Adds tech debt (explain):
- [x] Reduces existing tech debt

## Risk & Rollback
Risk: None — pure code reorder within a single class, no functional changes.
Rollback: Revert this PR.

## Quality Checklist
- [x] Code follows project conventions
- [x] No new ESLint/Ruff warnings introduced
- [x] All existing tests pass (258 .NET)
- [x] Changes tested manually
- [x] No security concerns introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)