### PR TITLE
feat: add JWST filter presets dropdown for composite wizard (B3.5)

### DIFF
--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -125,4 +125,5 @@ Quick reference for finding important files in the codebase.
 - `frontend/jwst-frontend/src/utils/cubeUtils.ts` - 3D FITS cube utilities (slice formatting, playback speed)
 - `frontend/jwst-frontend/src/utils/coordinateUtils.ts` - Pixel-to-WCS conversion, coordinate formatting, cursor info
 - `frontend/jwst-frontend/src/utils/wavelengthUtils.ts` - Wavelength conversion utilities
+- `frontend/jwst-frontend/src/utils/filterPresets.ts` - Curated JWST filter presets for composite wizard
 - `frontend/jwst-frontend/src/utils/validationUtils.ts` - Input validation (MongoDB ObjectId, etc.)

--- a/frontend/jwst-frontend/src/components/wizard/ChannelAssignStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/ChannelAssignStep.css
@@ -68,6 +68,135 @@
   color: #e5e7eb;
 }
 
+/* JWST Presets dropdown */
+.preset-dropdown-wrapper {
+  position: relative;
+}
+
+.btn-preset-dropdown {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.btn-preset-dropdown.active {
+  background: rgba(74, 144, 217, 0.15);
+  border-color: rgba(74, 144, 217, 0.4);
+}
+
+.dropdown-caret {
+  font-size: 0.65rem;
+  opacity: 0.7;
+}
+
+.preset-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  left: 0;
+  z-index: 50;
+  min-width: 320px;
+  max-height: 420px;
+  overflow-y: auto;
+  background: #1a1a2e;
+  border: 1px solid rgba(74, 144, 217, 0.3);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  padding: 0.375rem;
+}
+
+.preset-dropdown-menu::-webkit-scrollbar {
+  width: 6px;
+}
+
+.preset-dropdown-menu::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 3px;
+}
+
+.preset-dropdown-menu::-webkit-scrollbar-thumb {
+  background: rgba(74, 144, 217, 0.3);
+  border-radius: 3px;
+}
+
+.preset-group {
+  padding: 0.25rem 0;
+}
+
+.preset-group + .preset-group {
+  border-top: 1px solid rgba(74, 144, 217, 0.15);
+  margin-top: 0.25rem;
+  padding-top: 0.5rem;
+}
+
+.preset-group-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+  padding: 0.25rem 0.5rem;
+}
+
+.preset-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.5rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  color: #e5e7eb;
+  transition: all 0.12s ease;
+}
+
+.preset-menu-item:hover {
+  background: rgba(74, 144, 217, 0.1);
+  border-color: rgba(74, 144, 217, 0.2);
+}
+
+.preset-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.preset-item-name {
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.preset-item-filters {
+  font-size: 0.7rem;
+  color: #9ca3af;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preset-match-badge {
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.15rem 0.4rem;
+  border-radius: 10px;
+  background: rgba(74, 144, 217, 0.15);
+  color: #60a5fa;
+  border: 1px solid rgba(74, 144, 217, 0.3);
+}
+
+.preset-match-badge.full-match {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
 /* Main body: channels on top (scrolls), pool on bottom (scrolls) */
 .assign-body {
   flex: 1;

--- a/frontend/jwst-frontend/src/utils/filterPresets.test.ts
+++ b/frontend/jwst-frontend/src/utils/filterPresets.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from 'vitest';
+import { JwstDataModel } from '../types/JwstDataTypes';
+import {
+  FILTER_PRESETS,
+  getPresetsByInstrument,
+  createChannelsFromPreset,
+  matchImagesToPreset,
+  countPresetMatches,
+} from './filterPresets';
+
+/** Helper to create a minimal JwstDataModel with a filter name */
+function makeImage(id: string, filter: string): JwstDataModel {
+  return {
+    id,
+    userId: 'u1',
+    groupId: 'g1',
+    fileName: `${id}.fits`,
+    fileSize: 1000,
+    status: 'completed',
+    imageInfo: { width: 100, height: 100, filter },
+  } as unknown as JwstDataModel;
+}
+
+describe('FILTER_PRESETS', () => {
+  it('contains 7 presets', () => {
+    expect(FILTER_PRESETS).toHaveLength(7);
+  });
+
+  it('all presets have unique IDs', () => {
+    const ids = FILTER_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('all presets have at least 3 filters', () => {
+    for (const preset of FILTER_PRESETS) {
+      expect(preset.filters.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it('all filters have positive wavelengths', () => {
+    for (const preset of FILTER_PRESETS) {
+      for (const f of preset.filters) {
+        expect(f.wavelengthUm).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('getPresetsByInstrument', () => {
+  it('groups into NIRCam, MIRI, and Mixed', () => {
+    const groups = getPresetsByInstrument();
+    expect(groups.has('NIRCam')).toBe(true);
+    expect(groups.has('MIRI')).toBe(true);
+    expect(groups.has('Mixed')).toBe(true);
+  });
+
+  it('NIRCam has 3 presets', () => {
+    const groups = getPresetsByInstrument();
+    expect(groups.get('NIRCam')).toHaveLength(3);
+  });
+
+  it('MIRI has 3 presets', () => {
+    const groups = getPresetsByInstrument();
+    expect(groups.get('MIRI')).toHaveLength(3);
+  });
+
+  it('Mixed has 1 preset', () => {
+    const groups = getPresetsByInstrument();
+    expect(groups.get('Mixed')).toHaveLength(1);
+  });
+});
+
+describe('createChannelsFromPreset', () => {
+  const deepField = FILTER_PRESETS.find((p) => p.id === 'nircam-deep-field')!;
+
+  it('creates one channel per filter', () => {
+    const channels = createChannelsFromPreset(deepField);
+    expect(channels).toHaveLength(6);
+  });
+
+  it('channels have filter names as labels', () => {
+    const channels = createChannelsFromPreset(deepField);
+    expect(channels.map((c) => c.label)).toEqual([
+      'F090W',
+      'F150W',
+      'F200W',
+      'F277W',
+      'F356W',
+      'F444W',
+    ]);
+  });
+
+  it('channels have wavelengthUm set', () => {
+    const channels = createChannelsFromPreset(deepField);
+    expect(channels[0].wavelengthUm).toBe(0.901);
+    expect(channels[5].wavelengthUm).toBe(4.421);
+  });
+
+  it('channels have hue-based colors (shorter wavelength = higher hue)', () => {
+    const channels = createChannelsFromPreset(deepField);
+    // F090W (0.9um) should have higher hue than F444W (4.4um)
+    const hueF090 = channels[0].color.hue!;
+    const hueF444 = channels[5].color.hue!;
+    expect(hueF090).toBeGreaterThan(hueF444);
+  });
+
+  it('channels start with empty dataIds', () => {
+    const channels = createChannelsFromPreset(deepField);
+    for (const ch of channels) {
+      expect(ch.dataIds).toEqual([]);
+    }
+  });
+
+  it('channels have unique IDs', () => {
+    const channels = createChannelsFromPreset(deepField);
+    const ids = channels.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('matchImagesToPreset', () => {
+  const threeFilter = FILTER_PRESETS.find((p) => p.id === 'nircam-3filter')!;
+
+  it('matches images by exact filter name (case-insensitive)', () => {
+    const channels = createChannelsFromPreset(threeFilter);
+    const images = [
+      makeImage('img1', 'F090W'),
+      makeImage('img2', 'f200w'), // lowercase
+      makeImage('img3', 'F444W'),
+    ];
+
+    const matched = matchImagesToPreset(channels, images);
+    expect(matched[0].dataIds).toEqual(['img1']); // F090W
+    expect(matched[1].dataIds).toEqual(['img2']); // F200W
+    expect(matched[2].dataIds).toEqual(['img3']); // F444W
+  });
+
+  it('handles compound filter names like CLEAR-F444W', () => {
+    const channels = createChannelsFromPreset(threeFilter);
+    const images = [makeImage('img1', 'CLEAR-F444W')];
+
+    const matched = matchImagesToPreset(channels, images);
+    expect(matched[2].dataIds).toEqual(['img1']); // F444W channel
+  });
+
+  it('handles compound filter names like F200W-CLEAR', () => {
+    const channels = createChannelsFromPreset(threeFilter);
+    const images = [makeImage('img1', 'F200W-CLEAR')];
+
+    const matched = matchImagesToPreset(channels, images);
+    expect(matched[1].dataIds).toEqual(['img1']); // F200W channel
+  });
+
+  it('assigns multiple images with same filter to the same channel', () => {
+    const channels = createChannelsFromPreset(threeFilter);
+    const images = [
+      makeImage('img1', 'F090W'),
+      makeImage('img2', 'F090W'),
+      makeImage('img3', 'F090W'),
+    ];
+
+    const matched = matchImagesToPreset(channels, images);
+    expect(matched[0].dataIds).toEqual(['img1', 'img2', 'img3']);
+    expect(matched[1].dataIds).toEqual([]); // F200W unmatched
+    expect(matched[2].dataIds).toEqual([]); // F444W unmatched
+  });
+
+  it('leaves unmatched channels with empty dataIds', () => {
+    const channels = createChannelsFromPreset(threeFilter);
+    const images = [makeImage('img1', 'F090W')];
+
+    const matched = matchImagesToPreset(channels, images);
+    expect(matched[0].dataIds).toEqual(['img1']);
+    expect(matched[1].dataIds).toEqual([]);
+    expect(matched[2].dataIds).toEqual([]);
+  });
+
+  it('ignores images with no filter info', () => {
+    const channels = createChannelsFromPreset(threeFilter);
+    const images = [
+      {
+        id: 'no-filter',
+        userId: 'u1',
+        groupId: 'g1',
+        fileName: 'x.fits',
+        fileSize: 100,
+        status: 'completed',
+      } as unknown as JwstDataModel,
+    ];
+
+    const matched = matchImagesToPreset(channels, images);
+    for (const ch of matched) {
+      expect(ch.dataIds).toEqual([]);
+    }
+  });
+
+  it('ignores images that match no preset filter', () => {
+    const channels = createChannelsFromPreset(threeFilter);
+    const images = [makeImage('img1', 'F770W')]; // MIRI filter, not in nircam-3filter
+
+    const matched = matchImagesToPreset(channels, images);
+    for (const ch of matched) {
+      expect(ch.dataIds).toEqual([]);
+    }
+  });
+});
+
+describe('countPresetMatches', () => {
+  const threeFilter = FILTER_PRESETS.find((p) => p.id === 'nircam-3filter')!;
+
+  it('counts matched distinct filters', () => {
+    const images = [makeImage('img1', 'F090W'), makeImage('img2', 'F444W')];
+
+    const result = countPresetMatches(threeFilter, images);
+    expect(result).toEqual({ matched: 2, total: 3 });
+  });
+
+  it('returns 0 matched for no matching images', () => {
+    const images = [makeImage('img1', 'F770W')];
+    const result = countPresetMatches(threeFilter, images);
+    expect(result).toEqual({ matched: 0, total: 3 });
+  });
+
+  it('returns full match when all filters present', () => {
+    const images = [
+      makeImage('img1', 'F090W'),
+      makeImage('img2', 'F200W'),
+      makeImage('img3', 'F444W'),
+    ];
+
+    const result = countPresetMatches(threeFilter, images);
+    expect(result).toEqual({ matched: 3, total: 3 });
+  });
+
+  it('counts compound filter names', () => {
+    const images = [makeImage('img1', 'CLEAR-F090W')];
+    const result = countPresetMatches(threeFilter, images);
+    expect(result).toEqual({ matched: 1, total: 3 });
+  });
+
+  it('does not double-count multiple images with same filter', () => {
+    const images = [
+      makeImage('img1', 'F090W'),
+      makeImage('img2', 'F090W'),
+      makeImage('img3', 'F090W'),
+    ];
+
+    const result = countPresetMatches(threeFilter, images);
+    expect(result).toEqual({ matched: 1, total: 3 });
+  });
+
+  it('works for a large preset', () => {
+    const stephan = FILTER_PRESETS.find((p) => p.id === 'mixed-stephans-quintet')!;
+    const images = [
+      makeImage('img1', 'F090W'),
+      makeImage('img2', 'F150W'),
+      makeImage('img3', 'F200W'),
+      makeImage('img4', 'F277W'),
+      makeImage('img5', 'F356W'),
+      makeImage('img6', 'F444W'),
+      makeImage('img7', 'F770W'),
+    ];
+
+    const result = countPresetMatches(stephan, images);
+    expect(result).toEqual({ matched: 7, total: 7 });
+  });
+});

--- a/frontend/jwst-frontend/src/utils/filterPresets.ts
+++ b/frontend/jwst-frontend/src/utils/filterPresets.ts
@@ -1,0 +1,220 @@
+/**
+ * Curated JWST filter presets for common observation filter sets.
+ * Each preset defines channels that match iconic JWST composite images
+ * (Pillars of Creation, Deep Field, Southern Ring, etc.).
+ */
+
+import { JwstDataModel } from '../types/JwstDataTypes';
+import {
+  NChannelState,
+  createDefaultNChannel,
+  DEFAULT_CHANNEL_PARAMS,
+} from '../types/CompositeTypes';
+import { wavelengthToHue } from './wavelengthUtils';
+
+export type PresetInstrument = 'NIRCam' | 'MIRI' | 'Mixed';
+
+export interface PresetFilter {
+  name: string; // e.g. "F444W"
+  wavelengthUm: number;
+}
+
+export interface FilterPreset {
+  id: string;
+  name: string;
+  instrument: PresetInstrument;
+  filters: PresetFilter[];
+}
+
+export const FILTER_PRESETS: FilterPreset[] = [
+  // NIRCam presets
+  {
+    id: 'nircam-deep-field',
+    name: 'NIRCam Deep Field',
+    instrument: 'NIRCam',
+    filters: [
+      { name: 'F090W', wavelengthUm: 0.901 },
+      { name: 'F150W', wavelengthUm: 1.501 },
+      { name: 'F200W', wavelengthUm: 1.989 },
+      { name: 'F277W', wavelengthUm: 2.762 },
+      { name: 'F356W', wavelengthUm: 3.568 },
+      { name: 'F444W', wavelengthUm: 4.421 },
+    ],
+  },
+  {
+    id: 'nircam-pillars',
+    name: 'NIRCam Pillars of Creation',
+    instrument: 'NIRCam',
+    filters: [
+      { name: 'F090W', wavelengthUm: 0.901 },
+      { name: 'F187N', wavelengthUm: 1.874 },
+      { name: 'F200W', wavelengthUm: 1.989 },
+      { name: 'F335M', wavelengthUm: 3.362 },
+      { name: 'F444W', wavelengthUm: 4.421 },
+      { name: 'F470N', wavelengthUm: 4.707 },
+    ],
+  },
+  {
+    id: 'nircam-3filter',
+    name: 'NIRCam 3-Filter',
+    instrument: 'NIRCam',
+    filters: [
+      { name: 'F090W', wavelengthUm: 0.901 },
+      { name: 'F200W', wavelengthUm: 1.989 },
+      { name: 'F444W', wavelengthUm: 4.421 },
+    ],
+  },
+  // MIRI presets
+  {
+    id: 'miri-southern-ring',
+    name: 'MIRI Southern Ring',
+    instrument: 'MIRI',
+    filters: [
+      { name: 'F770W', wavelengthUm: 7.7 },
+      { name: 'F1130W', wavelengthUm: 11.3 },
+      { name: 'F1280W', wavelengthUm: 12.8 },
+      { name: 'F1800W', wavelengthUm: 18.0 },
+    ],
+  },
+  {
+    id: 'miri-pillars',
+    name: 'MIRI Pillars of Creation',
+    instrument: 'MIRI',
+    filters: [
+      { name: 'F770W', wavelengthUm: 7.7 },
+      { name: 'F1130W', wavelengthUm: 11.3 },
+      { name: 'F1800W', wavelengthUm: 18.0 },
+      { name: 'F2100W', wavelengthUm: 21.0 },
+    ],
+  },
+  {
+    id: 'miri-broadband',
+    name: 'MIRI 5-Filter Broadband',
+    instrument: 'MIRI',
+    filters: [
+      { name: 'F560W', wavelengthUm: 5.6 },
+      { name: 'F770W', wavelengthUm: 7.7 },
+      { name: 'F1000W', wavelengthUm: 10.0 },
+      { name: 'F1130W', wavelengthUm: 11.3 },
+      { name: 'F1280W', wavelengthUm: 12.8 },
+    ],
+  },
+  // Mixed
+  {
+    id: 'mixed-stephans-quintet',
+    name: "Stephan's Quintet",
+    instrument: 'Mixed',
+    filters: [
+      { name: 'F090W', wavelengthUm: 0.901 },
+      { name: 'F150W', wavelengthUm: 1.501 },
+      { name: 'F200W', wavelengthUm: 1.989 },
+      { name: 'F277W', wavelengthUm: 2.762 },
+      { name: 'F356W', wavelengthUm: 3.568 },
+      { name: 'F444W', wavelengthUm: 4.421 },
+      { name: 'F770W', wavelengthUm: 7.7 },
+    ],
+  },
+];
+
+/**
+ * Group presets by instrument for dropdown display.
+ */
+export function getPresetsByInstrument(): Map<PresetInstrument, FilterPreset[]> {
+  const groups = new Map<PresetInstrument, FilterPreset[]>();
+  for (const preset of FILTER_PRESETS) {
+    const list = groups.get(preset.instrument) || [];
+    list.push(preset);
+    groups.set(preset.instrument, list);
+  }
+  return groups;
+}
+
+/**
+ * Create NChannelState[] from a preset definition.
+ * Each filter becomes one channel with hue derived from wavelength.
+ */
+export function createChannelsFromPreset(preset: FilterPreset): NChannelState[] {
+  return preset.filters.map((f) => {
+    const hue = wavelengthToHue(f.wavelengthUm);
+    const channel = createDefaultNChannel(hue);
+    channel.label = f.name;
+    channel.wavelengthUm = f.wavelengthUm;
+    channel.params = { ...DEFAULT_CHANNEL_PARAMS };
+    return channel;
+  });
+}
+
+/**
+ * Extract a simple filter name from a potentially compound filter string.
+ * Handles formats like "CLEAR-F444W", "F444W-CLEAR", "NIRCAM/F444W".
+ */
+function extractFilterName(raw: string): string {
+  const upper = raw.toUpperCase().trim();
+  // Split on common separators
+  const parts = upper.split(/[-/;]+/);
+  // Return the first part that looks like a JWST filter (F###X)
+  for (const part of parts) {
+    if (/^F\d{2,4}[WMNLP]/.test(part.trim())) {
+      // Extract just the filter code (e.g. F444W from F444W2)
+      const match = part.trim().match(/^F\d{2,4}[WMNLP]\d?/);
+      if (match) return match[0];
+    }
+  }
+  return upper;
+}
+
+/**
+ * Match user images to preset channels by filter name.
+ * Returns a new channels array with dataIds populated for matched images.
+ *
+ * Matching rules:
+ * 1. Case-insensitive filter name comparison
+ * 2. Compound name extraction (e.g. "CLEAR-F444W" matches "F444W")
+ * 3. Multiple images with same filter go to the same channel
+ * 4. Unmatched channels keep empty dataIds
+ */
+export function matchImagesToPreset(
+  channels: NChannelState[],
+  images: JwstDataModel[]
+): NChannelState[] {
+  return channels.map((ch) => {
+    const presetFilter = ch.label?.toUpperCase() || '';
+    const matchedIds: string[] = [];
+
+    for (const img of images) {
+      const imgFilter = img.imageInfo?.filter;
+      if (!imgFilter) continue;
+
+      const extracted = extractFilterName(imgFilter);
+      if (extracted === presetFilter) {
+        matchedIds.push(img.id);
+      }
+    }
+
+    return { ...ch, dataIds: matchedIds };
+  });
+}
+
+/**
+ * Count how many user images match a preset's filters.
+ * Returns count of distinct filters that have at least one matching image.
+ */
+export function countPresetMatches(
+  preset: FilterPreset,
+  images: JwstDataModel[]
+): { matched: number; total: number } {
+  const total = preset.filters.length;
+  let matched = 0;
+
+  for (const filter of preset.filters) {
+    const filterName = filter.name.toUpperCase();
+    const hasMatch = images.some((img) => {
+      const imgFilter = img.imageInfo?.filter;
+      if (!imgFilter) return false;
+      return extractFilterName(imgFilter) === filterName;
+    });
+    if (hasMatch) matched++;
+  }
+
+  return { matched, total };
+}


### PR DESCRIPTION
## Summary
Add 7 curated JWST filter presets to the composite wizard's channel assignment step. Users can now recreate iconic NASA composites (Pillars of Creation, Deep Field, Southern Ring, Stephan's Quintet, etc.) with a single click instead of manually configuring 4-7 channels.

## Why
Users trying to recreate NASA's published JWST composites currently need to manually set up channels with the correct filters and colors. This is tedious and error-prone, especially for 6-7 filter sets. Curated presets remove this friction and help users learn which filter combinations produce iconic images.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Created `filterPresets.ts` with 7 preset definitions (3 NIRCam, 3 MIRI, 1 Mixed), plus `createChannelsFromPreset()`, `matchImagesToPreset()`, and `countPresetMatches()` utility functions
- Created `filterPresets.test.ts` with 27 unit tests covering preset data integrity, channel creation, image matching (exact, case-insensitive, compound filter names), and match counting
- Added "JWST Presets" dropdown button to `ChannelAssignStep.tsx` between the LRGB button group and Auto-Assign button, with click-outside/Escape dismissal
- Dropdown groups presets by instrument (NIRCam / MIRI / Mixed) with filter list in monospace and match badges showing how many user images match each preset
- Added dropdown CSS styles to `ChannelAssignStep.css` with consistent dark theme styling
- Marked B3.5 complete in development plan
- Added `filterPresets.ts` to key-files documentation

### Presets included:
| Preset | Instrument | Filters |
|--------|-----------|---------|
| NIRCam Deep Field | NIRCam | F090W, F150W, F200W, F277W, F356W, F444W |
| NIRCam Pillars of Creation | NIRCam | F090W, F187N, F200W, F335M, F444W, F470N |
| NIRCam 3-Filter | NIRCam | F090W, F200W, F444W |
| MIRI Southern Ring | MIRI | F770W, F1130W, F1280W, F1800W |
| MIRI Pillars of Creation | MIRI | F770W, F1130W, F1800W, F2100W |
| MIRI 5-Filter Broadband | MIRI | F560W, F770W, F1000W, F1130W, F1280W |
| Stephan's Quintet | Mixed | F090W, F150W, F200W, F277W, F356W, F444W, F770W |

## Test Plan
- [x] Run `npx vitest run` — all 51 tests pass (27 new + 24 existing)
- [x] Run `npx tsc --noEmit` — no type errors
- [x] Run `npm run lint && npm run format:check` — clean
- [ ] Open the app at `http://localhost:3000`, log in, navigate to a data group with JWST images
- [ ] Click "Create Composite" to open the wizard
- [ ] Verify the "JWST Presets ▾" dropdown button appears between LRGB and Auto-Assign by Filter
- [ ] Click "JWST Presets ▾" — verify dropdown menu appears with 3 groups (NIRCam, MIRI, Mixed)
- [ ] Verify each preset shows its name, filter list in monospace, and a match badge (e.g. "3/6") if any user images match
- [ ] Select a preset (e.g. NIRCam Deep Field) — verify channels are created with correct filter labels and wavelength-derived colors
- [ ] Verify matched images are auto-assigned to the correct channels
- [ ] Click outside the dropdown — verify it closes
- [ ] Press Escape while dropdown is open — verify it closes
- [ ] Verify RGB and LRGB preset buttons still work correctly

## Documentation Checklist
- [x] `docs/development-plan.md` — B3.5 marked complete
- [x] `docs/key-files.md` — added `filterPresets.ts`
- [ ] No new API endpoints (frontend-only change)
- [ ] No new backend controllers or services

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — frontend-only, no backend changes, no existing behavior modified.
Rollback: Revert this commit.

## Quality Checklist
- [x] Code follows project style guidelines
- [x] Unit tests added (27 tests)
- [x] TypeScript strict mode passes
- [x] ESLint clean (warnings only)
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)