### PR TITLE
fix: make MJD epoch timezone-aware to match datetime.now(UTC)

### DIFF
--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -343,7 +343,7 @@ class MastService:
         try:
             # Calculate MJD date range
             # MJD (Modified Julian Date) epoch is November 17, 1858
-            MJD_EPOCH = datetime(1858, 11, 17)
+            MJD_EPOCH = datetime(1858, 11, 17, tzinfo=UTC)
             today = datetime.now(UTC)
             start_date = today - timedelta(days=days_back)
 


### PR DESCRIPTION
## Summary

Fix `can't subtract offset-naive and offset-aware datetimes` error that breaks the WhatsNewPanel "What's New on MAST" recent releases query.

## Why

`datetime.now(UTC)` returns a timezone-aware datetime, but `MJD_EPOCH = datetime(1858, 11, 17)` was naive. Subtracting them raises a `TypeError`, causing a 500 error on the `/mast/search/recent` endpoint.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `processing-engine/app/mast/mast_service.py` — added `tzinfo=UTC` to `MJD_EPOCH` datetime constructor

## Test Plan

- [x] Ruff lint passes
- [x] Ruff format passes
- [ ] Manual: Open WhatsNewPanel → "Last 7 days" loads observations without error

## Documentation Checklist

- [x] No new controllers, services, or endpoints

## Tech Debt Impact

- [ ] Reduces tech debt
- [x] No change to tech debt
- [ ] Adds tech debt

## Risk & Rollback

Risk: Minimal — single-line fix to a datetime constructor.

Rollback: Revert this commit.

## Quality Checklist

- [x] No hardcoded secrets, tokens, or credentials
- [x] Follows existing patterns and naming conventions