### PR TITLE
feat: add Python CI coverage threshold at 50%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       working-directory: frontend/jwst-frontend
 
   python-test:
-    name: Python Setup
+    name: Python Tests
     runs-on: ubuntu-latest
     # No 'needs' - runs in parallel with other jobs
 
@@ -135,10 +135,9 @@ jobs:
         pip install -r requirements.txt
       working-directory: processing-engine
 
-    # TODO: Enable when pytest tests are added
-    # - name: Test Processing Engine
-    #   run: pytest
-    #   working-directory: processing-engine
+    - name: Test Processing Engine
+      run: pytest
+      working-directory: processing-engine
 
   docker-build:
     name: Docker Build

--- a/processing-engine/pyproject.toml
+++ b/processing-engine/pyproject.toml
@@ -91,7 +91,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=50"
 asyncio_mode = "auto"
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/processing-engine/requirements.txt
+++ b/processing-engine/requirements.txt
@@ -31,5 +31,6 @@ boto3>=1.34.0
 # Testing
 pytest==9.0.2
 pytest-asyncio==1.3.0
+pytest-cov==6.2.1
 httpx==0.28.1
 ruff==0.15.2


### PR DESCRIPTION
## Summary
Adds a 50% code coverage floor for the Python processing engine in CI, preventing silent coverage regression. Also enables the Python test step that was previously commented out.

## Why
We have 359 Python tests but no coverage enforcement — coverage could silently regress to 0% and CI would still pass. The Python test job was also commented out entirely, meaning test failures wouldn't block PRs.

## Type of Change
- [x] Enhancement (improves existing functionality)

## Changes Made
- Added `pytest-cov==6.2.1` to `processing-engine/requirements.txt`
- Added `--cov=app --cov-report=term-missing --cov-fail-under=50` to pytest addopts in `pyproject.toml`
- Uncommented and enabled the Python test step in `.github/workflows/ci.yml`
- Renamed CI job from "Python Setup" to "Python Tests" (branch protection update required — see below)

## Test Plan
- [x] Verified locally: 359 tests pass, coverage at 55.06%, threshold at 50% — `Required test coverage of 50% reached`
- [ ] CI `Python Tests` job runs and passes (will initially fail until branch protection is updated — see note)
- [ ] Confirm coverage report appears in CI output with per-file breakdown

### Branch Protection Note
The required check name changes from "Python Setup" to "Python Tests". Branch protection will be updated via API after this PR is created.

## Documentation Checklist
- [x] No new controllers, services, or endpoints — no doc updates needed

## Tech Debt Impact
- [x] Reduces tech debt — enforces coverage floor, prevents regression

## Risk & Rollback
Risk: Low — adds a threshold to existing tests, no behavior changes. The 50% floor is 5% below current coverage (55%).
Rollback: Revert the commit; remove `pytest-cov` from requirements and coverage flags from pyproject.toml.

## Quality Checklist
- [x] Changes follow project coding standards
- [x] No sensitive data exposed
- [x] Changes are minimal and focused

Closes #433