### PR TITLE
fix: stabilize flaky E2E auth test with explicit navigation waits

### DIFF
--- a/frontend/jwst-frontend/e2e/auth.spec.ts
+++ b/frontend/jwst-frontend/e2e/auth.spec.ts
@@ -167,15 +167,16 @@ test.describe('Authentication', () => {
       await page.getByLabel('Organization').fill('Test Organization');
       await page.getByRole('button', { name: 'Create Account' }).click();
 
-      // Should redirect to dashboard after registration
-      await expect(page).not.toHaveURL(/\/(login|register)/);
+      // Wait for navigation away from auth pages after registration
+      await page.waitForURL(/^(?!.*\/(login|register))/, { timeout: 15000 });
 
       // Should show user menu with username
       await expect(page.getByText('E2E Test User')).toBeVisible();
 
       // Step 2: Logout
-      // Click on user menu to open dropdown
+      // Click on user menu to open dropdown and wait for it to appear
       await page.getByText('E2E Test User').click();
+      await expect(page.getByText('Sign Out')).toBeVisible();
       await page.getByText('Sign Out').click();
 
       // Should redirect to login
@@ -186,8 +187,8 @@ test.describe('Authentication', () => {
       await page.getByLabel('Password').fill(password);
       await page.getByRole('button', { name: 'Sign In' }).click();
 
-      // Should redirect to dashboard after login
-      await expect(page).not.toHaveURL(/\/(login|register)/);
+      // Wait for navigation away from auth pages after login
+      await page.waitForURL(/^(?!.*\/(login|register))/, { timeout: 15000 });
 
       // Should show user menu again
       await expect(page.getByText('E2E Test User')).toBeVisible();
@@ -207,8 +208,8 @@ test.describe('Authentication', () => {
       await page.getByLabel('Confirm Password').fill(password);
       await page.getByRole('button', { name: 'Create Account' }).click();
 
-      // Wait for dashboard
-      await expect(page).not.toHaveURL(/\/(login|register)/);
+      // Wait for navigation away from auth pages
+      await page.waitForURL(/^(?!.*\/(login|register))/, { timeout: 15000 });
 
       // Refresh the page
       await page.reload();
@@ -237,8 +238,8 @@ test.describe('Authentication', () => {
       await page.getByLabel('Organization').fill(organization);
       await page.getByRole('button', { name: 'Create Account' }).click();
 
-      // Wait for dashboard
-      await expect(page).not.toHaveURL(/\/(login|register)/);
+      // Wait for navigation away from auth pages
+      await page.waitForURL(/^(?!.*\/(login|register))/, { timeout: 15000 });
 
       // Open user menu
       await page.getByText(displayName).click();


### PR DESCRIPTION
## Summary
Fixes intermittent E2E auth test failure (`should register, logout, and login successfully`) caused by race conditions between UI actions and navigation under CI load.

## Why
This test has been failing sporadically in CI — it passes consistently locally but times out or fails when the CI runner is under load. The root cause is three spots where the test asserts on URL state without waiting for navigation to complete after form submissions.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Replace `expect(page).not.toHaveURL()` after form submissions with explicit `page.waitForURL()` calls that block until navigation completes (with 15s timeout)
- Add `expect(page.getByText('Sign Out')).toBeVisible()` wait before clicking dropdown menu item
- Apply same `waitForURL` fix to "persist authentication" and "user menu" tests that had the same race condition pattern

## Test Plan
- [x] E2E auth tests pass locally
- [ ] CI E2E tests pass (previously flaky test should now be stable)
- [ ] Run E2E suite 5+ times to verify no more flakiness

## Documentation Checklist
- [x] No documentation updates needed (test-only change)

## Tech Debt Impact
- [x] Reduces tech debt (eliminates known flaky test)

## Risk & Rollback
Risk: Low — test-only change, no production code modified.
Rollback: Revert the commit.

## Quality Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] No new warnings introduced