### PR TITLE
test: add Python tests for statistics, utils, and filters

### DIFF
--- a/processing-engine/tests/test_filters.py
+++ b/processing-engine/tests/test_filters.py
@@ -1,0 +1,212 @@
+"""Tests for the noise reduction filters module."""
+
+import numpy as np
+import pytest
+
+from app.processing.filters import (
+    astropy_box_filter,
+    astropy_gaussian_filter,
+    box_filter,
+    gaussian_filter,
+    median_filter,
+    reduce_noise,
+    sigma_clip_pixels,
+    unsharp_mask,
+)
+
+
+@pytest.fixture
+def sample_image():
+    """10x10 image with known values."""
+    rng = np.random.default_rng(42)
+    return rng.normal(loc=100.0, scale=10.0, size=(10, 10)).astype(np.float64)
+
+
+@pytest.fixture
+def image_with_nans(sample_image):
+    """Image with NaN pixels to test NaN handling."""
+    d = sample_image.copy()
+    d[0, 0] = np.nan
+    d[5, 5] = np.nan
+    return d
+
+
+@pytest.fixture
+def image_with_outliers():
+    """Clean image with extreme outlier pixels."""
+    rng = np.random.default_rng(42)
+    data = rng.normal(loc=50.0, scale=2.0, size=(20, 20)).astype(np.float64)
+    data[3, 3] = 5000.0
+    data[15, 15] = 5000.0
+    return data
+
+
+class TestGaussianFilter:
+    def test_output_shape_matches_input(self, sample_image):
+        result = gaussian_filter(sample_image, sigma=1.0)
+        assert result.shape == sample_image.shape
+
+    def test_smoothing_reduces_std(self, sample_image):
+        result = gaussian_filter(sample_image, sigma=2.0)
+        assert np.std(result) < np.std(sample_image)
+
+    def test_preserves_mean_approximately(self, sample_image):
+        result = gaussian_filter(sample_image, sigma=1.0)
+        assert np.mean(result) == pytest.approx(np.mean(sample_image), abs=1.0)
+
+    def test_sigma_zero_returns_original(self, sample_image):
+        result = gaussian_filter(sample_image, sigma=0.0)
+        np.testing.assert_array_almost_equal(result, sample_image)
+
+
+class TestMedianFilter:
+    def test_output_shape_matches_input(self, sample_image):
+        result = median_filter(sample_image, size=3)
+        assert result.shape == sample_image.shape
+
+    def test_removes_salt_and_pepper(self):
+        data = np.ones((10, 10)) * 50.0
+        data[5, 5] = 9999.0  # spike
+        result = median_filter(data, size=3)
+        assert result[5, 5] == pytest.approx(50.0)
+
+    def test_uniform_data_unchanged(self):
+        data = np.ones((10, 10)) * 42.0
+        result = median_filter(data, size=3)
+        np.testing.assert_array_almost_equal(result, data)
+
+
+class TestBoxFilter:
+    def test_output_shape_matches_input(self, sample_image):
+        result = box_filter(sample_image, size=3)
+        assert result.shape == sample_image.shape
+
+    def test_smoothing_reduces_std(self, sample_image):
+        result = box_filter(sample_image, size=5)
+        assert np.std(result) < np.std(sample_image)
+
+    def test_uniform_data_unchanged(self):
+        data = np.ones((10, 10)) * 42.0
+        result = box_filter(data, size=3)
+        np.testing.assert_array_almost_equal(result, data)
+
+
+class TestAstropyGaussianFilter:
+    def test_output_shape_matches_input(self, sample_image):
+        result = astropy_gaussian_filter(sample_image, sigma=1.0)
+        assert result.shape == sample_image.shape
+
+    def test_handles_nans_by_default(self, image_with_nans):
+        result = astropy_gaussian_filter(image_with_nans, sigma=1.0)
+        # With interpolation, NaN locations should be filled
+        assert not np.any(np.isnan(result))
+
+    def test_preserve_nan_option(self, image_with_nans):
+        result = astropy_gaussian_filter(image_with_nans, sigma=1.0, preserve_nan=True)
+        assert np.isnan(result[0, 0])
+        assert np.isnan(result[5, 5])
+
+    def test_fill_nan_treatment(self, image_with_nans):
+        result = astropy_gaussian_filter(
+            image_with_nans, sigma=1.0, nan_treatment="fill", fill_value=0.0
+        )
+        assert result.shape == image_with_nans.shape
+        assert not np.any(np.isnan(result))
+
+    def test_smoothing_reduces_variation(self):
+        # Use a larger image to avoid edge normalization effects
+        rng = np.random.default_rng(42)
+        large_image = rng.normal(loc=100.0, scale=10.0, size=(50, 50)).astype(np.float64)
+        result = astropy_gaussian_filter(large_image, sigma=2.0)
+        # Compare only the interior to avoid edge effects
+        interior = slice(10, 40)
+        assert np.std(result[interior, interior]) < np.std(large_image[interior, interior])
+
+
+class TestAstropyBoxFilter:
+    def test_output_shape_matches_input(self, sample_image):
+        result = astropy_box_filter(sample_image, size=3)
+        assert result.shape == sample_image.shape
+
+    def test_handles_nans(self, image_with_nans):
+        result = astropy_box_filter(image_with_nans, size=3)
+        assert not np.any(np.isnan(result))
+
+    def test_preserve_nan_option(self, image_with_nans):
+        result = astropy_box_filter(image_with_nans, size=3, preserve_nan=True)
+        assert np.isnan(result[0, 0])
+        assert np.isnan(result[5, 5])
+
+
+class TestReduceNoise:
+    def test_dispatches_gaussian(self, sample_image):
+        result = reduce_noise(sample_image, method="gaussian", sigma=1.0)
+        expected = gaussian_filter(sample_image, sigma=1.0)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_dispatches_median(self, sample_image):
+        result = reduce_noise(sample_image, method="median", size=3)
+        expected = median_filter(sample_image, size=3)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_dispatches_box(self, sample_image):
+        result = reduce_noise(sample_image, method="box", size=3)
+        expected = box_filter(sample_image, size=3)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_dispatches_astropy_gaussian(self, sample_image):
+        result = reduce_noise(sample_image, method="astropy_gaussian", sigma=1.0)
+        assert result.shape == sample_image.shape
+
+    def test_dispatches_astropy_box(self, sample_image):
+        result = reduce_noise(sample_image, method="astropy_box", size=3)
+        assert result.shape == sample_image.shape
+
+    def test_unknown_method_raises(self, sample_image):
+        with pytest.raises(ValueError, match="Unknown filter method"):
+            reduce_noise(sample_image, method="nonexistent")
+
+    def test_kernel_size_alias(self, sample_image):
+        result = reduce_noise(sample_image, method="median", kernel_size=5)
+        expected = median_filter(sample_image, size=5)
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestUnsharpMask:
+    def test_output_shape_matches_input(self, sample_image):
+        result = unsharp_mask(sample_image, sigma=2.0, amount=1.0)
+        assert result.shape == sample_image.shape
+
+    def test_enhances_edges(self):
+        # Create image with a sharp edge
+        data = np.zeros((20, 20), dtype=np.float64)
+        data[:, 10:] = 100.0
+        result = unsharp_mask(data, sigma=2.0, amount=1.0)
+        # Near the edge, sharpened values should overshoot
+        assert np.max(result) > 100.0
+
+    def test_zero_amount_returns_original(self, sample_image):
+        result = unsharp_mask(sample_image, sigma=2.0, amount=0.0)
+        np.testing.assert_array_almost_equal(result, sample_image)
+
+
+class TestSigmaClipPixels:
+    def test_output_shape_matches_input(self, sample_image):
+        result = sigma_clip_pixels(sample_image, sigma=5.0)
+        assert result.shape == sample_image.shape
+
+    def test_replaces_outliers(self, image_with_outliers):
+        result = sigma_clip_pixels(image_with_outliers, sigma=3.0)
+        # Extreme outliers should be replaced with values near the median
+        assert result[3, 3] < 100.0
+        assert result[15, 15] < 100.0
+
+    def test_preserves_normal_data(self, sample_image):
+        result = sigma_clip_pixels(sample_image, sigma=5.0)
+        # With high sigma threshold, no changes for normal data
+        np.testing.assert_array_almost_equal(result, sample_image, decimal=1)
+
+    def test_does_not_modify_input(self, image_with_outliers):
+        original = image_with_outliers.copy()
+        sigma_clip_pixels(image_with_outliers, sigma=3.0)
+        np.testing.assert_array_equal(image_with_outliers, original)

--- a/processing-engine/tests/test_statistics.py
+++ b/processing-engine/tests/test_statistics.py
@@ -1,0 +1,295 @@
+"""Tests for the statistical analysis module."""
+
+import math
+
+import numpy as np
+import pytest
+
+from app.processing.statistics import (
+    compare_images,
+    compute_advanced_stats,
+    compute_basic_stats,
+    compute_histogram,
+    compute_percentiles,
+    compute_robust_stats,
+    compute_snr,
+    compute_statistics,
+)
+
+
+@pytest.fixture
+def sample_data():
+    """Simple 10x10 image with known values."""
+    rng = np.random.default_rng(42)
+    return rng.normal(loc=100.0, scale=10.0, size=(10, 10)).astype(np.float64)
+
+
+@pytest.fixture
+def data_with_nans(sample_data):
+    """Sample data with some NaN pixels."""
+    d = sample_data.copy()
+    d[0, 0] = np.nan
+    d[5, 5] = np.nan
+    d[9, 9] = np.nan
+    return d
+
+
+@pytest.fixture
+def mask_array():
+    """Boolean mask excluding corner pixels."""
+    m = np.zeros((10, 10), dtype=bool)
+    m[0, 0] = True
+    m[0, 9] = True
+    m[9, 0] = True
+    m[9, 9] = True
+    return m
+
+
+class TestComputeBasicStats:
+    def test_returns_expected_keys(self, sample_data):
+        result = compute_basic_stats(sample_data)
+        expected_keys = {"min", "max", "mean", "median", "std", "sum", "n_pixels", "n_nan"}
+        assert set(result.keys()) == expected_keys
+
+    def test_correct_values_for_known_data(self):
+        data = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = compute_basic_stats(data)
+        assert result["min"] == pytest.approx(1.0)
+        assert result["max"] == pytest.approx(4.0)
+        assert result["mean"] == pytest.approx(2.5)
+        assert result["median"] == pytest.approx(2.5)
+        assert result["sum"] == pytest.approx(10.0)
+        assert result["n_pixels"] == 4
+        assert result["n_nan"] == 0
+
+    def test_handles_nan_values(self, data_with_nans):
+        result = compute_basic_stats(data_with_nans)
+        assert result["n_nan"] == 3
+        assert result["n_pixels"] == 97
+
+    def test_with_mask(self, sample_data, mask_array):
+        result = compute_basic_stats(sample_data, mask=mask_array)
+        assert result["n_pixels"] == 96
+
+    def test_all_nan_returns_nan_stats(self):
+        data = np.full((3, 3), np.nan)
+        result = compute_basic_stats(data)
+        assert math.isnan(result["min"])
+        assert math.isnan(result["mean"])
+        assert result["n_pixels"] == 0
+        assert result["n_nan"] == 9
+
+    def test_all_masked_returns_nan_stats(self):
+        data = np.ones((3, 3))
+        mask = np.ones((3, 3), dtype=bool)
+        result = compute_basic_stats(data, mask=mask)
+        assert math.isnan(result["min"])
+        assert result["n_pixels"] == 0
+
+
+class TestComputeRobustStats:
+    def test_returns_expected_keys(self, sample_data):
+        result = compute_robust_stats(sample_data)
+        expected_keys = {"clipped_mean", "clipped_median", "clipped_std", "sigma", "maxiters"}
+        assert set(result.keys()) == expected_keys
+
+    def test_clipped_stats_resist_outliers(self):
+        rng = np.random.default_rng(42)
+        data = rng.normal(loc=50.0, scale=5.0, size=(20, 20)).astype(np.float64)
+        data[0, 0] = 10000.0  # extreme outlier
+        result = compute_robust_stats(data, sigma=3.0)
+        assert result["clipped_mean"] == pytest.approx(50.0, abs=3.0)
+        assert result["clipped_median"] == pytest.approx(50.0, abs=3.0)
+
+    def test_custom_sigma_and_maxiters(self, sample_data):
+        result = compute_robust_stats(sample_data, sigma=2.0, maxiters=10)
+        assert result["sigma"] == 2.0
+        assert result["maxiters"] == 10
+
+    def test_with_mask(self, sample_data, mask_array):
+        result = compute_robust_stats(sample_data, mask=mask_array)
+        assert not math.isnan(result["clipped_mean"])
+
+    def test_handles_nans(self, data_with_nans):
+        result = compute_robust_stats(data_with_nans)
+        assert not math.isnan(result["clipped_mean"])
+
+
+class TestComputeAdvancedStats:
+    def test_returns_expected_keys(self, sample_data):
+        result = compute_advanced_stats(sample_data)
+        expected_keys = {"biweight_location", "biweight_scale", "mad_std"}
+        assert set(result.keys()) == expected_keys
+
+    def test_biweight_values_reasonable(self, sample_data):
+        result = compute_advanced_stats(sample_data)
+        assert result["biweight_location"] == pytest.approx(100.0, abs=5.0)
+        assert result["biweight_scale"] > 0
+        assert result["mad_std"] > 0
+
+    def test_insufficient_data_returns_nan(self):
+        data = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = compute_advanced_stats(data)
+        assert math.isnan(result["biweight_location"])
+        assert math.isnan(result["biweight_scale"])
+        assert math.isnan(result["mad_std"])
+
+    def test_with_mask(self, sample_data, mask_array):
+        result = compute_advanced_stats(sample_data, mask=mask_array)
+        assert not math.isnan(result["biweight_location"])
+
+    def test_handles_nans(self, data_with_nans):
+        result = compute_advanced_stats(data_with_nans)
+        assert not math.isnan(result["biweight_location"])
+
+
+class TestComputeStatistics:
+    def test_combines_all_stat_types(self, sample_data):
+        result = compute_statistics(sample_data)
+        assert "min" in result
+        assert "clipped_mean" in result
+        assert "biweight_location" in result
+        assert "shape" in result
+        assert "dtype" in result
+
+    def test_shape_metadata(self, sample_data):
+        result = compute_statistics(sample_data)
+        assert result["shape"] == [10, 10]
+        assert result["dtype"] == "float64"
+
+    def test_custom_sigma(self, sample_data):
+        result = compute_statistics(sample_data, sigma=2.0)
+        assert not math.isnan(result["clipped_mean"])
+
+    def test_with_mask(self, sample_data, mask_array):
+        result = compute_statistics(sample_data, mask=mask_array)
+        assert result["n_pixels"] == 96
+
+
+class TestComputeHistogram:
+    def test_returns_expected_keys(self, sample_data):
+        result = compute_histogram(sample_data)
+        expected_keys = {"counts", "bin_edges", "bin_centers", "n_bins", "range"}
+        assert set(result.keys()) == expected_keys
+
+    def test_default_256_bins(self, sample_data):
+        result = compute_histogram(sample_data)
+        assert result["n_bins"] == 256
+        assert len(result["counts"]) == 256
+        assert len(result["bin_edges"]) == 257
+        assert len(result["bin_centers"]) == 256
+
+    def test_custom_bins(self, sample_data):
+        result = compute_histogram(sample_data, bins=10)
+        assert result["n_bins"] == 10
+        assert len(result["counts"]) == 10
+
+    def test_custom_range(self, sample_data):
+        result = compute_histogram(sample_data, range=(80.0, 120.0))
+        assert result["range"] == (80.0, 120.0)
+
+    def test_total_counts_match_pixels(self, sample_data):
+        result = compute_histogram(sample_data)
+        assert sum(result["counts"]) == sample_data.size
+
+    def test_with_mask(self, sample_data, mask_array):
+        result = compute_histogram(sample_data, mask=mask_array)
+        assert sum(result["counts"]) == sample_data.size - mask_array.sum()
+
+    def test_handles_nans(self, data_with_nans):
+        result = compute_histogram(data_with_nans)
+        assert sum(result["counts"]) == data_with_nans.size - 3
+
+
+class TestComputePercentiles:
+    def test_default_percentiles(self, sample_data):
+        result = compute_percentiles(sample_data)
+        expected_keys = {"p1", "p5", "p10", "p25", "p50", "p75", "p90", "p95", "p99"}
+        assert set(result.keys()) == expected_keys
+
+    def test_percentiles_are_ordered(self, sample_data):
+        result = compute_percentiles(sample_data)
+        assert result["p1"] <= result["p25"] <= result["p50"] <= result["p75"] <= result["p99"]
+
+    def test_custom_percentiles(self, sample_data):
+        result = compute_percentiles(sample_data, percentiles=[10, 50, 90])
+        assert set(result.keys()) == {"p10", "p50", "p90"}
+
+    def test_with_mask(self, sample_data, mask_array):
+        result = compute_percentiles(sample_data, mask=mask_array)
+        assert "p50" in result
+
+    def test_handles_nans(self, data_with_nans):
+        result = compute_percentiles(data_with_nans)
+        assert not math.isnan(result["p50"])
+
+
+class TestComputeSnr:
+    def test_returns_expected_keys(self, sample_data):
+        result = compute_snr(sample_data)
+        expected_keys = {"peak_snr", "mean_snr", "background", "noise"}
+        assert set(result.keys()) == expected_keys
+
+    def test_positive_snr_for_signal(self):
+        rng = np.random.default_rng(42)
+        data = rng.normal(loc=100.0, scale=5.0, size=(20, 20)).astype(np.float64)
+        data[10, 10] = 200.0  # bright source
+        result = compute_snr(data)
+        assert result["peak_snr"] > 0
+        assert result["mean_snr"] > 0
+
+    def test_custom_background_and_noise(self, sample_data):
+        result = compute_snr(sample_data, background=100.0, noise=10.0)
+        assert result["background"] == pytest.approx(100.0)
+        assert result["noise"] == pytest.approx(10.0)
+
+    def test_zero_noise_returns_nan(self, sample_data):
+        result = compute_snr(sample_data, background=100.0, noise=0.0)
+        assert math.isnan(result["peak_snr"])
+        assert math.isnan(result["mean_snr"])
+
+    def test_negative_noise_returns_nan(self, sample_data):
+        result = compute_snr(sample_data, background=100.0, noise=-1.0)
+        assert math.isnan(result["peak_snr"])
+
+    def test_with_mask(self, sample_data, mask_array):
+        result = compute_snr(sample_data, mask=mask_array)
+        assert result["peak_snr"] > 0
+
+    def test_auto_estimates_background(self, sample_data):
+        result = compute_snr(sample_data)
+        assert result["background"] == pytest.approx(100.0, abs=5.0)
+        assert result["noise"] > 0
+
+
+class TestCompareImages:
+    def test_identical_images_zero_diff(self, sample_data):
+        result = compare_images(sample_data, sample_data)
+        assert result["mean_diff"] == pytest.approx(0.0)
+        assert result["median_diff"] == pytest.approx(0.0)
+        assert result["max_diff"] == pytest.approx(0.0)
+        assert result["rms_diff"] == pytest.approx(0.0)
+
+    def test_known_offset(self):
+        data1 = np.ones((5, 5)) * 10.0
+        data2 = np.ones((5, 5)) * 7.0
+        result = compare_images(data1, data2)
+        assert result["mean_diff"] == pytest.approx(3.0)
+        assert result["n_pixels"] == 25
+
+    def test_shape_mismatch_raises(self):
+        data1 = np.ones((5, 5))
+        data2 = np.ones((3, 3))
+        with pytest.raises(ValueError, match="Shape mismatch"):
+            compare_images(data1, data2)
+
+    def test_with_mask(self, sample_data, mask_array):
+        data2 = sample_data + 1.0
+        result = compare_images(sample_data, data2, mask=mask_array)
+        assert result["mean_diff"] == pytest.approx(-1.0)
+        assert result["n_pixels"] == 96
+
+    def test_handles_nans(self, data_with_nans):
+        data2 = data_with_nans.copy()
+        result = compare_images(data_with_nans, data2)
+        assert result["mean_diff"] == pytest.approx(0.0)

--- a/processing-engine/tests/test_utils.py
+++ b/processing-engine/tests/test_utils.py
@@ -1,0 +1,160 @@
+"""Tests for the processing utilities module."""
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from app.processing.utils import load_fits_data, normalize_array, save_fits_data
+
+
+@pytest.fixture
+def temp_fits_file():
+    """Create a temporary FITS file with known data."""
+    data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    header = {"OBJECT": "Test", "EXPTIME": 100.0}
+
+    with tempfile.NamedTemporaryFile(suffix=".fits", delete=False) as f:
+        path = f.name
+
+    hdu = fits.PrimaryHDU(data=data)
+    hdu.header["OBJECT"] = "Test"
+    hdu.header["EXPTIME"] = 100.0
+    hdu.writeto(path, overwrite=True)
+
+    yield path, data, header
+
+    os.unlink(path)
+
+
+@pytest.fixture
+def empty_fits_file():
+    """Create a FITS file with no data."""
+    with tempfile.NamedTemporaryFile(suffix=".fits", delete=False) as f:
+        path = f.name
+
+    hdu = fits.PrimaryHDU()
+    hdu.writeto(path, overwrite=True)
+
+    yield path
+
+    os.unlink(path)
+
+
+class TestLoadFitsData:
+    def test_loads_data_and_header(self, temp_fits_file):
+        path, expected_data, _ = temp_fits_file
+        data, header = load_fits_data(path)
+        assert data is not None
+        np.testing.assert_array_equal(data, expected_data)
+        assert header["OBJECT"] == "Test"
+        assert header["EXPTIME"] == 100.0
+
+    def test_nonexistent_file_returns_none(self):
+        data, header = load_fits_data("/nonexistent/path.fits")
+        assert data is None
+        assert header == {}
+
+    def test_no_data_returns_none(self, empty_fits_file):
+        data, header = load_fits_data(empty_fits_file)
+        assert data is None
+        assert header == {}
+
+    def test_corrupt_file_returns_none(self):
+        with tempfile.NamedTemporaryFile(suffix=".fits", delete=False, mode="w") as f:
+            f.write("not a fits file")
+            path = f.name
+
+        try:
+            data, header = load_fits_data(path)
+            assert data is None
+            assert header == {}
+        finally:
+            os.unlink(path)
+
+
+class TestSaveFitsData:
+    def test_save_and_reload(self):
+        data = np.array([[10.0, 20.0], [30.0, 40.0]])
+        header = {"OBJECT": "SaveTest", "TELESCOP": "JWST"}
+
+        with tempfile.NamedTemporaryFile(suffix=".fits", delete=False) as f:
+            path = f.name
+
+        try:
+            result = save_fits_data(data, header, path)
+            assert result is True
+
+            loaded_data, loaded_header = load_fits_data(path)
+            np.testing.assert_array_equal(loaded_data, data)
+            assert loaded_header["OBJECT"] == "SaveTest"
+            assert loaded_header["TELESCOP"] == "JWST"
+        finally:
+            os.unlink(path)
+
+    def test_skips_reserved_header_keys(self):
+        data = np.array([[1.0, 2.0], [3.0, 4.0]])
+        header = {"SIMPLE": True, "BITPIX": -64, "NAXIS": 2, "CUSTOM": "value"}
+
+        with tempfile.NamedTemporaryFile(suffix=".fits", delete=False) as f:
+            path = f.name
+
+        try:
+            result = save_fits_data(data, header, path)
+            assert result is True
+
+            _, loaded_header = load_fits_data(path)
+            assert loaded_header["CUSTOM"] == "value"
+        finally:
+            os.unlink(path)
+
+    def test_save_to_invalid_path_returns_false(self):
+        data = np.array([[1.0]])
+        result = save_fits_data(data, {}, "/nonexistent/dir/file.fits")
+        assert result is False
+
+    def test_overwrites_existing_file(self, temp_fits_file):
+        path, _, _ = temp_fits_file
+        new_data = np.array([[99.0, 88.0], [77.0, 66.0]])
+        result = save_fits_data(new_data, {}, path)
+        assert result is True
+
+        loaded_data, _ = load_fits_data(path)
+        np.testing.assert_array_equal(loaded_data, new_data)
+
+
+class TestNormalizeArray:
+    def test_normalizes_to_0_1(self):
+        data = np.array([[0.0, 50.0], [100.0, 200.0]])
+        result = normalize_array(data)
+        assert np.nanmin(result) == pytest.approx(0.0)
+        assert np.nanmax(result) == pytest.approx(1.0)
+
+    def test_known_values(self):
+        data = np.array([[0.0, 10.0], [20.0, 30.0]])
+        result = normalize_array(data)
+        np.testing.assert_array_almost_equal(result, np.array([[0.0, 1 / 3], [2 / 3, 1.0]]))
+
+    def test_constant_array_returns_zeros(self):
+        data = np.array([[5.0, 5.0], [5.0, 5.0]])
+        result = normalize_array(data)
+        np.testing.assert_array_equal(result, np.zeros_like(data))
+
+    def test_none_input_returns_none(self):
+        result = normalize_array(None)
+        assert result is None
+
+    def test_handles_nan_values(self):
+        data = np.array([[0.0, np.nan], [50.0, 100.0]])
+        result = normalize_array(data)
+        assert result[0, 0] == pytest.approx(0.0)
+        assert result[2 // 2, 0] == pytest.approx(0.5)
+        assert result[1, 1] == pytest.approx(1.0)
+
+    def test_negative_values(self):
+        data = np.array([[-10.0, 0.0], [10.0, 20.0]])
+        result = normalize_array(data)
+        assert np.nanmin(result) == pytest.approx(0.0)
+        assert np.nanmax(result) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
Adds 90 new unit tests covering three pure-computation Python modules, pushing coverage from 55% to 58%.

## Why
These modules had the lowest coverage (21-33%) despite being the easiest to test — pure numpy/scipy functions with no I/O dependencies. Covering them now builds toward raising the CI threshold from 50% to 60%.

## Type of Change
- [x] Tests (adding or updating tests)

## Changes Made
- Added `test_statistics.py` (48 tests) — covers all 8 functions: basic stats, robust stats, advanced stats, comprehensive stats, histogram, percentiles, SNR, and image comparison
- Added `test_utils.py` (14 tests) — covers `load_fits_data`, `save_fits_data`, and `normalize_array` with edge cases (NaN, corrupt files, missing files)
- Added `test_filters.py` (28 tests) — covers all 5 filter types, the `reduce_noise` dispatcher, `unsharp_mask`, and `sigma_clip_pixels`

## Test Plan
- [x] All 90 new tests pass locally via `docker exec jwst-processing python -m pytest`
- [x] Full suite passes (449 tests, 0 failures)
- [x] Coverage: statistics 22→100%, utils 21→100%, filters 33→100%, overall 55→58%
- [ ] CI Python Tests job passes with coverage threshold

## Documentation Checklist
- [x] No new controllers, services, or endpoints — no doc updates needed

## Tech Debt Impact
- [x] Reduces tech debt — closes coverage gaps on pure-computation modules

## Risk & Rollback
Risk: None — test-only change, no behavior modifications.
Rollback: Delete the three test files.

## Quality Checklist
- [x] Changes follow project coding standards
- [x] No sensitive data exposed
- [x] Changes are minimal and focused