### PR TITLE
chore: bump Python CI coverage threshold to 60%

### DIFF
--- a/processing-engine/pyproject.toml
+++ b/processing-engine/pyproject.toml
@@ -91,7 +91,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=55"
+addopts = "-v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=60"
 asyncio_mode = "auto"
 filterwarnings = [
     "ignore::DeprecationWarning",


### PR DESCRIPTION
## Summary
Raises the Python CI coverage floor from 55% to 60%.

## Why
Current coverage is 62% after adding 161 tests in PRs #435 and #436. The threshold should track closer to actual coverage to catch regressions early.

## Type of Change
- [x] Chore (maintenance, configuration)

## Changes Made
- Updated `--cov-fail-under` from 55 to 60 in `processing-engine/pyproject.toml`

## Test Plan
- [x] Current coverage is 62%, passes 60% threshold with 2% buffer
- [ ] CI Python Tests job passes

## Documentation Checklist
- [x] No doc updates needed — config-only change

## Tech Debt Impact
- [x] Reduces tech debt — tighter regression guard

## Risk & Rollback
Risk: None — config change only, no code modifications.
Rollback: Change `--cov-fail-under=60` back to `55`.

## Quality Checklist
- [x] Changes follow project coding standards
- [x] No sensitive data exposed
- [x] Changes are minimal and focused