### PR TITLE
fix: resolve all 41 backend test lint warnings (SA/CA rules)

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/CompositeControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/CompositeControllerTests.cs
@@ -405,7 +405,9 @@ public class CompositeControllerTests
         var request = CreateValidNChannelRequest();
         mockCompositeService.Setup(s => s.GenerateNChannelCompositeAsync(
                 request, TestUserId, true, false))
+#pragma warning disable CA2201
             .ThrowsAsync(new Exception("Something broke"));
+#pragma warning restore CA2201
 
         // Act
         var result = await sut.GenerateNChannelComposite(request);
@@ -416,7 +418,6 @@ public class CompositeControllerTests
     }
 
     // ===== Helpers =====
-
     private static NChannelCompositeRequestDto CreateValidNChannelRequest()
     {
         return new NChannelCompositeRequestDto

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/DataManagementControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/DataManagementControllerTests.cs
@@ -36,7 +36,6 @@ public class DataManagementControllerTests
     }
 
     // ========== Search Tests ==========
-
     [Fact]
     public async Task Search_ReturnsOk_WithResults()
     {
@@ -138,7 +137,6 @@ public class DataManagementControllerTests
     }
 
     // ========== GetStatistics Tests ==========
-
     [Fact]
     public async Task GetStatistics_ReturnsOk()
     {
@@ -171,7 +169,6 @@ public class DataManagementControllerTests
     }
 
     // ========== GetPublicData Tests ==========
-
     [Fact]
     public async Task GetPublicData_ReturnsOk()
     {
@@ -208,7 +205,6 @@ public class DataManagementControllerTests
     }
 
     // ========== GetValidatedData Tests ==========
-
     [Fact]
     public async Task GetValidatedData_ReturnsOk()
     {
@@ -257,7 +253,6 @@ public class DataManagementControllerTests
     }
 
     // ========== GetByFileFormat Tests ==========
-
     [Fact]
     public async Task GetByFileFormat_ReturnsOk()
     {
@@ -294,7 +289,6 @@ public class DataManagementControllerTests
     }
 
     // ========== GetCommonTags Tests ==========
-
     [Fact]
     public async Task GetCommonTags_ReturnsOk()
     {
@@ -337,7 +331,6 @@ public class DataManagementControllerTests
     }
 
     // ========== BulkUpdateTags Tests ==========
-
     [Fact]
     public async Task BulkUpdateTags_ReturnsBadRequest_WhenNoDataIds()
     {
@@ -389,7 +382,6 @@ public class DataManagementControllerTests
     }
 
     // ========== BulkUpdateStatus Tests ==========
-
     [Fact]
     public async Task BulkUpdateStatus_ReturnsBadRequest_WhenNoDataIds()
     {
@@ -424,7 +416,6 @@ public class DataManagementControllerTests
     }
 
     // ========== ExportData Tests ==========
-
     [Fact]
     public async Task ExportData_ReturnsBadRequest_WhenNoDataIds()
     {
@@ -463,7 +454,6 @@ public class DataManagementControllerTests
     }
 
     // ========== DownloadExport Tests ==========
-
     [Fact]
     public async Task DownloadExport_ReturnsBadRequest_ForInvalidGuid()
     {
@@ -498,7 +488,6 @@ public class DataManagementControllerTests
     }
 
     // ========== ScanAndImportFiles Tests ==========
-
     [Fact]
     public async Task ScanAndImportFiles_ReturnsOk()
     {
@@ -537,7 +526,6 @@ public class DataManagementControllerTests
     }
 
     // ========== ClaimOrphanedData Tests ==========
-
     [Fact]
     public async Task ClaimOrphanedData_ReturnsUnauthorized_WhenNoUserId()
     {
@@ -574,7 +562,6 @@ public class DataManagementControllerTests
     }
 
     // ========== MigrateStorageKeys Tests ==========
-
     [Fact]
     public async Task MigrateStorageKeys_ReturnsOk()
     {
@@ -626,7 +613,6 @@ public class DataManagementControllerTests
     }
 
     // ========== Helper Methods ==========
-
     private void SetupAuthenticatedUser(string userId)
     {
         var claims = new List<Claim>

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/MosaicControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/MosaicControllerTests.cs
@@ -252,7 +252,9 @@ public class MosaicControllerTests
         // Arrange
         var request = CreateValidMosaicRequest();
         mockMosaicService.Setup(s => s.GenerateMosaicAsync(request))
+#pragma warning disable CA2201
             .ThrowsAsync(new Exception("Something broke"));
+#pragma warning restore CA2201
 
         // Act
         var result = await sut.GenerateMosaic(request);
@@ -415,7 +417,9 @@ public class MosaicControllerTests
         var request = CreateValidMosaicRequest();
         mockMosaicService.Setup(s => s.GenerateAndSaveMosaicAsync(
                 request, TestUserId, true, false))
+#pragma warning disable CA2201
             .ThrowsAsync(new Exception("Something broke"));
+#pragma warning restore CA2201
 
         // Act
         var result = await sut.GenerateAndSaveMosaic(request);
@@ -466,7 +470,7 @@ public class MosaicControllerTests
     public async Task GetFootprint_ReturnsBadRequest_WhenDataIdEmpty()
     {
         // Arrange
-        var request = new FootprintRequestDto { DataIds = ["id1", ""] };
+        var request = new FootprintRequestDto { DataIds = ["id1", string.Empty] };
 
         // Act
         var result = await sut.GetFootprint(request);
@@ -583,7 +587,6 @@ public class MosaicControllerTests
     }
 
     // ===== Helpers =====
-
     private static MosaicRequestDto CreateValidMosaicRequest()
     {
         return new MosaicRequestDto

--- a/backend/JwstDataAnalysis.API.Tests/Services/AnalysisServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/AnalysisServiceTests.cs
@@ -52,7 +52,8 @@ public class AnalysisServiceTests
     {
         // Arrange
         SetupMongoData("data-123", "mast/obs1/file.fits");
-        SetupMockResponse(HttpStatusCode.OK,
+        SetupMockResponse(
+            HttpStatusCode.OK,
             "{\"pixel_count\":100,\"mean\":50.5,\"std\":10.2,\"min\":0,\"max\":100,\"sum\":5050}");
 
         var request = new RegionStatisticsRequestDto
@@ -139,7 +140,8 @@ public class AnalysisServiceTests
     {
         // Arrange
         SetupMongoData("data-123", "mast/obs1/file.fits");
-        SetupMockResponse(HttpStatusCode.OK,
+        SetupMockResponse(
+            HttpStatusCode.OK,
             "{\"n_sources\":5,\"method\":\"daofind\",\"sources\":[]}");
 
         var request = new SourceDetectionRequestDto { DataId = "data-123", Method = "daofind" };
@@ -183,7 +185,8 @@ public class AnalysisServiceTests
     {
         // Arrange
         SetupMongoData("data-123", "mast/obs1/file.fits");
-        SetupMockResponse(HttpStatusCode.OK,
+        SetupMockResponse(
+            HttpStatusCode.OK,
             "{\"table_hdus\":[{\"index\":1,\"name\":\"DATA\",\"n_rows\":100,\"n_columns\":5,\"columns\":[]}]}");
 
         // Act
@@ -224,7 +227,8 @@ public class AnalysisServiceTests
     {
         // Arrange
         SetupMongoData("data-123", "mast/obs1/file.fits");
-        SetupMockResponse(HttpStatusCode.OK,
+        SetupMockResponse(
+            HttpStatusCode.OK,
             "{\"total_rows\":100,\"page\":0,\"page_size\":50,\"rows\":[]}");
 
         // Act
@@ -249,7 +253,8 @@ public class AnalysisServiceTests
 
         HttpRequestMessage? capturedRequest = null;
         mockHandler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
             .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedRequest = req)
@@ -299,7 +304,8 @@ public class AnalysisServiceTests
     public async Task GetSpectralDataAsync_ReturnsResult_OnSuccess()
     {
         // Arrange
-        SetupMockResponse(HttpStatusCode.OK,
+        SetupMockResponse(
+            HttpStatusCode.OK,
             "{\"hdu_index\":1,\"hdu_name\":\"EXTRACT1D\",\"n_points\":100,\"columns\":[],\"data\":{}}");
 
         // Act
@@ -347,7 +353,8 @@ public class AnalysisServiceTests
         // The HTTP mock captures the URL to verify the resolved path
         HttpRequestMessage? capturedRequest = null;
         mockHandler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
             .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedRequest = req)
@@ -371,7 +378,6 @@ public class AnalysisServiceTests
     }
 
     // ===== Helper Methods =====
-
     private void SetupMongoData(string dataId, string filePath)
     {
         mockMongoService.Setup(m => m.GetAsync(dataId))
@@ -381,7 +387,8 @@ public class AnalysisServiceTests
     private void SetupMockResponse(HttpStatusCode statusCode, string content)
     {
         mockHandler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(new HttpResponseMessage

--- a/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
@@ -38,61 +38,6 @@ public class CompositeServiceTests
             .Build();
     }
 
-    private CompositeService CreateService(HttpClient? httpClient = null)
-    {
-        return new CompositeService(
-            httpClient ?? new HttpClient(),
-            mockMongo.Object,
-            mockStorage.Object,
-            mockLogger.Object,
-            configuration);
-    }
-
-    private static NChannelCompositeRequestDto CreateRequest(
-        List<string>? dataIds = null,
-        OverallAdjustmentsDto? overall = null)
-    {
-        return new NChannelCompositeRequestDto
-        {
-            Channels =
-            [
-                new NChannelConfigDto
-                {
-                    DataIds = dataIds ?? ["data-1"],
-                    Stretch = "zscale",
-                    BlackPoint = 0.0,
-                    WhitePoint = 1.0,
-                    Gamma = 1.0,
-                    AsinhA = 0.1,
-                    Curve = "linear",
-                    Weight = 1.0,
-                    Color = new ChannelColorDto { Hue = 0.0 },
-                    Label = "F200W",
-                    WavelengthUm = 2.0,
-                },
-            ],
-            Overall = overall,
-            BackgroundNeutralization = true,
-            OutputFormat = "png",
-            Quality = 95,
-            Width = 1000,
-            Height = 1000,
-        };
-    }
-
-    private static JwstDataModel CreateDataModel(
-        string id = "data-1",
-        bool isPublic = true,
-        string? userId = null,
-        string? filePath = "/app/data/test/file.fits")
-    {
-        var model = TestDataFixtures.CreateSampleData(id: id);
-        model.IsPublic = isPublic;
-        model.UserId = userId ?? "owner-user";
-        model.FilePath = filePath!;
-        return model;
-    }
-
     [Fact]
     public async Task GenerateNChannelComposite_Success_ReturnsImageBytes()
     {
@@ -449,6 +394,61 @@ public class CompositeServiceTests
 
         // Assert - service was created (default URL is http://localhost:8000)
         sut.Should().NotBeNull();
+    }
+
+    private static NChannelCompositeRequestDto CreateRequest(
+        List<string>? dataIds = null,
+        OverallAdjustmentsDto? overall = null)
+    {
+        return new NChannelCompositeRequestDto
+        {
+            Channels =
+            [
+                new NChannelConfigDto
+                {
+                    DataIds = dataIds ?? ["data-1"],
+                    Stretch = "zscale",
+                    BlackPoint = 0.0,
+                    WhitePoint = 1.0,
+                    Gamma = 1.0,
+                    AsinhA = 0.1,
+                    Curve = "linear",
+                    Weight = 1.0,
+                    Color = new ChannelColorDto { Hue = 0.0 },
+                    Label = "F200W",
+                    WavelengthUm = 2.0,
+                },
+            ],
+            Overall = overall,
+            BackgroundNeutralization = true,
+            OutputFormat = "png",
+            Quality = 95,
+            Width = 1000,
+            Height = 1000,
+        };
+    }
+
+    private static JwstDataModel CreateDataModel(
+        string id = "data-1",
+        bool isPublic = true,
+        string? userId = null,
+        string? filePath = "/app/data/test/file.fits")
+    {
+        var model = TestDataFixtures.CreateSampleData(id: id);
+        model.IsPublic = isPublic;
+        model.UserId = userId ?? "owner-user";
+        model.FilePath = filePath!;
+        return model;
+    }
+
+    private CompositeService CreateService(HttpClient? httpClient = null)
+    {
+        return new CompositeService(
+            httpClient ?? new HttpClient(),
+            mockMongo.Object,
+            mockStorage.Object,
+            mockLogger.Object,
+            configuration);
     }
 
     /// <summary>

--- a/backend/JwstDataAnalysis.API.Tests/Services/DataScanServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/DataScanServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) JWST Data Analysis. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Text.Json;
 
 using FluentAssertions;
@@ -16,8 +17,9 @@ namespace JwstDataAnalysis.API.Tests.Services;
 /// </summary>
 public class DataScanServiceTests
 {
-    // ========== ParseFileInfo Tests ==========
+    private static readonly int[] TestArray = [1, 2, 3];
 
+    // ========== ParseFileInfo Tests ==========
     [Theory]
     [InlineData("jw02733001001_02101_00001_nrca1_uncal.fits", "L1", "raw", true)]
     [InlineData("jw02733001001_02101_00001_nrca1_rate.fits", "L2a", "sensor", true)]
@@ -75,7 +77,6 @@ public class DataScanServiceTests
     }
 
     // ========== BuildMastMetadata Tests ==========
-
     [Fact]
     public void BuildMastMetadata_WithNullObsMeta_ReturnsDictWithBaseKeys()
     {
@@ -161,7 +162,6 @@ public class DataScanServiceTests
     }
 
     // ========== ConvertJsonElement Tests ==========
-
     [Fact]
     public void ConvertJsonElement_String_ReturnsString()
     {
@@ -179,7 +179,7 @@ public class DataScanServiceTests
         var element = JsonSerializer.SerializeToElement(42);
         var result = DataScanService.ConvertJsonElement(element);
         result.Should().BeAssignableTo<IConvertible>();
-        Convert.ToInt64(result).Should().Be(42L);
+        Convert.ToInt64(result, CultureInfo.InvariantCulture).Should().Be(42L);
     }
 
     [Fact]
@@ -218,7 +218,7 @@ public class DataScanServiceTests
     [Fact]
     public void ConvertJsonElement_Array_ReturnsToString()
     {
-        var element = JsonSerializer.SerializeToElement(new[] { 1, 2, 3 });
+        var element = JsonSerializer.SerializeToElement(TestArray);
         var result = DataScanService.ConvertJsonElement(element);
         result.Should().BeOfType<string>();
         ((string)result).Should().Contain("1");
@@ -234,7 +234,6 @@ public class DataScanServiceTests
     }
 
     // ========== CreateImageMetadata Tests ==========
-
     [Fact]
     public void CreateImageMetadata_NullObsMeta_ReturnsNull()
     {

--- a/backend/JwstDataAnalysis.API.Tests/Services/MastServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/MastServiceTests.cs
@@ -266,7 +266,8 @@ public class MastServiceTests
     {
         // Arrange
         mockHandler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Connection refused"));
@@ -482,7 +483,8 @@ public class MastServiceTests
     {
         // Arrange
         mockHandler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Connection refused"));
@@ -537,11 +539,11 @@ public class MastServiceTests
     }
 
     // ===== Helper Methods =====
-
     private void SetupMockResponse(HttpStatusCode statusCode, string content)
     {
         mockHandler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(new HttpResponseMessage


### PR DESCRIPTION
## Summary

Resolves all 41 StyleCop/CA analyzer warnings across 7 backend test files so the build passes clean with `--warnaserror`.

## Why

Backend lint (`dotnet build --warnaserror`) was failing with 41 SA/CA warnings. These were masked by build caching in prior compliance checks.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Test coverage
- [ ] Documentation
- [x] Configuration

## Changes Made

- **SA1512** (22 occurrences): Removed blank lines after section comment headers in DataManagementControllerTests, CompositeControllerTests, MosaicControllerTests, AnalysisServiceTests, DataScanServiceTests, MastServiceTests
- **SA1116** (11 occurrences): Reformatted multi-line method calls so first parameter starts on a new line in AnalysisServiceTests, MastServiceTests
- **SA1122** (1 occurrence): Changed `""` to `string.Empty` in MosaicControllerTests
- **SA1202/SA1204** (2 occurrences): Reordered members in CompositeServiceTests (public before private, static after instance)
- **CA1305** (1 occurrence): Added `CultureInfo.InvariantCulture` to `Convert.ToInt64` in DataScanServiceTests
- **CA1861** (1 occurrence): Extracted inline array to `private static readonly` field in DataScanServiceTests
- **CA2201** (3 occurrences): Added `#pragma warning disable/restore` for intentional base `Exception` throws in catch-all 500 handler tests

## Test Plan

- [x] All 604 backend tests pass (0 skipped)
- [x] Build passes with `--warnaserror` (0 warnings, 0 errors)
- [x] No behavioral changes — formatting and style fixes only

## Documentation Checklist

- [x] No documentation updates needed (style fixes only)

## Tech Debt Impact

- [x] Reduces tech debt (eliminates all analyzer warnings in test project)
- [ ] No change
- [ ] Adds tech debt (explain below)

## Risk & Rollback

Risk: None — style/formatting changes only, no behavioral changes.
Rollback: Revert commit.

## Quality Checklist

- [x] Code follows project style guidelines
- [x] Build passes with --warnaserror
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)