### PR TITLE
fix: convert MAST thumbnail URIs to HTTPS URLs

### DIFF
--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -22,6 +22,24 @@ logger = logging.getLogger(__name__)
 # Type alias for progress callback
 ProgressCallback = Callable[[str, int, int], None]  # (filename, current, total)
 
+# MAST download base for converting mast: URIs to HTTPS URLs
+_MAST_DOWNLOAD_BASE = "https://mast.stsci.edu/api/v0.1/Download/file"
+
+
+def _convert_mast_uris(rows: list[dict[str, Any]]) -> None:
+    """Convert mast: URI scheme fields (jpegURL, dataURL) to downloadable HTTPS URLs.
+
+    MAST returns URIs like 'mast:JWST/product/filename.jpg' which browsers
+    can't load directly. This converts them to:
+    https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/filename.jpg
+    """
+    uri_fields = ("jpegURL", "dataURL")
+    for row in rows:
+        for field in uri_fields:
+            val = row.get(field)
+            if isinstance(val, str) and val.startswith("mast:"):
+                row[field] = f"{_MAST_DOWNLOAD_BASE}?uri={quote(val)}"
+
 
 class MastService:
     """Service for interacting with MAST portal via astroquery."""
@@ -896,6 +914,9 @@ class MastService:
                     elif isinstance(val, float) and (math.isnan(val) or math.isinf(val)):
                         row[key] = None
 
+            # Convert mast: URIs to downloadable HTTPS URLs
+            _convert_mast_uris(result)
+
             logger.info(f"Total conversion took {time.time() - start:.2f}s")
             return result
 
@@ -924,4 +945,5 @@ class MastService:
                     else:
                         row_dict[col] = str(val) if val is not None else None
                 result.append(row_dict)
+            _convert_mast_uris(result)
             return result


### PR DESCRIPTION
## Summary

- Convert MAST `mast:` URI scheme fields to browser-loadable HTTPS URLs

## Why

MAST API returns `jpegURL` and `dataURL` fields using the `mast:` URI scheme (e.g., `mast:JWST/product/filename.jpg`). Browsers don't recognize this scheme, causing `net::ERR_UNKNOWN_URL_SCHEME` errors and broken thumbnail images in the What's New panel and search results.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `_convert_mast_uris()` helper function in `processing-engine/app/mast/mast_service.py` that converts `mast:` URIs to downloadable HTTPS URLs via `https://mast.stsci.edu/api/v0.1/Download/file?uri=...`
- Called in both the fast (pandas) and fallback paths of `_table_to_dict_list()` so all MAST query results get converted
- Uses `urllib.parse.quote()` for proper URL encoding of the `mast:` URI

## Test Plan

- [x] Python linting passes (Ruff)
- [x] 368 Python tests pass (1 unrelated disk space error in container)
- [x] Verified MAST Download API returns HTTP 200 with correct `image/jpeg` content type for converted URLs
- [ ] Manual: Open What's New panel — observation thumbnails should load instead of showing placeholder icons

## Documentation Checklist

- [x] No new controllers, services, or endpoints added
- [x] `key-files.md` — N/A
- [x] `backend-development.md` — N/A
- [x] `architecture.md` — N/A
- [x] `quick-reference.md` — N/A

## Tech Debt Impact

- [ ] Reduces tech debt
- [x] No change to tech debt
- [ ] Adds tech debt (explain below)

## Risk & Rollback

Risk: Low. Only affects thumbnail/preview URL construction. If MAST Download API changes, thumbnails revert to placeholder icons (graceful degradation already exists via `failedThumbnails` state).

Rollback: Revert this PR. Thumbnails go back to showing placeholders.

## Quality Checklist

- [x] No `console.log` in production code
- [x] No hardcoded secrets, tokens, or credentials
- [x] Follows existing patterns and naming conventions