### PR TITLE
feat: S3 storage providers, SeaweedFS infrastructure & config wiring

### DIFF
--- a/backend/JwstDataAnalysis.API/Configuration/S3Settings.cs
+++ b/backend/JwstDataAnalysis.API/Configuration/S3Settings.cs
@@ -1,0 +1,59 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+namespace JwstDataAnalysis.API.Configuration
+{
+    /// <summary>
+    /// Configuration settings for S3-compatible object storage.
+    /// Bound from the "Storage:S3" configuration section.
+    /// </summary>
+    public class S3Settings
+    {
+        /// <summary>
+        /// Gets or sets the S3 bucket name for storing application data.
+        /// </summary>
+        public string BucketName { get; set; } = "jwst-data";
+
+        /// <summary>
+        /// Gets or sets the custom S3 endpoint URL (e.g., "http://seaweedfs-s3:8333" for local dev).
+        /// Leave null to use the default AWS S3 endpoint.
+        /// </summary>
+        public string? Endpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the S3 access key. Required for non-AWS providers (SeaweedFS, MinIO).
+        /// For AWS, prefer IAM roles/instance profiles instead.
+        /// </summary>
+        public string? AccessKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the S3 secret key. Required for non-AWS providers (SeaweedFS, MinIO).
+        /// </summary>
+        public string? SecretKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to force path-style addressing (bucket in path, not subdomain).
+        /// Required for SeaweedFS, MinIO, and other S3-compatible services.
+        /// </summary>
+        public bool ForcePathStyle { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the AWS region (used for signing requests). Defaults to us-east-1.
+        /// For non-AWS providers, this can be any valid region string.
+        /// </summary>
+        public string Region { get; set; } = "us-east-1";
+
+        /// <summary>
+        /// Gets or sets the default expiry for presigned download URLs.
+        /// </summary>
+        public TimeSpan PresignedUrlExpiry { get; set; } = TimeSpan.FromMinutes(15);
+
+        /// <summary>
+        /// Gets or sets the public endpoint for generating presigned URLs reachable from the browser.
+        /// For local dev, this should be the externally-accessible SeaweedFS URL
+        /// (e.g., "http://localhost:8333") since the Docker internal hostname
+        /// isn't reachable from the browser.
+        /// </summary>
+        public string? PublicEndpoint { get; set; }
+    }
+}

--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -1620,21 +1620,24 @@ namespace JwstDataAnalysis.API.Controllers
                     }
                 }
 
-                // Try to remove the observation directory if empty
-                var observationDir = storageProvider.ResolveLocalPath(
-                    $"mast/{observationBaseId}");
+                // Try to remove the observation directory if empty (local storage only)
+                if (storageProvider.SupportsLocalPath)
+                {
+                    var observationDir = storageProvider.ResolveLocalPath(
+                        $"mast/{observationBaseId}");
 
-                try
-                {
-                    if (Directory.Exists(observationDir) && !Directory.EnumerateFileSystemEntries(observationDir).Any())
+                    try
                     {
-                        Directory.Delete(observationDir);
-                        LogRemovedEmptyDirectory(observationDir);
+                        if (Directory.Exists(observationDir) && !Directory.EnumerateFileSystemEntries(observationDir).Any())
+                        {
+                            Directory.Delete(observationDir);
+                            LogRemovedEmptyDirectory(observationDir);
+                        }
                     }
-                }
-                catch (Exception ex)
-                {
-                    LogCouldNotRemoveDirectory(ex, observationDir);
+                    catch (Exception ex)
+                    {
+                        LogCouldNotRemoveDirectory(ex, observationDir);
+                    }
                 }
 
                 // Delete all database records

--- a/backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj
+++ b/backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -35,7 +35,18 @@ builder.Services.Configure<IpRateLimitOptions>(builder.Configuration.GetSection(
 builder.Services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
 builder.Services.AddInMemoryRateLimiting();
 
-builder.Services.AddSingleton<IStorageProvider, LocalStorageProvider>();
+// Storage provider: conditional registration based on configuration
+var storageProviderType = builder.Configuration.GetValue<string>("Storage:Provider")?.ToLowerInvariant() ?? "local";
+if (storageProviderType == "s3")
+{
+    builder.Services.Configure<S3Settings>(builder.Configuration.GetSection("Storage:S3"));
+    builder.Services.AddSingleton<IStorageProvider, S3StorageProvider>();
+}
+else
+{
+    builder.Services.AddSingleton<IStorageProvider, LocalStorageProvider>();
+}
+
 builder.Services.AddSingleton<IMongoDBService, MongoDBService>();
 builder.Services.AddSingleton<IImportJobTracker, ImportJobTracker>();
 

--- a/backend/JwstDataAnalysis.API/Services/Storage/IStorageProvider.cs
+++ b/backend/JwstDataAnalysis.API/Services/Storage/IStorageProvider.cs
@@ -10,6 +10,13 @@ namespace JwstDataAnalysis.API.Services.Storage
     public interface IStorageProvider
     {
         /// <summary>
+        /// Gets a value indicating whether this provider supports local filesystem paths.
+        /// Returns true for local storage, false for cloud providers like S3.
+        /// Use this to guard calls to <see cref="ResolveLocalPath"/> without try/catch.
+        /// </summary>
+        bool SupportsLocalPath { get; }
+
+        /// <summary>
         /// Write data from a stream to storage.
         /// </summary>
         Task WriteAsync(string key, Stream data, CancellationToken ct = default);

--- a/backend/JwstDataAnalysis.API/Services/Storage/LocalStorageProvider.cs
+++ b/backend/JwstDataAnalysis.API/Services/Storage/LocalStorageProvider.cs
@@ -19,6 +19,9 @@ namespace JwstDataAnalysis.API.Services.Storage
         }
 
         /// <inheritdoc/>
+        public bool SupportsLocalPath => true;
+
+        /// <inheritdoc/>
         public async Task WriteAsync(string key, Stream data, CancellationToken ct = default)
         {
             var fullPath = ToFullPath(key);

--- a/backend/JwstDataAnalysis.API/Services/Storage/S3StorageProvider.cs
+++ b/backend/JwstDataAnalysis.API/Services/Storage/S3StorageProvider.cs
@@ -1,0 +1,197 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Transfer;
+
+using JwstDataAnalysis.API.Configuration;
+
+using Microsoft.Extensions.Options;
+
+namespace JwstDataAnalysis.API.Services.Storage
+{
+    /// <summary>
+    /// S3-compatible object storage implementation of <see cref="IStorageProvider"/>.
+    /// Works with AWS S3, SeaweedFS, and other S3-compatible services.
+    /// </summary>
+    public sealed partial class S3StorageProvider : IStorageProvider, IDisposable
+    {
+        private const long LargeObjectThreshold = 100 * 1024 * 1024; // 100MB
+
+        private readonly AmazonS3Client client;
+        private readonly string bucketName;
+        private readonly S3Settings settings;
+        private readonly ILogger<S3StorageProvider> logger;
+        private bool disposed;
+
+        public S3StorageProvider(IOptions<S3Settings> options, ILogger<S3StorageProvider> logger)
+        {
+            settings = options.Value;
+            this.logger = logger;
+            bucketName = settings.BucketName;
+
+            var config = new AmazonS3Config
+            {
+                ForcePathStyle = settings.ForcePathStyle,
+            };
+
+            if (!string.IsNullOrEmpty(settings.Endpoint))
+            {
+                config.ServiceURL = settings.Endpoint;
+            }
+            else if (!string.IsNullOrEmpty(settings.Region))
+            {
+                config.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(settings.Region);
+            }
+
+            if (!string.IsNullOrEmpty(settings.AccessKey) && !string.IsNullOrEmpty(settings.SecretKey))
+            {
+                client = new AmazonS3Client(settings.AccessKey, settings.SecretKey, config);
+            }
+            else
+            {
+                // Use default credential chain (IAM roles, environment variables, etc.)
+                client = new AmazonS3Client(config);
+            }
+
+            LogInitialized(bucketName, settings.Endpoint ?? "default AWS");
+        }
+
+        /// <inheritdoc/>
+        public bool SupportsLocalPath => false;
+
+        /// <inheritdoc/>
+        public async Task WriteAsync(string key, Stream data, CancellationToken ct = default)
+        {
+            // Use TransferUtility for large objects (multipart upload)
+            if (data.CanSeek && data.Length > LargeObjectThreshold)
+            {
+                using var transferUtility = new TransferUtility(client);
+                var uploadRequest = new TransferUtilityUploadRequest
+                {
+                    BucketName = bucketName,
+                    Key = key,
+                    InputStream = data,
+                };
+                await transferUtility.UploadAsync(uploadRequest, ct);
+            }
+            else
+            {
+                var request = new PutObjectRequest
+                {
+                    BucketName = bucketName,
+                    Key = key,
+                    InputStream = data,
+                };
+                await client.PutObjectAsync(request, ct);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<Stream> ReadStreamAsync(string key, CancellationToken ct = default)
+        {
+            try
+            {
+                var response = await client.GetObjectAsync(bucketName, key, ct);
+                return response.ResponseStream;
+            }
+            catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                throw new FileNotFoundException($"File not found in S3: {key}", key);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> ExistsAsync(string key, CancellationToken ct = default)
+        {
+            try
+            {
+                await client.GetObjectMetadataAsync(bucketName, key, ct);
+                return true;
+            }
+            catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task DeleteAsync(string key, CancellationToken ct = default)
+        {
+            await client.DeleteObjectAsync(bucketName, key, ct);
+        }
+
+        /// <inheritdoc/>
+        public Task<string?> GetPresignedUrlAsync(string key, TimeSpan expiry, CancellationToken ct = default)
+        {
+            var request = new GetPreSignedUrlRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                Expires = DateTime.UtcNow.Add(expiry),
+                Verb = HttpVerb.GET,
+            };
+
+            var url = client.GetPreSignedURL(request);
+
+            // Rewrite internal Docker hostname to public endpoint if configured
+            if (!string.IsNullOrEmpty(settings.PublicEndpoint) && !string.IsNullOrEmpty(settings.Endpoint))
+            {
+                url = url.Replace(settings.Endpoint, settings.PublicEndpoint);
+            }
+
+            return Task.FromResult<string?>(url);
+        }
+
+        /// <inheritdoc/>
+        public async IAsyncEnumerable<string> ListAsync(
+            string prefix,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            var request = new ListObjectsV2Request
+            {
+                BucketName = bucketName,
+                Prefix = prefix,
+            };
+
+            ListObjectsV2Response response;
+            do
+            {
+                ct.ThrowIfCancellationRequested();
+                response = await client.ListObjectsV2Async(request, ct);
+
+                foreach (var obj in response.S3Objects)
+                {
+                    yield return obj.Key;
+                }
+
+                request.ContinuationToken = response.NextContinuationToken;
+            }
+            while (response.IsTruncated == true);
+        }
+
+        /// <inheritdoc/>
+        public string ResolveLocalPath(string key)
+        {
+            throw new NotSupportedException(
+                "S3 storage does not support local filesystem paths. " +
+                "Check SupportsLocalPath before calling this method.");
+        }
+
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                client.Dispose();
+                disposed = true;
+            }
+        }
+
+        [LoggerMessage(EventId = 4001, Level = LogLevel.Information,
+            Message = "Initialized S3 storage provider (bucket={Bucket}, endpoint={Endpoint})")]
+        private partial void LogInitialized(string bucket, string endpoint);
+    }
+}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -50,6 +50,22 @@ MAST_DOWNLOAD_DIR=/app/data/mast
 MAST_DOWNLOAD_TIMEOUT=3600
 
 # =============================================================================
+# Storage Configuration
+# =============================================================================
+# Storage provider: "local" (default) or "s3"
+STORAGE_PROVIDER=local
+
+# S3-compatible storage settings (only used when STORAGE_PROVIDER=s3)
+# For local development with SeaweedFS: docker compose --profile s3 up -d
+S3_BUCKET_NAME=jwst-data
+S3_ENDPOINT=http://seaweedfs-s3:8333
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+S3_FORCE_PATH_STYLE=true
+# Public endpoint for presigned URLs (must be reachable from browser)
+S3_PUBLIC_ENDPOINT=http://localhost:8333
+
+# =============================================================================
 # Network Binding
 # =============================================================================
 # All service ports are bound to 127.0.0.1 (localhost only) by default.

--- a/docker/docker-compose.agent.yml
+++ b/docker/docker-compose.agent.yml
@@ -27,6 +27,13 @@ services:
       - ProcessingEngine__BaseUrl=http://processing-engine:8000
       - ASPNETCORE_ENVIRONMENT=Development
       - CORS_ALLOWED_ORIGINS=http://localhost:${FRONTEND_PORT}
+      - Storage__Provider=${STORAGE_PROVIDER:-local}
+      - Storage__S3__BucketName=${S3_BUCKET_NAME:-jwst-data}
+      - Storage__S3__Endpoint=${S3_ENDPOINT:-http://seaweedfs-s3:8333}
+      - Storage__S3__AccessKey=${S3_ACCESS_KEY:-}
+      - Storage__S3__SecretKey=${S3_SECRET_KEY:-}
+      - Storage__S3__ForcePathStyle=${S3_FORCE_PATH_STYLE:-true}
+      - Storage__S3__PublicEndpoint=${S3_PUBLIC_ENDPOINT:-http://localhost:8333}
     volumes:
       - ${DATA_DIR:?DATA_DIR required}:/app/data
     networks:
@@ -43,6 +50,14 @@ services:
       - MAST_DOWNLOAD_DIR=${MAST_DOWNLOAD_DIR:-/app/data/mast}
       - MAST_DOWNLOAD_TIMEOUT=${MAST_DOWNLOAD_TIMEOUT:-3600}
       - MAX_MOSAIC_OUTPUT_PIXELS=${MAX_MOSAIC_OUTPUT_PIXELS:-64000000}
+      - STORAGE_PROVIDER=${STORAGE_PROVIDER:-local}
+      - STORAGE_BASE_PATH=/app/data
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME:-jwst-data}
+      - S3_ENDPOINT=${S3_ENDPOINT:-http://seaweedfs-s3:8333}
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY:-}
+      - S3_SECRET_KEY=${S3_SECRET_KEY:-}
+      - S3_FORCE_PATH_STYLE=${S3_FORCE_PATH_STYLE:-true}
+      - S3_PUBLIC_ENDPOINT=${S3_PUBLIC_ENDPOINT:-http://localhost:8333}
     volumes:
       - ${DATA_DIR:?DATA_DIR required}:/app/data
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,6 +34,13 @@ services:
       - MongoDB__DatabaseName=${MONGO_DATABASE:-jwst_data_analysis}
       - ProcessingEngine__BaseUrl=http://processing-engine:8000
       - Storage__BasePath=/app/data
+      - Storage__Provider=${STORAGE_PROVIDER:-local}
+      - Storage__S3__BucketName=${S3_BUCKET_NAME:-jwst-data}
+      - Storage__S3__Endpoint=${S3_ENDPOINT:-http://seaweedfs-s3:8333}
+      - Storage__S3__AccessKey=${S3_ACCESS_KEY:-}
+      - Storage__S3__SecretKey=${S3_SECRET_KEY:-}
+      - Storage__S3__ForcePathStyle=${S3_FORCE_PATH_STYLE:-true}
+      - Storage__S3__PublicEndpoint=${S3_PUBLIC_ENDPOINT:-http://localhost:8333}
     volumes:
       - ../data:/app/data
     depends_on:
@@ -53,8 +60,14 @@ services:
       - MAST_DOWNLOAD_DIR=${MAST_DOWNLOAD_DIR:-/app/data/mast}
       - MAST_DOWNLOAD_TIMEOUT=${MAST_DOWNLOAD_TIMEOUT:-3600}
       - MAX_MOSAIC_OUTPUT_PIXELS=${MAX_MOSAIC_OUTPUT_PIXELS:-64000000}
-      - STORAGE_PROVIDER=local
+      - STORAGE_PROVIDER=${STORAGE_PROVIDER:-local}
       - STORAGE_BASE_PATH=/app/data
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME:-jwst-data}
+      - S3_ENDPOINT=${S3_ENDPOINT:-http://seaweedfs-s3:8333}
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY:-}
+      - S3_SECRET_KEY=${S3_SECRET_KEY:-}
+      - S3_FORCE_PATH_STYLE=${S3_FORCE_PATH_STYLE:-true}
+      - S3_PUBLIC_ENDPOINT=${S3_PUBLIC_ENDPOINT:-http://localhost:8333}
     volumes:
       - ../data:/app/data
     depends_on:
@@ -86,6 +99,59 @@ services:
     networks:
       - jwst-network
 
+  # SeaweedFS S3-compatible object storage (local development)
+  # Only used when STORAGE_PROVIDER=s3. All four services use the same image.
+  seaweedfs-master:
+    image: chrislusf/seaweedfs:latest
+    container_name: jwst-seaweedfs-master
+    restart: unless-stopped
+    command: "master -ip=seaweedfs-master -ip.bind=0.0.0.0"
+    profiles:
+      - s3
+    networks:
+      - jwst-network
+
+  seaweedfs-volume:
+    image: chrislusf/seaweedfs:latest
+    container_name: jwst-seaweedfs-volume
+    restart: unless-stopped
+    command: "volume -mserver=seaweedfs-master:9333 -ip.bind=0.0.0.0 -port=8080"
+    volumes:
+      - seaweedfs_data:/data
+    depends_on:
+      - seaweedfs-master
+    profiles:
+      - s3
+    networks:
+      - jwst-network
+
+  seaweedfs-filer:
+    image: chrislusf/seaweedfs:latest
+    container_name: jwst-seaweedfs-filer
+    restart: unless-stopped
+    command: "filer -master=seaweedfs-master:9333 -ip.bind=0.0.0.0"
+    depends_on:
+      - seaweedfs-master
+      - seaweedfs-volume
+    profiles:
+      - s3
+    networks:
+      - jwst-network
+
+  seaweedfs-s3:
+    image: chrislusf/seaweedfs:latest
+    container_name: jwst-seaweedfs-s3
+    restart: unless-stopped
+    command: "s3 -filer=seaweedfs-filer:8888 -ip.bind=0.0.0.0 -port=8333"
+    ports:
+      - "127.0.0.1:8333:8333"
+    depends_on:
+      - seaweedfs-filer
+    profiles:
+      - s3
+    networks:
+      - jwst-network
+
   docs:
     image: squidfunk/mkdocs-material:9
     container_name: jwst-docs
@@ -102,6 +168,7 @@ services:
 
 volumes:
   mongodb_data:
+  seaweedfs_data:
 
 networks:
   jwst-network:

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -304,14 +304,14 @@ Replace the shared Docker volume with S3 for all application data. Bucket struct
 
 | Task   | Description                                                                     | Blocked By   | Status   |
 | ------ | ------------------------------------------------------------------------------- | ------------ | -------- |
-| F3.1   | `S3StorageProvider` implementation (backend .NET, AWS SDK)                      | F2.1, F2.2   | [ ]      |
-| F3.2   | `S3Storage` implementation (processing engine Python, boto3)                    | F2.3, F2.4   | [ ]      |
+| F3.1   | `S3StorageProvider` implementation (backend .NET, AWS SDK)                      | F2.1, F2.2   | [x]      |
+| F3.2   | `S3Storage` implementation (processing engine Python, boto3)                    | F2.3, F2.4   | [x]      |
 | F3.3   | MAST downloads to S3 — stream via S3 multipart upload, LRU temp cache for processing | F3.1, F3.2   | [ ]      |
 | F3.4   | User uploads to S3 — stream multipart form data to `uploads/{userId}/{guid}{ext}` | F3.1         | [ ]      |
 | F3.5   | Generated outputs to S3 — mosaic/composite results to `mosaic/` and `exports/` prefixes | F3.2         | [ ]      |
 | F3.6   | Presigned URLs for file downloads (15-min expiry, skip proxying through backend) | F3.1         | [ ]      |
 | F3.7   | S3 Intelligent-Tiering lifecycle policy on `mast/` prefix                       | F3.1         | [ ]      |
-| F3.8   | Local dev parity — MinIO container in `docker-compose.override.yml`             | F3.1         | [ ]      |
+| F3.8   | Local dev parity — SeaweedFS in docker-compose.yml (s3 profile)                 | F3.1         | [x]      |
 
 **Why**: The shared Docker volume doesn't scale beyond a single host, costs ~$53/mo on EFS for 177GB of MAST data vs ~$5/mo on S3 with Intelligent-Tiering. S3 also enables CDN distribution and eliminates the need to proxy large files through the backend.
 

--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -37,9 +37,11 @@ Quick reference for finding important files in the codebase.
 - `backend/JwstDataAnalysis.API/Services/ThumbnailQueue.cs` - Channel-based background queue for thumbnail batches
 - `backend/JwstDataAnalysis.API/Services/ThumbnailBackgroundService.cs` - BackgroundService that processes queued thumbnail batches
 - `backend/JwstDataAnalysis.API/Services/FileContentValidator.cs` - File upload validation
-- `backend/JwstDataAnalysis.API/Services/Storage/IStorageProvider.cs` - Storage abstraction interface
+- `backend/JwstDataAnalysis.API/Services/Storage/IStorageProvider.cs` - Storage abstraction interface (with `SupportsLocalPath`)
 - `backend/JwstDataAnalysis.API/Services/Storage/LocalStorageProvider.cs` - Local filesystem storage implementation
+- `backend/JwstDataAnalysis.API/Services/Storage/S3StorageProvider.cs` - S3-compatible object storage implementation (AWS SDK)
 - `backend/JwstDataAnalysis.API/Services/Storage/StorageKeyHelper.cs` - Shared utility for converting file paths to relative storage keys
+- `backend/JwstDataAnalysis.API/Configuration/S3Settings.cs` - S3 configuration POCO (bucket, endpoint, credentials, presigned URL settings)
 - `backend/JwstDataAnalysis.API/Services/ProcessingEngineHealthCheck.cs` - IHealthCheck for processing engine connectivity
 - `backend/JwstDataAnalysis.API/Services/SeedDataService.cs` - Database initialization
 - `backend/JwstDataAnalysis.API/Models/JwstDataModel.cs` - Data models and DTOs
@@ -114,7 +116,9 @@ Quick reference for finding important files in the codebase.
 - `processing-engine/app/analysis/models.py` - Analysis Pydantic models
 - `processing-engine/app/storage/provider.py` - Storage abstraction ABC
 - `processing-engine/app/storage/local_storage.py` - Local filesystem storage implementation
-- `processing-engine/app/storage/factory.py` - Storage provider factory (singleton)
+- `processing-engine/app/storage/s3_storage.py` - S3-compatible storage implementation (boto3)
+- `processing-engine/app/storage/temp_cache.py` - LRU temp file cache for S3 downloads (2GB default)
+- `processing-engine/app/storage/factory.py` - Storage provider factory (singleton, supports `local` and `s3`)
 - `processing-engine/app/processing/analysis.py` - Analysis algorithms (in progress)
 - `processing-engine/app/processing/utils.py` - FITS utilities (in progress)
 

--- a/processing-engine/Dockerfile
+++ b/processing-engine/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 # Create non-root user and writable data directories for MAST downloads/processing
 RUN groupadd --system --gid 1001 appgroup && \
     useradd --system --uid 1001 --gid appgroup --no-create-home appuser && \
-    mkdir -p /app/data/mast /tmp/matplotlib && \
+    mkdir -p /app/data/mast /tmp/matplotlib /tmp/jwst-cache && \
     chown -R appuser:appgroup /app/data && \
     chown -R appuser:appgroup /app /tmp/matplotlib
 

--- a/processing-engine/app/storage/factory.py
+++ b/processing-engine/app/storage/factory.py
@@ -23,8 +23,7 @@ def get_storage_provider() -> StorageProvider:
     """
     Get the singleton storage provider instance.
 
-    Currently only supports 'local'. Future providers (e.g. 's3')
-    can be added here.
+    Supports 'local' (default) and 's3' provider types.
     """
     global _instance
     if _instance is not None:
@@ -36,12 +35,17 @@ def get_storage_provider() -> StorageProvider:
             return _instance
 
         provider_type = os.environ.get("STORAGE_PROVIDER", "local").lower()
-        base_path = os.environ.get("STORAGE_BASE_PATH", "/app/data")
 
         if provider_type == "local":
+            base_path = os.environ.get("STORAGE_BASE_PATH", "/app/data")
             _instance = LocalStorage(base_path=base_path)
-            logger.info(f"Initialized local storage provider (base_path={base_path})")
+            logger.info("Initialized local storage provider (base_path=%s)", base_path)
+        elif provider_type == "s3":
+            from .s3_storage import S3Storage
+
+            _instance = S3Storage()
+            logger.info("Initialized S3 storage provider")
         else:
-            raise ValueError(f"Unknown storage provider: {provider_type}. Supported: local")
+            raise ValueError(f"Unknown storage provider: {provider_type}. Supported: local, s3")
 
         return _instance

--- a/processing-engine/app/storage/s3_storage.py
+++ b/processing-engine/app/storage/s3_storage.py
@@ -1,0 +1,129 @@
+"""
+S3-compatible object storage provider.
+
+Works with AWS S3, SeaweedFS, and other S3-compatible services.
+Downloads files to a local LRU temp cache for astropy to open.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from .provider import StorageProvider
+from .temp_cache import TempFileCache
+
+
+logger = logging.getLogger(__name__)
+
+
+class S3Storage(StorageProvider):
+    """S3-compatible storage implementation of StorageProvider."""
+
+    def __init__(
+        self,
+        bucket_name: str | None = None,
+        endpoint: str | None = None,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        force_path_style: bool = True,
+        region: str = "us-east-1",
+        public_endpoint: str | None = None,
+    ):
+        self._bucket = bucket_name or os.environ.get("S3_BUCKET_NAME", "jwst-data")
+        self._endpoint = endpoint or os.environ.get("S3_ENDPOINT")
+        self._public_endpoint = public_endpoint or os.environ.get("S3_PUBLIC_ENDPOINT")
+        access = access_key or os.environ.get("S3_ACCESS_KEY")
+        secret = secret_key or os.environ.get("S3_SECRET_KEY")
+        force_ps = (
+            force_path_style or os.environ.get("S3_FORCE_PATH_STYLE", "true").lower() == "true"
+        )
+
+        config = Config(s3={"addressing_style": "path"} if force_ps else {})
+
+        client_kwargs: dict = {
+            "service_name": "s3",
+            "config": config,
+            "region_name": region,
+        }
+        if self._endpoint:
+            client_kwargs["endpoint_url"] = self._endpoint
+        if access and secret:
+            client_kwargs["aws_access_key_id"] = access
+            client_kwargs["aws_secret_access_key"] = secret
+
+        self._client = boto3.client(**client_kwargs)
+        self._cache = TempFileCache()
+
+        logger.info(
+            "Initialized S3 storage provider (bucket=%s, endpoint=%s)",
+            self._bucket,
+            self._endpoint or "default AWS",
+        )
+
+    def read_to_temp(self, key: str) -> Path:
+        """Download from S3 to local temp cache if not already cached."""
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+
+        local_path = self._cache.put(key)
+        try:
+            self._client.download_file(self._bucket, key, str(local_path))
+            logger.debug("Downloaded s3://%s/%s -> %s", self._bucket, key, local_path)
+        except ClientError as e:
+            # Clean up partial download
+            if local_path.exists():
+                local_path.unlink()
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ("404", "NoSuchKey"):
+                raise FileNotFoundError(f"File not found in S3: {key}") from e
+            raise
+
+        self._cache.evict_if_needed()
+        return local_path
+
+    def write_from_path(self, key: str, local_path: Path) -> None:
+        """Upload a local file to S3."""
+        self._client.upload_file(str(local_path), self._bucket, key)
+        logger.debug("Uploaded %s -> s3://%s/%s", local_path, self._bucket, key)
+
+    def write_from_bytes(self, key: str, data: bytes) -> None:
+        """Write raw bytes to S3."""
+        self._client.put_object(Bucket=self._bucket, Key=key, Body=data)
+
+    def exists(self, key: str) -> bool:
+        """Check whether a key exists in S3."""
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=key)
+            return True
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                return False
+            raise
+
+    def delete(self, key: str) -> None:
+        """Delete an object from S3."""
+        self._client.delete_object(Bucket=self._bucket, Key=key)
+
+    def presigned_url(self, key: str, expiry: int = 900) -> str | None:
+        """Generate a presigned download URL."""
+        url = self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self._bucket, "Key": key},
+            ExpiresIn=expiry,
+        )
+        # Rewrite internal Docker hostname to public endpoint if configured
+        if self._public_endpoint and self._endpoint and url:
+            url = url.replace(self._endpoint, self._public_endpoint)
+        return url
+
+    def resolve_local_path(self, key: str) -> Path:
+        """Not supported for S3 storage."""
+        raise NotImplementedError(
+            "S3 storage does not support local filesystem paths. "
+            "Use read_to_temp() to get a local copy."
+        )

--- a/processing-engine/app/storage/temp_cache.py
+++ b/processing-engine/app/storage/temp_cache.py
@@ -1,0 +1,116 @@
+"""
+LRU temp file cache for S3 downloads.
+
+When the processing engine runs with S3 storage, FITS files must be
+downloaded to local disk for astropy to open them. This cache avoids
+re-downloading frequently accessed files by keeping them in a bounded
+local directory with LRU eviction.
+"""
+
+import contextlib
+import logging
+import os
+import threading
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+
+# Default 2GB cache budget
+DEFAULT_MAX_BYTES = int(os.environ.get("STORAGE_TEMP_CACHE_MAX_BYTES", str(2 * 1024**3)))
+DEFAULT_CACHE_DIR = Path(os.environ.get("STORAGE_TEMP_CACHE_DIR", "/tmp/jwst-cache"))
+
+
+class TempFileCache:
+    """Thread-safe LRU file cache with configurable size budget."""
+
+    def __init__(
+        self,
+        cache_dir: Path = DEFAULT_CACHE_DIR,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+    ):
+        self._cache_dir = cache_dir
+        self._max_bytes = max_bytes
+        self._lock = threading.Lock()
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def cache_dir(self) -> Path:
+        return self._cache_dir
+
+    def get(self, key: str) -> Path | None:
+        """Return cached file path if it exists, updating access time."""
+        local_path = self._key_to_path(key)
+        if local_path.exists():
+            # Touch to update access time for LRU
+            local_path.touch()
+            return local_path
+        return None
+
+    def put(self, key: str) -> Path:
+        """
+        Reserve a cache slot for a key and return the local path to write to.
+
+        Caller is responsible for writing the file content. After writing,
+        the file is considered cached. Call evict() after writing if needed.
+        """
+        local_path = self._key_to_path(key)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        return local_path
+
+    def evict_if_needed(self) -> int:
+        """
+        Remove oldest files until total cache size is within budget.
+
+        Returns the number of files evicted.
+        """
+        with self._lock:
+            files = self._get_cached_files()
+            total_size = sum(f.stat().st_size for f in files)
+
+            if total_size <= self._max_bytes:
+                return 0
+
+            # Sort by access time (oldest first)
+            files.sort(key=lambda f: f.stat().st_atime)
+
+            evicted = 0
+            for f in files:
+                if total_size <= self._max_bytes:
+                    break
+                try:
+                    size = f.stat().st_size
+                    f.unlink()
+                    total_size -= size
+                    evicted += 1
+                    logger.debug("Evicted cached file: %s (%d bytes)", f, size)
+                except OSError:
+                    pass  # File may have been deleted by another thread
+
+            if evicted > 0:
+                logger.info(
+                    "Cache eviction: removed %d files, %d bytes remaining (budget: %d)",
+                    evicted,
+                    total_size,
+                    self._max_bytes,
+                )
+
+            # Clean up empty directories
+            self._cleanup_empty_dirs()
+            return evicted
+
+    def _key_to_path(self, key: str) -> Path:
+        """Convert a storage key to a local cache path."""
+        # Preserve the key structure as subdirectories
+        return self._cache_dir / key
+
+    def _get_cached_files(self) -> list[Path]:
+        """List all files in the cache directory."""
+        return [f for f in self._cache_dir.rglob("*") if f.is_file()]
+
+    def _cleanup_empty_dirs(self) -> None:
+        """Remove empty directories from the cache tree."""
+        for dirpath in sorted(self._cache_dir.rglob("*"), reverse=True):
+            if dirpath.is_dir():
+                with contextlib.suppress(OSError):
+                    dirpath.rmdir()  # Only succeeds if empty

--- a/processing-engine/tests/test_s3_storage.py
+++ b/processing-engine/tests/test_s3_storage.py
@@ -1,0 +1,163 @@
+"""Unit tests for S3 storage provider and temp file cache."""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from app.storage.s3_storage import S3Storage
+from app.storage.temp_cache import TempFileCache
+
+
+class TestTempFileCache:
+    def test_get_miss(self, tmp_path):
+        cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=1024)
+        assert cache.get("missing/key.fits") is None
+
+    def test_put_and_get(self, tmp_path):
+        cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=1024)
+        local_path = cache.put("mast/obs/file.fits")
+        local_path.write_bytes(b"fits data")
+        result = cache.get("mast/obs/file.fits")
+        assert result is not None
+        assert result.read_bytes() == b"fits data"
+
+    def test_eviction(self, tmp_path):
+        cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=100)
+
+        # Fill cache with 3 files of 50 bytes each (150 > 100 budget)
+        for i in range(3):
+            path = cache.put(f"file{i}.fits")
+            path.write_bytes(b"x" * 50)
+
+        evicted = cache.evict_if_needed()
+        assert evicted >= 1  # At least one file evicted
+
+        # Total size should be within budget
+        total = sum(f.stat().st_size for f in cache.cache_dir.rglob("*") if f.is_file())
+        assert total <= 100
+
+    def test_preserves_key_structure(self, tmp_path):
+        cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=1024)
+        local_path = cache.put("mast/obs123/file.fits")
+        assert "mast" in str(local_path)
+        assert "obs123" in str(local_path)
+
+
+class TestS3Storage:
+    @pytest.fixture
+    def mock_boto3(self):
+        with patch("app.storage.s3_storage.boto3") as mock:
+            mock_client = MagicMock()
+            mock.client.return_value = mock_client
+            yield mock_client
+
+    @pytest.fixture
+    def s3_storage(self, mock_boto3, tmp_path):  # noqa: ARG002 — mock_boto3 patches boto3 globally
+        storage = S3Storage(
+            bucket_name="test-bucket",
+            endpoint="http://localhost:8333",
+            access_key="test",
+            secret_key="test",
+        )
+        # Replace cache with a test-scoped one
+        storage._cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=1024)
+        return storage
+
+    def test_exists_true(self, s3_storage, mock_boto3):
+        mock_boto3.head_object.return_value = {}
+        assert s3_storage.exists("mast/obs/file.fits") is True
+        mock_boto3.head_object.assert_called_once_with(
+            Bucket="test-bucket", Key="mast/obs/file.fits"
+        )
+
+    def test_exists_false(self, s3_storage, mock_boto3):
+        error = ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+        mock_boto3.head_object.side_effect = error
+        assert s3_storage.exists("missing.fits") is False
+
+    def test_write_from_bytes(self, s3_storage, mock_boto3):
+        s3_storage.write_from_bytes("test/key.fits", b"data")
+        mock_boto3.put_object.assert_called_once_with(
+            Bucket="test-bucket", Key="test/key.fits", Body=b"data"
+        )
+
+    def test_write_from_path(self, s3_storage, mock_boto3, tmp_path):
+        source = tmp_path / "local.fits"
+        source.write_bytes(b"local data")
+        s3_storage.write_from_path("s3/key.fits", source)
+        mock_boto3.upload_file.assert_called_once_with(str(source), "test-bucket", "s3/key.fits")
+
+    def test_delete(self, s3_storage, mock_boto3):
+        s3_storage.delete("mast/obs/file.fits")
+        mock_boto3.delete_object.assert_called_once_with(
+            Bucket="test-bucket", Key="mast/obs/file.fits"
+        )
+
+    def test_presigned_url(self, s3_storage, mock_boto3):
+        mock_boto3.generate_presigned_url.return_value = (
+            "http://localhost:8333/test-bucket/key?sig=abc"
+        )
+        url = s3_storage.presigned_url("key", expiry=300)
+        assert url is not None
+        assert "key" in url
+        mock_boto3.generate_presigned_url.assert_called_once()
+
+    def test_resolve_local_path_raises(self, s3_storage):
+        with pytest.raises(NotImplementedError):
+            s3_storage.resolve_local_path("any/key.fits")
+
+    def test_read_to_temp_downloads(self, s3_storage, mock_boto3):
+        # Simulate download by writing to the path
+        def fake_download(bucket, key, path):
+            Path(path).write_bytes(b"downloaded")
+
+        mock_boto3.download_file.side_effect = fake_download
+        result = s3_storage.read_to_temp("mast/obs/file.fits")
+        assert result.exists()
+        assert result.read_bytes() == b"downloaded"
+
+    def test_read_to_temp_cache_hit(self, s3_storage, mock_boto3):
+        # Pre-populate cache
+        cache_path = s3_storage._cache.put("cached/file.fits")
+        cache_path.write_bytes(b"cached data")
+
+        result = s3_storage.read_to_temp("cached/file.fits")
+        assert result.read_bytes() == b"cached data"
+        # Should not have called download
+        mock_boto3.download_file.assert_not_called()
+
+    def test_read_to_temp_not_found(self, s3_storage, mock_boto3):
+        error = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
+            "GetObject",
+        )
+        mock_boto3.download_file.side_effect = error
+        with pytest.raises(FileNotFoundError):
+            s3_storage.read_to_temp("missing.fits")
+
+
+class TestS3StorageFactory:
+    def test_factory_creates_s3(self):
+        import app.storage.factory as factory_module
+
+        factory_module._instance = None
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "STORAGE_PROVIDER": "s3",
+                    "S3_BUCKET_NAME": "test",
+                    "S3_ENDPOINT": "http://localhost:8333",
+                    "S3_ACCESS_KEY": "test",
+                    "S3_SECRET_KEY": "test",
+                },
+            ),
+            patch("app.storage.s3_storage.boto3"),
+        ):
+            provider = factory_module.get_storage_provider()
+            assert isinstance(provider, S3Storage)
+        # Reset singleton
+        factory_module._instance = None


### PR DESCRIPTION
## Summary

Add S3-compatible object storage to both backend (.NET) and processing engine (Python), with SeaweedFS for local development and conditional DI wiring. This is PR 1 of 4 in the F3: S3 Storage for Application Data epic.

## Why

The app stores all files on a shared Docker volume at `/app/data`. This doesn't scale beyond a single host and costs ~$53/mo on EFS for 177GB vs ~$5/mo on S3 with Intelligent-Tiering. The storage abstraction layer (F2) exists but only has local implementations. This PR adds the S3 implementations and infrastructure.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Add `S3StorageProvider` (.NET) using AWS SDK with multipart upload for files >100MB
- Add `S3Settings` configuration POCO for bucket, endpoint, credentials, presigned URLs
- Add `SupportsLocalPath` property to `IStorageProvider` interface for clean S3/local branching
- Add conditional DI in `Program.cs` — switches between local and S3 based on `Storage:Provider` config
- Add `S3Storage` (Python) using boto3 with `read_to_temp()` download-to-cache pattern for astropy
- Add `TempFileCache` — LRU cache manager (2GB default, thread-safe eviction) for S3 downloads
- Update storage factory to support `"s3"` provider type
- Add SeaweedFS services in `docker-compose.yml` (master/volume/filer/s3) behind `s3` profile
- Add S3 env vars to backend and processing-engine in both compose files
- Update `.env.example` with S3 configuration section
- Fix `DataScanService` to be S3-safe: uses `ListAsync("mast/")` for S3, `Directory.GetFiles` for local
- Fix `MosaicService` to verify file size via stream instead of `FileInfo`
- Fix `JwstDataController` to guard empty-dir cleanup with `SupportsLocalPath` check
- Add 15 Python unit tests for S3Storage, TempFileCache, and factory integration
- Update `docs/key-files.md` and `docs/development-plan.md` (mark F3.1, F3.2, F3.8 complete)

## Test Plan

- [x] All 267 backend unit tests pass
- [x] All 32 Python storage tests pass (including 15 new S3/cache tests)
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass (build, test, lint, format)
- [ ] `docker compose up -d` starts normally with `STORAGE_PROVIDER=local` (default) — no behavior change
- [ ] `docker compose --profile s3 up -d` starts SeaweedFS (4 services healthy)
- [ ] Set `STORAGE_PROVIDER=s3` — backend/processing-engine initialize S3 providers without errors
- [ ] With `STORAGE_PROVIDER=local`: full E2E test (MAST search → download → view → mosaic) works unchanged

## Documentation Checklist

- [x] `docs/key-files.md` updated (added S3StorageProvider, S3Settings, s3_storage.py, temp_cache.py)
- [x] `docs/development-plan.md` updated (F3.1, F3.2, F3.8 marked complete)
- [ ] `docs/standards/backend-development.md` — no new controllers or endpoints
- [ ] `docs/architecture.md` — no structural changes to service layer diagram
- [ ] `docs/quick-reference.md` — no new API endpoints
- [ ] `docs/tech-debt.md` — N/A

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Adds tech debt (tracked in `docs/tech-debt.md`)
- [ ] Reduces existing tech debt

## Risk & Rollback

Risk: Low. Default `STORAGE_PROVIDER=local` is unchanged. S3 code paths only activate when explicitly configured. SeaweedFS uses Docker `profiles: [s3]` so it doesn't start by default.

Rollback: Revert this PR. No data migrations or schema changes.

## Quality Checklist

- [x] Code compiles without errors
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] No hardcoded secrets or credentials
- [x] Error handling follows project patterns
- [x] Documentation updated