### PR TITLE
test: fix SA1516, SA1202, CA2201 lint errors in test files

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/AnalysisControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/AnalysisControllerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Security.Claims;
+
 using FluentAssertions;
 using JwstDataAnalysis.API.Controllers;
 using JwstDataAnalysis.API.Models;
@@ -29,31 +30,6 @@ public class AnalysisControllerTests
         var mockLogger = new Mock<ILogger<AnalysisController>>();
         sut = new AnalysisController(mockAnalysisService.Object, mockMongoDBService.Object, mockLogger.Object);
         SetupAuthenticatedUser("test-user");
-    }
-
-    private void SetupAuthenticatedUser(string userId, bool isAdmin = false)
-    {
-        var claims = new List<Claim>
-        {
-            new(ClaimTypes.NameIdentifier, userId),
-        };
-        if (isAdmin)
-        {
-            claims.Add(new Claim(ClaimTypes.Role, "Admin"));
-        }
-
-        var identity = new ClaimsIdentity(claims, "TestAuth");
-        var principal = new ClaimsPrincipal(identity);
-        sut.ControllerContext = new ControllerContext
-        {
-            HttpContext = new DefaultHttpContext { User = principal },
-        };
-    }
-
-    private void SetupAccessibleData(string dataId, string ownerId = "test-user")
-    {
-        mockMongoDBService.Setup(s => s.GetAsync(dataId))
-            .ReturnsAsync(new JwstDataModel { Id = dataId, UserId = ownerId, IsPublic = true });
     }
 
     [Fact]
@@ -161,7 +137,7 @@ public class AnalysisControllerTests
         var request = new RegionStatisticsRequestDto { DataId = "data-1", RegionType = "rectangle" };
         SetupAccessibleData("data-1");
         mockAnalysisService.Setup(s => s.GetRegionStatisticsAsync(request))
-            .ThrowsAsync(new Exception("Unexpected"));
+            .ThrowsAsync(new TimeoutException("Unexpected"));
 
         var result = await sut.GetRegionStatistics(request);
 
@@ -238,5 +214,30 @@ public class AnalysisControllerTests
         var result = await sut.DetectSources(request);
 
         result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    private void SetupAuthenticatedUser(string userId, bool isAdmin = false)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId),
+        };
+        if (isAdmin)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, "Admin"));
+        }
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = principal },
+        };
+    }
+
+    private void SetupAccessibleData(string dataId, string ownerId = "test-user")
+    {
+        mockMongoDBService.Setup(s => s.GetAsync(dataId))
+            .ReturnsAsync(new JwstDataModel { Id = dataId, UserId = ownerId, IsPublic = true });
     }
 }

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/AuthControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/AuthControllerTests.cs
@@ -59,7 +59,7 @@ public class AuthControllerTests
     public async Task Login_Returns500_OnException()
     {
         mockAuthService.Setup(s => s.LoginAsync(It.IsAny<LoginRequest>()))
-            .ThrowsAsync(new Exception("DB error"));
+            .ThrowsAsync(new TimeoutException("DB error"));
 
         var result = await sut.Login(new LoginRequest { Username = "a", Password = "b" });
 
@@ -101,7 +101,7 @@ public class AuthControllerTests
     public async Task Register_Returns500_OnException()
     {
         mockAuthService.Setup(s => s.RegisterAsync(It.IsAny<RegisterRequest>()))
-            .ThrowsAsync(new Exception("DB error"));
+            .ThrowsAsync(new TimeoutException("DB error"));
 
         var result = await sut.Register(new RegisterRequest
         {
@@ -141,7 +141,7 @@ public class AuthControllerTests
     public async Task RefreshToken_Returns500_OnException()
     {
         mockAuthService.Setup(s => s.RefreshTokenAsync(It.IsAny<RefreshTokenRequest>()))
-            .ThrowsAsync(new Exception("fail"));
+            .ThrowsAsync(new TimeoutException("fail"));
 
         var result = await sut.RefreshToken(new RefreshTokenRequest { RefreshToken = "x" });
 
@@ -181,7 +181,7 @@ public class AuthControllerTests
     {
         SetupAuthenticatedUser(TestUserId);
         mockAuthService.Setup(s => s.RevokeRefreshTokenAsync(TestUserId))
-            .ThrowsAsync(new Exception("fail"));
+            .ThrowsAsync(new TimeoutException("fail"));
 
         var result = await sut.Logout();
 

--- a/backend/JwstDataAnalysis.API.Tests/Services/SeedDataServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/SeedDataServiceTests.cs
@@ -32,12 +32,6 @@ public class SeedDataServiceTests
         mockEnv.Setup(e => e.EnvironmentName).Returns("Development");
     }
 
-    private SeedDataService CreateSut(bool enabled = true)
-    {
-        var settings = Options.Create(new SeedingSettings { Enabled = enabled });
-        return new SeedDataService(mockMongo.Object, mockAuth.Object, settings, mockEnv.Object, mockLogger.Object);
-    }
-
     [Fact]
     public async Task SeedUsersAsync_WhenDisabled_DoesNothing()
     {
@@ -95,5 +89,11 @@ public class SeedDataServiceTests
         await act.Should().NotThrowAsync();
 
         mockAuth.Verify(a => a.RegisterAsync(It.IsAny<RegisterRequest>()), Times.Exactly(2));
+    }
+
+    private SeedDataService CreateSut(bool enabled = true)
+    {
+        var settings = Options.Create(new SeedingSettings { Enabled = enabled });
+        return new SeedDataService(mockMongo.Object, mockAuth.Object, settings, mockEnv.Object, mockLogger.Object);
     }
 }


### PR DESCRIPTION
## Summary
Fix 8 pre-existing StyleCop and code analysis lint errors in backend test files that cause `dotnet build --warnaserror` to fail.

## Why
These warnings were introduced in #441 and went unnoticed because CI runs `dotnet test` (which doesn't use `--warnaserror`). The local compliance check catches them, and they should be clean.

## Type of Change
- [x] Refactoring (no functional changes)

## Changes Made
- **SA1516** (`AnalysisControllerTests.cs`): Added blank line between `System.*` and non-System using directive groups
- **SA1202** (`AnalysisControllerTests.cs`, `SeedDataServiceTests.cs`): Moved private helper methods after public test methods to satisfy member ordering rule
- **CA2201** (`AnalysisControllerTests.cs`, `AuthControllerTests.cs`): Replaced `new Exception()` with `new TimeoutException()` in 5 test cases that exercise generic 500-status catch blocks — CA2201 requires exception types more specific than `Exception`/`ApplicationException`

## Test Plan
- [x] `dotnet build --warnaserror` passes with 0 warnings, 0 errors
- [x] All 407 backend tests pass
- [x] No functional changes — only member ordering, using formatting, and exception type specificity

## Documentation Checklist
- [x] No documentation updates needed (test-only changes)

## Tech Debt Impact
- [x] Reduces tech debt (eliminates 8 pre-existing lint errors)

## Risk & Rollback
Risk: None — test-only changes with no behavioral impact.
Rollback: Revert commit.

## Quality Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)