### PR TITLE
feat: extend access token to 60 minutes and add visibility-based refresh

### DIFF
--- a/backend/JwstDataAnalysis.API/Configuration/JwtSettings.cs
+++ b/backend/JwstDataAnalysis.API/Configuration/JwtSettings.cs
@@ -27,7 +27,7 @@ namespace JwstDataAnalysis.API.Configuration
         /// <summary>
         /// Gets or sets the access token expiration time in minutes.
         /// </summary>
-        public int AccessTokenExpirationMinutes { get; set; } = 15;
+        public int AccessTokenExpirationMinutes { get; set; } = 60;
 
         /// <summary>
         /// Gets or sets the refresh token expiration time in days.

--- a/backend/JwstDataAnalysis.API/appsettings.json
+++ b/backend/JwstDataAnalysis.API/appsettings.json
@@ -10,7 +10,7 @@
     "SecretKey": "CHANGE_THIS_IN_PRODUCTION_MIN_32_CHARS_SECURE_KEY_HERE",
     "Issuer": "JwstDataAnalysis",
     "Audience": "JwstDataAnalysisClient",
-    "AccessTokenExpirationMinutes": 15,
+    "AccessTokenExpirationMinutes": 60,
     "RefreshTokenExpirationDays": 7,
     "ClockSkewSeconds": 30
   },


### PR DESCRIPTION
## Summary
Extends access token lifetime from 15 minutes to 60 minutes and adds a `visibilitychange` listener that refreshes tokens when a backgrounded tab returns to focus.

## Why
With a 15-minute access token, users needed to be constantly active to stay logged in. Background tabs had their `setTimeout` throttled by the browser, so the proactive refresh timer often missed its window. This meant stepping away for a few minutes or switching tabs could result in a logout.

## Type of Change
- [x] Enhancement

## Changes Made
- **Backend: JwtSettings default** — `AccessTokenExpirationMinutes` changed from 15 to 60
- **Backend: appsettings.json** — `AccessTokenExpirationMinutes` changed from 15 to 60
- **Frontend: AuthContext** — added `visibilitychange` event listener that checks token expiry when tab becomes visible; if within 60s of expiry, triggers `attemptTokenRefresh()` through the existing deduplication layer

## Test Plan
- [x] `dotnet test` — all 274 backend tests pass
- [x] `npx vitest run` — all 51 frontend tests pass
- [ ] Manual: Login → switch to another tab for 30+ minutes → switch back → verify still logged in
- [ ] Manual: Login → close laptop lid for 30+ minutes → reopen → verify still logged in or session restores seamlessly
- [ ] Verify proactive refresh still fires correctly at ~59 minutes

## Documentation Checklist
- [x] No new controllers, services, or endpoints — no doc updates needed
- [ ] `docs/tech-debt.md` — N/A

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Reduces existing tech debt
- [ ] Adds tech debt (explain below)

## Risk & Rollback

Risk: Low. Longer access tokens are standard for single-user apps. The 7-day refresh token is the real security boundary. The visibility listener is additive and goes through the existing deduplication layer.

Rollback: Revert the commit and change `AccessTokenExpirationMinutes` back to 15.

## Quality Checklist
- [x] Code follows project conventions
- [x] No commented-out code
- [x] No unnecessary dependencies added
- [x] Error handling is appropriate
- [x] Security implications considered (60 min is standard for non-sensitive apps; refresh token rotation + grace window still enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)