### PR TITLE
docs: mark B3.1 and B3.2 as complete in development plan

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -252,8 +252,8 @@ NASA's published JWST composites typically use 4–6 filters mapped to distinct 
 
 | Task   | Description                                                                        | Blocked By   | Status   |
 | ------ | ---------------------------------------------------------------------------------- | ------------ | -------- |
-| B3.1   | N-channel color mapping engine (processing engine — map N filters to RGB via hue)  | —            | [ ]      |
-| B3.2   | Backend API support for N-channel composite requests                               | B3.1         | [ ]      |
+| B3.1   | N-channel color mapping engine (processing engine — map N filters to RGB via hue)  | —            | [x]      |
+| B3.2   | Backend API support for N-channel composite requests                               | B3.1         | [x]      |
 | B3.3   | Wizard UI: dynamic channel list with color picker / wavelength-to-hue auto-assign  | B3.2         | [ ]      |
 | B3.4   | Luminance channel support (L in LRGB — broadband or combined for detail)           | B3.1         | [ ]      |
 | B3.5   | Preset color mappings for common JWST filter sets (NIRCam, MIRI)                   | B3.3         | [ ]      |


### PR DESCRIPTION
## Summary
- Marks B3.1 (N-channel color mapping engine) and B3.2 (backend API) as complete in the development plan
- These were completed in PRs #360 and #361 but checkboxes were missed

## Why
The dev plan task checkboxes fell out of sync with actual progress. B3.1 and B3.2 were merged but still showed `[ ]`. Added a process rule to update checkboxes in the same PR going forward.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactoring (no functional changes)
- [x] Documentation only
- [ ] Infrastructure/CI

## Changes Made
- Changed B3.1 and B3.2 status from `[ ]` to `[x]` in `docs/development-plan.md`

## Test Plan
- [x] Verify B3.1 and B3.2 show as checked in the development plan
- [x] Verify no other tasks were accidentally modified

## Documentation Checklist
- [x] `docs/development-plan.md` — updated (this PR)
- [x] `docs/key-files.md` — no changes needed
- [x] `docs/standards/backend-development.md` — no changes needed
- [x] `docs/architecture.md` — no changes needed
- [x] `docs/quick-reference.md` — no changes needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt added (explain below)
- [ ] Tech debt reduced (explain below)

## Risk & Rollback
Risk: None — documentation-only change.
Rollback: Revert the commit.

## Quality Checklist
- [x] Changes are focused and minimal
- [x] No unrelated modifications included
- [x] Self-reviewed the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)