### PR TITLE
chore: remove dead DTO types from backend and frontend

### DIFF
--- a/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
@@ -234,23 +234,6 @@ namespace JwstDataAnalysis.API.Models
         public Dictionary<string, object>? Metadata { get; set; }
     }
 
-    public class FileUploadResponse
-    {
-        public string Id { get; set; } = string.Empty;
-
-        public string FileName { get; set; } = string.Empty;
-
-        public long FileSize { get; set; }
-
-        public string? FileFormat { get; set; }
-
-        public bool IsValidated { get; set; }
-
-        public string? ValidationMessage { get; set; }
-
-        public DateTime UploadDate { get; set; }
-    }
-
     // Validation attributes for astronomical data
     public class AstronomicalDataValidationAttribute : ValidationAttribute
     {

--- a/frontend/jwst-frontend/src/types/MastTypes.ts
+++ b/frontend/jwst-frontend/src/types/MastTypes.ts
@@ -1,26 +1,3 @@
-export interface MastTargetSearchRequest {
-  targetName: string;
-  radius?: number;
-  calibLevel?: number[];
-}
-
-export interface MastCoordinateSearchRequest {
-  ra: number;
-  dec: number;
-  radius?: number;
-  calibLevel?: number[];
-}
-
-export interface MastObservationSearchRequest {
-  obsId: string;
-  calibLevel?: number[];
-}
-
-export interface MastProgramSearchRequest {
-  programId: string;
-  calibLevel?: number[];
-}
-
 export interface MastRecentReleasesRequest {
   daysBack?: number;
   instrument?: string; // NIRCAM, MIRI, NIRSPEC, NIRISS
@@ -56,14 +33,6 @@ export interface MastObservationResult {
   [key: string]: unknown;
 }
 
-export interface MastImportRequest {
-  obsId: string;
-  productType?: string;
-  userId?: string;
-  tags?: string[];
-  isPublic?: boolean;
-}
-
 export interface MastImportResponse {
   status: string;
   obsId: string;
@@ -71,21 +40,6 @@ export interface MastImportResponse {
   importedCount: number;
   error?: string;
   timestamp: string;
-}
-
-export interface MastDataProduct {
-  productId?: string;
-  fileName?: string;
-  productType?: string;
-  description?: string;
-  size?: number;
-  dataUri?: string;
-}
-
-export interface MastDataProductsResponse {
-  obs_id: string;
-  products: MastDataProduct[];
-  product_count: number;
 }
 
 export type MastSearchType = 'target' | 'coordinates' | 'observation' | 'program';
@@ -154,13 +108,6 @@ export interface ResumableJobSummary {
 export interface ResumableJobsResponse {
   jobs: ResumableJobSummary[];
   count: number;
-}
-
-// Metadata refresh response
-export interface MetadataRefreshResponse {
-  obsId: string;
-  updatedCount: number;
-  message: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
Remove 9 unused DTO types identified during a comprehensive dead code audit across backend and frontend.

## Why
Dead types add noise, increase cognitive load, and can mislead future developers into thinking they're part of the API contract. Removing them keeps the codebase honest and reduces maintenance surface.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / code cleanup
- [ ] Performance improvement
- [ ] Test update
- [ ] CI/CD or build change

## Changes Made
- Removed `FileUploadResponse` from `DataValidationModels.cs` (backend) — never referenced by any controller, service, or test
- Removed 8 dead TypeScript interfaces from `MastTypes.ts` (frontend):
  - `MastTargetSearchRequest`, `MastCoordinateSearchRequest`, `MastObservationSearchRequest`, `MastProgramSearchRequest` — search params are defined inline in `mastService.ts`
  - `MastImportRequest` — import params defined inline in `mastService.ts`
  - `MastDataProduct`, `MastDataProductsResponse` — never imported or used
  - `MetadataRefreshResponse` — only in its own definition file, never imported

## Test Plan
- [x] Backend builds with zero warnings (`dotnet build --warnaserror`)
- [x] All 294 backend tests pass
- [x] Frontend TypeScript compiles with zero errors (`npx tsc --noEmit`)
- [x] All 51 frontend unit tests pass
- [x] Grep confirms no remaining references to any removed type

## Documentation Checklist
- [x] No new endpoints, controllers, or services — no doc updates needed
- [ ] `docs/tech-debt.md` updated (if applicable)
- [ ] `docs/key-files.md` updated (if applicable)

## Tech Debt Impact
- [x] Reduces tech debt (removes dead code)
- [ ] No impact on tech debt
- [ ] Adds tech debt (explain why)

## Risk & Rollback
Risk: Minimal. All removed types confirmed unused via grep. No runtime behavior change.
Rollback: `git revert <sha>` restores all types.

## Quality Checklist
- [x] Code compiles without warnings
- [x] All tests pass
- [x] No unnecessary changes included