### PR TITLE
fix: use mast_obs_id for imported status matching in MAST search

### DIFF
--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -72,12 +72,16 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
   const [showFloatingBar, setShowFloatingBar] = useState(false);
   const analysisRowRef = useRef<HTMLDivElement>(null);
 
-  // Extract unique observation IDs that have been imported (for MAST search display)
+  // Extract unique MAST observation IDs that have been imported (for MAST search display).
+  // Uses metadata.mast_obs_id (the original MAST obs_id like "jw02733-o002_t001_miri_f1130w")
+  // rather than observationBaseId (compact filename-derived format like "jw02733002002"),
+  // because MAST search results use the MAST obs_id format for comparison.
   const importedObsIds = useMemo(() => {
     const ids = new Set<string>();
     data.forEach((item) => {
-      if (item.observationBaseId) {
-        ids.add(item.observationBaseId);
+      const mastObsId = item.metadata?.mast_obs_id;
+      if (typeof mastObsId === 'string' && mastObsId) {
+        ids.add(mastObsId);
       }
     });
     return ids;


### PR DESCRIPTION
## Summary
- Fix MAST search "Imported" badge never appearing after importing an observation

## Why
The `importedObsIds` set was built from `observationBaseId` (compact filename-derived format like `jw02733002002`) but compared against MAST search `obs_id` (MAST format like `jw02733-o002_t001_miri_f1130w`). These formats never match, so imported observations were never marked as "Imported" in search results.

## Type of Change
- [x] Bug fix

## Changes Made
- Changed `JwstDataDashboard.tsx` to build `importedObsIds` from `metadata.mast_obs_id` instead of `observationBaseId`, since `mast_obs_id` matches the format used by MAST search results

## Test Plan
- [x] Search MAST for a target (e.g. IC-5332) and import an observation
- [x] After import completes, verify the "Import" button changes to "Imported"
- [x] Navigate away from search and back — verify imported status persists
- [x] Search for a different target and verify non-imported observations still show "Import" button

## Documentation Checklist
- [x] No new controllers, services, or endpoints
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — single-line logic change in frontend only, no backend changes.
Rollback: Revert commit to restore previous `observationBaseId` comparison.

## Quality Checklist
- [x] Code follows project conventions
- [x] All pre-commit checks pass (ESLint, Prettier, 810 tests)
- [x] No security concerns