### PR TITLE
fix: close mermaid code fences in architecture.md and revert mkdocs.yml

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ flowchart TB
     MastModule -->|astroquery| MAST
     MAST --> STScI
     FastAPI -->|StorageProvider| ObjectStore
-```mermaid
+```
 
 ---
 
@@ -98,7 +98,7 @@ sequenceDiagram
     Backend->>MongoDB: Update record with results
     Backend-->>Frontend: Return updated record
     Frontend-->>User: Display processed data
-```mermaid
+```
 
 ### MAST Import Flow
 
@@ -168,7 +168,7 @@ sequenceDiagram
         Processing->>Processing: Load state from JSON
         Processing->>MAST: Continue with Range header
     end
-```text
+```
 
 ---
 
@@ -220,7 +220,7 @@ flowchart TB
     style L2b fill:#ffffcc
     style L3 fill:#ccffcc
     style Tables fill:#e0e0e0
-```text
+```
 
 ### Lineage Grouping
 
@@ -246,7 +246,7 @@ flowchart LR
 
         obs2_uncal --> obs2_rate --> obs2_cal
     end
-```tsx
+```
 
 ---
 
@@ -311,7 +311,7 @@ flowchart TB
     Dashboard --> Header
     Dashboard --> Controls
     Dashboard --> Content
-```text
+```
 
 ---
 
@@ -396,7 +396,7 @@ classDiagram
     ImageMetadata "1" *-- "0..1" WcsInfo : wcs
 
     note for JwstDataModel "dataType determines which\nmetadata type is populated:\nimage → ImageMetadata\nsensor → SensorMetadata\nspectral → SpectralMetadata"
-```text
+```
 
 ---
 
@@ -467,7 +467,7 @@ flowchart TB
     MosaicSvc -->|HttpClient| ProcessingAPI
     AnalysisSvc -->|HttpClient| ProcessingAPI
     ThumbnailSvc -->|HttpClient| ProcessingAPI
-```text
+```
 
 ### MongoDBService Operations
 
@@ -498,7 +498,7 @@ flowchart LR
         Stats["GetStatisticsAsync()"]
         FacetSearch["FacetedSearchAsync()"]
     end
-```text
+```
 
 ---
 
@@ -571,7 +571,7 @@ flowchart TB
     MosaicRoutes --> StorageABC
     AnalysisRoutes --> StorageABC
     MastRoutes --> StorageABC
-```tsx
+```
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_mermaid_format
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
Mermaid diagrams in the docs site render as raw text instead of interactive diagrams.

## Why
All 10 mermaid blocks in `architecture.md` were terminated with ` ```text `, ` ```tsx `, or ` ```mermaid ` instead of plain ` ``` `. This meant no mermaid block ever properly closed — each one bled into the next, and Material's Mermaid JS couldn't parse them.

PR #399 incorrectly changed `mkdocs.yml` from `fence_code_format` to `fence_mermaid_format`, which doesn't exist in the container's pymdownx version and crashed the docs server. This PR reverts that and fixes the actual root cause.

## Type of Change
- [x] Bug fix

## Changes Made
- `docs/architecture.md` — Fixed 10 mermaid code fence closers: replaced ` ```text `, ` ```tsx `, ` ```mermaid ` with plain ` ``` `
- `mkdocs.yml` — Reverted `fence_mermaid_format` (from PR #399) back to `fence_code_format`, which is the correct setting for Material 9.7+

## Test Plan
- [x] Docs server starts without errors (`docker compose restart docs`)
- [x] `curl` shows 11 separate `<pre class="mermaid">` blocks in rendered HTML
- [ ] Open http://localhost:8001/architecture/ and verify all 11 diagrams render as interactive flowcharts/sequence diagrams

## Documentation Checklist
- [x] No additional documentation updates needed (this IS the docs fix)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — docs-only markdown fence fixes and config revert.
Rollback: Revert commit.

## Quality Checklist
- [x] Changes follow project coding standards
- [x] No unnecessary changes included
- [x] Self-reviewed the diff