### PR TITLE
fix: increase default FITS file size limit from 2GB to 4GB

### DIFF
--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -39,8 +39,8 @@ ALLOWED_DATA_DIR = Path(os.environ.get("DATA_DIR", "/app/data")).resolve()
 # Resource limits for FITS processing (configurable via environment)
 # Prevents memory exhaustion from processing extremely large files (DoS protection)
 MAX_FITS_FILE_SIZE_BYTES = (
-    int(os.environ.get("MAX_FITS_FILE_SIZE_MB", "2048")) * 1024 * 1024
-)  # Default 2GB
+    int(os.environ.get("MAX_FITS_FILE_SIZE_MB", "4096")) * 1024 * 1024
+)  # Default 4GB
 MAX_FITS_ARRAY_ELEMENTS = int(
     os.environ.get("MAX_FITS_ARRAY_ELEMENTS", "100000000")
 )  # Default 100M pixels


### PR DESCRIPTION
## Summary
- Increases the default `MAX_FITS_FILE_SIZE_MB` from 2048 (2GB) to 4096 (4GB) in the processing engine
- Fixes 413 errors when viewing large JWST mosaic products

## Why
Large JWST mosaic products like `jw05552-o008_t008_nircam_clear-f200w_i2d.fits` (3.5 GB) are blocked by the 2 GB default file size limit. All viewer endpoints (`/preview`, `/histogram`, `/pixeldata`, `/cubeinfo`) return 413 before even attempting to load the data. The actual memory safety is already enforced by the separate `MAX_FITS_ARRAY_ELEMENTS` limit (100M pixels), so the raw file size check can be more generous.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation only
- [ ] Infrastructure/CI

## Changes Made
- Changed default value for `MAX_FITS_FILE_SIZE_MB` from `"2048"` to `"4096"` in `processing-engine/main.py`

## Test Plan
- [x] Find a FITS file >2 GB in the application (e.g. `jw05552-o008_t008_nircam_clear-f200w_i2d.fits` at 3.5 GB)
- [x] Click to view it — confirm it no longer returns a 413 error
- [x] Verify the preview, histogram, and pixel data all load successfully

## Documentation Checklist
- [x] `docs/development-plan.md` — no changes needed
- [x] `docs/key-files.md` — no new files
- [x] `docs/standards/backend-development.md` — no new endpoints
- [x] `docs/architecture.md` — no architecture changes
- [x] `docs/quick-reference.md` — no new endpoints

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt added (explain below)
- [ ] Tech debt reduced (explain below)

## Risk & Rollback
Risk: Low — increases a safety limit by 2x. Memory safety is still enforced by the array element limit. The limit remains configurable via `MAX_FITS_FILE_SIZE_MB` env var.
Rollback: Revert the commit or set `MAX_FITS_FILE_SIZE_MB=2048` in docker-compose environment.

## Quality Checklist
- [x] Changes are focused and minimal
- [x] No unrelated modifications included
- [x] Self-reviewed the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)