### PR TITLE
feat: add N-channel color mapping engine for multi-filter composites

### DIFF
--- a/processing-engine/app/composite/color_mapping.py
+++ b/processing-engine/app/composite/color_mapping.py
@@ -1,0 +1,120 @@
+"""
+N-channel color mapping engine for multi-filter JWST composites.
+
+Maps N filters to RGB via hue-based color assignment. Each filter gets a color
+(hue or explicit RGB weight), and their contributions are summed to produce
+a final RGB image.
+"""
+
+import colorsys
+import math
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def hue_to_rgb_weights(hue_degrees: float) -> tuple[float, float, float]:
+    """Convert a hue angle (in degrees) to RGB weights.
+
+    Uses HSV→RGB conversion with full saturation and value to produce
+    a pure-color weight vector suitable for tinting astronomical data.
+
+    Args:
+        hue_degrees: Hue angle in degrees (0-360). Values outside this
+            range are wrapped via modulo 360.
+
+    Returns:
+        Tuple of (r, g, b) weights, each in [0, 1].
+    """
+    hue_normalized = (hue_degrees % 360) / 360.0
+    r, g, b = colorsys.hsv_to_rgb(hue_normalized, 1.0, 1.0)
+    return (r, g, b)
+
+
+def wavelength_to_hue(wavelength_um: float) -> float:
+    """Map a JWST filter wavelength to a hue angle.
+
+    Uses log-scale mapping across the JWST wavelength range (0.6-28 µm).
+    Shorter wavelengths map to blue (270°), longer to red (0°).
+    The hue range is 0-270°, skipping magenta which has no physical
+    wavelength equivalent.
+
+    Log scale ensures NIRCam (0.7-5 µm) and MIRI (5-28 µm) each get
+    a balanced portion of the color space.
+
+    Args:
+        wavelength_um: Filter wavelength in micrometers. Values outside
+            the 0.6-28 µm range are clamped to the boundaries.
+
+    Returns:
+        Hue angle in degrees (0-270).
+    """
+    wl_min = 0.6
+    wl_max = 28.0
+    hue_max = 270.0
+
+    clamped = max(wl_min, min(wl_max, wavelength_um))
+
+    log_min = math.log(wl_min)
+    log_max = math.log(wl_max)
+    log_wl = math.log(clamped)
+
+    # Normalize to [0, 1] where 0 = shortest, 1 = longest
+    t = (log_wl - log_min) / (log_max - log_min)
+
+    # Invert: shortest wavelength → highest hue (blue), longest → 0 (red)
+    hue = hue_max * (1.0 - t)
+
+    return hue
+
+
+def combine_channels_to_rgb(
+    channels: list[tuple[NDArray, tuple[float, float, float]]],
+) -> NDArray:
+    """Combine N stretched channels into a single RGB image.
+
+    Each channel contributes to the final image weighted by its RGB color.
+    The result is normalized per-component (R, G, B independently) to [0, 1].
+
+    Args:
+        channels: List of (data, rgb_weights) tuples where:
+            - data: 2D numpy array [H, W] of stretched pixel values
+            - rgb_weights: (r, g, b) tuple of color weights, each in [0, 1]
+
+    Returns:
+        3D numpy array [H, W, 3] with values in [0, 1], dtype float64.
+
+    Raises:
+        ValueError: If channels list is empty or array shapes don't match.
+    """
+    if not channels:
+        raise ValueError("At least one channel is required")
+
+    # Validate all arrays have the same 2D shape
+    ref_shape = channels[0][0].shape
+    if len(ref_shape) != 2:
+        raise ValueError(f"Channel data must be 2D, got shape {ref_shape}")
+
+    for i, (data, _) in enumerate(channels[1:], start=1):
+        if data.shape != ref_shape:
+            raise ValueError(
+                f"Channel {i} shape {data.shape} doesn't match channel 0 shape {ref_shape}"
+            )
+
+    h, w = ref_shape
+    rgb = np.zeros((h, w, 3), dtype=np.float64)
+
+    for data, (wr, wg, wb) in channels:
+        arr = data.astype(np.float64)
+        rgb[:, :, 0] += arr * wr
+        rgb[:, :, 1] += arr * wg
+        rgb[:, :, 2] += arr * wb
+
+    # Per-component normalization to [0, 1]
+    for c in range(3):
+        component = rgb[:, :, c]
+        c_max = component.max()
+        if c_max > 0:
+            component /= c_max
+
+    return rgb

--- a/processing-engine/app/composite/models.py
+++ b/processing-engine/app/composite/models.py
@@ -4,7 +4,7 @@ Pydantic models for composite image generation.
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 CurveType = Literal["linear", "s_curve", "inverse_s", "shadows", "highlights"]
@@ -82,3 +82,61 @@ class CompositeResponse(BaseModel):
     width: int
     height: int
     format: str
+
+
+# --- N-Channel Composite Models (B3.1) ---
+
+
+class ChannelColor(BaseModel):
+    """Color assignment for a single channel — either hue or explicit RGB weights."""
+
+    hue: float | None = Field(default=None, ge=0, le=360, description="Hue angle (0-360°)")
+    rgb: tuple[float, float, float] | None = Field(
+        default=None, description="Explicit RGB weights, each in [0, 1]"
+    )
+
+    @model_validator(mode="after")
+    def exactly_one_color_spec(self) -> "ChannelColor":
+        if self.hue is not None and self.rgb is not None:
+            raise ValueError("Provide either hue or rgb, not both")
+        if self.hue is None and self.rgb is None:
+            raise ValueError("Provide either hue or rgb")
+        return self
+
+    @field_validator("rgb")
+    @classmethod
+    def rgb_components_in_range(cls, v: tuple[float, float, float] | None):
+        if v is not None:
+            for i, component in enumerate(v):
+                if not 0.0 <= component <= 1.0:
+                    raise ValueError(f"RGB component {i} value {component} outside [0, 1]")
+        return v
+
+
+class NChannelConfig(ChannelConfig):
+    """Configuration for a single channel in an N-channel composite."""
+
+    color: ChannelColor = Field(..., description="Color assignment for this channel")
+    label: str | None = Field(default=None, description="Filter name (e.g. 'F444W')")
+    wavelength_um: float | None = Field(
+        default=None, gt=0, description="Filter wavelength in micrometers"
+    )
+
+
+class NChannelCompositeRequest(BaseModel):
+    """Request to generate an N-channel composite image."""
+
+    channels: list[NChannelConfig] = Field(
+        ..., min_length=1, description="Channel configurations with color assignments"
+    )
+    overall: OverallAdjustments | None = Field(
+        default=None, description="Optional global post-stack levels and stretch adjustments"
+    )
+    background_neutralization: bool = Field(
+        default=True,
+        description="Subtract per-channel sky background to neutralize color casts",
+    )
+    output_format: Literal["png", "jpeg"] = Field(default="png", description="Output image format")
+    quality: int = Field(default=95, ge=1, le=100, description="JPEG quality (1-100)")
+    width: int = Field(default=1000, gt=0, le=4096, description="Output image width")
+    height: int = Field(default=1000, gt=0, le=4096, description="Output image height")

--- a/processing-engine/tests/test_color_mapping.py
+++ b/processing-engine/tests/test_color_mapping.py
@@ -1,0 +1,265 @@
+"""Tests for the N-channel color mapping engine."""
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from app.composite.color_mapping import (
+    combine_channels_to_rgb,
+    hue_to_rgb_weights,
+    wavelength_to_hue,
+)
+from app.composite.models import ChannelColor
+
+
+class TestHueToRgbWeights:
+    """Tests for hue_to_rgb_weights conversion."""
+
+    def test_red_at_0_degrees(self):
+        r, g, b = hue_to_rgb_weights(0)
+        assert r == pytest.approx(1.0)
+        assert g == pytest.approx(0.0)
+        assert b == pytest.approx(0.0)
+
+    def test_green_at_120_degrees(self):
+        r, g, b = hue_to_rgb_weights(120)
+        assert r == pytest.approx(0.0)
+        assert g == pytest.approx(1.0)
+        assert b == pytest.approx(0.0)
+
+    def test_blue_at_240_degrees(self):
+        r, g, b = hue_to_rgb_weights(240)
+        assert r == pytest.approx(0.0)
+        assert g == pytest.approx(0.0)
+        assert b == pytest.approx(1.0)
+
+    def test_yellow_at_60_degrees(self):
+        r, g, b = hue_to_rgb_weights(60)
+        assert r == pytest.approx(1.0)
+        assert g == pytest.approx(1.0)
+        assert b == pytest.approx(0.0)
+
+    def test_cyan_at_180_degrees(self):
+        r, g, b = hue_to_rgb_weights(180)
+        assert r == pytest.approx(0.0)
+        assert g == pytest.approx(1.0)
+        assert b == pytest.approx(1.0)
+
+    def test_magenta_at_300_degrees(self):
+        r, g, b = hue_to_rgb_weights(300)
+        assert r == pytest.approx(1.0)
+        assert g == pytest.approx(0.0)
+        assert b == pytest.approx(1.0)
+
+    def test_360_wraps_to_red(self):
+        assert hue_to_rgb_weights(360) == pytest.approx(hue_to_rgb_weights(0))
+
+    def test_negative_wraps(self):
+        # -60° should equal 300°
+        assert hue_to_rgb_weights(-60) == pytest.approx(hue_to_rgb_weights(300))
+
+    def test_large_value_wraps(self):
+        assert hue_to_rgb_weights(480) == pytest.approx(hue_to_rgb_weights(120))
+
+    def test_all_components_in_range(self):
+        """Property: all outputs should be in [0, 1] for any hue."""
+        for hue in range(0, 360, 5):
+            r, g, b = hue_to_rgb_weights(hue)
+            assert 0.0 <= r <= 1.0, f"r={r} out of range at hue={hue}"
+            assert 0.0 <= g <= 1.0, f"g={g} out of range at hue={hue}"
+            assert 0.0 <= b <= 1.0, f"b={b} out of range at hue={hue}"
+
+
+class TestWavelengthToHue:
+    """Tests for wavelength_to_hue mapping."""
+
+    def test_shortest_wavelength_maps_to_blue(self):
+        hue = wavelength_to_hue(0.6)
+        assert hue == pytest.approx(270.0)
+
+    def test_longest_wavelength_maps_to_red(self):
+        hue = wavelength_to_hue(28.0)
+        assert hue == pytest.approx(0.0)
+
+    def test_monotonically_decreasing(self):
+        """Longer wavelengths should produce lower hue values."""
+        wavelengths = [0.7, 1.0, 2.0, 5.0, 10.0, 20.0, 28.0]
+        hues = [wavelength_to_hue(wl) for wl in wavelengths]
+        for i in range(len(hues) - 1):
+            assert hues[i] > hues[i + 1], (
+                f"Not monotonically decreasing: hue({wavelengths[i]})={hues[i]} "
+                f"<= hue({wavelengths[i + 1]})={hues[i + 1]}"
+            )
+
+    def test_clamping_below_range(self):
+        """Wavelengths below 0.6 µm should clamp to boundary."""
+        assert wavelength_to_hue(0.1) == pytest.approx(wavelength_to_hue(0.6))
+
+    def test_clamping_above_range(self):
+        """Wavelengths above 28 µm should clamp to boundary."""
+        assert wavelength_to_hue(100.0) == pytest.approx(wavelength_to_hue(28.0))
+
+    def test_hue_within_valid_range(self):
+        """All hues should be in [0, 270]."""
+        wavelengths = [0.6, 0.7, 1.0, 2.0, 5.0, 10.0, 15.0, 20.0, 28.0]
+        for wl in wavelengths:
+            hue = wavelength_to_hue(wl)
+            assert 0.0 <= hue <= 270.0, f"hue={hue} out of range at wl={wl}"
+
+    def test_log_distribution_balance(self):
+        """Mid-point of JWST range (geometric mean) should map near mid-hue."""
+        import math
+
+        geometric_mid = math.sqrt(0.6 * 28.0)
+        hue = wavelength_to_hue(geometric_mid)
+        assert hue == pytest.approx(135.0, abs=1.0)
+
+
+class TestCombineChannelsToRgb:
+    """Tests for combine_channels_to_rgb."""
+
+    def test_three_channel_basic(self):
+        """3-channel with pure R/G/B weights should produce expected result."""
+        h, w = 10, 10
+        r_data = np.ones((h, w)) * 0.8
+        g_data = np.ones((h, w)) * 0.5
+        b_data = np.ones((h, w)) * 0.3
+
+        channels = [
+            (r_data, (1.0, 0.0, 0.0)),
+            (g_data, (0.0, 1.0, 0.0)),
+            (b_data, (0.0, 0.0, 1.0)),
+        ]
+        result = combine_channels_to_rgb(channels)
+
+        assert result.shape == (h, w, 3)
+        # Per-component normalization: each channel's max becomes 1.0
+        assert result[0, 0, 0] == pytest.approx(1.0)  # 0.8/0.8
+        assert result[0, 0, 1] == pytest.approx(1.0)  # 0.5/0.5
+        assert result[0, 0, 2] == pytest.approx(1.0)  # 0.3/0.3
+
+    def test_single_channel_monochromatic(self):
+        """Single channel with a hue should produce monochromatic image."""
+        h, w = 5, 5
+        data = np.ones((h, w)) * 0.7
+        # Yellow weights: R=1, G=1, B=0
+        channels = [(data, (1.0, 1.0, 0.0))]
+        result = combine_channels_to_rgb(channels)
+
+        assert result.shape == (h, w, 3)
+        assert result[0, 0, 0] == pytest.approx(1.0)
+        assert result[0, 0, 1] == pytest.approx(1.0)
+        assert result[0, 0, 2] == pytest.approx(0.0)
+
+    def test_five_channel_combination(self):
+        """Five channels combine correctly with various hues."""
+        h, w = 8, 8
+        channels = []
+        for i in range(5):
+            data = np.ones((h, w)) * (i + 1) * 0.1
+            hue = i * 60  # 0, 60, 120, 180, 240
+            from app.composite.color_mapping import hue_to_rgb_weights
+
+            weights = hue_to_rgb_weights(hue)
+            channels.append((data, weights))
+
+        result = combine_channels_to_rgb(channels)
+        assert result.shape == (h, w, 3)
+        # All values should be in [0, 1]
+        assert result.min() >= 0.0
+        assert result.max() <= 1.0
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="At least one channel"):
+            combine_channels_to_rgb([])
+
+    def test_mismatched_shapes_raises(self):
+        a = np.ones((10, 10))
+        b = np.ones((10, 12))
+        with pytest.raises(ValueError, match="doesn't match"):
+            combine_channels_to_rgb([(a, (1, 0, 0)), (b, (0, 1, 0))])
+
+    def test_3d_input_raises(self):
+        a = np.ones((10, 10, 3))
+        with pytest.raises(ValueError, match="must be 2D"):
+            combine_channels_to_rgb([(a, (1, 0, 0))])
+
+    def test_all_zero_data(self):
+        """All-zero data should produce all-zero output."""
+        h, w = 5, 5
+        data = np.zeros((h, w))
+        channels = [(data, (1.0, 0.0, 0.0)), (data, (0.0, 1.0, 0.0))]
+        result = combine_channels_to_rgb(channels)
+        np.testing.assert_array_equal(result, np.zeros((h, w, 3)))
+
+    def test_output_shape_various_n(self):
+        """Output is always [H, W, 3] regardless of N."""
+        h, w = 6, 8
+        for n in [1, 2, 3, 4, 6]:
+            channels = [(np.ones((h, w)), (0.5, 0.5, 0.5))] * n
+            result = combine_channels_to_rgb(channels)
+            assert result.shape == (h, w, 3), f"Wrong shape for N={n}"
+
+    def test_output_dtype_float64(self):
+        data = np.ones((4, 4), dtype=np.float32)
+        result = combine_channels_to_rgb([(data, (1.0, 0.0, 0.0))])
+        assert result.dtype == np.float64
+
+    def test_varying_pixel_values(self):
+        """Non-uniform data should normalize correctly."""
+        data = np.array([[1.0, 0.5], [0.25, 0.0]])
+        channels = [(data, (1.0, 0.0, 0.0))]
+        result = combine_channels_to_rgb(channels)
+        # Max red value is 1.0, so normalized: 1.0, 0.5, 0.25, 0.0
+        assert result[0, 0, 0] == pytest.approx(1.0)
+        assert result[0, 1, 0] == pytest.approx(0.5)
+        assert result[1, 0, 0] == pytest.approx(0.25)
+        assert result[1, 1, 0] == pytest.approx(0.0)
+
+
+class TestChannelColorModel:
+    """Tests for the ChannelColor Pydantic model."""
+
+    def test_hue_only_valid(self):
+        color = ChannelColor(hue=120.0)
+        assert color.hue == 120.0
+        assert color.rgb is None
+
+    def test_rgb_only_valid(self):
+        color = ChannelColor(rgb=(0.5, 0.3, 0.8))
+        assert color.rgb == (0.5, 0.3, 0.8)
+        assert color.hue is None
+
+    def test_both_raises(self):
+        with pytest.raises(ValidationError, match="not both"):
+            ChannelColor(hue=120.0, rgb=(0.5, 0.3, 0.8))
+
+    def test_neither_raises(self):
+        with pytest.raises(ValidationError, match="either hue or rgb"):
+            ChannelColor()
+
+    def test_hue_out_of_range_raises(self):
+        with pytest.raises(ValidationError):
+            ChannelColor(hue=400.0)
+
+    def test_hue_negative_raises(self):
+        with pytest.raises(ValidationError):
+            ChannelColor(hue=-10.0)
+
+    def test_rgb_component_out_of_range_raises(self):
+        with pytest.raises(ValidationError, match="outside"):
+            ChannelColor(rgb=(1.5, 0.0, 0.0))
+
+    def test_rgb_negative_component_raises(self):
+        with pytest.raises(ValidationError, match="outside"):
+            ChannelColor(rgb=(0.0, -0.1, 0.0))
+
+    def test_hue_boundary_values(self):
+        assert ChannelColor(hue=0.0).hue == 0.0
+        assert ChannelColor(hue=360.0).hue == 360.0
+
+    def test_rgb_boundary_values(self):
+        color = ChannelColor(rgb=(0.0, 0.0, 0.0))
+        assert color.rgb == (0.0, 0.0, 0.0)
+        color = ChannelColor(rgb=(1.0, 1.0, 1.0))
+        assert color.rgb == (1.0, 1.0, 1.0)


### PR DESCRIPTION
## Summary
Adds the core B3.1 N-channel color mapping engine — pure Python functions and Pydantic models that map N JWST filters to RGB via hue-based color assignment. This is the foundation that B3.2 (API) and B3.3 (UI) will build on.

## Why
The current composite pipeline is hardcoded to 3 channels (R/G/B). NASA JWST composites typically use 4-6 filters mapped to distinct colors. This engine enables that by providing hue→RGB conversion, wavelength→hue mapping, and N-channel combination with per-component normalization.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test update
- [ ] Other (describe):

## Changes Made
- Added `processing-engine/app/composite/color_mapping.py` with three pure functions:
  - `hue_to_rgb_weights()` — converts hue angle to RGB weight vector via `colorsys`
  - `wavelength_to_hue()` — log-scale mapping of JWST wavelength range (0.6-28 µm) to hue (0-270°)
  - `combine_channels_to_rgb()` — accumulates N weighted channels into [H,W,3] RGB with per-component normalization
- Added three new Pydantic models to `processing-engine/app/composite/models.py` (append-only, no existing models modified):
  - `ChannelColor` — hue OR rgb color spec with mutual exclusion validator
  - `NChannelConfig` — extends `ChannelConfig` with color, label, and wavelength fields
  - `NChannelCompositeRequest` — N-channel equivalent of `CompositeRequest`
- Added `processing-engine/tests/test_color_mapping.py` with 37 tests across 4 test classes

## Test Plan
- [x] Rebuild the processing engine: `docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d --build processing-engine`
- [x] Run the new tests: `docker exec jwst-processing python -m pytest tests/test_color_mapping.py -v` — all 37 pass
- [x] Run the full suite: `docker exec jwst-processing python -m pytest -v` — all 261 tests pass, zero regressions
- [x] Verify no existing composite behavior changed — `CompositeRequest`, `ChannelConfig`, and all existing models are untouched

## Documentation Checklist
- [ ] `docs/development-plan.md` updated (N/A — B3 epic already added in #359)
- [ ] `docs/key-files.md` updated (N/A — new file will be added when API endpoint is created in B3.2)
- [x] `docs/standards/backend-development.md` updated (N/A — no new controllers/endpoints in this PR)
- [x] No documentation updates needed (engine-only, no API or endpoint changes)

## Tech Debt Impact
- [ ] Adds new tech debt (explain below)
- [x] No impact on tech debt
- [ ] Reduces existing tech debt

## Risk & Rollback
Risk: Very low — all new code, no existing code modified. The new models are append-only additions to models.py with the only import change being adding `field_validator` and `model_validator` from pydantic.
Rollback: Delete the two new files and revert the models.py additions.

## Quality Checklist
- [x] Code follows project conventions
- [x] Tests pass locally
- [x] No unnecessary changes included
- [x] Error handling is appropriate
- [x] No security concerns introduced