### PR TITLE
fix: propagate actual MAST errors instead of generic 503

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/MastController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.cs
@@ -71,7 +71,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogTargetSearchFailed(ex, request.TargetName);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
             catch (Exception ex)
             {
@@ -96,7 +96,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogCoordinateSearchFailed(ex, request.Ra, request.Dec);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
             catch (Exception ex)
             {
@@ -121,7 +121,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogObservationSearchFailed(ex, request.ObsId);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
             catch (Exception ex)
             {
@@ -146,7 +146,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogProgramSearchFailed(ex, request.ProgramId);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
             catch (Exception ex)
             {
@@ -171,7 +171,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogRecentReleasesSearchFailed(ex, request.DaysBack);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
             catch (Exception ex)
             {
@@ -196,7 +196,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogFailedToGetProducts(ex, request.ObsId);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
             catch (Exception ex)
             {
@@ -220,7 +220,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogDownloadFailed(ex, request.ObsId);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
             catch (Exception ex)
             {
@@ -415,7 +415,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogFailedToResumeImport(ex, jobId);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
         }
 
@@ -526,7 +526,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogFailedToGetResumableDownloads(ex);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
         }
 
@@ -549,7 +549,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogFailedToDismissDownload(ex, jobId);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
         }
 
@@ -902,6 +902,21 @@ namespace JwstDataAnalysis.API.Controllers
         // ===== Private instance methods =====
 
         /// <summary>
+        /// Return an appropriate error response for a processing engine failure.
+        /// If the engine responded with a status code, forward the actual error;
+        /// otherwise treat it as a connectivity failure (503).
+        /// </summary>
+        private ObjectResult ProcessingEngineError(HttpRequestException ex)
+        {
+            if (ex.StatusCode.HasValue)
+            {
+                return StatusCode((int)ex.StatusCode, new { error = ex.Message });
+            }
+
+            return StatusCode(503, new { error = "Processing engine unavailable" });
+        }
+
+        /// <summary>
         /// Gets the current user ID from JWT claims.
         /// </summary>
         private string? GetCurrentUserId()
@@ -969,7 +984,7 @@ namespace JwstDataAnalysis.API.Controllers
             catch (HttpRequestException ex)
             {
                 LogFailedToResumeImport(ex, downloadJobId);
-                return StatusCode(503, new { error = "Processing engine unavailable" });
+                return ProcessingEngineError(ex);
             }
         }
 


### PR DESCRIPTION
## Summary
MAST search errors (e.g. "Could not resolve target name '3132'") were being swallowed by the backend and returned as generic 503 "Processing engine unavailable" messages. Now the backend distinguishes connectivity failures from response errors and forwards the actual error message to the frontend.

## Why
Users searching for an invalid target name saw "The processing engine is currently unavailable" which is misleading — the engine is available, it just can't resolve the target. This fix gives users actionable error messages so they can correct their search query.

## Type of Change
- [x] Bug fix

## Changes Made
- **`MastService.PostToProcessingEngineAsync`**: Extract `detail` from the processing engine's JSON error response and set `StatusCode` on the `HttpRequestException` (previously threw with raw status/response dump and no status code)
- **`MastController`**: Add `ProcessingEngineError()` helper method that checks `ex.StatusCode.HasValue` — if the processing engine responded with a status code, forward the actual error; if null (connectivity failure), return 503
- Replace all 11 hardcoded `StatusCode(503, "Processing engine unavailable")` returns in catch blocks with the new helper

## Test Plan
- [x] Search for unresolvable target "3132" → now returns `{"error": "Could not resolve target name '3132' using variants: ['3132']"}` with HTTP 500 (forwarded from processing engine)
- [x] Search for valid target "NGC 3132" → returns 10 results as before
- [x] All 267 .NET backend tests pass
- [x] All 359 Python processing engine tests pass
- [ ] Verify the frontend displays the actual error message (not "Processing engine is currently unavailable") when searching "3132"
- [ ] Verify connectivity failure (e.g. stop processing engine) still shows "Processing engine unavailable" with 503

## Documentation Checklist
- [x] No new controllers, services, or endpoints
- [x] No documentation updates needed — this is a bug fix to existing error handling

## Tech Debt Impact
- [x] Reduces tech debt — error handling is now more correct and consistent

## Risk & Rollback
Risk: Low — only changes error response format, no happy-path changes.
Rollback: Revert commit to restore previous generic 503 behavior.

## Quality Checklist
- [x] Code compiles without warnings (only pre-existing NU1901 for AWSSDK.Core)
- [x] All tests pass
- [x] No security concerns — error messages are already public-facing strings from the processing engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)