### PR TITLE
test: add comprehensive E2E test suite with 53 new tests

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -894,6 +894,7 @@ namespace JwstDataAnalysis.API.Controllers
                     UploadDate = DateTime.UtcNow,
                     ProcessingStatus = ProcessingStatuses.Pending,
                     FileFormat = extension.TrimStart('.'),
+                    UserId = GetCurrentUserId(),
 
                     // Basic image metadata if it's an image
                     ImageInfo = (dataType == DataTypes.Image) ? new ImageMetadata { Format = extension.TrimStart('.') } : null,

--- a/frontend/jwst-frontend/e2e/auth.spec.ts
+++ b/frontend/jwst-frontend/e2e/auth.spec.ts
@@ -8,9 +8,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-
-// Generate unique usernames to avoid conflicts between test runs
-const uniqueId = () => crypto.randomUUID().substring(0, 8);
+import { uniqueId } from './helpers';
 
 test.describe('Authentication', () => {
   test.describe('Login Page', () => {

--- a/frontend/jwst-frontend/e2e/comparison-viewer.spec.ts
+++ b/frontend/jwst-frontend/e2e/comparison-viewer.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedUserWithData,
+  loginWithTokens,
+  SeedResult,
+} from './helpers';
+
+let seed: SeedResult;
+
+test.describe('Comparison viewer', () => {
+  test.beforeAll(async ({ request }) => {
+    seed = await seedUserWithData(request, { prefix: 'compare', fileCount: 2 });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginWithTokens(page, seed);
+  });
+
+  test('opens comparison image picker via Compare button', async ({ page }) => {
+    await page.getByRole('button', { name: /Compare/i }).click();
+    await expect(page.locator('.comparison-picker-overlay')).toBeVisible();
+    await expect(page.locator('.comparison-picker-modal')).toBeVisible();
+    await expect(page.locator('.comparison-picker-modal h2')).toHaveText(
+      'Select Images to Compare'
+    );
+  });
+
+  test('shows two image selection columns', async ({ page }) => {
+    await page.getByRole('button', { name: /Compare/i }).click();
+    await expect(page.locator('.comparison-picker-modal')).toBeVisible();
+
+    const columns = page.locator('.comparison-picker-column');
+    await expect(columns).toHaveCount(2);
+    await expect(columns.first().locator('h3')).toHaveText('Image A');
+    await expect(columns.last().locator('h3')).toHaveText('Image B');
+  });
+
+  test('shows selectable image items in picker', async ({ page }) => {
+    await page.getByRole('button', { name: /Compare/i }).click();
+    await expect(page.locator('.comparison-picker-modal')).toBeVisible();
+
+    const items = page.locator('.comparison-picker-item');
+    expect(await items.count()).toBeGreaterThanOrEqual(2);
+  });
+
+  test('selects images and enables Compare button', async ({ page }) => {
+    await page.getByRole('button', { name: /Compare/i }).click();
+    await expect(page.locator('.comparison-picker-modal')).toBeVisible();
+
+    // Compare button should be disabled initially
+    const compareBtn = page.locator('.comparison-picker-btn.primary');
+    await expect(compareBtn).toBeDisabled();
+
+    // Select first item in column A (first column)
+    const columnA = page.locator('.comparison-picker-column').first();
+    const columnB = page.locator('.comparison-picker-column').last();
+    await columnA.locator('.comparison-picker-item').first().click();
+
+    // Select first non-disabled item in column B
+    const itemsB = columnB.locator('.comparison-picker-item:not(.disabled)');
+    await itemsB.first().click();
+
+    // Compare button should be enabled
+    await expect(compareBtn).toBeEnabled();
+  });
+
+  test('launches comparison viewer overlay', async ({ page }) => {
+    await page.getByRole('button', { name: /Compare/i }).click();
+    await expect(page.locator('.comparison-picker-modal')).toBeVisible();
+
+    // Select images
+    const columnA = page.locator('.comparison-picker-column').first();
+    const columnB = page.locator('.comparison-picker-column').last();
+    await columnA.locator('.comparison-picker-item').first().click();
+    const itemsB = columnB.locator('.comparison-picker-item:not(.disabled)');
+    await itemsB.first().click();
+
+    // Click Compare
+    await page.locator('.comparison-picker-btn.primary').click();
+
+    // Viewer overlay should appear
+    await expect(page.locator('.comparison-viewer-overlay')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('defaults to blink mode with mode buttons', async ({ page }) => {
+    await page.getByRole('button', { name: /Compare/i }).click();
+
+    const columnA = page.locator('.comparison-picker-column').first();
+    const columnB = page.locator('.comparison-picker-column').last();
+    await columnA.locator('.comparison-picker-item').first().click();
+    const itemsB = columnB.locator('.comparison-picker-item:not(.disabled)');
+    await itemsB.first().click();
+    await page.locator('.comparison-picker-btn.primary').click();
+
+    await expect(page.locator('.comparison-viewer-overlay')).toBeVisible({ timeout: 10_000 });
+
+    // Mode buttons should be visible
+    const modeButtons = page.locator('.comparison-mode-btn');
+    expect(await modeButtons.count()).toBe(3);
+
+    // Blink should be active by default
+    const blinkBtn = page.locator('.comparison-mode-btn').filter({ hasText: 'Blink' });
+    await expect(blinkBtn).toHaveClass(/active/);
+  });
+
+  test('closes comparison viewer', async ({ page }) => {
+    await page.getByRole('button', { name: /Compare/i }).click();
+
+    const columnA = page.locator('.comparison-picker-column').first();
+    const columnB = page.locator('.comparison-picker-column').last();
+    await columnA.locator('.comparison-picker-item').first().click();
+    const itemsB = columnB.locator('.comparison-picker-item:not(.disabled)');
+    await itemsB.first().click();
+    await page.locator('.comparison-picker-btn.primary').click();
+
+    await expect(page.locator('.comparison-viewer-overlay')).toBeVisible({ timeout: 10_000 });
+
+    // Close the viewer (back button in header)
+    const closeBtn = page.locator('.comparison-header .btn-icon').first();
+    await closeBtn.click();
+
+    await expect(page.locator('.comparison-viewer-overlay')).not.toBeVisible();
+  });
+});

--- a/frontend/jwst-frontend/e2e/composite-wizard.spec.ts
+++ b/frontend/jwst-frontend/e2e/composite-wizard.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedUserWithData,
+  loginWithTokens,
+  SeedResult,
+} from './helpers';
+
+let seed: SeedResult;
+
+test.describe('Composite wizard', () => {
+  test.beforeAll(async ({ request }) => {
+    seed = await seedUserWithData(request, { prefix: 'comp', fileCount: 3 });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginWithTokens(page, seed);
+  });
+
+  test('opens wizard modal via Composite button', async ({ page }) => {
+    await page.getByRole('button', { name: /Composite/i }).click();
+    await expect(page.locator('.composite-wizard-backdrop')).toBeVisible();
+    await expect(page.locator('.composite-wizard-modal')).toBeVisible();
+  });
+
+  test('displays 2-step wizard stepper', async ({ page }) => {
+    await page.getByRole('button', { name: /Composite/i }).click();
+    await expect(page.locator('.composite-wizard-modal')).toBeVisible();
+
+    const steps = page.locator('.wizard-stepper .wizard-step');
+    await expect(steps).toHaveCount(2);
+    // First step should be active
+    await expect(steps.first()).toHaveClass(/active/);
+  });
+
+  test('shows channel lanes on step 1', async ({ page }) => {
+    await page.getByRole('button', { name: /Composite/i }).click();
+    await expect(page.locator('.composite-wizard-modal')).toBeVisible();
+
+    await expect(page.locator('.channel-lanes')).toBeVisible();
+    // Should have at least the default channel lanes (RGB preset starts with 3)
+    const lanes = page.locator('.channel-lane');
+    expect(await lanes.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test('shows image pool with available images', async ({ page }) => {
+    await page.getByRole('button', { name: /Composite/i }).click();
+    await expect(page.locator('.composite-wizard-modal')).toBeVisible();
+
+    await expect(page.locator('.image-pool')).toBeVisible();
+    // We uploaded 3 images — pool should show some cards
+    const poolCards = page.locator('.image-pool .dnd-image-card');
+    expect(await poolCards.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test('navigates between steps (forward and back)', async ({ page }) => {
+    await page.getByRole('button', { name: /Composite/i }).click();
+    await expect(page.locator('.composite-wizard-modal')).toBeVisible();
+
+    // Next should be disabled without images assigned
+    const nextBtn = page.locator('.wizard-footer .btn-wizard.btn-primary');
+    await expect(nextBtn).toBeDisabled();
+
+    // Drag an image from the pool into the first channel lane
+    const poolCard = page.locator('.image-pool .dnd-image-card').first();
+    await expect(poolCard).toBeVisible({ timeout: 10_000 });
+    const channelLane = page.locator('.channel-lane').first();
+    await poolCard.dragTo(channelLane);
+
+    // Next should now be enabled
+    await expect(nextBtn).toBeEnabled({ timeout: 5_000 });
+    await nextBtn.click();
+
+    // Step 2 should be active
+    const steps = page.locator('.wizard-stepper .wizard-step');
+    await expect(steps.nth(1)).toHaveClass(/active/);
+
+    // Click Back to return to step 1
+    const backBtn = page.locator('.wizard-footer .btn-wizard.btn-secondary');
+    await backBtn.click();
+    await expect(steps.first()).toHaveClass(/active/);
+  });
+
+  test('closes wizard via close button', async ({ page }) => {
+    await page.getByRole('button', { name: /Composite/i }).click();
+    await expect(page.locator('.composite-wizard-modal')).toBeVisible();
+
+    await page.locator('.composite-wizard-modal .btn-close').click();
+    await expect(page.locator('.composite-wizard-modal')).not.toBeVisible();
+  });
+});

--- a/frontend/jwst-frontend/e2e/dashboard.spec.ts
+++ b/frontend/jwst-frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { apiRegisterUser, loginWithTokens, ApiAuthResult } from './helpers';
+
+let auth: ApiAuthResult;
+
+test.describe('Dashboard controls and panels', () => {
+  test.beforeAll(async ({ request }) => {
+    auth = await apiRegisterUser(request, 'dash');
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginWithTokens(page, auth);
+  });
+
+  test('shows Upload button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Upload Data' })).toBeVisible();
+  });
+
+  test('shows Search MAST toggle', async ({ page }) => {
+    await expect(
+      page.getByRole('button', { name: /(Search MAST|Hide MAST Search)/i })
+    ).toBeVisible();
+  });
+
+  test('shows What\'s New toggle', async ({ page }) => {
+    await expect(
+      page.getByRole('button', { name: /(What's New|Hide What's New)/i })
+    ).toBeVisible();
+  });
+
+  test('shows Lineage / By Target view toggles', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /Lineage/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /By Target/i })).toBeVisible();
+  });
+
+  test('shows archive toggle', async ({ page }) => {
+    await expect(
+      page.getByRole('button', { name: /(Show Archived|Show Active)/i })
+    ).toBeVisible();
+  });
+
+  test('opens MAST search panel', async ({ page }) => {
+    const mastBtn = page.getByRole('button', { name: /(Search MAST|Hide MAST Search)/i });
+    await mastBtn.click();
+    await expect(page.locator('.mast-search')).toBeVisible();
+  });
+
+  test('shows search type radio buttons in MAST panel', async ({ page }) => {
+    const mastBtn = page.getByRole('button', { name: /(Search MAST|Hide MAST Search)/i });
+    await mastBtn.click();
+    await expect(page.locator('.mast-search')).toBeVisible();
+    await expect(page.locator('.search-type-selector')).toBeVisible();
+    await expect(page.locator('.search-type-selector label')).toHaveCount(4);
+  });
+
+  test('shows search button in MAST panel', async ({ page }) => {
+    const mastBtn = page.getByRole('button', { name: /(Search MAST|Hide MAST Search)/i });
+    await mastBtn.click();
+    await expect(page.locator('.search-button')).toBeVisible();
+  });
+
+  test('opens upload modal', async ({ page }) => {
+    await page.getByRole('button', { name: 'Upload Data' }).click();
+    await expect(page.locator('.upload-modal')).toBeVisible();
+    await expect(page.locator('.upload-content h3')).toHaveText('Upload JWST Data');
+  });
+
+  test('shows file input, data type, and submit in upload modal', async ({ page }) => {
+    await page.getByRole('button', { name: 'Upload Data' }).click();
+    await expect(page.locator('.upload-modal')).toBeVisible();
+
+    await expect(page.locator('#file-upload')).toBeAttached();
+    await expect(page.locator('#data-type-select')).toBeVisible();
+    await expect(page.locator('.form-actions button[type="submit"]')).toBeVisible();
+    await expect(page.locator('.form-actions button[type="submit"]')).toHaveText('Upload');
+  });
+});

--- a/frontend/jwst-frontend/e2e/export.spec.ts
+++ b/frontend/jwst-frontend/e2e/export.spec.ts
@@ -1,134 +1,82 @@
-import { test, expect, Page } from '@playwright/test';
-import { randomUUID } from 'node:crypto';
+import { test, expect } from '@playwright/test';
+import {
+  seedUserWithData,
+  loginWithTokens,
+  openImageViewer,
+  SeedResult,
+} from './helpers';
 
-const uniqueId = () => randomUUID().replace(/-/g, '').slice(0, 12);
-
-async function registerAndOpenDashboard(page: Page): Promise<void> {
-  const id = uniqueId();
-  const username = `export_e2e_${id}`;
-  const email = `${username}@example.com`;
-  const password = 'TestPassword123';
-
-  await page.goto('/register');
-
-  await page.getByLabel('Username').fill(username);
-  await page.getByLabel('Email').fill(email);
-  await page.getByLabel(/^Password/).fill(password);
-  await page.getByLabel(/^Confirm Password/).fill(password);
-  await page.getByLabel('Display Name').fill(`Export E2E ${id}`);
-  await page.getByLabel('Organization').fill('E2E Lab');
-  await page.getByRole('button', { name: 'Create Account' }).click();
-
-  await expect(page).not.toHaveURL(/\/(login|register)/);
-  await expect(page.locator('.dashboard .controls')).toBeVisible();
-}
-
-// Register, navigate to dashboard, open an image viewer on a viewable file
-async function openImageViewer(page: Page): Promise<boolean> {
-  await registerAndOpenDashboard(page);
-
-  // Switch to "By Target" view where View buttons are visible on cards
-  const byTargetBtn = page.getByRole('button', { name: /By Target/i });
-  if ((await byTargetBtn.count()) > 0) {
-    await byTargetBtn.click();
-  }
-
-  // Look for an enabled View button on any data card
-  const viewButton = page.locator('.view-file-btn:not(.disabled)').first();
-  if ((await viewButton.count()) === 0) {
-    return false;
-  }
-
-  // Click the View button to open the image viewer
-  await viewButton.click();
-  await expect(page.locator('.image-viewer-overlay')).toBeVisible();
-  return true;
-}
+let seed: SeedResult;
 
 test.describe('Image Export Feature', () => {
+  test.beforeAll(async ({ request }) => {
+    seed = await seedUserWithData(request, { prefix: 'export', fileCount: 1 });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginWithTokens(page, seed);
+  });
+
+  async function openViewerOrSkip(page: import('@playwright/test').Page) {
+    const opened = await openImageViewer(page);
+    if (!opened) {
+      test.skip(true, 'No viewable data available for testing export');
+    }
+  }
+
   test.describe('Export Options Panel', () => {
     test('should open export options panel when export button is clicked', async ({ page }) => {
-      const hasData = await openImageViewer(page);
-      if (!hasData) {
-        test.skip(true, 'No viewable data available for testing export');
-        return;
-      }
+      await openViewerOrSkip(page);
 
-      // Find and click the export button in the viewer header
       const exportButton = page.locator('.export-button-container button.btn-icon');
       await expect(exportButton).toBeVisible();
       await exportButton.click();
 
-      // Verify the export options panel appears
       await expect(page.locator('.export-options-panel')).toBeVisible();
       await expect(page.locator('.export-options-title')).toHaveText('Export Image');
     });
 
     test('should show format selection with PNG and JPEG options', async ({ page }) => {
-      const hasData = await openImageViewer(page);
-      if (!hasData) {
-        test.skip(true, 'No viewable data available for testing export');
-        return;
-      }
+      await openViewerOrSkip(page);
 
       const exportButton = page.locator('.export-button-container button.btn-icon');
       await exportButton.click();
 
-      // Check both format buttons exist
       const pngButton = page.locator('.export-format-btn:has-text("PNG")');
       const jpegButton = page.locator('.export-format-btn:has-text("JPEG")');
 
       await expect(pngButton).toBeVisible();
       await expect(jpegButton).toBeVisible();
-
-      // PNG should be active by default
       await expect(pngButton).toHaveClass(/active/);
     });
 
     test('should show quality slider only when JPEG is selected', async ({ page }) => {
-      const hasData = await openImageViewer(page);
-      if (!hasData) {
-        test.skip(true, 'No viewable data available for testing export');
-        return;
-      }
+      await openViewerOrSkip(page);
 
       const exportButton = page.locator('.export-button-container button.btn-icon');
       await exportButton.click();
 
-      // Quality slider should NOT be visible with PNG selected (default)
       const qualitySlider = page.locator('.export-slider');
       await expect(qualitySlider).not.toBeVisible();
 
-      // Click JPEG button
       const jpegButton = page.locator('.export-format-btn:has-text("JPEG")');
       await jpegButton.click();
-
-      // Now quality slider should be visible
       await expect(qualitySlider).toBeVisible();
 
-      // Click back to PNG
       const pngButton = page.locator('.export-format-btn:has-text("PNG")');
       await pngButton.click();
-
-      // Quality slider should be hidden again
       await expect(qualitySlider).not.toBeVisible();
     });
 
     test('should show resolution presets dropdown', async ({ page }) => {
-      const hasData = await openImageViewer(page);
-      if (!hasData) {
-        test.skip(true, 'No viewable data available for testing export');
-        return;
-      }
+      await openViewerOrSkip(page);
 
       const exportButton = page.locator('.export-button-container button.btn-icon');
       await exportButton.click();
 
-      // Check resolution select exists
       const resolutionSelect = page.locator('.export-select');
       await expect(resolutionSelect).toBeVisible();
 
-      // Verify preset options exist
       await expect(resolutionSelect.locator('option[value="standard"]')).toHaveText(
         'Standard (1200px)'
       );
@@ -142,95 +90,64 @@ test.describe('Image Export Feature', () => {
     test('should show custom dimension inputs when Custom resolution is selected', async ({
       page,
     }) => {
-      const hasData = await openImageViewer(page);
-      if (!hasData) {
-        test.skip(true, 'No viewable data available for testing export');
-        return;
-      }
+      await openViewerOrSkip(page);
 
       const exportButton = page.locator('.export-button-container button.btn-icon');
       await exportButton.click();
 
-      // Custom dimension inputs should NOT be visible initially
       const dimensionInputs = page.locator('.export-dimension-inputs');
       await expect(dimensionInputs).not.toBeVisible();
 
-      // Select Custom resolution
       const resolutionSelect = page.locator('.export-select');
       await resolutionSelect.selectOption('custom');
 
-      // Custom dimension inputs should now be visible
       await expect(dimensionInputs).toBeVisible();
 
-      // Verify width and height inputs exist
       const widthInput = page.locator('.export-dimension-input').first();
       const heightInput = page.locator('.export-dimension-input').last();
 
       await expect(widthInput).toBeVisible();
       await expect(heightInput).toBeVisible();
-
-      // Default values should be 1200
       await expect(widthInput).toHaveValue('1200');
       await expect(heightInput).toHaveValue('1200');
     });
 
     test('should close export panel when close button is clicked', async ({ page }) => {
-      const hasData = await openImageViewer(page);
-      if (!hasData) {
-        test.skip(true, 'No viewable data available for testing export');
-        return;
-      }
+      await openViewerOrSkip(page);
 
       const exportButton = page.locator('.export-button-container button.btn-icon');
       await exportButton.click();
 
-      // Panel should be visible
       const panel = page.locator('.export-options-panel');
       await expect(panel).toBeVisible();
 
-      // Click close button
       const closeButton = page.locator('.export-close-btn');
       await closeButton.click();
-
-      // Panel should be hidden
       await expect(panel).not.toBeVisible();
     });
 
     test('should have export button with correct format label', async ({ page }) => {
-      const hasData = await openImageViewer(page);
-      if (!hasData) {
-        test.skip(true, 'No viewable data available for testing export');
-        return;
-      }
+      await openViewerOrSkip(page);
 
       const exportButton = page.locator('.export-button-container button.btn-icon');
       await exportButton.click();
 
-      // Export button should say "Export PNG" by default
       const primaryButton = page.locator('.export-btn-primary');
       await expect(primaryButton).toContainText('Export PNG');
 
-      // Switch to JPEG
       const jpegButton = page.locator('.export-format-btn:has-text("JPEG")');
       await jpegButton.click();
-
-      // Export button should now say "Export JPEG"
       await expect(primaryButton).toContainText('Export JPEG');
     });
   });
 
   test.describe('Export Download', () => {
     test('should trigger PNG export with correct parameters', async ({ page }) => {
-      const hasData = await openImageViewer(page);
-      if (!hasData) {
-        test.skip(true, 'No viewable data available for testing export');
-        return;
-      }
+      await openViewerOrSkip(page);
 
       const exportIconButton = page.locator('.export-button-container button.btn-icon');
       await exportIconButton.click();
 
-      // Set up request interception to verify the export URL
       let exportRequestUrl = '';
       page.on('request', (request) => {
         if (request.url().includes('/preview') && request.url().includes('format=png')) {
@@ -238,38 +155,27 @@ test.describe('Image Export Feature', () => {
         }
       });
 
-      // Click export button
       const primaryButton = page.locator('.export-btn-primary');
       await primaryButton.click();
-
-      // Wait a moment for the request to be made
       await page.waitForTimeout(2000);
 
-      // Verify the request was made with PNG format
       expect(exportRequestUrl).toContain('format=png');
       expect(exportRequestUrl).toContain('width=1200');
       expect(exportRequestUrl).toContain('height=1200');
     });
 
     test('should trigger JPEG export with quality parameter', async ({ page }) => {
-      const hasData = await openImageViewer(page);
-      if (!hasData) {
-        test.skip(true, 'No viewable data available for testing export');
-        return;
-      }
+      await openViewerOrSkip(page);
 
       const exportIconButton = page.locator('.export-button-container button.btn-icon');
       await exportIconButton.click();
 
-      // Switch to JPEG
       const jpegButton = page.locator('.export-format-btn:has-text("JPEG")');
       await jpegButton.click();
 
-      // Adjust quality slider to 50
       const qualitySlider = page.locator('.export-slider');
       await qualitySlider.fill('50');
 
-      // Set up request interception to verify the export URL
       let exportRequestUrl = '';
       page.on('request', (request) => {
         if (request.url().includes('/preview') && request.url().includes('format=jpeg')) {
@@ -277,14 +183,10 @@ test.describe('Image Export Feature', () => {
         }
       });
 
-      // Click export button
       const primaryButton = page.locator('.export-btn-primary');
       await primaryButton.click();
-
-      // Wait a moment for the request to be made
       await page.waitForTimeout(2000);
 
-      // Verify the request was made with JPEG format and quality
       expect(exportRequestUrl).toContain('format=jpeg');
       expect(exportRequestUrl).toContain('quality=50');
     });

--- a/frontend/jwst-frontend/e2e/fits-viewer.spec.ts
+++ b/frontend/jwst-frontend/e2e/fits-viewer.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedUserWithData,
+  loginWithTokens,
+  openImageViewer,
+  SeedResult,
+} from './helpers';
+
+let seed: SeedResult;
+
+test.describe('FITS image viewer', () => {
+  test.beforeAll(async ({ request }) => {
+    seed = await seedUserWithData(request, { prefix: 'viewer', fileCount: 1 });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginWithTokens(page, seed);
+  });
+
+  async function openViewerOrSkip(page: import('@playwright/test').Page) {
+    const opened = await openImageViewer(page);
+    if (!opened) {
+      test.skip(true, 'No viewable data available');
+    }
+  }
+
+  test('opens viewer overlay via View button', async ({ page }) => {
+    await openViewerOrSkip(page);
+    await expect(page.locator('.image-viewer-overlay')).toBeVisible();
+  });
+
+  test('displays scientific image in canvas viewport', async ({ page }) => {
+    await openViewerOrSkip(page);
+    // The main rendered image is an <img> with class scientific-canvas (hidden until loaded)
+    const img = page.locator('img.scientific-canvas');
+    await expect(img).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('shows stretch controls panel (not collapsed)', async ({ page }) => {
+    await openViewerOrSkip(page);
+    const stretch = page.locator('.stretch-controls').first();
+    await expect(stretch).toBeVisible();
+    await expect(stretch).not.toHaveClass(/collapsed/);
+  });
+
+  test('shows histogram panel', async ({ page }) => {
+    await openViewerOrSkip(page);
+    const histogram = page.locator('.histogram-panel').first();
+    await expect(histogram).toBeVisible();
+  });
+
+  test('displays pixel coordinates in status bar', async ({ page }) => {
+    await openViewerOrSkip(page);
+    const statusBar = page.locator('.viewer-status-bar');
+    await expect(statusBar).toBeVisible();
+  });
+
+  test('shows metadata sidebar', async ({ page }) => {
+    await openViewerOrSkip(page);
+    const sidebar = page.locator('.viewer-sidebar');
+    await expect(sidebar).toBeVisible();
+  });
+
+  test('shows floating toolbar with zoom controls', async ({ page }) => {
+    await openViewerOrSkip(page);
+    const toolbar = page.locator('.viewer-floating-toolbar');
+    await expect(toolbar).toBeVisible();
+
+    // Zoom buttons exist
+    await expect(toolbar.locator('[title="Zoom In"]')).toBeVisible();
+    await expect(toolbar.locator('[title="Zoom Out"]')).toBeVisible();
+  });
+
+  test('closes viewer via back button', async ({ page }) => {
+    await openViewerOrSkip(page);
+    await expect(page.locator('.image-viewer-overlay')).toBeVisible();
+
+    // Click the back button in the viewer header
+    const backButton = page.locator('.viewer-header .header-left .btn-icon').first();
+    await backButton.click();
+
+    await expect(page.locator('.image-viewer-overlay')).not.toBeVisible();
+    await expect(page.locator('.dashboard .controls')).toBeVisible();
+  });
+});

--- a/frontend/jwst-frontend/e2e/helpers.ts
+++ b/frontend/jwst-frontend/e2e/helpers.ts
@@ -1,0 +1,229 @@
+import { Page, APIRequestContext } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+export const BACKEND_URL = 'http://localhost:5001';
+export const TEST_PASSWORD = 'TestPassword123';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** Absolute path to the shared FITS fixture used for seeding data. */
+export const FIXTURE_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'e2e',
+  'mast',
+  'e2e-test-obs',
+  'test_mirimage_i2d.fits'
+);
+
+/* ------------------------------------------------------------------ */
+/*  Utilities                                                          */
+/* ------------------------------------------------------------------ */
+
+/** 8-char random hex string for test isolation. */
+export function uniqueId(): string {
+  return randomUUID().replace(/-/g, '').slice(0, 8);
+}
+
+/* ------------------------------------------------------------------ */
+/*  API helpers (headless — no browser needed)                         */
+/* ------------------------------------------------------------------ */
+
+export interface ApiAuthResult {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+  username: string;
+  user: Record<string, unknown>;
+}
+
+/**
+ * Register a new user via the backend API.
+ * Returns tokens + user info for injection into localStorage.
+ */
+export async function apiRegisterUser(
+  request: APIRequestContext,
+  prefix = 'e2e'
+): Promise<ApiAuthResult> {
+  const id = uniqueId();
+  const username = `${prefix}_${id}`;
+
+  const res = await request.post(`${BACKEND_URL}/api/auth/register`, {
+    data: {
+      username,
+      email: `${username}@example.com`,
+      password: TEST_PASSWORD,
+      displayName: `E2E ${id}`,
+      organization: 'E2E Lab',
+    },
+  });
+
+  if (!res.ok()) {
+    throw new Error(`API register failed (${res.status()}): ${await res.text()}`);
+  }
+
+  const body = await res.json();
+  return {
+    accessToken: body.accessToken,
+    refreshToken: body.refreshToken,
+    expiresAt: body.expiresAt,
+    username,
+    user: body.user,
+  };
+}
+
+export interface UploadResult {
+  id: string;
+  fileName: string;
+}
+
+/**
+ * Upload the shared FITS fixture via the backend API.
+ * Requires a valid access token.
+ */
+export async function apiUploadFixture(
+  request: APIRequestContext,
+  accessToken: string
+): Promise<UploadResult> {
+  const buffer = fs.readFileSync(FIXTURE_PATH);
+
+  const res = await request.post(`${BACKEND_URL}/api/jwstdata/upload`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    multipart: {
+      File: { name: 'test_mirimage_i2d.fits', mimeType: 'application/octet-stream', buffer },
+      DataType: 'image',
+    },
+  });
+
+  if (!res.ok()) {
+    throw new Error(`API upload failed (${res.status()}): ${await res.text()}`);
+  }
+
+  const body = await res.json();
+  return { id: body.id, fileName: body.fileName };
+}
+
+export interface SeedResult extends ApiAuthResult {
+  dataIds: UploadResult[];
+}
+
+/**
+ * Register a user and upload N FITS fixtures in one call.
+ */
+export async function seedUserWithData(
+  request: APIRequestContext,
+  opts: { prefix?: string; fileCount?: number } = {}
+): Promise<SeedResult> {
+  const { prefix = 'e2e', fileCount = 1 } = opts;
+
+  const auth = await apiRegisterUser(request, prefix);
+  const dataIds: UploadResult[] = [];
+
+  for (let i = 0; i < fileCount; i++) {
+    dataIds.push(await apiUploadFixture(request, auth.accessToken));
+  }
+
+  return { ...auth, dataIds };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Browser helpers                                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Inject auth tokens into localStorage so the app treats the browser
+ * as authenticated without going through the login UI.
+ */
+export async function injectAuthTokens(
+  page: Page,
+  tokens: {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: string;
+    user: Record<string, unknown>;
+  }
+): Promise<void> {
+  await page.evaluate(
+    ({ accessToken, refreshToken, expiresAt, user }) => {
+      localStorage.setItem('jwst_auth_token', accessToken);
+      localStorage.setItem('jwst_refresh_token', refreshToken);
+      localStorage.setItem('jwst_expires_at', expiresAt);
+      localStorage.setItem('jwst_user', JSON.stringify(user));
+    },
+    tokens
+  );
+}
+
+/**
+ * Full one-shot helper: register via API, navigate to `/`, inject tokens,
+ * and wait for the dashboard controls to appear.
+ */
+export async function setupAuthenticatedDashboard(
+  page: Page,
+  request: APIRequestContext,
+  opts: { prefix?: string; fileCount?: number } = {}
+): Promise<SeedResult> {
+  const seed = await seedUserWithData(request, opts);
+  await loginWithTokens(page, seed);
+  return seed;
+}
+
+/**
+ * Inject tokens and navigate to the dashboard.
+ * Uses a two-step approach to avoid race conditions:
+ * 1. Navigate to /login to establish page context on the app origin
+ * 2. Inject tokens into localStorage
+ * 3. Navigate to / — app finds tokens and renders dashboard
+ */
+export async function loginWithTokens(
+  page: Page,
+  tokens: {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: string;
+    user: Record<string, unknown>;
+  }
+): Promise<void> {
+  await page.goto('/login', { waitUntil: 'domcontentloaded' });
+  await injectAuthTokens(page, tokens);
+  await page.goto('/');
+  await page.waitForSelector('.dashboard .controls', { state: 'visible', timeout: 15_000 });
+}
+
+/**
+ * From an authenticated dashboard with data, open the first viewable
+ * image in the FITS viewer. Returns `true` if a viewer was opened,
+ * `false` if no viewable files exist (caller should skip).
+ */
+export async function openImageViewer(page: Page): Promise<boolean> {
+  // Switch to "By Target" view where View buttons are visible on cards
+  const byTargetBtn = page.getByRole('button', { name: /By Target/i });
+  if ((await byTargetBtn.count()) > 0) {
+    await byTargetBtn.click();
+  }
+
+  // Wait for data to load
+  await page.waitForTimeout(1000);
+
+  // Look for an enabled View button on any data card
+  const viewButton = page.locator('.view-file-btn:not(.disabled)').first();
+  if ((await viewButton.count()) === 0) {
+    return false;
+  }
+
+  await viewButton.click();
+  await page.waitForSelector('.image-viewer-overlay', { state: 'visible', timeout: 15_000 });
+  return true;
+}

--- a/frontend/jwst-frontend/e2e/mast-search.spec.ts
+++ b/frontend/jwst-frontend/e2e/mast-search.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { apiRegisterUser, loginWithTokens, ApiAuthResult } from './helpers';
+
+let auth: ApiAuthResult;
+
+test.describe('MAST search panel', () => {
+  test.beforeAll(async ({ request }) => {
+    auth = await apiRegisterUser(request, 'mast');
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginWithTokens(page, auth);
+
+    // Open the MAST panel for every test (use specific toggle button class)
+    const mastToggle = page.locator('button.mast-search-btn');
+    await mastToggle.click();
+    await expect(page.locator('.mast-search')).toBeVisible();
+  });
+
+  test('toggles MAST search panel open and close', async ({ page }) => {
+    // Panel is already open from beforeEach — close it
+    const mastToggle = page.locator('button.mast-search-btn');
+    await mastToggle.click();
+    await expect(page.locator('.mast-search')).not.toBeVisible();
+
+    // Re-open
+    await mastToggle.click();
+    await expect(page.locator('.mast-search')).toBeVisible();
+  });
+
+  test('defaults to target name search type', async ({ page }) => {
+    const selectedLabel = page.locator('.search-type-selector label.selected');
+    await expect(selectedLabel).toContainText('Target Name');
+  });
+
+  test('switches between search types', async ({ page }) => {
+    // Click on "Coordinates" radio
+    const coordLabel = page.locator('.search-type-selector label').filter({ hasText: 'Coordinates' });
+    await coordLabel.click();
+    await expect(coordLabel).toHaveClass(/selected/);
+
+    // Click on "Observation ID"
+    const obsLabel = page.locator('.search-type-selector label').filter({ hasText: 'Observation ID' });
+    await obsLabel.click();
+    await expect(obsLabel).toHaveClass(/selected/);
+  });
+
+  test('shows radius input for target search', async ({ page }) => {
+    // Target search is default — should show radius
+    await expect(page.locator('input[placeholder*="Radius"]')).toBeVisible();
+  });
+
+  test('search button is visible and enabled', async ({ page }) => {
+    const searchBtn = page.locator('.search-button');
+    await expect(searchBtn).toBeVisible();
+    await expect(searchBtn).toBeEnabled();
+  });
+});

--- a/frontend/jwst-frontend/e2e/mosaic-wizard.spec.ts
+++ b/frontend/jwst-frontend/e2e/mosaic-wizard.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedUserWithData,
+  loginWithTokens,
+  SeedResult,
+} from './helpers';
+
+let seed: SeedResult;
+
+test.describe('Mosaic wizard', () => {
+  test.beforeAll(async ({ request }) => {
+    seed = await seedUserWithData(request, { prefix: 'mosaic', fileCount: 2 });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginWithTokens(page, seed);
+  });
+
+  test('opens wizard modal via WCS Mosaic button', async ({ page }) => {
+    await page.getByRole('button', { name: /WCS Mosaic/i }).click();
+    await expect(page.locator('.mosaic-wizard-backdrop')).toBeVisible();
+    await expect(page.locator('.mosaic-wizard-modal')).toBeVisible();
+  });
+
+  test('displays 2-step wizard stepper', async ({ page }) => {
+    await page.getByRole('button', { name: /WCS Mosaic/i }).click();
+    await expect(page.locator('.mosaic-wizard-modal')).toBeVisible();
+
+    const steps = page.locator('.wizard-stepper .wizard-step');
+    await expect(steps).toHaveCount(2);
+    await expect(steps.first()).toHaveClass(/active/);
+  });
+
+  test('shows file selection cards on step 1', async ({ page }) => {
+    await page.getByRole('button', { name: /WCS Mosaic/i }).click();
+    await expect(page.locator('.mosaic-wizard-modal')).toBeVisible();
+
+    // Wait for image cards to load
+    const cards = page.locator('.mosaic-image-card');
+    await expect(cards.first()).toBeVisible({ timeout: 10_000 });
+    expect(await cards.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test('enables Next when 2+ files selected', async ({ page }) => {
+    await page.getByRole('button', { name: /WCS Mosaic/i }).click();
+    await expect(page.locator('.mosaic-wizard-modal')).toBeVisible();
+
+    const cards = page.locator('.mosaic-image-card');
+    await expect(cards.first()).toBeVisible({ timeout: 10_000 });
+
+    // Select first two cards
+    await cards.nth(0).click();
+    await cards.nth(1).click();
+
+    // Next button should be enabled
+    const nextBtn = page.locator('.wizard-footer .btn-wizard.btn-primary');
+    await expect(nextBtn).toBeEnabled();
+  });
+
+  test('navigates to step 2 and shows generate button', async ({ page }) => {
+    await page.getByRole('button', { name: /WCS Mosaic/i }).click();
+    await expect(page.locator('.mosaic-wizard-modal')).toBeVisible();
+
+    const cards = page.locator('.mosaic-image-card');
+    await expect(cards.first()).toBeVisible({ timeout: 10_000 });
+
+    // Select 2 images
+    await cards.nth(0).click();
+    await cards.nth(1).click();
+
+    // Go to step 2
+    const nextBtn = page.locator('.wizard-footer .btn-wizard.btn-primary');
+    await nextBtn.click();
+
+    // Step 2 active
+    const steps = page.locator('.wizard-stepper .wizard-step');
+    await expect(steps.nth(1)).toHaveClass(/active/);
+
+    // Generate button visible
+    const generateBtn = page.locator('.btn-wizard.btn-generate');
+    await expect(generateBtn).toBeVisible();
+  });
+});

--- a/frontend/jwst-frontend/e2e/session-persistence.spec.ts
+++ b/frontend/jwst-frontend/e2e/session-persistence.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import {
+  apiRegisterUser,
+  injectAuthTokens,
+  loginWithTokens,
+  ApiAuthResult,
+} from './helpers';
+
+let auth: ApiAuthResult;
+
+test.describe('Session persistence and token handling', () => {
+  test.beforeAll(async ({ request }) => {
+    auth = await apiRegisterUser(request, 'sess');
+  });
+
+  test('redirects to login with no tokens', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('stays authenticated after page reload', async ({ page }) => {
+    await loginWithTokens(page, auth);
+    await page.reload();
+    await expect(page).not.toHaveURL(/\/(login|register)/);
+    await expect(page.locator('.dashboard .controls')).toBeVisible();
+  });
+
+  test('auto-refreshes when access token is expired but refresh token is valid', async ({
+    page,
+    request,
+  }) => {
+    // Get fresh tokens
+    const freshAuth = await apiRegisterUser(request, 'refresh');
+
+    // Navigate to login first to establish page context
+    await page.goto('/login', { waitUntil: 'domcontentloaded' });
+
+    // Inject tokens with an expired access token time
+    await page.evaluate(
+      ({ accessToken, refreshToken, user }) => {
+        localStorage.setItem('jwst_auth_token', accessToken);
+        localStorage.setItem('jwst_refresh_token', refreshToken);
+        // Set expiry to the past to trigger refresh
+        localStorage.setItem('jwst_expires_at', new Date(Date.now() - 60_000).toISOString());
+        localStorage.setItem('jwst_user', JSON.stringify(user));
+      },
+      freshAuth
+    );
+
+    // Navigate to root — app should detect expired token and refresh
+    await page.goto('/');
+
+    // Should still end up on dashboard (refresh succeeded)
+    await expect(page).not.toHaveURL(/\/(login|register)/, { timeout: 10_000 });
+    await expect(page.locator('.dashboard .controls')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('redirects to login when all tokens are cleared', async ({ page }) => {
+    await loginWithTokens(page, auth);
+    await expect(page.locator('.dashboard .controls')).toBeVisible();
+
+    // Clear all tokens
+    await page.evaluate(() => {
+      localStorage.removeItem('jwst_auth_token');
+      localStorage.removeItem('jwst_refresh_token');
+      localStorage.removeItem('jwst_user');
+      localStorage.removeItem('jwst_expires_at');
+    });
+
+    await page.reload();
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/frontend/jwst-frontend/e2e/smoke.spec.ts
+++ b/frontend/jwst-frontend/e2e/smoke.spec.ts
@@ -1,7 +1,5 @@
 import { test, expect } from '@playwright/test';
-
-// Generate unique usernames to avoid conflicts between test runs
-const uniqueId = () => crypto.randomUUID().substring(0, 8);
+import { uniqueId } from './helpers';
 
 test.describe('Application Smoke Tests', () => {
     test('should load the application', async ({ page }) => {

--- a/frontend/jwst-frontend/e2e/ux-regression.spec.ts
+++ b/frontend/jwst-frontend/e2e/ux-regression.spec.ts
@@ -1,48 +1,23 @@
-import { test, expect, Page } from '@playwright/test';
-import { randomUUID } from 'node:crypto';
+import { test, expect } from '@playwright/test';
+import {
+  seedUserWithData,
+  loginWithTokens,
+  openImageViewer,
+  SeedResult,
+} from './helpers';
 
-const uniqueId = () => randomUUID().replace(/-/g, '').slice(0, 12);
-
-async function registerAndOpenDashboard(page: Page): Promise<void> {
-  const id = uniqueId();
-  const username = `uxe2e_${id}`;
-  const email = `${username}@example.com`;
-  const password = 'TestPassword123';
-
-  await page.goto('/register');
-
-  await page.getByLabel('Username').fill(username);
-  await page.getByLabel('Email').fill(email);
-  await page.getByLabel(/^Password/).fill(password);
-  await page.getByLabel(/^Confirm Password/).fill(password);
-  await page.getByLabel('Display Name').fill(`UX E2E ${id}`);
-  await page.getByLabel('Organization').fill('E2E Lab');
-  await page.getByRole('button', { name: 'Create Account' }).click();
-
-  await expect(page).not.toHaveURL(/\/(login|register)/);
-  await expect(page.locator('.dashboard .controls')).toBeVisible();
-}
-
-async function openViewerIfAvailable(page: Page): Promise<boolean> {
-  const byTargetButton = page.getByRole('button', { name: /By Target/i });
-  if ((await byTargetButton.count()) > 0) {
-    await byTargetButton.click();
-  }
-
-  const viewButton = page.locator('.view-file-btn:not(.disabled)').first();
-  if ((await viewButton.count()) === 0) {
-    return false;
-  }
-
-  await viewButton.click();
-  await expect(page.locator('.image-viewer-overlay')).toBeVisible();
-  return true;
-}
+let seed: SeedResult;
 
 test.describe('UX regression coverage', () => {
-  test('renders dashboard controls in grouped hierarchy', async ({ page }) => {
-    await registerAndOpenDashboard(page);
+  test.beforeAll(async ({ request }) => {
+    seed = await seedUserWithData(request, { prefix: 'uxe2e', fileCount: 1 });
+  });
 
+  test.beforeEach(async ({ page }) => {
+    await loginWithTokens(page, seed);
+  });
+
+  test('renders dashboard controls in grouped hierarchy', async ({ page }) => {
     const filtersRow = page.locator('.controls-row-filters');
     const primaryActionsRow = page.locator('.controls-row-primary-actions');
     const secondaryActionsRow = page.locator('.controls-row-secondary-actions');
@@ -73,8 +48,6 @@ test.describe('UX regression coverage', () => {
   });
 
   test('shows labeled destructive controls in lineage view', async ({ page }) => {
-    await registerAndOpenDashboard(page);
-
     const observationDeleteLabel = page
       .locator('.lineage-header .delete-observation-btn .action-label')
       .first();
@@ -100,9 +73,7 @@ test.describe('UX regression coverage', () => {
     test.use({ viewport: { width: 390, height: 844 } });
 
     test('enables compact layout and content-first panel defaults', async ({ page }) => {
-      await registerAndOpenDashboard(page);
-
-      const opened = await openViewerIfAvailable(page);
+      const opened = await openImageViewer(page);
       if (!opened) {
         test.skip(true, 'No viewable files available for compact-viewer assertions');
         return;
@@ -122,9 +93,7 @@ test.describe('UX regression coverage', () => {
     test.use({ viewport: { width: 1280, height: 900 } });
 
     test('keeps desktop layout when viewport exceeds compact threshold', async ({ page }) => {
-      await registerAndOpenDashboard(page);
-
-      const opened = await openViewerIfAvailable(page);
+      const opened = await openImageViewer(page);
       if (!opened) {
         test.skip(true, 'No viewable files available for desktop-viewer assertions');
         return;

--- a/frontend/jwst-frontend/e2e/viewer-tools.spec.ts
+++ b/frontend/jwst-frontend/e2e/viewer-tools.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedUserWithData,
+  loginWithTokens,
+  openImageViewer,
+  SeedResult,
+} from './helpers';
+
+let seed: SeedResult;
+
+test.describe('Viewer tools: regions, annotations, WCS grid, curves', () => {
+  test.beforeAll(async ({ request }) => {
+    seed = await seedUserWithData(request, { prefix: 'tools', fileCount: 1 });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginWithTokens(page, seed);
+
+    const opened = await openImageViewer(page);
+    if (!opened) {
+      test.skip(true, 'No viewable data available');
+    }
+  });
+
+  test('shows rectangle and ellipse region tool buttons', async ({ page }) => {
+    const headerRight = page.locator('.header-right');
+    await expect(headerRight.locator('[title="Rectangle Region"]')).toBeVisible();
+    await expect(headerRight.locator('[title="Ellipse Region"]')).toBeVisible();
+  });
+
+  test('toggles region mode on and off', async ({ page }) => {
+    const rectBtn = page.locator('.header-right [title="Rectangle Region"]');
+    await rectBtn.click();
+    await expect(rectBtn).toHaveClass(/active/);
+
+    await rectBtn.click();
+    await expect(rectBtn).not.toHaveClass(/active/);
+  });
+
+  test('shows annotation tool buttons', async ({ page }) => {
+    const headerRight = page.locator('.header-right');
+    await expect(headerRight.locator('[title="Text Label"]')).toBeVisible();
+    await expect(headerRight.locator('[title="Arrow"]')).toBeVisible();
+    await expect(headerRight.locator('[title="Circle / Ellipse"]')).toBeVisible();
+  });
+
+  test('activates text annotation mode', async ({ page }) => {
+    const textBtn = page.locator('.header-right [title="Text Label"]');
+    await textBtn.click();
+    await expect(textBtn).toHaveClass(/active/);
+  });
+
+  test('toggles annotation mode off', async ({ page }) => {
+    const textBtn = page.locator('.header-right [title="Text Label"]');
+    await textBtn.click();
+    await expect(textBtn).toHaveClass(/active/);
+
+    await textBtn.click();
+    await expect(textBtn).not.toHaveClass(/active/);
+  });
+
+  test('toggles WCS grid (skip if unavailable)', async ({ page }) => {
+    const wcsBtn = page.locator('.viewer-floating-toolbar [title="Toggle WCS Grid"]');
+
+    if ((await wcsBtn.count()) === 0) {
+      // WCS not available for this image — check the disabled variant exists instead
+      const disabledBtn = page.locator('.viewer-floating-toolbar [title="WCS not available"]');
+      await expect(disabledBtn).toBeVisible();
+      return;
+    }
+
+    await wcsBtn.click();
+    await expect(wcsBtn).toHaveClass(/active/);
+
+    await wcsBtn.click();
+    await expect(wcsBtn).not.toHaveClass(/active/);
+  });
+
+  test('shows curves editor panel', async ({ page }) => {
+    const curvesPanel = page.locator('.curves-editor');
+    await expect(curvesPanel).toBeVisible();
+  });
+
+  test('shows curve presets', async ({ page }) => {
+    // Ensure curves editor is expanded (click header if collapsed)
+    const curvesPanel = page.locator('.curves-editor');
+    if (await curvesPanel.evaluate((el) => el.classList.contains('collapsed'))) {
+      await page.locator('.curves-editor-header').click();
+    }
+
+    const presets = page.locator('.curves-presets .curves-preset-btn');
+    await expect(presets.first()).toBeVisible();
+    // Should have multiple presets
+    expect(await presets.count()).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 8 new Playwright spec files and a shared helpers module covering all core scientific features. Refactors existing 4 spec files to use API-based data seeding. Fixes a backend bug where uploaded files had null `UserId`. Total E2E coverage goes from 32 tests to 85 (1 skipped).

## Why

The app had zero E2E coverage for its core scientific features — viewer, composite/mosaic/comparison wizards, region tools, annotations, WCS grid, curves editor, dashboard controls, MAST search, and session persistence. This made regressions invisible until manual testing.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **New `e2e/helpers.ts`** — shared utilities: `uniqueId()`, `apiRegisterUser()`, `apiUploadFixture()`, `seedUserWithData()`, `injectAuthTokens()`, `loginWithTokens()`, `openImageViewer()`. API-based seeding is ~10x faster than UI registration per test.
- **8 new spec files** (53 new tests):
  - `fits-viewer.spec.ts` (8) — viewer overlay, scientific image, stretch, histogram, status bar, sidebar, toolbar, close
  - `composite-wizard.spec.ts` (6) — wizard modal, stepper, channels, image pool, navigation, close
  - `mosaic-wizard.spec.ts` (5) — wizard modal, stepper, file selection, Next enablement, generate button
  - `comparison-viewer.spec.ts` (7) — picker modal, columns, item selection, Compare button, overlay, blink mode, close
  - `viewer-tools.spec.ts` (8) — region tools, annotation tools, WCS grid toggle, curves editor, presets
  - `dashboard.spec.ts` (8) — Upload/MAST/What's New/archive toggles, view modes, MAST panel, upload modal
  - `mast-search.spec.ts` (5) — toggle, default search type, type switching, radius input, search button
  - `session-persistence.spec.ts` (4) — no-token redirect, authenticated reload, expired token refresh, token clearing
- **Refactored 4 existing specs** (auth, smoke, export, ux-regression) to import shared helpers, eliminating duplicated `uniqueId()` and `registerAndOpenDashboard()`. Export and ux-regression specs switched from per-test UI registration to `beforeAll` API seeding.
- **Backend bug fix** — `JwstDataController.Upload` now sets `UserId = GetCurrentUserId()` on the created `JwstDataModel`. Previously uploaded files had `userId: null` and were invisible to the uploader via `GET /api/jwstdata`.

## Test Plan

- [x] Start Docker stack: `cd docker && docker compose up -d --build`
- [x] Wait for backend: `curl http://localhost:5001/api/jwstdata` should return 200
- [x] Run full E2E suite: `cd frontend/jwst-frontend && npx playwright test --project=chromium`
- [x] Verify: **85 passed, 1 skipped, 0 failed** (~36s)
- [x] Run individual spec to verify a new feature:
   - `npx playwright test --project=chromium e2e/fits-viewer.spec.ts` → 8 passed
   - `npx playwright test --project=chromium e2e/composite-wizard.spec.ts` → 6 passed
- [x] Verify existing tests still pass: `npx playwright test --project=chromium e2e/auth.spec.ts` → 16 passed
- [x] Test the backend fix: upload a FITS file via the UI, confirm it appears in the dashboard file list

## Documentation Checklist

- [x] No new controllers, services, or endpoints (backend fix is 1-line in existing Upload method)
- [x] No new frontend components
- [x] No documentation updates needed — this is a test-only change with a 1-line backend bug fix

## Tech Debt Impact

- [x] Reduces tech debt — consolidates duplicated test helpers, adds test coverage for features that had none

## Risk & Rollback

Risk: Low — test files only, plus a 1-line backend fix that correctly associates uploaded data with the authenticated user.
Rollback: Revert the commit. The backend fix is backward-compatible — existing data with null userId is unaffected.

## Quality Checklist

- [x] Code follows project conventions
- [x] Tests pass locally
- [x] No new warnings introduced
- [x] Changes are focused and minimal