### PR TITLE
fix: increase default FITS array element limit from 100M to 200M

### DIFF
--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -42,8 +42,8 @@ MAX_FITS_FILE_SIZE_BYTES = (
     int(os.environ.get("MAX_FITS_FILE_SIZE_MB", "4096")) * 1024 * 1024
 )  # Default 4GB
 MAX_FITS_ARRAY_ELEMENTS = int(
-    os.environ.get("MAX_FITS_ARRAY_ELEMENTS", "100000000")
-)  # Default 100M pixels
+    os.environ.get("MAX_FITS_ARRAY_ELEMENTS", "200000000")
+)  # Default 200M pixels
 
 
 def validate_file_path(file_path: str) -> Path:


### PR DESCRIPTION
## Summary
- Increases the default `MAX_FITS_ARRAY_ELEMENTS` from 100,000,000 to 200,000,000 in the processing engine
- Fixes 413 errors when viewing large JWST L3 mosaic products

## Why
JWST Level 3 mosaic products like `jw05552-o008_t008_nircam_clear-f200w_i2d.fits` have dimensions of ~10,770 x 10,770 = 116M pixels, which exceeds the 100M pixel limit. The viewer downscales images to 1200px max before rendering, so actual memory usage is well within safe bounds. This was the second layer blocking the same file after the file size limit was fixed in #363.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation only
- [ ] Infrastructure/CI

## Changes Made
- Changed default value for `MAX_FITS_ARRAY_ELEMENTS` from `"100000000"` to `"200000000"` in `processing-engine/main.py`

## Test Plan
- [x] Find the jw05552 NIRCam F200W i2d file (3.5 GB, 116M pixels) in the application
- [x] Click to view it — confirm preview loads without 413 error
- [x] Verify histogram and pixel data endpoints also respond successfully

## Documentation Checklist
- [x] `docs/development-plan.md` — no changes needed
- [x] `docs/key-files.md` — no new files
- [x] `docs/standards/backend-development.md` — no new endpoints
- [x] `docs/architecture.md` — no architecture changes
- [x] `docs/quick-reference.md` — no new endpoints

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt added (explain below)
- [ ] Tech debt reduced (explain below)

## Risk & Rollback
Risk: Low — increases a safety limit by 2x. The downscaling step limits actual memory usage regardless. The limit remains configurable via `MAX_FITS_ARRAY_ELEMENTS` env var.
Rollback: Revert the commit or set `MAX_FITS_ARRAY_ELEMENTS=100000000` in docker-compose environment.

## Quality Checklist
- [x] Changes are focused and minimal
- [x] No unrelated modifications included
- [x] Self-reviewed the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)