### PR TITLE
fix: use fence_mermaid_format for Mermaid diagram rendering in MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+          format: !!python/name:pymdownx.superfences.fence_mermaid_format
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
Mermaid diagrams in MkDocs render as plain code blocks instead of interactive diagrams.

## Why
The superfences config used `fence_code_format` which outputs `<code>` elements. Material 9.7+ requires `fence_mermaid_format` to activate its built-in Mermaid JS integration.

## Type of Change
- [x] Bug fix

## Changes Made
- `mkdocs.yml` — Changed `pymdownx.superfences.fence_code_format` to `pymdownx.superfences.fence_mermaid_format`

## Test Plan
- [x] Restart docs container (`docker compose restart docs`)
- [ ] Open http://localhost:8001 and navigate to Architecture page
- [ ] Verify all 5 Mermaid diagrams render as interactive flowcharts, not code blocks

## Documentation Checklist
- [x] No documentation updates needed (this IS the docs fix)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — single config line change, docs-only.
Rollback: Revert commit.

## Quality Checklist
- [x] Changes follow project coding standards
- [x] No unnecessary changes included
- [x] Self-reviewed the diff