### PR TITLE
docs: add F1 S3 direct access epic to development plan

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -263,6 +263,24 @@ NASA's published JWST composites typically use 4–6 filters mapped to distinct 
 
 **Related**: Issue #357 (refine default stretch/background neutralization)
 
+#### **Data Acquisition (F-series):**
+
+##### **F1: S3 Direct Access for FITS Downloads** — Use `s3://stpubdata/jwst/public/` for faster data access
+
+STScI mirrors the full JWST public archive on AWS S3 (`s3://stpubdata/jwst/public/`). Downloading via S3 is significantly faster than HTTP from MAST (no rate limiting, AWS-native throughput, supports multipart downloads). The bucket is public — no authentication required, only a `--no-sign-request` flag.
+
+| Task   | Description                                                                     | Blocked By   | Status   |
+| ------ | ------------------------------------------------------------------------------- | ------------ | -------- |
+| F1.1   | S3 client integration in processing engine (boto3, anonymous access)            | —            | [ ]      |
+| F1.2   | S3 path resolution — map MAST observation metadata to S3 key paths              | F1.1         | [ ]      |
+| F1.3   | Download engine: S3 multipart download with progress tracking                   | F1.1         | [ ]      |
+| F1.4   | Backend API to select download source (S3 preferred, HTTP fallback)             | F1.2, F1.3   | [ ]      |
+| F1.5   | Frontend: download source indicator and preference setting                      | F1.4         | [ ]      |
+
+**Why**: Current HTTP downloads from MAST are slow for large programs (dozens of FITS files, often >100 MB each). S3 access removes the bottleneck and is the same source professional pipelines use.
+
+**Placement**: Start after B3 (Multi-Channel Composite) is complete.
+
 #### **Image Analysis (C-series):**
 
 - [x] C2: Region selection and statistics (mean, median, std, min, max, sum, pixel count)


### PR DESCRIPTION
## Summary
- Adds new **Data Acquisition (F-series)** section to the Phase 4 development plan
- Introduces **F1: S3 Direct Access for FITS Downloads** — 5 tasks covering boto3 integration, S3 path resolution, multipart downloads, backend API, and frontend indicator
- Scheduled to start after B3 (Multi-Channel Composite) completes

## Why
STScI mirrors the full JWST public archive on AWS S3 (`s3://stpubdata/jwst/public/`). S3 downloads are significantly faster than HTTP from MAST — no rate limiting, native AWS throughput, and multipart support. This is the same source professional pipelines use, and will dramatically improve the data acquisition experience for large programs.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Enhancement to existing feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation only
- [ ] Infrastructure/CI

## Changes Made
- Added `Data Acquisition (F-series)` section to Phase 4 in `docs/development-plan.md`
- Added F1 epic with 5 subtasks (F1.1–F1.5) covering the full stack from processing engine to frontend
- Placed after B3 section, before C-series, with explicit note to start after B3 completes

## Test Plan
- [x] Open `docs/development-plan.md` and verify F-series section appears between B3 and C-series
- [x] Confirm F1 task table renders correctly with 5 rows (F1.1–F1.5)
- [x] Confirm placement note says "Start after B3 (Multi-Channel Composite) is complete"

## Documentation Checklist
- [x] `docs/development-plan.md` — updated (this PR)
- [x] `docs/key-files.md` — no new files added
- [x] `docs/standards/backend-development.md` — no new endpoints
- [x] `docs/architecture.md` — no architecture changes
- [x] `docs/quick-reference.md` — no new endpoints

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt added (explain below)
- [ ] Tech debt reduced (explain below)

## Risk & Rollback
Risk: None — documentation-only change.
Rollback: Revert the commit.

## Quality Checklist
- [x] Changes are focused and minimal
- [x] No unrelated modifications included
- [x] Self-reviewed the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)