### PR TITLE
test: add unit tests for ImportJobTracker, FileContentValidator, LocalStorageProvider

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/FileContentValidatorTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/FileContentValidatorTests.cs
@@ -1,0 +1,275 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text;
+
+using FluentAssertions;
+using JwstDataAnalysis.API.Services;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace JwstDataAnalysis.API.Tests.Services;
+
+/// <summary>
+/// Unit tests for FileContentValidator.
+/// </summary>
+public class FileContentValidatorTests
+{
+    // --- FITS validation ---
+    [Fact]
+    public async Task ValidateFileContentAsync_ValidFits_ReturnsValid()
+    {
+        // FITS files start with "SIMPLE"
+        var content = Encoding.ASCII.GetBytes("SIMPLE  =                    T / Standard FITS");
+        var file = CreateFormFile("test.fits", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+        error.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_InvalidFits_ReturnsError()
+    {
+        var content = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        var file = CreateFormFile("test.fits", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain(".fits");
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_TooSmallFits_ReturnsError()
+    {
+        var file = CreateFormFile("test.fits", new byte[] { 0x01, 0x02 });
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("too small");
+    }
+
+    // --- Gzipped FITS validation ---
+    [Fact]
+    public async Task ValidateFileContentAsync_ValidGzipFits_ReturnsValid()
+    {
+        // Gzip magic bytes: 1F 8B
+        var content = new byte[] { 0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        var file = CreateFormFile("test.fits.gz", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_InvalidGzipFits_ReturnsError()
+    {
+        var content = Encoding.ASCII.GetBytes("not a gzip file at all");
+        var file = CreateFormFile("test.fits.gz", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeFalse();
+    }
+
+    // --- Image format validation ---
+    [Fact]
+    public async Task ValidateFileContentAsync_ValidPng_ReturnsValid()
+    {
+        var content = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00 };
+        var file = CreateFormFile("image.png", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_ValidJpeg_ReturnsValid()
+    {
+        var content = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46 };
+        var file = CreateFormFile("photo.jpg", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_ValidTiffLittleEndian_ReturnsValid()
+    {
+        var content = new byte[] { 0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00 };
+        var file = CreateFormFile("image.tiff", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_ValidTiffBigEndian_ReturnsValid()
+    {
+        var content = new byte[] { 0x4D, 0x4D, 0x00, 0x2A, 0x00, 0x00, 0x00, 0x08 };
+        var file = CreateFormFile("image.tif", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_PngAsFits_ReturnsError()
+    {
+        // PNG magic bytes but with .fits extension
+        var content = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+        var file = CreateFormFile("renamed.fits", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("does not match");
+    }
+
+    // --- JSON validation ---
+    [Fact]
+    public async Task ValidateFileContentAsync_ValidJson_ReturnsValid()
+    {
+        var file = CreateFormFile("data.json", "{\"key\": \"value\"}");
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_ValidJsonArray_ReturnsValid()
+    {
+        var file = CreateFormFile("data.json", "[1, 2, 3]");
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_InvalidJson_ReturnsError()
+    {
+        var file = CreateFormFile("data.json", "this is not json at all");
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("JSON");
+    }
+
+    // --- CSV validation ---
+    [Fact]
+    public async Task ValidateFileContentAsync_ValidCsv_ReturnsValid()
+    {
+        var csv = "name,value,count\nfoo,1,10\nbar,2,20\n";
+        var file = CreateFormFile("data.csv", csv);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_SingleColumnCsv_ReturnsValid()
+    {
+        var csv = "header\nrow1\nrow2\n";
+        var file = CreateFormFile("data.csv", csv);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_InconsistentCsv_ReturnsError()
+    {
+        var csv = "a,b,c,d,e\nonly_one\nonly_one\nonly_one\nonly_one\nonly_one\nonly_one\nonly_one\nonly_one\nonly_one\n";
+        var file = CreateFormFile("data.csv", csv);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("inconsistent");
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_EmptyCsv_ReturnsError()
+    {
+        var file = CreateFormFile("data.csv", string.Empty);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("empty");
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_BinaryAsCsv_ReturnsError()
+    {
+        var content = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+        var file = CreateFormFile("data.csv", content);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("binary");
+    }
+
+    // --- Unknown extension ---
+    [Fact]
+    public async Task ValidateFileContentAsync_UnknownExtension_ReturnsValid()
+    {
+        var file = CreateFormFile("data.xyz", new byte[] { 0x01, 0x02, 0x03 });
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    // --- Semicolon and tab delimited CSV ---
+    [Fact]
+    public async Task ValidateFileContentAsync_SemicolonCsv_ReturnsValid()
+    {
+        var csv = "name;value;count\nfoo;1;10\nbar;2;20\n";
+        var file = CreateFormFile("data.csv", csv);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateFileContentAsync_TabCsv_ReturnsValid()
+    {
+        var csv = "name\tvalue\tcount\nfoo\t1\t10\nbar\t2\t20\n";
+        var file = CreateFormFile("data.csv", csv);
+
+        var (isValid, error) = await FileContentValidator.ValidateFileContentAsync(file);
+
+        isValid.Should().BeTrue();
+    }
+
+    private static IFormFile CreateFormFile(string fileName, byte[] content)
+    {
+        var stream = new MemoryStream(content);
+        var mock = new Mock<IFormFile>();
+        mock.Setup(f => f.FileName).Returns(fileName);
+        mock.Setup(f => f.Length).Returns(content.Length);
+        mock.Setup(f => f.OpenReadStream()).Returns(() => new MemoryStream(content));
+        return mock.Object;
+    }
+
+    private static IFormFile CreateFormFile(string fileName, string textContent)
+    {
+        return CreateFormFile(fileName, Encoding.UTF8.GetBytes(textContent));
+    }
+}

--- a/backend/JwstDataAnalysis.API.Tests/Services/ImportJobTrackerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/ImportJobTrackerTests.cs
@@ -1,0 +1,251 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using JwstDataAnalysis.API.Models;
+using JwstDataAnalysis.API.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace JwstDataAnalysis.API.Tests.Services;
+
+/// <summary>
+/// Unit tests for ImportJobTracker.
+/// </summary>
+public class ImportJobTrackerTests
+{
+    private readonly ImportJobTracker sut;
+
+    public ImportJobTrackerTests()
+    {
+        var mockLogger = new Mock<ILogger<ImportJobTracker>>();
+        sut = new ImportJobTracker(mockLogger.Object);
+    }
+
+    [Fact]
+    public void CreateJob_ReturnsValidJobId()
+    {
+        var jobId = sut.CreateJob("obs-123");
+
+        jobId.Should().NotBeNullOrEmpty();
+        jobId.Should().HaveLength(12);
+    }
+
+    [Fact]
+    public void CreateJob_SetsInitialState()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        var job = sut.GetJob(jobId);
+
+        job.Should().NotBeNull();
+        job!.JobId.Should().Be(jobId);
+        job.ObsId.Should().Be("obs-123");
+        job.Progress.Should().Be(0);
+        job.Stage.Should().Be(ImportStages.Starting);
+        job.IsComplete.Should().BeFalse();
+        job.StartedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void CreateJob_CreatesUniquIds()
+    {
+        var id1 = sut.CreateJob("obs-1");
+        var id2 = sut.CreateJob("obs-2");
+
+        id1.Should().NotBe(id2);
+    }
+
+    [Fact]
+    public void GetJob_ReturnsNull_WhenNotFound()
+    {
+        sut.GetJob("nonexistent").Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCancellationToken_ReturnsValidToken()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        var token = sut.GetCancellationToken(jobId);
+
+        token.Should().NotBe(CancellationToken.None);
+        token.IsCancellationRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetCancellationToken_ReturnsNone_WhenNotFound()
+    {
+        var token = sut.GetCancellationToken("nonexistent");
+        token.Should().Be(CancellationToken.None);
+    }
+
+    [Fact]
+    public void CancelJob_SetsCancellationToken()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        var token = sut.GetCancellationToken(jobId);
+
+        sut.CancelJob(jobId).Should().BeTrue();
+
+        token.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CancelJob_UpdatesJobState()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.CancelJob(jobId);
+
+        var job = sut.GetJob(jobId);
+        job!.Stage.Should().Be(ImportStages.Cancelled);
+        job.IsComplete.Should().BeTrue();
+        job.CompletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CancelJob_ReturnsFalse_WhenNotFound()
+    {
+        sut.CancelJob("nonexistent").Should().BeFalse();
+    }
+
+    [Fact]
+    public void CancelJob_DoesNotUpdateCompletedJob()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.CompleteJob(jobId, new MastImportResponse { ImportedCount = 1 });
+        sut.CancelJob(jobId);
+
+        var job = sut.GetJob(jobId);
+        job!.Stage.Should().Be(ImportStages.Complete);
+    }
+
+    [Fact]
+    public void UpdateProgress_SetsValues()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.UpdateProgress(jobId, 50, ImportStages.Downloading, "Downloading files...");
+
+        var job = sut.GetJob(jobId);
+        job!.Progress.Should().Be(50);
+        job.Stage.Should().Be(ImportStages.Downloading);
+        job.Message.Should().Be("Downloading files...");
+    }
+
+    [Theory]
+    [InlineData(-10, 0)]
+    [InlineData(0, 0)]
+    [InlineData(50, 50)]
+    [InlineData(100, 100)]
+    [InlineData(150, 100)]
+    public void UpdateProgress_ClampsValue(int input, int expected)
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.UpdateProgress(jobId, input, "stage", "msg");
+
+        sut.GetJob(jobId)!.Progress.Should().Be(expected);
+    }
+
+    [Fact]
+    public void UpdateProgress_IgnoresUnknownJob()
+    {
+        // Should not throw
+        sut.UpdateProgress("nonexistent", 50, "stage", "msg");
+    }
+
+    [Fact]
+    public void UpdateByteProgress_SetsValues()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.UpdateByteProgress(jobId, 500, 1000, 100.0, 5.0);
+
+        var job = sut.GetJob(jobId);
+        job!.DownloadedBytes.Should().Be(500);
+        job.TotalBytes.Should().Be(1000);
+        job.SpeedBytesPerSec.Should().Be(100.0);
+        job.EtaSeconds.Should().Be(5.0);
+        job.DownloadProgressPercent.Should().Be(50.0);
+    }
+
+    [Fact]
+    public void UpdateByteProgress_HandlesZeroTotal()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.UpdateByteProgress(jobId, 0, 0, 0.0, null);
+
+        sut.GetJob(jobId)!.DownloadProgressPercent.Should().Be(0);
+    }
+
+    [Fact]
+    public void UpdateByteProgress_SetsFileProgress()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        var fileProgress = new List<FileDownloadProgress>
+        {
+            new() { FileName = "file1.fits" },
+        };
+        sut.UpdateByteProgress(jobId, 500, 1000, 100.0, 5.0, fileProgress);
+
+        sut.GetJob(jobId)!.FileProgress.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void SetDownloadJobId_SetsValue()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.SetDownloadJobId(jobId, "download-456");
+
+        sut.GetJob(jobId)!.DownloadJobId.Should().Be("download-456");
+    }
+
+    [Fact]
+    public void SetResumable_SetsValue()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.SetResumable(jobId, true);
+
+        sut.GetJob(jobId)!.IsResumable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CompleteJob_SetsCompletionState()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        var result = new MastImportResponse { ImportedCount = 5 };
+
+        sut.CompleteJob(jobId, result);
+
+        var job = sut.GetJob(jobId);
+        job!.Progress.Should().Be(100);
+        job.Stage.Should().Be(ImportStages.Complete);
+        job.IsComplete.Should().BeTrue();
+        job.CompletedAt.Should().NotBeNull();
+        job.Result.Should().Be(result);
+        job.Message.Should().Contain("5");
+    }
+
+    [Fact]
+    public void FailJob_SetsFailureState()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.FailJob(jobId, "Something went wrong");
+
+        var job = sut.GetJob(jobId);
+        job!.Stage.Should().Be(ImportStages.Failed);
+        job.IsComplete.Should().BeTrue();
+        job.Error.Should().Be("Something went wrong");
+        job.CompletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void RemoveJob_ReturnsTrue_WhenExists()
+    {
+        var jobId = sut.CreateJob("obs-123");
+        sut.RemoveJob(jobId).Should().BeTrue();
+        sut.GetJob(jobId).Should().BeNull();
+    }
+
+    [Fact]
+    public void RemoveJob_ReturnsFalse_WhenNotFound()
+    {
+        sut.RemoveJob("nonexistent").Should().BeFalse();
+    }
+}

--- a/backend/JwstDataAnalysis.API.Tests/Services/LocalStorageProviderTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/LocalStorageProviderTests.cs
@@ -1,0 +1,215 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text;
+
+using FluentAssertions;
+using JwstDataAnalysis.API.Services.Storage;
+using Microsoft.Extensions.Configuration;
+
+namespace JwstDataAnalysis.API.Tests.Services;
+
+/// <summary>
+/// Unit tests for LocalStorageProvider.
+/// </summary>
+public class LocalStorageProviderTests : IDisposable
+{
+    private readonly string tempDir;
+    private readonly LocalStorageProvider sut;
+
+    public LocalStorageProviderTests()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), $"jwst-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Storage:BasePath", tempDir },
+            })
+            .Build();
+
+        sut = new LocalStorageProvider(config);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(tempDir))
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void SupportsLocalPath_ReturnsTrue()
+    {
+        sut.SupportsLocalPath.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WriteAsync_CreatesFileWithContent()
+    {
+        var data = Encoding.UTF8.GetBytes("hello world");
+        using var stream = new MemoryStream(data);
+
+        await sut.WriteAsync("test/file.txt", stream);
+
+        File.Exists(Path.Combine(tempDir, "test", "file.txt")).Should().BeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(tempDir, "test", "file.txt"));
+        content.Should().Be("hello world");
+    }
+
+    [Fact]
+    public async Task WriteAsync_CreatesDirectoryStructure()
+    {
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        await sut.WriteAsync("deep/nested/dir/file.dat", stream);
+
+        File.Exists(Path.Combine(tempDir, "deep", "nested", "dir", "file.dat")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ReadStreamAsync_ReturnsFileContent()
+    {
+        var filePath = Path.Combine(tempDir, "read-test.txt");
+        await File.WriteAllTextAsync(filePath, "test content");
+
+        using var stream = await sut.ReadStreamAsync("read-test.txt");
+        using var reader = new StreamReader(stream);
+        var content = await reader.ReadToEndAsync();
+
+        content.Should().Be("test content");
+    }
+
+    [Fact]
+    public async Task ReadStreamAsync_ThrowsForMissingFile()
+    {
+        var act = () => sut.ReadStreamAsync("nonexistent.txt");
+
+        await act.Should().ThrowAsync<FileNotFoundException>();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_ReturnsTrue_WhenFileExists()
+    {
+        await File.WriteAllTextAsync(Path.Combine(tempDir, "exists.txt"), "data");
+
+        var result = await sut.ExistsAsync("exists.txt");
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_ReturnsFalse_WhenFileMissing()
+    {
+        var result = await sut.ExistsAsync("missing.txt");
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesFile()
+    {
+        var filePath = Path.Combine(tempDir, "delete-me.txt");
+        await File.WriteAllTextAsync(filePath, "data");
+
+        await sut.DeleteAsync("delete-me.txt");
+
+        File.Exists(filePath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DoesNotThrow_WhenFileMissing()
+    {
+        var act = () => sut.DeleteAsync("nonexistent.txt");
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task GetSizeAsync_ReturnsCorrectSize()
+    {
+        var data = new byte[1024];
+        await File.WriteAllBytesAsync(Path.Combine(tempDir, "sized.dat"), data);
+
+        var size = await sut.GetSizeAsync("sized.dat");
+
+        size.Should().Be(1024);
+    }
+
+    [Fact]
+    public async Task GetPresignedUrlAsync_ReturnsNull()
+    {
+        var url = await sut.GetPresignedUrlAsync("any-key", TimeSpan.FromMinutes(5));
+
+        url.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsAllFiles()
+    {
+        // Create some files in a subdirectory
+        var subDir = Path.Combine(tempDir, "list-test");
+        Directory.CreateDirectory(subDir);
+        await File.WriteAllTextAsync(Path.Combine(subDir, "a.txt"), "a");
+        await File.WriteAllTextAsync(Path.Combine(subDir, "b.txt"), "b");
+        var nestedDir = Path.Combine(subDir, "nested");
+        Directory.CreateDirectory(nestedDir);
+        await File.WriteAllTextAsync(Path.Combine(nestedDir, "c.txt"), "c");
+
+        var keys = new List<string>();
+        await foreach (var key in sut.ListAsync("list-test"))
+        {
+            keys.Add(key);
+        }
+
+        keys.Should().HaveCount(3);
+        keys.Should().Contain(k => k.Contains("a.txt"));
+        keys.Should().Contain(k => k.Contains("b.txt"));
+        keys.Should().Contain(k => k.Contains("c.txt"));
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsEmpty_WhenDirectoryMissing()
+    {
+        var keys = new List<string>();
+        await foreach (var key in sut.ListAsync("nonexistent"))
+        {
+            keys.Add(key);
+        }
+
+        keys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ResolveLocalPath_ReturnsFullPath()
+    {
+        var path = sut.ResolveLocalPath("subdir/file.fits");
+
+        path.Should().Be(Path.Combine(tempDir, "subdir", "file.fits"));
+    }
+
+    [Fact]
+    public void ResolveLocalPath_ThrowsForPathTraversal()
+    {
+        var act = () => sut.ResolveLocalPath("../../etc/passwd");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task WriteAndRead_RoundTrip()
+    {
+        var original = Encoding.UTF8.GetBytes("round trip data");
+        using var writeStream = new MemoryStream(original);
+        await sut.WriteAsync("roundtrip/data.bin", writeStream);
+
+        using var readStream = await sut.ReadStreamAsync("roundtrip/data.bin");
+        using var ms = new MemoryStream();
+        await readStream.CopyToAsync(ms);
+
+        ms.ToArray().Should().BeEquivalentTo(original);
+    }
+}


### PR DESCRIPTION
## Summary
Adds 58 new unit tests covering three previously untested .NET backend services, raising line coverage from ~20% to ~24%.

## Why
Continuing the coverage improvement effort started in #438. These three services (ImportJobTracker, FileContentValidator, LocalStorageProvider) were identified as easy wins with high test value and zero external dependencies.

## Type of Change
- [x] Test (adding or updating tests)

## Changes Made
- **ImportJobTrackerTests** (22 tests): Job creation, unique ID generation, initial state, cancellation (token + state), progress tracking with clamping, byte progress with file-level detail, download job ID, resumable flag, completion, failure, removal
- **FileContentValidatorTests** (20 tests): FITS magic byte validation, gzip FITS, PNG/JPEG/TIFF (both endianness) image validation, extension mismatch detection, JSON parsing, CSV consistency checks (comma/semicolon/tab delimiters), edge cases (empty, binary-as-text, too-small, unknown extension)
- **LocalStorageProviderTests** (16 tests): Write with directory creation, read stream, exists check, delete (including idempotent), file size, presigned URL (returns null for local), recursive listing, path resolution, path traversal protection, full write-read round trip

## Test Plan
- [x] All 357 backend tests pass locally (0 warnings, 0 errors)
- [x] Coverage improved from ~20% to ~24% line coverage
- [x] StyleCop warnings resolved (member ordering, comment formatting)

## Documentation Checklist
- [x] No documentation updates needed (test-only change)

## Tech Debt Impact
- [x] Reduces tech debt (improves coverage for previously untested services)

## Risk & Rollback
Risk: None — test-only change, no production code modified.
Rollback: Revert the commit.

## Quality Checklist
- [x] Tests pass locally
- [x] No warnings or errors
- [x] Follows existing test patterns (FluentAssertions, Moq, xUnit)