### PR TITLE
feat: add .NET backend CI coverage threshold at 15%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,13 @@ jobs:
       run: dotnet build backend/JwstDataAnalysis.sln --no-restore
 
     - name: Test Backend
-      run: dotnet test backend/JwstDataAnalysis.API.Tests --no-build --verbosity normal
+      run: >-
+        dotnet test backend/JwstDataAnalysis.API.Tests --no-build --verbosity normal
+        /p:CollectCoverage=true
+        /p:CoverletOutputFormat=cobertura
+        /p:ThresholdType=line
+        /p:Threshold=15
+        /p:Exclude="[*]Microsoft.AspNetCore.OpenApi.Generated.*%2c[*]System.Text.RegularExpressions.Generated.*%2c[*]System.Runtime.CompilerServices.*%2c[*]Program"
 
   frontend-test:
     name: Frontend Tests

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/
 obj/
 *.user
 *.suo
+coverage.cobertura.xml
 
 # Docker
 *.pid

--- a/backend/JwstDataAnalysis.API.Tests/JwstDataAnalysis.API.Tests.csproj
+++ b/backend/JwstDataAnalysis.API.Tests/JwstDataAnalysis.API.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
## Summary
Adds code coverage enforcement for the .NET backend in CI, with auto-generated code excluded from measurement.

## Why
We have 294 backend tests but no coverage enforcement — coverage could silently regress. The Python engine already has a 60% threshold; the backend should have one too. Starting at 15% (current: 20%) to establish the floor without blocking existing work.

## Type of Change
- [x] Enhancement (improves existing functionality)

## Changes Made
- Added `coverlet.msbuild` v6.0.4 to test project for threshold enforcement
- Updated CI `Test Backend` step with coverage flags:
  - `CollectCoverage=true` — enables coverage collection
  - `ThresholdType=line` / `Threshold=15` — fails CI if line coverage drops below 15%
  - `Exclude` filter — removes auto-generated code from measurement:
    - `Microsoft.AspNetCore.OpenApi.Generated.*` (OpenAPI source generator)
    - `System.Text.RegularExpressions.Generated.*` (regex source generator)
    - `System.Runtime.CompilerServices.*` (compiler attributes)
    - `Program` (startup code, not unit-testable)
- Added `coverage.cobertura.xml` to `.gitignore`

## Test Plan
- [x] Verified locally: 294 tests pass, 20.15% line coverage, threshold=15 passes
- [x] Verified threshold enforcement: setting threshold=25 correctly fails the build
- [ ] CI Backend Tests job passes with coverage report in output

## Documentation Checklist
- [x] No new controllers, services, or endpoints — no doc updates needed

## Tech Debt Impact
- [x] Reduces tech debt — establishes coverage floor, prevents regression

## Risk & Rollback
Risk: Low — adds threshold to existing tests. The 15% floor is 5% below current coverage (20%).
Rollback: Remove `coverlet.msbuild` from csproj and revert CI test command.

## Quality Checklist
- [x] Changes follow project coding standards
- [x] No sensitive data exposed
- [x] Changes are minimal and focused