### PR TITLE
fix: remove overly restrictive file size limit from viewer endpoints

### DIFF
--- a/frontend/jwst-frontend/src/components/ImageComparisonViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageComparisonViewer.tsx
@@ -35,7 +35,13 @@ async function fetchAuthBlob(url: string): Promise<string> {
   const response = await fetch(url, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
-  if (!response.ok) throw new Error(`Preview failed: ${response.status}`);
+  if (!response.ok) {
+    const detail = await response
+      .json()
+      .then((d) => d.detail)
+      .catch(() => null);
+    throw new Error(detail || `Preview failed (${response.status})`);
+  }
   const blob = await response.blob();
   return URL.createObjectURL(blob);
 }

--- a/frontend/jwst-frontend/src/components/ImageViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageViewer.tsx
@@ -430,7 +430,13 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
         const response = await fetch(url, {
           headers: token ? { Authorization: `Bearer ${token}` } : {},
         });
-        if (!response.ok) throw new Error(`Preview failed: ${response.status}`);
+        if (!response.ok) {
+          const detail = await response
+            .json()
+            .then((d) => d.detail)
+            .catch(() => null);
+          throw new Error(detail || `Preview failed (${response.status})`);
+        }
         const blob = await response.blob();
         if (revoked) return;
         setBlobUrl((prev) => {

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -25,7 +25,7 @@ from app.processing.enhancement import (
     zscale_stretch,
 )
 from app.processing.statistics import compute_histogram, compute_percentiles
-from app.storage.helpers import resolve_fits_path, validate_fits_file_size
+from app.storage.helpers import resolve_fits_path
 
 
 # Configure logging
@@ -430,7 +430,6 @@ async def generate_preview(
 
         # Resolve storage key to local path (works with local or S3 storage)
         local_path = resolve_fits_path(file_path)
-        validate_fits_file_size(local_path)
         logger.info(
             f"Generating preview for: {local_path} with stretch={stretch}, gamma={gamma}, format={format}"
         )
@@ -668,7 +667,6 @@ async def get_histogram(
 
         # Resolve storage key to local path (works with local or S3 storage)
         local_path = resolve_fits_path(file_path)
-        validate_fits_file_size(local_path)
         logger.info(f"Computing histogram for: {local_path}")
 
         # Read FITS file
@@ -833,7 +831,6 @@ async def get_pixel_data(
 
         # Resolve storage key to local path (works with local or S3 storage)
         local_path = resolve_fits_path(file_path)
-        validate_fits_file_size(local_path)
         logger.info(f"Getting pixel data for: {local_path}")
 
         # Read FITS file
@@ -962,7 +959,6 @@ async def get_cube_info(data_id: str, file_path: str):
     try:
         # Resolve storage key to local path (works with local or S3 storage)
         local_path = resolve_fits_path(file_path)
-        validate_fits_file_size(local_path)
         logger.info(f"Getting cube info for: {local_path}")
 
         # Read FITS file


### PR DESCRIPTION
## Summary

Remove the 4GB `validate_fits_file_size` check from preview, histogram, pixeldata, and cubeinfo endpoints, and improve frontend error messages to show actual error details instead of raw status codes.

## Why

A 5.2GB NIRCam mosaic (`jw02731-o001_t017_nircam_clear-f187n_i2d.fits`) was completely unviewable — all viewer endpoints returned 413. The file size limit was a copy-paste from mosaic operations where entire arrays are loaded into memory. Viewer endpoints use memory-efficient patterns (memmap, subsample, header-only reads) and don't need this guard.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Removed `validate_fits_file_size` calls from preview, histogram, pixeldata, and cubeinfo endpoints in `processing-engine/main.py`
- Kept `validate_fits_file_size` on mosaic endpoint (which loads full arrays for reprojection)
- Updated `ImageViewer.tsx` and `ImageComparisonViewer.tsx` to extract `detail` from JSON error responses instead of showing raw "Preview failed: 413"
- Removed unused `validate_fits_file_size` import from `main.py`

## Test Plan

- [x] All 359 Python tests pass
- [x] All 51 frontend tests pass
- [x] Pre-commit hooks pass
- [x] Verified 5.2GB file now returns 200 preview (was 413)
- [ ] Open the F187N NIRCam mosaic in the viewer — preview, histogram, pixel data, and cube info should all load
- [ ] Open a normal-sized file — verify no regression
- [ ] Trigger an actual error (e.g. corrupted file) — verify error message shows detail text, not just status code

## Documentation Checklist

- [x] No new controllers/services/endpoints — viewer behavior fix only

## Tech Debt Impact

- [x] Reduces existing tech debt

## Risk & Rollback

Risk: Low. Only removes an overly restrictive guard from read-only endpoints. The mosaic size limit (the one that matters for memory safety) is unchanged. The `MAX_FITS_ARRAY_ELEMENTS` guard in each endpoint still prevents memory exhaustion after data is loaded.

Rollback: Revert this commit.

## Quality Checklist

- [x] Code compiles without errors
- [x] All existing tests pass
- [x] Error handling follows project patterns