### PR TITLE
fix: admin-gate migration endpoints and prevent ownership spoofing on create

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Fixtures/TestDataFixtures.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Fixtures/TestDataFixtures.cs
@@ -197,7 +197,6 @@ public static class TestDataFixtures
             DataType = dataType,
             Description = "Test create request",
             Tags = ["new", "test"],
-            UserId = "test-user-123",
         };
     }
 

--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -799,7 +799,7 @@ namespace JwstDataAnalysis.API.Controllers
                     Description = request.Description,
                     Metadata = request.Metadata ?? [],
                     Tags = request.Tags ?? [],
-                    UserId = request.UserId,
+                    UserId = GetCurrentUserId(),
                     UploadDate = DateTime.UtcNow,
                     ProcessingStatus = ProcessingStatuses.Pending,
                     ImageInfo = request.ImageInfo,
@@ -1839,6 +1839,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// Migrate existing data to populate processing level fields.
         /// </summary>
         [HttpPost("migrate/processing-levels")]
+        [Authorize(Policy = "AdminOnly")]
         public async Task<IActionResult> MigrateProcessingLevels()
         {
             try
@@ -1930,6 +1931,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// Migrate existing data to reclassify data types and set IsViewable based on filename patterns.
         /// </summary>
         [HttpPost("migrate/data-types")]
+        [Authorize(Policy = "AdminOnly")]
         public async Task<IActionResult> MigrateDataTypes()
         {
             try

--- a/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/DataValidationModels.cs
@@ -25,8 +25,6 @@ namespace JwstDataAnalysis.API.Models
 
         public List<string>? Tags { get; set; }
 
-        public string? UserId { get; set; }
-
         // Type-specific metadata
         public ImageMetadata? ImageInfo { get; set; }
 
@@ -226,8 +224,6 @@ namespace JwstDataAnalysis.API.Models
         public string? Description { get; set; }
 
         public List<string>? Tags { get; set; }
-
-        public string? UserId { get; set; }
 
         public bool IsPublic { get; set; }
 


### PR DESCRIPTION
## Summary
Two critical security fixes: admin-gate migration endpoints and prevent ownership spoofing on the create endpoint.

## Why
Security audit identified these as Critical (Bucket 1) access control gaps:
- **#444**: Migration endpoints that rewrite all DB records were callable by any authenticated user
- **#445**: Create endpoint trusted client-supplied UserId, enabling ownership spoofing

## Type of Change
- [x] Bug fix (security)

## Changes Made
- Added `[Authorize(Policy = "AdminOnly")]` to `migrate/processing-levels` and `migrate/data-types` endpoints
- Replaced `request.UserId` with `GetCurrentUserId()` on the create endpoint to derive ownership from JWT claims
- Removed dead `UserId` field from `CreateDataRequest` and `FileUploadRequest` DTOs
- Updated test fixture to match DTO change

## Test Plan
- [x] All 399 backend tests pass
- [x] Verify migration endpoints return 403 for non-admin users (manual test with demo account)
- [x] Verify created records have the authenticated user's ID, not a client-supplied value

## Documentation Checklist
- [x] No documentation updates needed (security fix, no API surface change for legitimate usage)

## Tech Debt Impact
- [x] Reduces tech debt (closes 2 security issues)

## Risk & Rollback
Risk: Low — adds authorization checks to existing endpoints. Any client sending UserId on create was already using an undocumented/unsupported flow.
Rollback: Revert the commit.

## Quality Checklist
- [x] Tests pass locally
- [x] No new warnings
- [x] Follows existing authorization patterns (AdminOnly policy)

Closes #444
Closes #445