### PR TITLE
feat: add archiving animation feedback to file cards

### DIFF
--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -53,6 +53,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
   );
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const [isArchivingLevel, setIsArchivingLevel] = useState<boolean>(false);
+  const [archivingIds, setArchivingIds] = useState<Set<string>>(new Set());
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
   const [showCompositeWizard, setShowCompositeWizard] = useState<boolean>(false);
   const [showMosaicWizard, setShowMosaicWizard] = useState<boolean>(false);
@@ -269,6 +270,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
   };
 
   const handleArchive = async (dataId: string, isCurrentlyArchived: boolean) => {
+    setArchivingIds((prev) => new Set(prev).add(dataId));
     try {
       if (isCurrentlyArchived) {
         await jwstDataService.unarchive(dataId);
@@ -284,6 +286,12 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
       } else {
         alert('Error updating archive status');
       }
+    } finally {
+      setArchivingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(dataId);
+        return next;
+      });
     }
   };
 
@@ -490,6 +498,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
             collapsedGroups={collapsedGroups}
             selectedFiles={selectedFiles}
             selectedTag={selectedTag}
+            archivingIds={archivingIds}
             onToggleGroup={toggleGroupCollapse}
             onFileSelect={handleFileSelect}
             onView={handleViewItem}
@@ -503,6 +512,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
             collapsedLineages={collapsedLineages}
             expandedLevels={expandedLevels}
             selectedFiles={selectedFiles}
+            archivingIds={archivingIds}
             onToggleLineage={toggleLineageCollapse}
             onToggleLevel={toggleLevelExpand}
             onDeleteObservation={handleDeleteObservationClick}

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.css
@@ -221,8 +221,31 @@
   background: transparent;
 }
 
-.card-actions .archive-btn:hover {
+.card-actions .archive-btn:hover:not(:disabled) {
   background: var(--color-warning-subtle);
+}
+
+/* Archiving animation */
+.data-card.archiving {
+  opacity: 0.6;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.card-actions .archive-btn:disabled {
+  opacity: 0.7;
+  cursor: wait;
+  animation: archive-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes archive-pulse {
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 /* View button states */

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -9,6 +9,7 @@ import './DataCard.css';
 interface DataCardProps {
   item: JwstDataModel;
   isSelected: boolean;
+  isArchiving: boolean;
   selectedTag: string;
   onFileSelect: (dataId: string, event: React.MouseEvent) => void;
   onView: (item: JwstDataModel) => void;
@@ -20,6 +21,7 @@ interface DataCardProps {
 const DataCard: React.FC<DataCardProps> = ({
   item,
   isSelected,
+  isArchiving,
   selectedTag,
   onFileSelect,
   onView,
@@ -31,7 +33,9 @@ const DataCard: React.FC<DataCardProps> = ({
   const canSelect = fitsInfo.viewable;
 
   return (
-    <div className={`data-card ${isSelected ? 'selected-composite' : ''}`}>
+    <div
+      className={`data-card ${isSelected ? 'selected-composite' : ''} ${isArchiving ? 'archiving' : ''}`}
+    >
       {fitsInfo.viewable && (
         <div className="card-thumbnail">
           {item.hasThumbnail ? (
@@ -127,8 +131,18 @@ const DataCard: React.FC<DataCardProps> = ({
         </button>
         <button onClick={() => onProcess(item.id, 'basic_analysis')}>Analyze</button>
         <button onClick={() => onProcess(item.id, 'image_enhancement')}>Enhance</button>
-        <button className="archive-btn" onClick={() => onArchive(item.id, item.isArchived)}>
-          {item.isArchived ? 'Unarchive' : 'Archive'}
+        <button
+          className="archive-btn"
+          onClick={() => onArchive(item.id, item.isArchived)}
+          disabled={isArchiving}
+        >
+          {isArchiving
+            ? item.isArchived
+              ? 'Unarchiving...'
+              : 'Archiving...'
+            : item.isArchived
+              ? 'Unarchive'
+              : 'Archive'}
         </button>
       </div>
     </div>

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.css
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.css
@@ -135,3 +135,26 @@
 .lineage-file-card.selected-composite .file-header {
   background: linear-gradient(135deg, rgba(78, 205, 196, 0.08) 0%, transparent 50%);
 }
+
+/* Archiving animation */
+.lineage-file-card.archiving {
+  opacity: 0.6;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.lineage-file-card .file-actions button.archive-btn:disabled {
+  opacity: 0.7;
+  cursor: wait;
+  animation: archive-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes archive-pulse {
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
@@ -9,6 +9,7 @@ import './LineageFileCard.css';
 interface LineageFileCardProps {
   item: JwstDataModel;
   isSelected: boolean;
+  isArchiving: boolean;
   onFileSelect: (dataId: string, event: React.MouseEvent) => void;
   onView: (item: JwstDataModel) => void;
   onProcess: (dataId: string, algorithm: string) => void;
@@ -18,6 +19,7 @@ interface LineageFileCardProps {
 const LineageFileCard: React.FC<LineageFileCardProps> = ({
   item,
   isSelected,
+  isArchiving,
   onFileSelect,
   onView,
   onProcess,
@@ -27,7 +29,9 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
   const canSelect = fitsInfo.viewable;
 
   return (
-    <div className={`lineage-file-card ${isSelected ? 'selected-composite' : ''}`}>
+    <div
+      className={`lineage-file-card ${isSelected ? 'selected-composite' : ''} ${isArchiving ? 'archiving' : ''}`}
+    >
       {fitsInfo.viewable && (
         <div className="lineage-thumbnail">
           {item.hasThumbnail ? (
@@ -98,8 +102,18 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
             {fitsInfo.viewable ? 'View' : 'Table'}
           </button>
           <button onClick={() => onProcess(item.id, 'basic_analysis')}>Analyze</button>
-          <button className="archive-btn" onClick={() => onArchive(item.id, item.isArchived)}>
-            {item.isArchived ? 'Unarchive' : 'Archive'}
+          <button
+            className="archive-btn"
+            onClick={() => onArchive(item.id, item.isArchived)}
+            disabled={isArchiving}
+          >
+            {isArchiving
+              ? item.isArchived
+                ? 'Unarchiving...'
+                : 'Archiving...'
+              : item.isArchived
+                ? 'Unarchive'
+                : 'Archive'}
           </button>
         </div>
       </div>

--- a/frontend/jwst-frontend/src/components/dashboard/LineageView.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageView.tsx
@@ -14,6 +14,7 @@ interface LineageViewProps {
   collapsedLineages: Set<string>;
   expandedLevels: Set<string>;
   selectedFiles: Set<string>;
+  archivingIds: Set<string>;
   onToggleLineage: (obsId: string) => void;
   onToggleLevel: (key: string) => void;
   onDeleteObservation: (obsId: string, event: React.MouseEvent) => void;
@@ -60,6 +61,7 @@ const LineageView: React.FC<LineageViewProps> = ({
   collapsedLineages,
   expandedLevels,
   selectedFiles,
+  archivingIds,
   onToggleLineage,
   onToggleLevel,
   onDeleteObservation,
@@ -230,6 +232,7 @@ const LineageView: React.FC<LineageViewProps> = ({
                               key={item.id}
                               item={item}
                               isSelected={selectedFiles.has(item.id)}
+                              isArchiving={archivingIds.has(item.id)}
                               onFileSelect={onFileSelect}
                               onView={onView}
                               onProcess={onProcess}

--- a/frontend/jwst-frontend/src/components/dashboard/TargetGroupView.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/TargetGroupView.tsx
@@ -8,6 +8,7 @@ interface TargetGroupViewProps {
   collapsedGroups: Set<string>;
   selectedFiles: Set<string>;
   selectedTag: string;
+  archivingIds: Set<string>;
   onToggleGroup: (groupId: string) => void;
   onFileSelect: (dataId: string, event: React.MouseEvent) => void;
   onView: (item: JwstDataModel) => void;
@@ -21,6 +22,7 @@ const TargetGroupView: React.FC<TargetGroupViewProps> = ({
   collapsedGroups,
   selectedFiles,
   selectedTag,
+  archivingIds,
   onToggleGroup,
   onFileSelect,
   onView,
@@ -94,6 +96,7 @@ const TargetGroupView: React.FC<TargetGroupViewProps> = ({
                     key={item.id}
                     item={item}
                     isSelected={selectedFiles.has(item.id)}
+                    isArchiving={archivingIds.has(item.id)}
                     selectedTag={selectedTag}
                     onFileSelect={onFileSelect}
                     onView={onView}


### PR DESCRIPTION
## Summary
Adds visual feedback when archiving/unarchiving files — the card dims with a pulsing "Archiving..." button so users know the operation is in progress.

## Why
Previously clicking Archive gave no visual feedback until the background data refresh completed, making it unclear whether the action registered. This is especially noticeable on slower connections.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Changes Made
- Added `archivingIds` state tracking in `JwstDataDashboard` to know which files are mid-archive
- Both `DataCard` (target view) and `LineageFileCard` (lineage view) accept `isArchiving` prop
- When archiving: card gets reduced opacity (0.6), pointer events disabled, button shows "Archiving..."/"Unarchiving..." with a pulse animation
- Props threaded through `TargetGroupView` and `LineageView` intermediary components

## Test Plan
- [x] Navigate to lineage view, expand a processing level, click Archive on a file — card should dim and button should pulse with "Archiving..." text
- [x] After the operation completes, card returns to normal and button shows "Unarchive"
- [x] Repeat in target group view — same behavior on DataCard
- [x] Click Unarchive — should show "Unarchiving..." with same animation
- [x] All 51 frontend unit tests pass

## Documentation Checklist
- [x] No new endpoints, controllers, or services added
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — CSS-only animation plus a boolean state prop, no behavioral changes to the archive API call itself.
Rollback: Revert this commit.

## Quality Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Feature works in both view modes (lineage + target)