### PR TITLE
chore(deps): upgrade pytest-asyncio from 0.23.2 to 1.3.0

### DIFF
--- a/processing-engine/requirements-dev.txt
+++ b/processing-engine/requirements-dev.txt
@@ -14,6 +14,6 @@ mypy>=1.8.0
 pre-commit>=3.6.0
 
 # Testing (enhanced)
-pytest-asyncio>=0.23.0
+pytest-asyncio>=1.3.0
 pytest-cov>=4.1.0
 httpx>=0.26.0  # For testing FastAPI with async client

--- a/processing-engine/requirements.txt
+++ b/processing-engine/requirements.txt
@@ -30,6 +30,6 @@ boto3>=1.34.0
 
 # Testing
 pytest==9.0.2
-pytest-asyncio==0.23.2
+pytest-asyncio==1.3.0
 httpx==0.28.1
 ruff==0.15.2


### PR DESCRIPTION
## Summary
Upgrade pytest-asyncio to fix Python test suite that was completely broken due to version incompatibility.

## Why
`pytest-asyncio==0.23.2` is incompatible with `pytest==9.0.2`, causing an `INTERNALERROR` (`'Package' object has no attribute 'obj'`) that prevents all 359 Python tests from running. The 1.x series supports `pytest>=8.2,<10`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Performance improvement
- [ ] Test update
- [x] CI/CD or build change

## Changes Made
- Bumped `pytest-asyncio` from `0.23.2` to `1.3.0` in `requirements.txt`
- Bumped `pytest-asyncio` floor from `>=0.23.0` to `>=1.3.0` in `requirements-dev.txt`

## Test Plan
- [x] Docker rebuild succeeds (`docker compose up -d --build processing-engine`)
- [x] All 359 Python tests pass (`docker exec jwst-processing python -m pytest`)
- [x] No test code changes needed (no usage of removed `event_loop` fixture)
- [x] Python lint passes (`ruff check` + `ruff format --check`)

## Documentation Checklist
- [x] No new endpoints, controllers, or services — no doc updates needed
- [ ] `docs/tech-debt.md` updated (if applicable)
- [ ] `docs/key-files.md` updated (if applicable)

## Tech Debt Impact
- [x] Reduces tech debt (fixes broken test infrastructure)
- [ ] No impact on tech debt
- [ ] Adds tech debt (explain why)

## Risk & Rollback
Risk: Minimal. Dependency bump only, no test code changes. All 359 tests pass.
Rollback: `git revert <sha>`, rebuild Docker image.

## Quality Checklist
- [x] Code compiles without warnings
- [x] All tests pass
- [x] No unnecessary changes included