### PR TITLE
fix: update stale pytest match patterns for ChannelColor validation

### DIFF
--- a/processing-engine/tests/test_color_mapping.py
+++ b/processing-engine/tests/test_color_mapping.py
@@ -231,11 +231,11 @@ class TestChannelColorModel:
         assert color.hue is None
 
     def test_both_raises(self):
-        with pytest.raises(ValidationError, match="not both"):
+        with pytest.raises(ValidationError, match="Provide only one of"):
             ChannelColor(hue=120.0, rgb=(0.5, 0.3, 0.8))
 
     def test_neither_raises(self):
-        with pytest.raises(ValidationError, match="either hue or rgb"):
+        with pytest.raises(ValidationError, match="Provide one of"):
             ChannelColor()
 
     def test_hue_out_of_range_raises(self):


### PR DESCRIPTION
## Summary

Fixes 2 failing Python tests in `test_color_mapping.py` where `pytest.raises` match patterns were stale after the ChannelColor model's error messages were updated to include luminance support.

## Why

The ChannelColor validator messages changed from `"not both"` / `"either hue or rgb"` to `"Provide only one of: hue, rgb, or luminance=true"` / `"Provide one of: hue, rgb, or luminance=true"` when luminance channel support was added in #369, but the test patterns weren't updated. This caused 2 persistent test failures.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Updated `test_both_raises` match pattern from `"not both"` to `"Provide only one of"`
- Updated `test_neither_raises` match pattern from `"either hue or rgb"` to `"Provide one of"`

## Test Plan

- [x] Run Python tests: `docker exec jwst-processing python -m pytest` — 298 passed, 0 failed
- [x] Verify the 2 specific tests pass: `docker exec jwst-processing python -m pytest tests/test_color_mapping.py::TestChannelColorModel::test_both_raises tests/test_color_mapping.py::TestChannelColorModel::test_neither_raises`

## Documentation Checklist

- [x] No new controllers, services, or endpoints
- [x] No documentation updates needed

## Tech Debt Impact

- [x] Reduces tech debt — fixes broken tests

## Risk & Rollback

Risk: Minimal — only changes test match patterns, no production code affected.
Rollback: Revert the commit.

## Quality Checklist

- [x] Code follows project conventions
- [x] Tests pass locally
- [x] No new warnings introduced
- [x] Changes are focused and minimal