### PR TITLE
docs: add B3 multi-channel composite epic to development plan

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -246,6 +246,22 @@ Complete React frontend application with advanced FITS visualization capabilitie
 
 **Detailed Plan**: This epic is fully tracked in the table above (B2.1-B2.6) and related PR history.
 
+##### **B3: Multi-Channel Composite (4+ filters)** - Extend RGB composite to support N-channel color mapping
+
+NASA's published JWST composites typically use 4–6 filters mapped to distinct color channels (e.g., Southern Ring Nebula MIRI uses F770W→Blue, F1130W→Cyan, F1280W→Green, F1800W→Red). The current wizard only supports 3 channels (R/G/B), which limits how closely users can recreate reference images.
+
+| Task   | Description                                                                        | Blocked By   | Status   |
+| ------ | ---------------------------------------------------------------------------------- | ------------ | -------- |
+| B3.1   | N-channel color mapping engine (processing engine — map N filters to RGB via hue)  | —            | [ ]      |
+| B3.2   | Backend API support for N-channel composite requests                               | B3.1         | [ ]      |
+| B3.3   | Wizard UI: dynamic channel list with color picker / wavelength-to-hue auto-assign  | B3.2         | [ ]      |
+| B3.4   | Luminance channel support (L in LRGB — broadband or combined for detail)           | B3.1         | [ ]      |
+| B3.5   | Preset color mappings for common JWST filter sets (NIRCam, MIRI)                   | B3.3         | [ ]      |
+
+**Motivation**: Professional tools like PixInsight and SAOImageDS9 support arbitrary filter-to-hue mapping. JWST programs routinely observe in 4–8 filters per target. Limiting to 3 channels forces users to either drop filters or awkwardly combine filters into a single channel.
+
+**Related**: Issue #357 (refine default stretch/background neutralization)
+
 #### **Image Analysis (C-series):**
 
 - [x] C2: Region selection and statistics (mean, median, std, min, max, sum, pixel count)


### PR DESCRIPTION
## Summary
Adds B3: Multi-Channel Composite (4+ filters) as the next epic in the Color & Composite series, after the completed B1 (RGB Composite) and B2 (WCS Mosaic) epics.

## Why
NASA's published JWST composites routinely use 4–6 filters mapped to distinct hues (e.g., Southern Ring Nebula MIRI uses 4 filters: F770W→Blue, F1130W→Cyan, F1280W→Green, F1800W→Red). The current wizard only supports 3 channels (R/G/B), which limits how closely users can recreate reference images. This roadmap item tracks the work to close that gap.

## Type of Change
- [x] Documentation

## Changes Made
- Added B3 epic with 5 tasks (B3.1–B3.5) to `docs/development-plan.md`
- Tasks cover: N-channel color mapping engine, backend API, wizard UI with dynamic channels + color picker, luminance (LRGB) support, and preset filter mappings
- Links to related issue #357 (refine default stretch/background neutralization)

## Test Plan
- [x] Verify `docs/development-plan.md` renders correctly on GitHub
- [x] Confirm B3 section appears after B2 and before the C-series

## Documentation Checklist
- [x] `docs/development-plan.md` — updated (this is the change)
- [x] No new endpoints, controllers, or components added

## Tech Debt Impact
- [x] No tech debt impact — documentation only

## Risk & Rollback
Risk: None — documentation-only change.
Rollback: Revert the commit.

## Quality Checklist
- [x] Changes are minimal and focused
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)