### PR TITLE
refactor: route processing engine FITS access through storage layer

### DIFF
--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -119,6 +119,7 @@ Quick reference for finding important files in the codebase.
 - `processing-engine/app/storage/s3_storage.py` - S3-compatible storage implementation (boto3)
 - `processing-engine/app/storage/temp_cache.py` - LRU temp file cache for S3 downloads (2GB default)
 - `processing-engine/app/storage/factory.py` - Storage provider factory (singleton, supports `local` and `s3`)
+- `processing-engine/app/storage/helpers.py` - Shared helpers (`resolve_fits_path`, `validate_fits_file_size`) for route handlers
 - `processing-engine/app/processing/analysis.py` - Analysis algorithms (in progress)
 - `processing-engine/app/processing/utils.py` - FITS utilities (in progress)
 

--- a/processing-engine/app/storage/helpers.py
+++ b/processing-engine/app/storage/helpers.py
@@ -1,0 +1,84 @@
+"""
+Shared helpers for resolving storage keys to local file paths.
+
+All FITS file access in the processing engine should go through these
+helpers so the backend can transparently switch between local and S3.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from .factory import get_storage_provider
+
+
+logger = logging.getLogger(__name__)
+
+# Resource limits for FITS processing (configurable via environment)
+MAX_FITS_FILE_SIZE_BYTES = (
+    int(os.environ.get("MAX_FITS_FILE_SIZE_MB", "4096")) * 1024 * 1024
+)  # Default 4GB
+
+
+def resolve_fits_path(key: str) -> Path:
+    """
+    Resolve a storage key to a local file path that astropy can open.
+
+    For local storage, this returns the actual path on disk.
+    For S3 storage, this downloads the file to a temp cache and returns that path.
+
+    The key is validated against path traversal: absolute paths and '..'
+    components are rejected before the storage layer sees them.
+
+    Args:
+        key: Relative storage key (e.g. "mast/obs_id/file.fits")
+
+    Returns:
+        Path to a local file that can be opened with fits.open()
+
+    Raises:
+        HTTPException: 403 if key contains traversal, 404 if file not found
+    """
+    # Reject absolute paths and path traversal components
+    if os.path.isabs(key) or ".." in Path(key).parts:
+        logger.warning("Path traversal attempt blocked: %s", key)
+        raise HTTPException(status_code=403, detail="Access denied: invalid path")
+
+    storage = get_storage_provider()
+
+    if not storage.exists(key):
+        raise HTTPException(
+            status_code=404,
+            detail=f"File not found: {Path(key).name}",
+        )
+
+    local_path = storage.read_to_temp(key)
+
+    if not local_path.is_file():
+        raise HTTPException(status_code=400, detail="Path is not a file")
+
+    return local_path
+
+
+def validate_fits_file_size(local_path: Path, max_bytes: int = MAX_FITS_FILE_SIZE_BYTES) -> None:
+    """
+    Validate that a local FITS file doesn't exceed the maximum allowed size.
+
+    Args:
+        local_path: Path to the local file to check
+        max_bytes: Maximum file size in bytes
+
+    Raises:
+        HTTPException: 413 if file exceeds maximum size
+    """
+    file_size = local_path.stat().st_size
+    if file_size > max_bytes:
+        max_mb = max_bytes / (1024 * 1024)
+        file_mb = file_size / (1024 * 1024)
+        logger.warning("FITS file too large: %.1fMB (max %.1fMB)", file_mb, max_mb)
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large: {file_mb:.1f}MB exceeds maximum {max_mb:.1f}MB",
+        )

--- a/processing-engine/tests/test_mosaic_engine.py
+++ b/processing-engine/tests/test_mosaic_engine.py
@@ -25,6 +25,10 @@ from app.mosaic.mosaic_engine import (
     get_footprints,
     load_fits_2d_with_wcs,
 )
+from app.storage.local_storage import LocalStorage
+
+
+_STORAGE_PATCH_TARGET = "app.storage.helpers.get_storage_provider"
 
 
 def _make_fits_with_wcs(
@@ -312,21 +316,21 @@ class TestMosaicRoutes:
         )
         assert response.status_code == 422  # Pydantic validation error
 
-    @patch("app.mosaic.routes.ALLOWED_DATA_DIR", Path("/app/data").resolve())
     def test_path_traversal_blocked(self, client):
-        response = client.post(
-            "/mosaic/generate",
-            json={
-                "files": [
-                    {"file_path": "../../etc/passwd"},
-                    {"file_path": "test2.fits"},
-                ],
-            },
-        )
+        with patch(_STORAGE_PATCH_TARGET, return_value=LocalStorage(base_path="/app/data")):
+            response = client.post(
+                "/mosaic/generate",
+                json={
+                    "files": [
+                        {"file_path": "../../etc/passwd"},
+                        {"file_path": "test2.fits"},
+                    ],
+                },
+            )
         assert response.status_code in (403, 404)
 
     def test_generate_file_not_found(self, client, tmp_path):
-        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+        with patch(_STORAGE_PATCH_TARGET, return_value=LocalStorage(base_path=str(tmp_path))):
             response = client.post(
                 "/mosaic/generate",
                 json={
@@ -346,7 +350,7 @@ class TestMosaicRoutes:
         path1 = _make_fits_with_wcs(data1, crval1=180.0, tmp_dir=str(tmp_path))
         path2 = _make_fits_with_wcs(data2, crval1=180.05, tmp_dir=str(tmp_path))
 
-        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+        with patch(_STORAGE_PATCH_TARGET, return_value=LocalStorage(base_path=str(tmp_path))):
             response = client.post(
                 "/mosaic/generate",
                 json={
@@ -375,7 +379,7 @@ class TestMosaicRoutes:
         path1 = _make_fits_with_wcs(data1, crval1=180.0, tmp_dir=str(tmp_path))
         path2 = _make_fits_with_wcs(data2, crval1=180.05, tmp_dir=str(tmp_path))
 
-        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+        with patch(_STORAGE_PATCH_TARGET, return_value=LocalStorage(base_path=str(tmp_path))):
             response = client.post(
                 "/mosaic/generate",
                 json={
@@ -423,7 +427,7 @@ class TestMosaicRoutes:
             tmp_dir=str(tmp_path),
         )
 
-        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+        with patch(_STORAGE_PATCH_TARGET, return_value=LocalStorage(base_path=str(tmp_path))):
             response = client.post(
                 "/mosaic/generate",
                 json={
@@ -467,7 +471,7 @@ class TestMosaicRoutes:
         path1 = _make_fits_with_wcs(data1, crval1=180.0, tmp_dir=str(tmp_path))
         path2 = _make_fits_with_wcs(data2, crval1=180.05, tmp_dir=str(tmp_path))
 
-        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+        with patch(_STORAGE_PATCH_TARGET, return_value=LocalStorage(base_path=str(tmp_path))):
             response = client.post(
                 "/mosaic/generate",
                 json={
@@ -489,7 +493,7 @@ class TestMosaicRoutes:
         path1 = _make_fits_with_wcs(data, crval1=180.0, tmp_dir=str(tmp_path))
         path2 = _make_fits_with_wcs(data, crval1=180.05, tmp_dir=str(tmp_path))
 
-        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+        with patch(_STORAGE_PATCH_TARGET, return_value=LocalStorage(base_path=str(tmp_path))):
             response = client.post(
                 "/mosaic/footprint",
                 json={"file_paths": [path1.name, path2.name]},
@@ -508,7 +512,7 @@ class TestMosaicRoutes:
         path1 = _make_fits_no_wcs(data, tmp_dir=str(tmp_path))
         path2 = _make_fits_no_wcs(data, tmp_dir=str(tmp_path))
 
-        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+        with patch(_STORAGE_PATCH_TARGET, return_value=LocalStorage(base_path=str(tmp_path))):
             response = client.post(
                 "/mosaic/generate",
                 json={
@@ -530,7 +534,7 @@ class TestMosaicRoutes:
         path1 = _make_fits_with_wcs(data1, crval1=180.0, tmp_dir=str(tmp_path))
         path2 = _make_fits_with_wcs(data2, crval1=180.05, tmp_dir=str(tmp_path))
 
-        with patch("app.mosaic.routes.ALLOWED_DATA_DIR", tmp_path):
+        with patch(_STORAGE_PATCH_TARGET, return_value=LocalStorage(base_path=str(tmp_path))):
             response = client.post(
                 "/mosaic/generate",
                 json={

--- a/processing-engine/tests/test_nchannel_composite.py
+++ b/processing-engine/tests/test_nchannel_composite.py
@@ -5,6 +5,7 @@ Tests the /composite/generate-nchannel route, cache key generation,
 and the color resolution helper.
 """
 
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -322,8 +323,8 @@ class TestGenerateNChannelEndpoint:
 
         with (
             patch(
-                "app.composite.routes.validate_file_path",
-                return_value="/app/data/test.fits",
+                "app.composite.routes.resolve_fits_path",
+                return_value=Path("/app/data/test.fits"),
             ),
             patch(
                 "app.composite.routes.load_fits_2d_with_wcs",


### PR DESCRIPTION
## Summary

Refactors all processing engine route handlers to access FITS files through the storage abstraction layer instead of direct filesystem calls. This is the prerequisite for S3 storage to work end-to-end — without this, every endpoint calls `fits.open()` against hardcoded filesystem paths.

## Why

The storage abstraction (PR #390) introduced `StorageProvider` with `read_to_temp()` for transparently accessing files from local or S3 storage. But every route handler still used its own `validate_file_path()` + `ALLOWED_DATA_DIR` pattern, bypassing the abstraction entirely. This PR eliminates that duplication and routes all file access through the storage layer.

## Type of Change

- [x] Refactoring (no functional changes)

## Changes Made

- Created `processing-engine/app/storage/helpers.py` with shared `resolve_fits_path(key)` and `validate_fits_file_size(path)` utilities
- Removed 4 duplicate `validate_file_path()` definitions from `main.py`, `mosaic/routes.py`, `composite/routes.py`, `analysis/routes.py`
- Removed 4 duplicate `ALLOWED_DATA_DIR` declarations from the same files
- Removed duplicate `validate_fits_file_size()` from `main.py` and `mosaic/routes.py` (now in helpers)
- Updated all endpoints (thumbnail, preview, histogram, pixeldata, cubeinfo, mosaic/generate, mosaic/footprint, composite/generate-nchannel, analysis/region-statistics) to use `resolve_fits_path()`
- Fixed pre-existing indentation bug in `/thumbnail` endpoint where rendering code was unreachable dead code (indented under a `raise` statement)
- Updated all test files to mock `get_storage_provider` instead of `ALLOWED_DATA_DIR`
- Added `helpers.py` to `docs/key-files.md`

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/ -v` — all 119 tests pass
- [ ] Verify app starts normally with `docker compose up -d --build`
- [ ] With `STORAGE_PROVIDER=local` (default): open FITS viewer, verify preview/thumbnail/histogram/pixel data/cube info all work
- [ ] Generate a mosaic from 2+ files — verify it produces output
- [ ] Generate a composite — verify it produces output
- [ ] Use region selection tool — verify statistics compute correctly
- [ ] Verify path traversal attempts (../../etc/passwd) still return 403

## Documentation Checklist

- [x] `docs/key-files.md` — added `helpers.py` entry
- [ ] No new controllers, services, or endpoints (refactor only)

## Tech Debt Impact

- [x] Reduces tech debt — eliminates 4x copy-pasted validation functions (~200 lines removed net)

## Risk & Rollback

Risk: Medium — touches every route handler in the processing engine. All paths are exercised by existing tests.
Rollback: Revert this commit. No database or config changes.

## Quality Checklist

- [x] Code follows project conventions
- [x] No unnecessary changes beyond the refactor scope
- [x] All existing tests updated and passing (119/119)
- [x] Pre-commit hooks pass (ruff lint + format)