### PR TITLE
test: add enhancement and detection tests, bump coverage to 55%

### DIFF
--- a/processing-engine/pyproject.toml
+++ b/processing-engine/pyproject.toml
@@ -91,7 +91,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=50"
+addopts = "-v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=55"
 asyncio_mode = "auto"
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/processing-engine/tests/test_detection.py
+++ b/processing-engine/tests/test_detection.py
@@ -1,0 +1,246 @@
+"""Tests for the source detection module."""
+
+import numpy as np
+import pytest
+from astropy.table import Table
+
+from app.processing.detection import (
+    detect_extended_sources,
+    detect_point_sources,
+    detect_sources,
+    estimate_fwhm,
+    sources_to_dict,
+)
+
+
+def _make_starfield(n_stars=15, size=100, fwhm=3.0, peak_flux=500.0, seed=42):
+    """Create a synthetic image with Gaussian point sources on a flat background."""
+    rng = np.random.default_rng(seed)
+    data = rng.normal(loc=100.0, scale=5.0, size=(size, size)).astype(np.float64)
+
+    sigma = fwhm / 2.355
+    y_coords = rng.integers(10, size - 10, n_stars)
+    x_coords = rng.integers(10, size - 10, n_stars)
+
+    yy, xx = np.mgrid[0:size, 0:size]
+    for y, x in zip(y_coords, x_coords, strict=True):
+        star = peak_flux * np.exp(-((xx - x) ** 2 + (yy - y) ** 2) / (2 * sigma**2))
+        data += star
+
+    return data
+
+
+@pytest.fixture
+def starfield():
+    """100x100 image with 15 stars on a noisy background."""
+    return _make_starfield()
+
+
+@pytest.fixture
+def starfield_background():
+    """Flat background and RMS arrays matching the starfield."""
+    bg = np.full((100, 100), 100.0)
+    rms = np.full((100, 100), 5.0)
+    return bg, rms
+
+
+@pytest.fixture
+def faint_image():
+    """Image with no detectable sources (pure noise)."""
+    rng = np.random.default_rng(99)
+    return rng.normal(loc=100.0, scale=5.0, size=(50, 50)).astype(np.float64)
+
+
+class TestDetectPointSources:
+    def test_finds_sources_daofind(self, starfield):
+        bg_subtracted = starfield - 100.0
+        sources = detect_point_sources(bg_subtracted, threshold=25.0, fwhm=3.0, method="daofind")
+        assert sources is not None
+        assert len(sources) > 0
+        assert isinstance(sources, Table)
+
+    def test_finds_sources_iraf(self, starfield):
+        bg_subtracted = starfield - 100.0
+        sources = detect_point_sources(bg_subtracted, threshold=25.0, fwhm=3.0, method="iraf")
+        assert sources is not None
+        assert len(sources) > 0
+
+    def test_returns_none_for_no_sources(self, faint_image):
+        bg_subtracted = faint_image - 100.0
+        sources = detect_point_sources(bg_subtracted, threshold=1000.0, fwhm=3.0)
+        assert sources is None
+
+    def test_table_has_expected_columns(self, starfield):
+        bg_subtracted = starfield - 100.0
+        sources = detect_point_sources(bg_subtracted, threshold=25.0, fwhm=3.0)
+        assert "xcentroid" in sources.colnames
+        assert "ycentroid" in sources.colnames
+        assert "flux" in sources.colnames
+
+    def test_invalid_method_raises(self, starfield):
+        with pytest.raises(ValueError, match="Unknown method"):
+            detect_point_sources(starfield - 100.0, threshold=25.0, method="invalid")
+
+    def test_custom_sharpness_bounds(self, starfield):
+        bg_subtracted = starfield - 100.0
+        sources = detect_point_sources(
+            bg_subtracted, threshold=25.0, fwhm=3.0, sharplo=0.1, sharphi=2.0
+        )
+        assert sources is not None
+
+    def test_high_threshold_finds_fewer(self, starfield):
+        bg_subtracted = starfield - 100.0
+        sources_low = detect_point_sources(bg_subtracted, threshold=15.0, fwhm=3.0)
+        sources_high = detect_point_sources(bg_subtracted, threshold=100.0, fwhm=3.0)
+        n_low = len(sources_low) if sources_low is not None else 0
+        n_high = len(sources_high) if sources_high is not None else 0
+        assert n_low >= n_high
+
+
+class TestDetectExtendedSources:
+    def test_finds_extended_sources(self, starfield):
+        bg_subtracted = starfield - 100.0
+        threshold = 15.0
+        segm = detect_extended_sources(bg_subtracted, threshold=threshold, npixels=5)
+        assert segm is not None
+        assert segm.nlabels > 0
+
+    def test_returns_none_for_no_sources(self, faint_image):
+        bg_subtracted = faint_image - 100.0
+        segm = detect_extended_sources(bg_subtracted, threshold=1000.0, npixels=5)
+        assert segm is None
+
+    def test_no_deblend(self, starfield):
+        bg_subtracted = starfield - 100.0
+        segm = detect_extended_sources(bg_subtracted, threshold=15.0, npixels=5, deblend=False)
+        assert segm is not None
+
+    def test_with_mask(self, starfield):
+        bg_subtracted = starfield - 100.0
+        mask = np.zeros((100, 100), dtype=bool)
+        mask[:50, :] = True  # mask top half
+        segm = detect_extended_sources(bg_subtracted, threshold=15.0, npixels=5, mask=mask)
+        # Should find fewer or equal sources with mask
+        segm_full = detect_extended_sources(bg_subtracted, threshold=15.0, npixels=5)
+        if segm is not None and segm_full is not None:
+            assert segm.nlabels <= segm_full.nlabels
+
+    def test_connectivity_parameter(self, starfield):
+        bg_subtracted = starfield - 100.0
+        segm4 = detect_extended_sources(bg_subtracted, threshold=15.0, npixels=5, connectivity=4)
+        segm8 = detect_extended_sources(bg_subtracted, threshold=15.0, npixels=5, connectivity=8)
+        assert segm4 is not None
+        assert segm8 is not None
+
+
+class TestDetectSources:
+    def test_auto_method(self, starfield, starfield_background):
+        bg, rms = starfield_background
+        result = detect_sources(starfield, bg, rms, method="auto", threshold_sigma=5.0)
+        assert isinstance(result, dict)
+        assert result["n_sources"] > 0
+        assert result["method"] in ("daofind", "segmentation")
+
+    def test_daofind_method(self, starfield, starfield_background):
+        bg, rms = starfield_background
+        result = detect_sources(starfield, bg, rms, method="daofind", threshold_sigma=5.0)
+        assert result["method"] == "daofind"
+        assert result["n_sources"] > 0
+        assert result["sources"] is not None
+
+    def test_iraf_method(self, starfield, starfield_background):
+        bg, rms = starfield_background
+        result = detect_sources(starfield, bg, rms, method="iraf", threshold_sigma=5.0)
+        assert result["method"] == "iraf"
+        assert result["n_sources"] > 0
+
+    def test_segmentation_method(self, starfield, starfield_background):
+        bg, rms = starfield_background
+        result = detect_sources(
+            starfield, bg, rms, method="segmentation", threshold_sigma=3.0, npixels=5
+        )
+        assert result["method"] == "segmentation"
+        assert result["n_sources"] > 0
+        assert result["segmentation"] is not None
+        assert result["catalog"] is not None
+
+    def test_unknown_method_raises(self, starfield, starfield_background):
+        bg, rms = starfield_background
+        with pytest.raises(ValueError, match="Unknown method"):
+            detect_sources(starfield, bg, rms, method="invalid")
+
+    def test_high_threshold_finds_fewer(self, starfield, starfield_background):
+        bg, rms = starfield_background
+        result_low = detect_sources(starfield, bg, rms, method="daofind", threshold_sigma=3.0)
+        result_high = detect_sources(starfield, bg, rms, method="daofind", threshold_sigma=10.0)
+        assert result_low["n_sources"] >= result_high["n_sources"]
+
+    def test_result_keys(self, starfield, starfield_background):
+        bg, rms = starfield_background
+        result = detect_sources(starfield, bg, rms)
+        expected_keys = {
+            "method",
+            "threshold_sigma",
+            "threshold_value",
+            "n_sources",
+            "sources",
+            "segmentation",
+            "catalog",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_no_sources_returns_zero(self, faint_image):
+        bg = np.full_like(faint_image, 100.0)
+        rms = np.full_like(faint_image, 5.0)
+        result = detect_sources(faint_image, bg, rms, method="daofind", threshold_sigma=100.0)
+        assert result["n_sources"] == 0
+        assert result["sources"] is None
+
+    def test_auto_selects_segmentation_for_variable_rms(self, starfield):
+        bg = np.full((100, 100), 100.0)
+        # High RMS variation should trigger segmentation
+        rms = np.linspace(1, 20, 100).reshape(1, 100).repeat(100, axis=0)
+        result = detect_sources(starfield, bg, rms, method="auto", threshold_sigma=3.0, npixels=5)
+        assert result["method"] == "segmentation"
+
+
+class TestSourcesToDict:
+    def test_converts_table(self, starfield):
+        bg_subtracted = starfield - 100.0
+        sources = detect_point_sources(bg_subtracted, threshold=25.0, fwhm=3.0)
+        result = sources_to_dict(sources)
+        assert isinstance(result, list)
+        assert len(result) > 0
+        assert isinstance(result[0], dict)
+        assert "xcentroid" in result[0]
+        assert "flux" in result[0]
+
+    def test_none_returns_empty_list(self):
+        assert sources_to_dict(None) == []
+
+    def test_values_are_python_types(self, starfield):
+        bg_subtracted = starfield - 100.0
+        sources = detect_point_sources(bg_subtracted, threshold=25.0, fwhm=3.0)
+        result = sources_to_dict(sources)
+        for source in result:
+            for val in source.values():
+                assert not hasattr(val, "dtype"), f"Value {val} is still a numpy type"
+
+
+class TestEstimateFwhm:
+    def test_estimates_fwhm(self, starfield):
+        bg_subtracted = starfield - 100.0
+        fwhm = estimate_fwhm(bg_subtracted, threshold=25.0)
+        assert fwhm is not None
+        assert 1.0 <= fwhm <= 20.0
+
+    def test_returns_none_for_no_sources(self, faint_image):
+        bg_subtracted = faint_image - 100.0
+        fwhm = estimate_fwhm(bg_subtracted, threshold=1000.0)
+        assert fwhm is None
+
+    def test_result_clipped_to_range(self, starfield):
+        bg_subtracted = starfield - 100.0
+        fwhm = estimate_fwhm(bg_subtracted, threshold=25.0)
+        if fwhm is not None:
+            assert 1.0 <= fwhm <= 20.0

--- a/processing-engine/tests/test_enhancement.py
+++ b/processing-engine/tests/test_enhancement.py
@@ -1,0 +1,278 @@
+"""Tests for the image enhancement module."""
+
+import numpy as np
+import pytest
+
+from app.processing.enhancement import (
+    adjust_brightness_contrast,
+    apply_colormap,
+    asinh_stretch,
+    create_rgb_image,
+    enhance_image,
+    histogram_equalization,
+    log_stretch,
+    normalize_to_range,
+    power_stretch,
+    sqrt_stretch,
+    zscale_stretch,
+)
+
+
+@pytest.fixture
+def sample_image():
+    """20x20 image with a gradient and some bright pixels."""
+    rng = np.random.default_rng(42)
+    base = np.linspace(0, 1000, 400).reshape(20, 20).astype(np.float64)
+    noise = rng.normal(0, 10, size=(20, 20))
+    return base + noise
+
+
+@pytest.fixture
+def normalized_image():
+    """Image already in 0-1 range."""
+    rng = np.random.default_rng(42)
+    return rng.uniform(0, 1, size=(20, 20)).astype(np.float64)
+
+
+class TestNormalizeToRange:
+    def test_basic_normalization(self):
+        data = np.array([[0.0, 50.0], [100.0, 200.0]])
+        result = normalize_to_range(data)
+        assert np.nanmin(result) == pytest.approx(0.0)
+        assert np.nanmax(result) == pytest.approx(1.0)
+
+    def test_custom_vmin_vmax(self):
+        data = np.array([[0.0, 50.0], [100.0, 200.0]])
+        result = normalize_to_range(data, vmin=0.0, vmax=100.0)
+        assert result[0, 0] == pytest.approx(0.0)
+        assert result[0, 1] == pytest.approx(0.5)
+        assert result[1, 0] == pytest.approx(1.0)
+        # 200 gets clipped to 1.0
+        assert result[1, 1] == pytest.approx(1.0)
+
+    def test_constant_array_returns_zeros(self):
+        data = np.full((5, 5), 42.0)
+        result = normalize_to_range(data)
+        np.testing.assert_array_equal(result, np.zeros_like(data))
+
+    def test_output_clipped_to_01(self):
+        data = np.array([[-10.0, 0.0], [50.0, 110.0]])
+        result = normalize_to_range(data, vmin=0.0, vmax=100.0)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+
+class TestZscaleStretch:
+    def test_returns_tuple(self, sample_image):
+        result = zscale_stretch(sample_image)
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+
+    def test_output_in_01_range(self, sample_image):
+        normalized, vmin, vmax = zscale_stretch(sample_image)
+        assert np.all(normalized >= 0.0)
+        assert np.all(normalized <= 1.0)
+
+    def test_vmin_less_than_vmax(self, sample_image):
+        _, vmin, vmax = zscale_stretch(sample_image)
+        assert vmin < vmax
+
+    def test_contrast_parameter(self):
+        # Use a large image with wide dynamic range so ZScale contrast differences are visible
+        rng = np.random.default_rng(42)
+        large = rng.normal(loc=500.0, scale=100.0, size=(200, 200)).astype(np.float64)
+        _, vmin_low, vmax_low = zscale_stretch(large, contrast=0.05)
+        _, vmin_high, vmax_high = zscale_stretch(large, contrast=0.9)
+        # Different contrast values should produce different display ranges
+        range_low = vmax_low - vmin_low
+        range_high = vmax_high - vmin_high
+        assert range_low != pytest.approx(range_high, abs=1.0)
+
+
+class TestAsinhStretch:
+    def test_output_in_01_range(self, sample_image):
+        result = asinh_stretch(sample_image, a=0.1)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_shape_preserved(self, sample_image):
+        result = asinh_stretch(sample_image)
+        assert result.shape == sample_image.shape
+
+    def test_custom_vmin_vmax(self, sample_image):
+        result = asinh_stretch(sample_image, vmin=100.0, vmax=800.0)
+        assert result.shape == sample_image.shape
+
+    def test_different_a_values(self, sample_image):
+        result_small = asinh_stretch(sample_image, a=0.01)
+        result_large = asinh_stretch(sample_image, a=1.0)
+        # Different a values should produce different results
+        assert not np.allclose(result_small, result_large)
+
+
+class TestLogStretch:
+    def test_output_in_01_range(self, sample_image):
+        result = log_stretch(sample_image, a=1000.0)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_shape_preserved(self, sample_image):
+        result = log_stretch(sample_image)
+        assert result.shape == sample_image.shape
+
+    def test_custom_vmin_vmax(self, sample_image):
+        result = log_stretch(sample_image, vmin=50.0, vmax=900.0)
+        assert result.shape == sample_image.shape
+
+
+class TestSqrtStretch:
+    def test_output_in_01_range(self, sample_image):
+        result = sqrt_stretch(sample_image)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_shape_preserved(self, sample_image):
+        result = sqrt_stretch(sample_image)
+        assert result.shape == sample_image.shape
+
+    def test_custom_vmin_vmax(self, sample_image):
+        result = sqrt_stretch(sample_image, vmin=0.0, vmax=500.0)
+        assert result.shape == sample_image.shape
+
+
+class TestPowerStretch:
+    def test_output_in_01_range(self, sample_image):
+        result = power_stretch(sample_image, power=0.5)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_shape_preserved(self, sample_image):
+        result = power_stretch(sample_image)
+        assert result.shape == sample_image.shape
+
+    def test_different_powers(self, sample_image):
+        result_half = power_stretch(sample_image, power=0.5)
+        result_two = power_stretch(sample_image, power=2.0)
+        assert not np.allclose(result_half, result_two)
+
+
+class TestHistogramEqualization:
+    def test_output_in_01_range(self, sample_image):
+        result = histogram_equalization(sample_image)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_shape_preserved(self, sample_image):
+        result = histogram_equalization(sample_image)
+        assert result.shape == sample_image.shape
+
+    def test_custom_vmin_vmax(self, sample_image):
+        result = histogram_equalization(sample_image, vmin=100.0, vmax=800.0)
+        assert result.shape == sample_image.shape
+
+
+class TestEnhanceImage:
+    def test_zscale_method(self, sample_image):
+        result = enhance_image(sample_image, method="zscale")
+        assert result.shape == sample_image.shape
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_asinh_method(self, sample_image):
+        result = enhance_image(sample_image, method="asinh")
+        assert result.shape == sample_image.shape
+
+    def test_log_method(self, sample_image):
+        result = enhance_image(sample_image, method="log")
+        assert result.shape == sample_image.shape
+
+    def test_sqrt_method(self, sample_image):
+        result = enhance_image(sample_image, method="sqrt")
+        assert result.shape == sample_image.shape
+
+    def test_linear_method(self, sample_image):
+        result = enhance_image(sample_image, method="linear")
+        assert result.shape == sample_image.shape
+
+    def test_histogram_eq_method(self, sample_image):
+        result = enhance_image(sample_image, method="histogram_eq")
+        assert result.shape == sample_image.shape
+
+    def test_power_method(self, sample_image):
+        result = enhance_image(sample_image, method="power", power=0.5)
+        assert result.shape == sample_image.shape
+
+    def test_unknown_method_raises(self, sample_image):
+        with pytest.raises(ValueError, match="Unknown enhancement method"):
+            enhance_image(sample_image, method="nonexistent")
+
+    def test_linear_with_custom_limits(self, sample_image):
+        result = enhance_image(sample_image, method="linear", vmin=100.0, vmax=800.0)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+
+class TestAdjustBrightnessContrast:
+    def test_no_adjustment_preserves_data(self, normalized_image):
+        result = adjust_brightness_contrast(normalized_image, brightness=0.0, contrast=1.0)
+        np.testing.assert_array_almost_equal(result, normalized_image)
+
+    def test_brightness_increase(self, normalized_image):
+        result = adjust_brightness_contrast(normalized_image, brightness=0.2)
+        # On average, result should be brighter (higher values)
+        assert np.mean(result) > np.mean(normalized_image)
+
+    def test_brightness_decrease(self, normalized_image):
+        result = adjust_brightness_contrast(normalized_image, brightness=-0.2)
+        assert np.mean(result) < np.mean(normalized_image)
+
+    def test_contrast_increase(self, normalized_image):
+        result = adjust_brightness_contrast(normalized_image, contrast=2.0)
+        # Higher contrast should increase std (more spread)
+        assert np.std(result) >= np.std(normalized_image) * 0.5
+
+    def test_output_clipped_to_01(self, normalized_image):
+        result = adjust_brightness_contrast(normalized_image, brightness=0.9, contrast=3.0)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+
+class TestCreateRgbImage:
+    def test_output_shape(self, sample_image):
+        r = sample_image
+        g = sample_image * 0.8
+        b = sample_image * 0.6
+        result = create_rgb_image(r, g, b, stretch_method="asinh")
+        assert result.shape == (20, 20, 3)
+
+    def test_output_in_01_range(self, sample_image):
+        r = sample_image
+        g = sample_image * 0.8
+        b = sample_image * 0.6
+        result = create_rgb_image(r, g, b, stretch_method="asinh")
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_different_stretch_methods(self, sample_image):
+        r = sample_image
+        g = sample_image * 0.8
+        b = sample_image * 0.6
+        for method in ["asinh", "sqrt", "linear"]:
+            result = create_rgb_image(r, g, b, stretch_method=method)
+            assert result.shape == (20, 20, 3)
+
+
+class TestApplyColormap:
+    def test_output_shape_rgba(self, normalized_image):
+        result = apply_colormap(normalized_image, colormap="viridis")
+        assert result.shape == (20, 20, 4)
+
+    def test_output_in_01_range(self, normalized_image):
+        result = apply_colormap(normalized_image)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_different_colormaps(self, normalized_image):
+        result_v = apply_colormap(normalized_image, colormap="viridis")
+        result_h = apply_colormap(normalized_image, colormap="hot")
+        assert not np.allclose(result_v, result_h)


### PR DESCRIPTION
## Summary
Adds 71 new tests covering the enhancement and detection processing modules, and bumps the CI coverage threshold from 50% to 55%.

## Why
These modules had the lowest coverage (enhancement 43%, detection 17%) despite being pure computation with no I/O dependencies. With these tests, overall Python coverage jumps from 58% to 62%, giving comfortable headroom above the new 55% threshold.

## Type of Change
- [x] Tests (adding or updating tests)

## Changes Made
- Added `test_enhancement.py` (42 tests) — normalize_to_range, all 6 stretch methods (zscale, asinh, log, sqrt, power, histogram_eq), enhance_image dispatcher, brightness/contrast adjustment, RGB composite creation, and colormap application
- Added `test_detection.py` (29 tests) — DAOFIND and IRAF point source detection, extended source segmentation with deblending, unified detect_sources interface (auto/manual method selection), source catalog serialization, and FWHM estimation
- Bumped `--cov-fail-under` from 50 to 55 in `pyproject.toml`

## Test Plan
- [x] All 71 new tests pass locally via Docker
- [x] Full suite passes (520 tests, 0 failures, 4 expected warnings)
- [x] Coverage: enhancement 43→100%, detection 17→97%, overall 58→62%
- [x] CI threshold at 55% passes (62% actual)
- [ ] CI Python Tests job passes

## Documentation Checklist
- [x] No new controllers, services, or endpoints — no doc updates needed

## Tech Debt Impact
- [x] Reduces tech debt — closes coverage gaps on processing modules, raises CI floor

## Risk & Rollback
Risk: None — test-only change plus threshold bump. No behavior modifications.
Rollback: Delete the two test files and revert pyproject.toml threshold.

## Quality Checklist
- [x] Changes follow project coding standards
- [x] No sensitive data exposed
- [x] Changes are minimal and focused