### PR TITLE
chore: update AWSSDK.S3 to 4.0.18.6

### DIFF
--- a/backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj
+++ b/backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.1" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.18.6" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />


### PR DESCRIPTION
## Summary
Updates AWSSDK.S3 from 4.0.1 to 4.0.18.6 to resolve a known vulnerability in the transitive AWSSDK.Core dependency.

## Why
AWSSDK.Core 4.0.0.5 has a low-severity vulnerability ([GHSA-9cvc-h2w8-phrp](https://github.com/advisories/GHSA-9cvc-h2w8-phrp)) that causes `dotnet build --warnaserror` to fail with NU1901. Updating AWSSDK.S3 pulls in AWSSDK.Core 4.0.3.12 which resolves the advisory.

## Type of Change
- [x] Dependency update

## Changes Made
- `backend/JwstDataAnalysis.API/JwstDataAnalysis.API.csproj` — AWSSDK.S3 4.0.1 → 4.0.18.6 (AWSSDK.Core 4.0.0.5 → 4.0.3.12 transitively)

## Test Plan
- [x] `dotnet build --warnaserror` passes with 0 warnings
- [x] 267 backend tests pass
- [ ] Verify S3 storage operations still work (upload, download, presigned URLs)

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] Reduces existing tech debt

## Risk & Rollback
Risk: Low — minor version bump of AWS SDK, no breaking changes expected.
Rollback: Revert commit to pin back to 4.0.1.

## Quality Checklist
- [x] Changes follow project coding standards
- [x] No unnecessary changes included
- [x] Self-reviewed the diff