### PR TITLE
fix: prevent auth token expiry during long-running operations

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/AuthServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/AuthServiceTests.cs
@@ -1,0 +1,240 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+
+using JwstDataAnalysis.API.Configuration;
+using JwstDataAnalysis.API.Models;
+using JwstDataAnalysis.API.Services;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+namespace JwstDataAnalysis.API.Tests.Services;
+
+/// <summary>
+/// Unit tests for AuthService refresh token grace window logic.
+/// </summary>
+public class AuthServiceTests
+{
+    private const string UserId = "user-123";
+    private const string Username = "testuser";
+    private const string Email = "test@example.com";
+    private const int GraceWindowSeconds = 30;
+
+    private readonly Mock<IMongoDBService> mockMongoDb = new();
+    private readonly Mock<IJwtTokenService> mockJwtService = new();
+    private readonly IOptions<JwtSettings> jwtSettings;
+    private readonly AuthService sut;
+
+    public AuthServiceTests()
+    {
+        jwtSettings = Options.Create(new JwtSettings
+        {
+            RefreshTokenGraceWindowSeconds = GraceWindowSeconds,
+        });
+
+        sut = new AuthService(
+            mockMongoDb.Object,
+            mockJwtService.Object,
+            jwtSettings,
+            Mock.Of<ILogger<AuthService>>());
+
+        // Default JWT service behavior
+        mockJwtService.Setup(j => j.GenerateAccessToken(It.IsAny<User>()))
+            .Returns("new-access-token");
+        mockJwtService.Setup(j => j.GenerateRefreshToken())
+            .Returns("new-refresh-token");
+        mockJwtService.Setup(j => j.GetRefreshTokenExpiration())
+            .Returns(DateTime.UtcNow.AddDays(7));
+        mockJwtService.Setup(j => j.GetAccessTokenExpiration())
+            .Returns(DateTime.UtcNow.AddMinutes(15));
+    }
+
+    [Fact]
+    public async Task RefreshToken_NormalRotation_StoresPreviousToken()
+    {
+        // Arrange
+        var user = CreateTestUser();
+        mockMongoDb.Setup(m => m.GetUserByRefreshTokenAsync("current-refresh-token"))
+            .ReturnsAsync(user);
+
+        var request = new RefreshTokenRequest { RefreshToken = "current-refresh-token" };
+
+        // Act
+        var result = await sut.RefreshTokenAsync(request);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.AccessToken.Should().Be("new-access-token");
+        result.RefreshToken.Should().Be("new-refresh-token");
+
+        // Verify previous token is stored with grace window
+        mockMongoDb.Verify(m => m.UpdateRefreshTokenAsync(
+            UserId,
+            "new-refresh-token",
+            It.IsAny<DateTime>(),
+            "current-refresh-token",
+            It.Is<DateTime?>(d => d.HasValue && d.Value > DateTime.UtcNow)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshToken_GraceWindowHit_ReturnsCurrentTokensWithoutReRotation()
+    {
+        // Arrange — user already rotated, request comes with the OLD token
+        var user = CreateTestUser(
+            refreshToken: "new-refresh-token",
+            previousRefreshToken: "old-refresh-token",
+            previousRefreshTokenExpiresAt: DateTime.UtcNow.AddSeconds(20));
+
+        mockMongoDb.Setup(m => m.GetUserByRefreshTokenAsync("old-refresh-token"))
+            .ReturnsAsync(user);
+
+        var request = new RefreshTokenRequest { RefreshToken = "old-refresh-token" };
+
+        // Act
+        var result = await sut.RefreshTokenAsync(request);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.AccessToken.Should().Be("new-access-token");
+        result.RefreshToken.Should().Be("new-refresh-token");
+
+        // Should NOT call UpdateRefreshTokenAsync (no re-rotation)
+        mockMongoDb.Verify(m => m.UpdateRefreshTokenAsync(
+            It.IsAny<string>(),
+            It.IsAny<string?>(),
+            It.IsAny<DateTime?>(),
+            It.IsAny<string?>(),
+            It.IsAny<DateTime?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ExpiredGraceWindow_ReturnsNull()
+    {
+        // Arrange — previous token's grace window has expired
+        // GetUserByRefreshTokenAsync won't match because the DB query filters by expiry
+        mockMongoDb.Setup(m => m.GetUserByRefreshTokenAsync("expired-old-token"))
+            .ReturnsAsync((User?)null);
+
+        var request = new RefreshTokenRequest { RefreshToken = "expired-old-token" };
+
+        // Act
+        var result = await sut.RefreshTokenAsync(request);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RefreshToken_ConcurrentRequests_BothSucceedWithSameTokens()
+    {
+        // Arrange — simulate two concurrent requests with the old token
+        var user = CreateTestUser(
+            refreshToken: "rotated-refresh-token",
+            previousRefreshToken: "original-refresh-token",
+            previousRefreshTokenExpiresAt: DateTime.UtcNow.AddSeconds(20));
+
+        mockMongoDb.Setup(m => m.GetUserByRefreshTokenAsync("original-refresh-token"))
+            .ReturnsAsync(user);
+
+        var request = new RefreshTokenRequest { RefreshToken = "original-refresh-token" };
+
+        // Act — two "concurrent" calls with the same old token
+        var result1 = await sut.RefreshTokenAsync(request);
+        var result2 = await sut.RefreshTokenAsync(request);
+
+        // Assert — both should succeed and return the same refresh token
+        result1.Should().NotBeNull();
+        result2.Should().NotBeNull();
+        result1!.RefreshToken.Should().Be("rotated-refresh-token");
+        result2!.RefreshToken.Should().Be("rotated-refresh-token");
+
+        // Neither should trigger a re-rotation
+        mockMongoDb.Verify(m => m.UpdateRefreshTokenAsync(
+            It.IsAny<string>(),
+            It.IsAny<string?>(),
+            It.IsAny<DateTime?>(),
+            It.IsAny<string?>(),
+            It.IsAny<DateTime?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RevokeRefreshToken_ClearsBothTokens()
+    {
+        // Act
+        var result = await sut.RevokeRefreshTokenAsync(UserId);
+
+        // Assert
+        result.Should().BeTrue();
+
+        // UpdateRefreshTokenAsync is called with null for all token fields
+        // The optional params default to null, so both current and previous tokens are cleared
+        mockMongoDb.Verify(m => m.UpdateRefreshTokenAsync(
+            UserId,
+            null,
+            null,
+            null,
+            null),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshToken_InactiveUser_ReturnsNull()
+    {
+        // Arrange
+        var user = CreateTestUser();
+        user.IsActive = false;
+        mockMongoDb.Setup(m => m.GetUserByRefreshTokenAsync("current-refresh-token"))
+            .ReturnsAsync(user);
+
+        var request = new RefreshTokenRequest { RefreshToken = "current-refresh-token" };
+
+        // Act
+        var result = await sut.RefreshTokenAsync(request);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RefreshToken_ExpiredCurrentToken_ReturnsNull()
+    {
+        // Arrange
+        var user = CreateTestUser();
+        user.RefreshTokenExpiresAt = DateTime.UtcNow.AddHours(-1); // expired
+        mockMongoDb.Setup(m => m.GetUserByRefreshTokenAsync("current-refresh-token"))
+            .ReturnsAsync(user);
+
+        var request = new RefreshTokenRequest { RefreshToken = "current-refresh-token" };
+
+        // Act
+        var result = await sut.RefreshTokenAsync(request);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    private static User CreateTestUser(
+        string? refreshToken = "current-refresh-token",
+        string? previousRefreshToken = null,
+        DateTime? previousRefreshTokenExpiresAt = null)
+    {
+        return new User
+        {
+            Id = UserId,
+            Username = Username,
+            Email = Email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("password"),
+            Role = UserRoles.User,
+            IsActive = true,
+            RefreshToken = refreshToken,
+            RefreshTokenExpiresAt = DateTime.UtcNow.AddDays(7),
+            PreviousRefreshToken = previousRefreshToken,
+            PreviousRefreshTokenExpiresAt = previousRefreshTokenExpiresAt,
+        };
+    }
+}

--- a/backend/JwstDataAnalysis.API/Configuration/JwtSettings.cs
+++ b/backend/JwstDataAnalysis.API/Configuration/JwtSettings.cs
@@ -39,5 +39,12 @@ namespace JwstDataAnalysis.API.Configuration
         /// Compensates for clock drift between server and client in containerized environments.
         /// </summary>
         public int ClockSkewSeconds { get; set; } = 30;
+
+        /// <summary>
+        /// Gets or sets the grace window in seconds during which a previous refresh token
+        /// remains valid after token rotation. Prevents race conditions when concurrent
+        /// requests use the old token during rotation.
+        /// </summary>
+        public int RefreshTokenGraceWindowSeconds { get; set; } = 30;
     }
 }

--- a/backend/JwstDataAnalysis.API/Models/UserModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/UserModels.cs
@@ -56,6 +56,11 @@ namespace JwstDataAnalysis.API.Models
 
         public DateTime? RefreshTokenExpiresAt { get; set; }
 
+        // Previous refresh token for grace window during token rotation
+        public string? PreviousRefreshToken { get; set; }
+
+        public DateTime? PreviousRefreshTokenExpiresAt { get; set; }
+
         // Optional profile fields
         public string? DisplayName { get; set; }
 

--- a/backend/JwstDataAnalysis.API/Services/AuthService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/AuthService.Log.cs
@@ -58,6 +58,10 @@ namespace JwstDataAnalysis.API.Services
             Message = "Refresh token revoked for user: {UserId}")]
         private partial void LogRefreshTokenRevoked(string userId);
 
+        [LoggerMessage(EventId = 2206, Level = LogLevel.Information,
+            Message = "Grace window refresh for user: {UserId} — returning current tokens without re-rotation")]
+        private partial void LogGraceWindowRefresh(string userId);
+
         // Password operations (23xx)
         [LoggerMessage(EventId = 2301, Level = LogLevel.Warning,
             Message = "Password change failed: invalid current password for user: {UserId}")]

--- a/backend/JwstDataAnalysis.API/Services/IMongoDBService.cs
+++ b/backend/JwstDataAnalysis.API/Services/IMongoDBService.cs
@@ -132,7 +132,12 @@ namespace JwstDataAnalysis.API.Services
 
         Task UpdateUserAsync(User user);
 
-        Task UpdateRefreshTokenAsync(string userId, string? refreshToken, DateTime? expiresAt);
+        Task UpdateRefreshTokenAsync(
+            string userId,
+            string? refreshToken,
+            DateTime? expiresAt,
+            string? previousRefreshToken = null,
+            DateTime? previousRefreshTokenExpiresAt = null);
 
         // Data access control
         Task<List<JwstDataModel>> GetAccessibleDataAsync(string userId, bool isAdmin);

--- a/frontend/jwst-frontend/src/context/AuthContext.test.tsx
+++ b/frontend/jwst-frontend/src/context/AuthContext.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../services', () => ({
   clearTokenGetter: vi.fn(),
   setTokenRefresher: vi.fn(),
   clearTokenRefresher: vi.fn(),
+  attemptTokenRefresh: vi.fn().mockResolvedValue(true),
   setCompositeTokenGetter: vi.fn(),
   setMosaicTokenGetter: vi.fn(),
 }));

--- a/frontend/jwst-frontend/src/services/apiClient.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.ts
@@ -187,7 +187,7 @@ async function fallbackTokenRefresh(): Promise<boolean> {
  * Uses a shared promise to ensure only one refresh happens at a time.
  * Falls back to direct localStorage refresh if callback not registered.
  */
-async function attemptTokenRefresh(): Promise<boolean> {
+export async function attemptTokenRefresh(): Promise<boolean> {
   // If refresh already in progress, wait for it
   if (refreshPromise) {
     authLog('Token refresh already in progress, waiting...');

--- a/frontend/jwst-frontend/src/services/index.ts
+++ b/frontend/jwst-frontend/src/services/index.ts
@@ -12,6 +12,7 @@ export {
   clearTokenGetter,
   setTokenRefresher,
   clearTokenRefresher,
+  attemptTokenRefresh,
   getAuthLogs,
   printAuthLogs,
 } from './apiClient';


### PR DESCRIPTION
## Summary
Fixes race condition where long-running operations (e.g., 93s composite generation) cause token expiry and user logout. Adds a 30-second refresh token grace window on the backend and fixes stale closure + refresh path duplication on the frontend.

Closes #403

## Why
When a long-running operation is in flight, the access token expires. The proactive refresh fires, but after token rotation the old refresh token is immediately invalidated — so any concurrent or slightly-delayed refresh attempt fails with "Refresh token not found in database." After 3 retries, the user gets logged out mid-workflow.

## Type of Change
- [x] Bug fix

## Changes Made
- **Backend: Refresh token grace window** — after rotation, the old refresh token remains valid for 30 seconds (`RefreshTokenGraceWindowSeconds` in JwtSettings). If a request arrives with the old token during the grace window, the backend returns the current tokens without re-rotating.
- **Backend: User model** — added `PreviousRefreshToken` and `PreviousRefreshTokenExpiresAt` fields (no migration needed — MongoDB is schemaless).
- **Backend: MongoDBService** — `GetUserByRefreshTokenAsync` now matches on either current OR previous (within grace window) refresh token. `UpdateRefreshTokenAsync` accepts optional previous token fields.
- **Backend: AuthService** — `RefreshTokenAsync` detects grace window hits and returns current tokens without re-rotation. Normal rotation stores old token as previous with grace expiry.
- **Frontend: Fix stale closure** — `refreshAuth` now reads `refreshToken` from localStorage instead of `state.refreshToken`, eliminating stale closure in `scheduleRefresh`'s `setTimeout`.
- **Frontend: Unify refresh paths** — `scheduleRefresh` (proactive) now calls `attemptTokenRefresh()` from apiClient instead of `refreshAuth()` directly, ensuring both proactive and reactive (401) refresh paths go through the same deduplication (`refreshPromise`).
- **Backend tests** — 7 new AuthService unit tests covering normal rotation, grace window hit, expired grace window, concurrent requests, revoke clearing both tokens, inactive user, and expired current token.

## Test Plan
- [x] `dotnet test` — all 274 backend tests pass (7 new AuthService tests)
- [x] `npx vitest run` — all 51 frontend tests pass (17 AuthContext tests unaffected)
- [ ] Manual: Login → start a 5-channel composite → wait 90s+ → verify NOT logged out
- [ ] Manual: Open two tabs → refresh token in one → verify other tab still works
- [ ] Verify no "Refresh token not found in database" warnings in backend logs during normal use
- [ ] Verify login/logout/register flows still work normally

## Documentation Checklist
- [x] No new controllers, services, or endpoints — no doc updates needed
- [ ] `docs/tech-debt.md` — N/A (no tech debt changes)

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Reduces existing tech debt
- [ ] Adds tech debt (explain below)

## Risk & Rollback

Risk: Low. The grace window is additive — it only allows previously-valid tokens to work slightly longer. No existing behavior changes for single-client flows. The 30s window is short enough to not meaningfully expand the attack surface.

Rollback: Revert the commit. The `PreviousRefreshToken` and `PreviousRefreshTokenExpiresAt` fields will be ignored (null) by the old code since MongoDB is schemaless.

## Quality Checklist
- [x] Code follows project conventions
- [x] No commented-out code
- [x] No unnecessary dependencies added
- [x] Error handling is appropriate
- [x] Security implications considered (grace window is time-bounded and short)

🤖 Generated with [Claude Code](https://claude.com/claude-code)