### PR TITLE
fix: use dark-theme-friendly colors for Data Lineage diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,11 +215,11 @@ flowchart TB
     i2d --> cat
     s2d --> cat
 
-    style L1 fill:#ffcccc
-    style L2a fill:#ffeacc
-    style L2b fill:#ffffcc
-    style L3 fill:#ccffcc
-    style Tables fill:#e0e0e0
+    style L1 fill:#6b2c2c,color:#f0f0f0,stroke:#e57373
+    style L2a fill:#6b4c1e,color:#f0f0f0,stroke:#ffb74d
+    style L2b fill:#5c5c1e,color:#f0f0f0,stroke:#fff176
+    style L3 fill:#1e5c2c,color:#f0f0f0,stroke:#81c784
+    style Tables fill:#4a4a4a,color:#f0f0f0,stroke:#bdbdbd
 ```
 
 ### Lineage Grouping


### PR DESCRIPTION
## Summary
Data Lineage diagram in architecture docs is unreadable on the dark theme.

## Why
The pastel fill colors (`#ffcccc`, `#ffeacc`, etc.) were designed for light backgrounds and wash out on Material's slate dark theme, making text and subgraph labels invisible.

## Type of Change
- [x] Bug fix

## Changes Made
- `docs/architecture.md` — Replaced 5 pastel subgraph style directives with dark saturated fills, light text (`color:#f0f0f0`), and colored strokes for dark-theme readability

## Test Plan
- [x] Verified diagrams render with readable text on slate dark theme at http://localhost:8001/architecture/
- [ ] Confirm L1 (red), L2a (amber), L2b (olive), L3 (green), Tables (gray) subgroups are visually distinct

## Documentation Checklist
- [x] No additional documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — cosmetic color change in one diagram.
Rollback: Revert commit.

## Quality Checklist
- [x] Changes follow project coding standards
- [x] No unnecessary changes included
- [x] Self-reviewed the diff