### PR TITLE
chore: bump .NET coverage threshold from 15% to 20%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         /p:CollectCoverage=true
         /p:CoverletOutputFormat=cobertura
         /p:ThresholdType=line
-        /p:Threshold=15
+        /p:Threshold=20
         /p:Exclude="[*]Microsoft.AspNetCore.OpenApi.Generated.*%2c[*]System.Text.RegularExpressions.Generated.*%2c[*]System.Runtime.CompilerServices.*%2c[*]Program"
 
   frontend-test:


### PR DESCRIPTION
## Summary
Bumps the backend coverage threshold from 15% to 20% to lock in gains from PR #439.

## Why
Actual coverage is ~24% after adding 58 new tests. This raises the floor to prevent regression.

## Type of Change
- [x] Chore (maintenance, config)

## Changes Made
- Updated `/p:Threshold=15` to `/p:Threshold=20` in `.github/workflows/ci.yml`

## Test Plan
- [x] CI backend tests pass with the new threshold (actual ~24% > 20%)

## Documentation Checklist
- [x] No documentation updates needed (config-only change)

## Tech Debt Impact
- [x] Reduces tech debt (enforces higher coverage floor)

## Risk & Rollback
Risk: None — threshold is well below actual coverage.
Rollback: Revert the one-line change.

## Quality Checklist
- [x] CI passes