### PR TITLE
feat: floating analysis bar, unified file selection & mosaic auto-filter

### DIFF
--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -53,6 +53,7 @@ Quick reference for finding important files in the codebase.
 
 - `frontend/jwst-frontend/src/App.tsx` - Root component with data fetching
 - `frontend/jwst-frontend/src/components/JwstDataDashboard.tsx` - Main dashboard UI
+- `frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.tsx` - Floating bottom bar for analysis actions (visible when toolbar scrolls out of view)
 - `frontend/jwst-frontend/src/components/ImageViewer.tsx` - FITS viewer with analysis tools (central hub for visualization)
 - `frontend/jwst-frontend/src/components/MastSearch.tsx` - MAST portal search and import
 - `frontend/jwst-frontend/src/components/MosaicWizard.tsx` - WCS mosaic wizard shell (2-step: Select Files → Preview & Export)

--- a/frontend/jwst-frontend/eslint.config.js
+++ b/frontend/jwst-frontend/eslint.config.js
@@ -69,6 +69,7 @@ export default [
         RequestInit: 'readonly',
         Response: 'readonly',
         ResizeObserver: 'readonly',
+        IntersectionObserver: 'readonly',
         SVGSVGElement: 'readonly',
       },
     },

--- a/frontend/jwst-frontend/src/components/MosaicWizard.tsx
+++ b/frontend/jwst-frontend/src/components/MosaicWizard.tsx
@@ -10,6 +10,7 @@ import './MosaicWizard.css';
 
 interface MosaicWizardProps {
   allImages: JwstDataModel[];
+  initialSelection?: string[];
   onMosaicSaved?: () => void;
   onClose: () => void;
 }
@@ -26,11 +27,14 @@ const FOOTPRINT_DEBOUNCE_MS = 500;
  */
 export const MosaicWizard: React.FC<MosaicWizardProps> = ({
   allImages,
+  initialSelection,
   onMosaicSaved,
   onClose,
 }) => {
   const [currentStep, setCurrentStep] = useState<MosaicWizardStep>(1);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(
+    () => new Set(initialSelection ?? [])
+  );
 
   // Defer data refresh until wizard closes (calling onMosaicSaved immediately
   // triggers fetchData → setLoading(true) which unmounts the entire dashboard)
@@ -213,6 +217,7 @@ export const MosaicWizard: React.FC<MosaicWizardProps> = ({
               allImages={allImages}
               selectedIds={selectedIds}
               onSelectionChange={setSelectedIds}
+              initialSelection={initialSelection}
               footprintData={footprintData}
               footprintLoading={footprintLoading}
               footprintError={footprintError}

--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.css
@@ -291,6 +291,14 @@
   transition: all var(--transition-fast);
 }
 
+.mosaic-open-btn.ready {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+  cursor: pointer;
+}
+
+.mosaic-open-btn.ready:hover,
 .mosaic-open-btn:hover {
   background-color: var(--bg-surface-hover);
   color: var(--text-primary);

--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
@@ -36,10 +36,11 @@ interface DashboardToolbarProps {
   showWhatsNew: boolean;
   onToggleWhatsNew: () => void;
 
-  selectedForCompositeCount: number;
+  selectedCount: number;
   onOpenCompositeWizard: () => void;
   onOpenMosaicWizard: () => void;
   onOpenComparisonPicker: () => void;
+  analysisRowRef?: React.Ref<HTMLDivElement>;
 }
 
 const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
@@ -72,10 +73,11 @@ const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
   showWhatsNew,
   onToggleWhatsNew,
 
-  selectedForCompositeCount,
+  selectedCount,
   onOpenCompositeWizard,
   onOpenMosaicWizard,
   onOpenComparisonPicker,
+  analysisRowRef,
 }) => {
   const handleTypeFilterChange = (val: string) => {
     if (val === '__viewable' || val === '__table') {
@@ -232,9 +234,9 @@ const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
           </button>
         </div>
 
-        <div className="controls-row controls-row-analysis-actions">
+        <div className="controls-row controls-row-analysis-actions" ref={analysisRowRef}>
           <button
-            className={`composite-btn ${selectedForCompositeCount >= 3 ? 'ready' : ''}`}
+            className={`composite-btn ${selectedCount >= 3 ? 'ready' : ''}`}
             onClick={onOpenCompositeWizard}
             title="Create composite image"
           >
@@ -245,10 +247,10 @@ const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
                 <circle cx="12" cy="14" r="4" fill="#4488ff" opacity="0.8" />
               </svg>
             </span>
-            Composite{selectedForCompositeCount > 0 ? ` (${selectedForCompositeCount})` : ''}
+            Composite{selectedCount > 0 ? ` (${selectedCount})` : ''}
           </button>
           <button
-            className="mosaic-open-btn"
+            className={`mosaic-open-btn ${selectedCount >= 2 ? 'ready' : ''}`}
             onClick={onOpenMosaicWizard}
             title="Create a WCS-aligned mosaic from multiple FITS images"
           >
@@ -260,7 +262,7 @@ const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
                 <rect x="13" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#44ff88" />
               </svg>
             </span>
-            WCS Mosaic
+            WCS Mosaic{selectedCount > 0 ? ` (${selectedCount})` : ''}
           </button>
           <button
             className="compare-open-btn"

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -8,9 +8,9 @@ import './DataCard.css';
 
 interface DataCardProps {
   item: JwstDataModel;
-  isSelectedForComposite: boolean;
+  isSelected: boolean;
   selectedTag: string;
-  onCompositeSelect: (dataId: string, event: React.MouseEvent) => void;
+  onFileSelect: (dataId: string, event: React.MouseEvent) => void;
   onView: (item: JwstDataModel) => void;
   onProcess: (dataId: string, algorithm: string) => void;
   onArchive: (dataId: string, isArchived: boolean) => void;
@@ -19,19 +19,19 @@ interface DataCardProps {
 
 const DataCard: React.FC<DataCardProps> = ({
   item,
-  isSelectedForComposite,
+  isSelected,
   selectedTag,
-  onCompositeSelect,
+  onFileSelect,
   onView,
   onProcess,
   onArchive,
   onTagClick,
 }) => {
   const fitsInfo = getFitsFileInfo(item.fileName);
-  const canSelectForComposite = fitsInfo.viewable;
+  const canSelect = fitsInfo.viewable;
 
   return (
-    <div className={`data-card ${isSelectedForComposite ? 'selected-composite' : ''}`}>
+    <div className={`data-card ${isSelected ? 'selected-composite' : ''}`}>
       {fitsInfo.viewable && (
         <div className="card-thumbnail">
           {item.hasThumbnail ? (
@@ -53,12 +53,12 @@ const DataCard: React.FC<DataCardProps> = ({
       <div className="card-header">
         {fitsInfo.viewable && (
           <button
-            className={`composite-select-btn ${isSelectedForComposite ? 'selected' : ''}`}
-            onClick={(e) => onCompositeSelect(item.id, e)}
-            disabled={!canSelectForComposite}
-            title={isSelectedForComposite ? 'Remove from composite selection' : 'Add to composite'}
+            className={`composite-select-btn ${isSelected ? 'selected' : ''}`}
+            onClick={(e) => onFileSelect(item.id, e)}
+            disabled={!canSelect}
+            title={isSelected ? 'Remove from analysis selection' : 'Select for analysis'}
           >
-            {isSelectedForComposite ? <CheckIcon /> : <PlusIcon />}
+            {isSelected ? <CheckIcon /> : <PlusIcon />}
           </button>
         )}
         <h4>{item.fileName}</h4>

--- a/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.css
+++ b/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.css
@@ -1,0 +1,133 @@
+.floating-analysis-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  transform: translateY(100%);
+  transition: transform 0.25s ease;
+  pointer-events: none;
+}
+
+.floating-analysis-bar.visible {
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.floating-analysis-inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 10px 20px;
+  background: var(--bg-elevated);
+  border-top: 1px solid var(--border-default);
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);
+}
+
+/* Re-use existing button styles from DashboardToolbar */
+.floating-analysis-bar .composite-btn,
+.floating-analysis-bar .mosaic-open-btn,
+.floating-analysis-bar .compare-open-btn {
+  min-height: 38px;
+}
+
+.floating-analysis-bar .composite-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background-color: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  cursor: not-allowed;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+}
+
+.floating-analysis-bar .composite-btn.ready {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+  cursor: pointer;
+}
+
+.floating-analysis-bar .composite-btn.ready:hover {
+  background-color: var(--bg-surface-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
+.floating-analysis-bar .mosaic-open-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+}
+
+.floating-analysis-bar .mosaic-open-btn.ready {
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+
+.floating-analysis-bar .mosaic-open-btn.ready:hover,
+.floating-analysis-bar .mosaic-open-btn:hover {
+  background-color: var(--bg-surface-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
+.floating-analysis-bar .compare-open-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+}
+
+.floating-analysis-bar .compare-open-btn:hover {
+  background-color: var(--bg-surface-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
+.floating-analysis-bar .composite-icon,
+.floating-analysis-bar .mosaic-icon,
+.floating-analysis-bar .compare-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 768px) {
+  .floating-analysis-inner {
+    padding: 8px 12px;
+    gap: 6px;
+  }
+
+  .floating-analysis-bar .composite-btn,
+  .floating-analysis-bar .mosaic-open-btn,
+  .floating-analysis-bar .compare-open-btn {
+    padding: 8px 10px;
+    font-size: 13px;
+  }
+}

--- a/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import './FloatingAnalysisBar.css';
+
+interface FloatingAnalysisBarProps {
+  visible: boolean;
+  selectedCount: number;
+  onOpenCompositeWizard: () => void;
+  onOpenMosaicWizard: () => void;
+  onOpenComparisonPicker: () => void;
+}
+
+const FloatingAnalysisBar: React.FC<FloatingAnalysisBarProps> = ({
+  visible,
+  selectedCount,
+  onOpenCompositeWizard,
+  onOpenMosaicWizard,
+  onOpenComparisonPicker,
+}) => {
+  return (
+    <div className={`floating-analysis-bar ${visible ? 'visible' : ''}`}>
+      <div className="floating-analysis-inner">
+        <button
+          className={`composite-btn ${selectedCount >= 3 ? 'ready' : ''}`}
+          onClick={onOpenCompositeWizard}
+          title="Create composite image"
+        >
+          <span className="composite-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <circle cx="8" cy="8" r="4" fill="#ff4444" opacity="0.8" />
+              <circle cx="16" cy="8" r="4" fill="#44ff44" opacity="0.8" />
+              <circle cx="12" cy="14" r="4" fill="#4488ff" opacity="0.8" />
+            </svg>
+          </span>
+          Composite{selectedCount > 0 ? ` (${selectedCount})` : ''}
+        </button>
+        <button
+          className={`mosaic-open-btn ${selectedCount >= 2 ? 'ready' : ''}`}
+          onClick={onOpenMosaicWizard}
+          title="Create a WCS-aligned mosaic from multiple FITS images"
+        >
+          <span className="mosaic-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <rect x="2" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#4488ff" />
+              <rect x="13" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#44ddff" />
+              <rect x="2" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#8844ff" />
+              <rect x="13" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#44ff88" />
+            </svg>
+          </span>
+          WCS Mosaic{selectedCount > 0 ? ` (${selectedCount})` : ''}
+        </button>
+        <button
+          className="compare-open-btn"
+          onClick={onOpenComparisonPicker}
+          title="Compare two FITS images (blink, side-by-side, or overlay)"
+        >
+          <span className="compare-icon">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <rect x="2" y="3" width="8" height="18" rx="1" />
+              <rect x="14" y="3" width="8" height="18" rx="1" />
+            </svg>
+          </span>
+          Compare
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FloatingAnalysisBar;

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
@@ -8,24 +8,24 @@ import './LineageFileCard.css';
 
 interface LineageFileCardProps {
   item: JwstDataModel;
-  isSelectedForComposite: boolean;
-  onCompositeSelect: (dataId: string, event: React.MouseEvent) => void;
+  isSelected: boolean;
+  onFileSelect: (dataId: string, event: React.MouseEvent) => void;
   onView: (item: JwstDataModel) => void;
   onProcess: (dataId: string, algorithm: string) => void;
 }
 
 const LineageFileCard: React.FC<LineageFileCardProps> = ({
   item,
-  isSelectedForComposite,
-  onCompositeSelect,
+  isSelected,
+  onFileSelect,
   onView,
   onProcess,
 }) => {
   const fitsInfo = getFitsFileInfo(item.fileName);
-  const canSelectForComposite = fitsInfo.viewable;
+  const canSelect = fitsInfo.viewable;
 
   return (
-    <div className={`lineage-file-card ${isSelectedForComposite ? 'selected-composite' : ''}`}>
+    <div className={`lineage-file-card ${isSelected ? 'selected-composite' : ''}`}>
       {fitsInfo.viewable && (
         <div className="lineage-thumbnail">
           {item.hasThumbnail ? (
@@ -48,14 +48,12 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
         <div className="file-header">
           {fitsInfo.viewable && (
             <button
-              className={`composite-select-btn small ${isSelectedForComposite ? 'selected' : ''}`}
-              onClick={(e) => onCompositeSelect(item.id, e)}
-              disabled={!canSelectForComposite}
-              title={
-                isSelectedForComposite ? 'Remove from composite selection' : 'Add to composite'
-              }
+              className={`composite-select-btn small ${isSelected ? 'selected' : ''}`}
+              onClick={(e) => onFileSelect(item.id, e)}
+              disabled={!canSelect}
+              title={isSelected ? 'Remove from analysis selection' : 'Select for analysis'}
             >
-              {isSelectedForComposite ? <CheckIcon /> : <PlusIcon />}
+              {isSelected ? <CheckIcon /> : <PlusIcon />}
             </button>
           )}
           <span className="file-name" title={item.fileName}>

--- a/frontend/jwst-frontend/src/components/dashboard/LineageView.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageView.tsx
@@ -13,14 +13,14 @@ interface LineageViewProps {
   filteredData: JwstDataModel[];
   collapsedLineages: Set<string>;
   expandedLevels: Set<string>;
-  selectedForComposite: Set<string>;
+  selectedFiles: Set<string>;
   onToggleLineage: (obsId: string) => void;
   onToggleLevel: (key: string) => void;
   onDeleteObservation: (obsId: string, event: React.MouseEvent) => void;
   onDeleteLevel: (obsId: string, level: string, event: React.MouseEvent) => void;
   onArchiveLevel: (obsId: string, level: string, event: React.MouseEvent) => void;
   isArchivingLevel: boolean;
-  onCompositeSelect: (dataId: string, event: React.MouseEvent) => void;
+  onFileSelect: (dataId: string, event: React.MouseEvent) => void;
   onView: (item: JwstDataModel) => void;
   onProcess: (dataId: string, algorithm: string) => void;
 }
@@ -58,14 +58,14 @@ const LineageView: React.FC<LineageViewProps> = ({
   filteredData,
   collapsedLineages,
   expandedLevels,
-  selectedForComposite,
+  selectedFiles,
   onToggleLineage,
   onToggleLevel,
   onDeleteObservation,
   onDeleteLevel,
   onArchiveLevel,
   isArchivingLevel,
-  onCompositeSelect,
+  onFileSelect,
   onView,
   onProcess,
 }) => {
@@ -227,8 +227,8 @@ const LineageView: React.FC<LineageViewProps> = ({
                             <LineageFileCard
                               key={item.id}
                               item={item}
-                              isSelectedForComposite={selectedForComposite.has(item.id)}
-                              onCompositeSelect={onCompositeSelect}
+                              isSelected={selectedFiles.has(item.id)}
+                              onFileSelect={onFileSelect}
                               onView={onView}
                               onProcess={onProcess}
                             />

--- a/frontend/jwst-frontend/src/components/dashboard/TargetGroupView.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/TargetGroupView.tsx
@@ -6,10 +6,10 @@ import './TargetGroupView.css';
 interface TargetGroupViewProps {
   filteredData: JwstDataModel[];
   collapsedGroups: Set<string>;
-  selectedForComposite: Set<string>;
+  selectedFiles: Set<string>;
   selectedTag: string;
   onToggleGroup: (groupId: string) => void;
-  onCompositeSelect: (dataId: string, event: React.MouseEvent) => void;
+  onFileSelect: (dataId: string, event: React.MouseEvent) => void;
   onView: (item: JwstDataModel) => void;
   onProcess: (dataId: string, algorithm: string) => void;
   onArchive: (dataId: string, isArchived: boolean) => void;
@@ -19,10 +19,10 @@ interface TargetGroupViewProps {
 const TargetGroupView: React.FC<TargetGroupViewProps> = ({
   filteredData,
   collapsedGroups,
-  selectedForComposite,
+  selectedFiles,
   selectedTag,
   onToggleGroup,
-  onCompositeSelect,
+  onFileSelect,
   onView,
   onProcess,
   onArchive,
@@ -93,9 +93,9 @@ const TargetGroupView: React.FC<TargetGroupViewProps> = ({
                   <DataCard
                     key={item.id}
                     item={item}
-                    isSelectedForComposite={selectedForComposite.has(item.id)}
+                    isSelected={selectedFiles.has(item.id)}
                     selectedTag={selectedTag}
-                    onCompositeSelect={onCompositeSelect}
+                    onFileSelect={onFileSelect}
                     onView={onView}
                     onProcess={onProcess}
                     onArchive={onArchive}

--- a/frontend/jwst-frontend/src/components/wizard/MosaicSelectStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/MosaicSelectStep.css
@@ -115,6 +115,54 @@
   color: #e5e7eb;
 }
 
+/* Auto-filter notice (matching filter from pre-selected files) */
+.mosaic-auto-filter-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0 1.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(74, 144, 217, 0.12);
+  border: 1px solid rgba(74, 144, 217, 0.25);
+  border-radius: 6px;
+  font-size: 0.82rem;
+  color: #9dc9f0;
+}
+
+.mosaic-auto-filter-notice strong {
+  color: #d4e9fb;
+}
+
+.mosaic-auto-filter-clear {
+  padding: 0.25rem 0.5rem;
+  background: rgba(74, 144, 217, 0.2);
+  border: 1px solid rgba(74, 144, 217, 0.3);
+  border-radius: 4px;
+  color: #9dc9f0;
+  font-size: 0.75rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+
+.mosaic-auto-filter-clear:hover {
+  background: rgba(74, 144, 217, 0.35);
+  color: #d4e9fb;
+}
+
+/* Mixed filter warning */
+.mosaic-mixed-filter-warning {
+  margin: 0 1.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(234, 179, 8, 0.1);
+  border: 1px solid rgba(234, 179, 8, 0.25);
+  border-radius: 6px;
+  font-size: 0.82rem;
+  color: #eab308;
+  line-height: 1.4;
+}
+
 /* Scrollable card grid area */
 .mosaic-card-grid-scroll {
   flex: 1;


### PR DESCRIPTION
## Summary
- Adds a floating bottom bar that keeps analysis buttons accessible while scrolling the dashboard
- Unifies file selection so the same checkbox feeds both Composite and Mosaic wizards
- Auto-filters the Mosaic wizard's file list by wavelength when pre-selected files share a common filter

## Why
Users lose access to the Composite, Mosaic, and Compare buttons when scrolling through their files on the dashboard. Additionally, the Mosaic wizard had no way to accept pre-selected files from the dashboard, forcing users to re-select files inside the wizard. This change improves workflow efficiency and reduces redundant interaction.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Renamed `selectedForComposite` state to `selectedFiles` across 8 components (JwstDataDashboard, DashboardToolbar, LineageFileCard, DataCard, LineageView, TargetGroupView) to make file selection generic
- Both Composite and Mosaic buttons now display the selected file count; Mosaic button gets `.ready` styling when 2+ files selected
- MosaicWizard accepts `initialSelection` prop, initializes `selectedIds` from it
- MosaicSelectStep auto-detects filter from pre-selected files: if all share the same filter, auto-constrains the wavelength dropdown with a dismissible notice; if mixed, shows a yellow warning banner
- Created `FloatingAnalysisBar` component with fixed bottom positioning, slide-in/out CSS transition, and the same 3 analysis buttons
- Added `IntersectionObserver` in JwstDataDashboard to track when the toolbar's analysis row scrolls out of view, toggling the floating bar
- Added `IntersectionObserver` to ESLint browser globals whitelist
- Updated `docs/key-files.md` with the new component

## Test Plan
- [x] **Unified selection**: Check files on dashboard → both Composite and Mosaic buttons show count → open either wizard → files are pre-selected → close wizard → selection clears
- [ ] **Mosaic auto-filter**: Select 3 files with the same filter (e.g. F444W) → open Mosaic → Step 1 shows filter notice "Showing F444W files (matching selection)" → click "Clear constraint" → all files visible again
- [ ] **Mixed filter warning**: Select files with different filters → open Mosaic → yellow warning banner appears about using Composite instead
- [ ] **Floating bar**: Scroll down past toolbar → floating bar slides in at bottom → scroll back up → bar disappears → buttons in both locations trigger same actions
- [ ] **ESLint/build**: `npm run build` passes cleanly

## Documentation Checklist
- [x] `docs/key-files.md` — added FloatingAnalysisBar component
- [x] No new API endpoints, controllers, or services

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — purely UI changes, no backend impact. Prop renames are compile-checked by TypeScript.

Rollback: Revert this PR.

## Quality Checklist
- [x] Code follows project style guidelines
- [x] TypeScript strict mode passes
- [x] ESLint passes with no warnings/errors
- [x] All existing tests pass
- [x] Accessibility: button titles updated from "composite" to "analysis"