### PR TITLE
docs: add v1 plans — guided discovery, color mapping, job queue

### DIFF
--- a/docs/plans/color-mapping-research.md
+++ b/docs/plans/color-mapping-research.md
@@ -1,0 +1,140 @@
+# Color Mapping Research — Chromatic Ordering vs Wavelength-to-Hue
+
+## Origin
+
+Prompted by NASA's Feb 25, 2026 release of the Cranium Nebula (PMR 1) — [blog post](https://science.nasa.gov/missions/webb/nasas-webb-examines-cranium-nebula/). User downloaded all 8 FITS files (4 NIRCam + 4 MIRI) and attempted to recreate the composite. Result was recognizable but far from the NASA quality.
+
+## The NASA Release
+
+**Program 9224** (PI: M. Garcia Marin), observed March 30-31, 2025.
+Image Processing: **Joseph DePasquale (STScI)** — same person behind most iconic Webb releases.
+
+### Filter → Color assignments (from NASA)
+
+| Filter | Wavelength | Instrument | Assigned Color |
+|--------|-----------|------------|---------------|
+| F150W | 1.50 µm | NIRCam | Blue |
+| F187N | 1.87 µm | NIRCam | Green |
+| F444W | 4.42 µm | NIRCam | Orange |
+| F470N | 4.71 µm | NIRCam | Red |
+| F1000W | 10.0 µm | MIRI | Blue |
+| F1130W | 11.3 µm | MIRI | Green |
+| F1280W | 12.8 µm | MIRI | Orange |
+| F1800W | 18.0 µm | MIRI | Red |
+
+Three images released: NIRCam-only, MIRI-only, and side-by-side comparison.
+
+### Other observation details
+- Object: PMR 1 / PN G272.8+01.0 (Exposed Cranium Nebula), planetary nebula in Vela
+- Distance: 5,000 light-years
+- Image size: ~2.2 arcmin (~3.2 light-years)
+- Scale bar: 0.5 ly / 20 arcsec
+
+---
+
+## The Problem: Absolute Wavelength→Hue Mapping
+
+Our current `wavelengthToHue()` (in both Python and TypeScript) uses a log-scale mapping across the full JWST range (0.6–28 µm). Shorter wavelengths → hue 270° (blue), longer → hue 0° (red).
+
+### What this produces for Cranium Nebula NIRCam:
+
+| Filter | Wavelength | Auto-Hue | Resulting Color |
+|--------|-----------|----------|-----------------|
+| F150W | 1.50 µm | ~204° | Cyan-blue |
+| F187N | 1.87 µm | ~192° | Cyan |
+| F444W | 4.42 µm | ~139° | Teal-green |
+| F470N | 4.71 µm | ~135° | Green |
+
+**Problem**: All four filters land in a narrow cyan-to-green band. The 1.5–4.7 µm range is compressed because it's a small fraction of the full 0.6–28 µm log-scale range. Result: muddy, low-contrast, greenish image.
+
+### What this produces for Cranium Nebula MIRI:
+
+| Filter | Wavelength | Auto-Hue | Resulting Color |
+|--------|-----------|----------|-----------------|
+| F1000W | 10.0 µm | ~94° | Yellow-green |
+| F1130W | 11.3 µm | ~80° | Yellow |
+| F1280W | 12.8 µm | ~68° | Orange-yellow |
+| F1800W | 18.0 µm | ~42° | Orange |
+
+**Problem**: Even worse clustering. All four filters land in yellow-orange. No blue, no strong red. Looks washed out.
+
+### What NASA assigns:
+
+NASA uses **blue, green, orange, red** in both cases — a full spectral spread regardless of absolute wavelength.
+
+---
+
+## The Solution: Chromatic Ordering
+
+STScI image processors use **relative chromatic ordering** within each filter set:
+
+1. Sort filters by wavelength (ascending)
+2. Map the **shortest** to blue, **longest** to red
+3. Middle filters get evenly-spaced intermediate colors
+4. The specific color palette is: blue → cyan → green → yellow → orange → red
+
+This is a **relative** mapping — it doesn't matter whether the filters span 1–5 µm or 10–18 µm. The visual spread is always the full blue-to-red range.
+
+### Standard chromatic ordering palette (N filters)
+
+| N | Colors |
+|---|--------|
+| 2 | Blue, Red |
+| 3 | Blue, Green, Red |
+| 4 | Blue, Green, Orange, Red |
+| 5 | Blue, Cyan, Green, Orange, Red |
+| 6 | Blue, Cyan, Green, Yellow, Orange, Red |
+| 7 | Blue, Indigo, Cyan, Green, Yellow, Orange, Red |
+| 8+ | Evenly space hues from 240° (blue) to 0° (red) |
+
+### Suggested hue values
+
+| N | Hues (degrees) |
+|---|----------------|
+| 2 | 240, 0 |
+| 3 | 240, 120, 0 |
+| 4 | 240, 120, 30, 0 |
+| 5 | 240, 180, 120, 30, 0 |
+| 6 | 240, 180, 120, 60, 30, 0 |
+| N | Evenly space from 240 → 0 |
+
+---
+
+## Additional Quality Gaps (Beyond Color Mapping)
+
+### Per-component normalization flattens dynamic range
+
+`combine_channels_to_rgb()` normalizes R, G, B independently by dividing each by its max. This prevents color dominance but **flattens relative brightness** between channels. NASA images have bright white edges (all channels saturated) and strong color gradients in interiors. Our normalization compresses this.
+
+**Potential fix**: Optional "preserve relative brightness" mode that normalizes by the global max across all three components rather than per-component.
+
+### Stretch tuning per filter
+
+DePasquale almost certainly uses:
+- **Per-channel asinh** with different softening parameters per filter
+- **Different black points per channel** to control color balance
+- **Post-composite tone mapping** (S-curve on the final RGB)
+- **Star treatment** — managing star halos in NIRCam wide-band filters
+
+Our defaults (log stretch, same params for all channels) produce reasonable but untuned results.
+
+**Potential fix for v1**: The suggestion engine recipes should include per-channel stretch presets (not just color assignments). E.g., narrowband filters (F187N, F470N) often benefit from more aggressive stretch than broadband (F150W, F444W).
+
+### Background subtraction timing
+
+Our `neutralize_raw_backgrounds()` does sigma-clipped median subtraction before stretch — this is correct and matches professional workflows. No gap here.
+
+---
+
+## Implementation Plan
+
+### Files to modify:
+- `processing-engine/app/composite/color_mapping.py` — add `chromatic_order_colors(n)` function
+- `frontend/.../wavelengthUtils.ts` — add `chromaticOrderHues(n)` function, update `autoAssignNChannels()` to use it as default
+- `frontend/.../CompositeTypes.ts` — add color assignment mode toggle (chromatic vs scientific/wavelength)
+
+### Keep existing mode available
+The current wavelength-to-hue mapping is still useful as a "scientific" mode — it shows actual wavelength relationships. But chromatic ordering should be the **default** for auto-assignment and all recipe presets.
+
+### Mixed-instrument sets (NIRCam + MIRI combined)
+When filters span both instruments, still sort by wavelength and apply chromatic ordering across the full set. This naturally produces the right result — NIRCam filters get the bluer end, MIRI filters get the redder end.

--- a/docs/plans/guided-discovery-experience.md
+++ b/docs/plans/guided-discovery-experience.md
@@ -1,0 +1,474 @@
+# Guided Discovery Experience — Design Sketch
+
+## Vision
+
+Turn the app from a **tool-first** data dashboard into a **content-first** discovery experience.
+
+The core loop: **Discover → Create → Share**
+
+Target user: someone who thinks JWST images are cool but doesn't know target names, catalog IDs, or what a FITS file is. They want to end up with a composite image they're proud to share.
+
+---
+
+## Current Flow (tool-first)
+
+```
+Login → Empty dashboard → ??? → (user has to figure out MAST search,
+download, maybe mosaic, then composite wizard, then export)
+```
+
+Problem: requires prior knowledge of the workflow, target names, and tool purpose.
+
+## Proposed Flow (content-first)
+
+```
+Landing → Browse/discover targets → Pick one → App handles the rest →
+Tweak if you want → Export/download
+```
+
+---
+
+## Page Structure
+
+### 1. Home — Discovery Page (`/`)
+
+The landing page after login. Not a dashboard — a discovery feed.
+
+```
+┌─────────────────────────────────────────────────────┐
+│  JWST Data Analysis Platform            [My Library] │
+│                                                      │
+│  ┌────────────────────────────────────────────────┐  │
+│  │  🔍 Search targets (Carina Nebula, M31, ...)   │  │
+│  └────────────────────────────────────────────────┘  │
+│                                                      │
+│  ── Featured Targets ──────────────────────────────  │
+│                                                      │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────┐  │
+│  │ ░░░░░░░░ │ │ ░░░░░░░░ │ │ ░░░░░░░░ │ │ ░░░░░░ │  │
+│  │ ░ thumb ░ │ │ ░ thumb ░ │ │ ░ thumb ░ │ │ ░thum░ │  │
+│  │ ░░░░░░░░ │ │ ░░░░░░░░ │ │ ░░░░░░░░ │ │ ░░░░░░ │  │
+│  │ Carina   │ │ Pillars  │ │ Southern │ │ Stephan│  │
+│  │ Nebula   │ │ of Crea. │ │ Ring     │ │ Quintet│  │
+│  │ 6 filters│ │ 4 filters│ │ 8 filters│ │ 5 filt.│  │
+│  │ NIRCam   │ │ NIRCam   │ │ NIR+MIRI │ │ NIRCam │  │
+│  │ [Create] │ │ [Create] │ │ [Create] │ │[Create]│  │
+│  └──────────┘ └──────────┘ └──────────┘ └────────┘  │
+│                                                      │
+│  ── New from JWST (last 30 days) ──────────────────  │
+│                                                      │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────┐  │
+│  │ ░░░░░░░░ │ │ ░░░░░░░░ │ │ ░░░░░░░░ │ │ ░░░░░░ │  │
+│  │  (auto   │ │  (auto   │ │  (auto   │ │ (auto  │  │
+│  │ thumb or │ │ thumb or │ │ thumb or │ │  thumb │  │
+│  │ generic) │ │ generic) │ │ generic) │ │  or    │  │
+│  │ IC 2944  │ │ NGC 346  │ │ WR 124   │ │generic)│  │
+│  │ Released  │ │ Released  │ │ Released  │ │ Abell  │  │
+│  │ 3 days   │ │ 1 week   │ │ 2 weeks  │ │ 2744   │  │
+│  │ 6 filters│ │ 3 filters│ │ 5 filters│ │ 4 filt.│  │
+│  │ ⭐ Great  │ │ 🟢 Good  │ │ ⭐ Great  │ │ 🟢 Good│  │
+│  │ [Create] │ │ [Create] │ │ [Create] │ │[Create]│  │
+│  └──────────┘ └──────────┘ └──────────┘ └────────┘  │
+│                                                      │
+│  ── Browse by Category ────────────────────────────  │
+│                                                      │
+│  [Nebulae]  [Galaxies]  [Star Clusters]  [Planetary] │
+│                                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+**Card contents:**
+- Thumbnail — from MAST preview image if available, or a generic placeholder by category
+- Target name (common name if known, otherwise catalog ID)
+- Instrument(s) available
+- Number of usable filters
+- Composite potential score: Great (5+ filters, multi-instrument) / Good (3-4 filters) / Limited (1-2)
+- "Create" button → enters guided flow
+
+**"New from JWST" logic:**
+- Query MAST for observations released in last 30-90 days
+- Group by target/program
+- Score each group by composite potential (filter count, spatial coverage, instrument diversity)
+- Show top N, sorted by score then recency
+- Auto-refresh daily or on page load
+
+**Featured targets:**
+- Curated list of known-good targets (maintained as JSON/config)
+- Each entry: target name, MAST search params, example composite thumbnail, description
+- Start with ~10-15 iconic targets (the ones NASA already made press releases for)
+- Users will discover these produce great results since the data quality is proven
+
+**Categories:**
+- Map from MAST `target_classification` or `dataproduct_type`
+- Top-level: Nebulae, Galaxies, Star Clusters, Planetary/Solar System
+- Clicking a category shows a filtered discovery feed
+
+---
+
+### 2. Target Detail Page (`/target/:name` or `/target/:programId`)
+
+After clicking a card or searching, show what's available for this target.
+
+```
+┌─────────────────────────────────────────────────────┐
+│  ← Back                                [My Library]  │
+│                                                      │
+│  Carina Nebula (NGC 3372)                            │
+│  Program 2731 · NIRCam · Released 2022-07-12         │
+│                                                      │
+│  ── Suggested Composites ──────────────────────────  │
+│                                                      │
+│  ┌─────────────────────────────────────────────────┐ │
+│  │ ⭐ Recommended: 6-filter NIRCam                  │ │
+│  │                                                   │ │
+│  │ F090W · F187N · F200W · F335M · F444W · F470N    │ │
+│  │ [color swatch for each filter's mapped hue]      │ │
+│  │                                                   │ │
+│  │ Uses all available filters for maximum detail.    │ │
+│  │ Estimated processing time: ~45 seconds.           │ │
+│  │ Mosaic needed: No (single pointing)               │ │
+│  │                                                   │ │
+│  │              [ Create This Composite ]            │ │
+│  └─────────────────────────────────────────────────┘ │
+│                                                      │
+│  ┌─────────────────────────────────────────────────┐ │
+│  │ Classic 3-color                                   │ │
+│  │ F090W (blue) · F200W (green) · F444W (red)       │ │
+│  │ Quick & simple. ~15 seconds.                      │ │
+│  │              [ Create This Composite ]            │ │
+│  └─────────────────────────────────────────────────┘ │
+│                                                      │
+│  ┌─────────────────────────────────────────────────┐ │
+│  │ Narrowband Highlight                              │ │
+│  │ F187N (H-alpha) · F335M (PAH) · F470N ([ArIII]) │ │
+│  │ Emphasizes gas and emission features. ~15 sec.    │ │
+│  │              [ Create This Composite ]            │ │
+│  └─────────────────────────────────────────────────┘ │
+│                                                      │
+│  ── Or customize ──────────────────────────────────  │
+│  [ Advanced: Choose your own filters → ]             │
+│                                                      │
+│  ── Available Observations (12 files) ─────────────  │
+│  (collapsible table of individual FITS files)        │
+│                                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+**Suggestion engine logic:**
+- Takes the set of available observations for a target
+- Groups by instrument
+- For each instrument, generates recipes:
+  1. "All available" — use every filter, N-channel composite
+  2. "Classic 3-color" — pick 3 well-separated wavelengths (short=blue, mid=green, long=red)
+  3. "Narrowband" — if narrowband filters present (N suffix), group them
+  4. "Broadband" — if broadband (W suffix) available, clean wide-field composite
+- Each recipe includes: filter list, auto-assigned colors, estimated time, mosaic requirement
+- Rank by "visual impact" — more filters and wider wavelength spread = higher rank
+- "Recommended" = highest-ranked recipe
+
+**Mosaic detection:**
+- Check if multiple observations per filter share spatial overlap (compare RA/Dec + FOV)
+- If yes, note "Mosaic needed" and handle transparently in the creation flow
+- If observations don't overlap, they're separate pointings — offer each independently
+
+---
+
+### 3. Creation Flow (`/create`)
+
+After user clicks "Create This Composite" — a guided, mostly-automatic flow.
+
+```
+Step 1: Download          Step 2: Processing        Step 3: Your Composite
+━━━━━━━━━━━━●━━━━━━━━━━━━━━━━━━━━○━━━━━━━━━━━━━━━━━━━━○━━━
+
+┌─────────────────────────────────────────────────────┐
+│                                                      │
+│  Downloading Carina Nebula data...                   │
+│                                                      │
+│  ████████████████████░░░░░  4 of 6 files             │
+│                                                      │
+│  F090W  ✓ complete     (42 MB)                       │
+│  F187N  ✓ complete     (42 MB)                       │
+│  F200W  ✓ complete     (42 MB)                       │
+│  F335M  ████████░░░░   67% (28/42 MB)               │
+│  F444W  waiting...                                   │
+│  F470N  waiting...                                   │
+│                                                      │
+│  Using S3 direct access (faster)                     │
+│                                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+```
+Step 1: Download          Step 2: Processing        Step 3: Your Composite
+━━━━━━━━━━━━━━━━━━━━━━━━━●━━━━━━━━━━━●━━━━━━━━━━━━━━━━○━━━
+
+┌─────────────────────────────────────────────────────┐
+│                                                      │
+│  Creating your composite...                          │
+│                                                      │
+│  ✓ Files loaded                                      │
+│  ✓ Aligning to common grid                           │
+│  ● Applying color mapping...                         │
+│  ○ Final adjustments                                 │
+│                                                      │
+│  (This usually takes 30-60 seconds)                  │
+│                                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+```
+Step 1: Download          Step 2: Processing        Step 3: Your Composite
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━●━━━
+
+┌─────────────────────────────────────────────────────┐
+│                                                      │
+│  ┌───────────────────────────────────────────────┐   │
+│  │                                               │   │
+│  │                                               │   │
+│  │          (composite preview image)            │   │
+│  │                                               │   │
+│  │                                               │   │
+│  │                                               │   │
+│  └───────────────────────────────────────────────┘   │
+│                                                      │
+│  Carina Nebula — 6-filter NIRCam Composite           │
+│  Filters: F090W · F187N · F200W · F335M · F444W ·   │
+│           F470N                                      │
+│                                                      │
+│  ── Quick Adjustments ─────────────────────────────  │
+│  Brightness  ├────────●──────┤                       │
+│  Contrast    ├──────────●────┤                       │
+│  Saturation  ├───────●───────┤                       │
+│                                                      │
+│  [ Download PNG ]  [ Download JPEG ]                 │
+│                                                      │
+│  ── Want more control? ────────────────────────────  │
+│  [ Open in Advanced Editor → ]                       │
+│  (per-channel stretch, smoothing, annotations, etc.) │
+│                                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+**Key design decisions:**
+- Download + processing are sequential but feel like one flow
+- Existing download progress UI reused
+- Composite generation uses the job queue + SignalR (existing infra)
+- "Quick Adjustments" = simplified controls that map to existing stretch params
+  - Brightness → black/white point shift
+  - Contrast → stretch method or gamma
+  - Saturation → channel weight balance
+- "Advanced Editor" → opens existing ImageViewer/CompositeWizard with full controls
+- Export uses existing export flow (PNG/JPEG with resolution presets)
+
+---
+
+### 4. My Library (`/library`)
+
+The current dashboard, relocated. Contains:
+- Previously downloaded observations (existing DataCard grid)
+- Saved composites/mosaics/exports
+- Access to full viewer and all advanced tools
+- Upload functionality for local FITS files
+
+This is where power users live. The guided flow adds data here automatically.
+
+---
+
+## Navigation Structure
+
+```
+Home (/)
+├── Target Detail (/target/:name)
+│   └── Create Flow (/create?target=X&recipe=Y)
+│       └── Result → Advanced Editor (existing viewer modal)
+├── My Library (/library)  ← current dashboard
+│   ├── Viewer (modal, existing)
+│   ├── Composite Wizard (modal, existing)
+│   ├── Mosaic Wizard (modal, existing)
+│   └── MAST Search (existing, for manual searches)
+└── Search Results (/search?q=...)
+```
+
+**Routing change:** Moves from single-page modal-only to actual routes. Browser back button works. Deep-linking possible (foundation for permalinks later).
+
+---
+
+## New Backend Needs
+
+### 1. Suggestion Engine Endpoint
+
+```
+POST /api/discovery/suggest-composites
+Body: { targetName: string } or { observations: MastObservation[] }
+Response: {
+  target: { name, commonName, ra, dec, category },
+  recipes: [
+    {
+      name: "6-filter NIRCam",
+      rank: 1,
+      filters: ["F090W", "F187N", ...],
+      colorMapping: { "F090W": "#4444ff", ... },
+      instruments: ["NIRCam"],
+      requiresMosaic: false,
+      estimatedTimeSeconds: 45,
+      observationIds: ["obs1", "obs2", ...]
+    },
+    ...
+  ]
+}
+```
+
+Logic lives in Python processing engine (knows about JWST filters, wavelengths, instruments). Backend proxies.
+
+### 2. Featured Targets Config
+
+Start as a static JSON file:
+```json
+[
+  {
+    "name": "Carina Nebula",
+    "catalogId": "NGC 3372",
+    "category": "nebula",
+    "thumbnail": "/featured/carina-thumb.jpg",
+    "description": "Star-forming region, one of JWST's first images",
+    "mastSearchParams": { "target": "Carina Nebula", "instrument": "NIRCam" }
+  },
+  ...
+]
+```
+
+Can be promoted to a database-backed API later if we want community submissions.
+
+### 3. Recent Releases Query
+
+```
+GET /api/discovery/recent?days=30&minFilters=3
+```
+
+Wraps MAST search with:
+- `t_obs_release` date filter
+- Groups results by target
+- Scores composite potential
+- Returns top N targets with metadata
+
+### 4. Common Name Resolution
+
+Many MAST targets use catalog IDs (NGC, IC, Messier). Need a mapping to common names:
+- "NGC 3372" → "Carina Nebula"
+- "M16" → "Eagle Nebula / Pillars of Creation"
+- Could use SIMBAD API or a static lookup table
+
+---
+
+## What Changes vs. Stays
+
+### Stays (reused as-is):
+- All Python processing (composite, mosaic, preview, stretch)
+- S3/local storage providers
+- MAST search and download APIs
+- Export pipeline
+- Job queue + SignalR progress
+- Auth system
+- MongoDB data model
+
+### Changes:
+- **New frontend pages:** Home (discovery), Target Detail, Create Flow
+- **Router:** Add actual routes instead of modal-only navigation
+- **Dashboard:** Becomes "My Library" at `/library`
+- **New API endpoints:** suggestion engine, featured targets, recent releases
+- **New Python logic:** composite recipe scoring, filter grouping
+
+### Deferred (post-v1):
+- "New from JWST" discovery feed
+- Light mode
+- Sharing/gallery
+- Community-submitted featured targets
+- Category browsing
+- Common name resolution via SIMBAD
+- Public (no-auth) home page
+
+---
+
+## v1 Scope (Finalized)
+
+### In v1
+- **Home page** — featured targets (static JSON, ~10-15 curated) + search bar
+- **Target detail page** — suggestion engine shows 2-3 composite recipes per target
+- **Guided creation flow** — download → auto-mosaic if needed → auto-composite → simple adjustments → export
+- **My Library** — current dashboard relocated to `/library`, all existing tools accessible
+- **React Router** — real routes (`/`, `/library`, `/target/:name`, `/create`), browser back works
+- **Suggestion engine** — new Python endpoint for recipe generation (filter grouping, scoring, mosaic detection)
+- **Featured targets config** — static JSON with ~10-15 curated targets + MAST search params
+- **Chromatic ordering color mapping** — replace absolute wavelength→hue with relative chromatic ordering (shortest=blue, longest=red, middle filters evenly spaced). Matches how STScI/DePasquale creates NASA press releases. See `docs/plans/color-mapping-research.md` for analysis.
+- **Smart defaults** — stretch/color settings tuned so first composite looks good without tweaking
+- **Token enforcement** — design system consistency across all pages in the core loop
+- **Loading/error states** — for discovery, download, processing, and result screens
+
+### NOT in v1
+- "New from JWST" discovery feed (v1.1 — needs date queries + scoring)
+- Categories / browse by type (v1.1)
+- Common name resolution via SIMBAD (featured targets have names hardcoded)
+- Light mode
+- Sharing / gallery / public links
+- Public home page (auth still required for v1)
+- Pre-computed thumbnails (use MAST preview images or placeholders)
+- Mobile-optimized layouts
+- Onboarding tooltips (guided flow IS the onboarding)
+- Remaining Phase 5 items (batch processing, spectral analysis, photometry)
+- Smoothing/annotations/source detection polish (stays in Advanced Editor as-is)
+
+### NOT in v1 but stays accessible
+All existing power-user features live in My Library → Viewer. No changes needed — they're the advanced layer for users who go deeper.
+
+---
+
+## Phased Implementation
+
+### Phase A — Foundation (routing + home page shell)
+- Add React Router with actual routes (`/`, `/library`, `/target/:name`, `/create`)
+- Move current dashboard to `/library`
+- Create Home page component with search bar + featured target cards
+- Featured targets JSON config (~10-15 entries with MAST search params)
+- Design token enforcement on new pages from the start
+
+### Phase B — Suggestion Engine + Target Detail
+- Python endpoint: given MAST observations, generate composite recipes
+- Filter grouping logic (broadband vs narrowband, wavelength sorting)
+- Multi-pointing detection (compare RA/Dec separation vs instrument FOV)
+- Recipe scoring (filter count, wavelength spread, known-good combos)
+- **Chromatic ordering color mapping** — new `chromatic_order` mode in `color_mapping.py` and `wavelengthUtils.ts`. Sort filters by wavelength, assign blue→green→orange→red spread relative to the set. Keep existing hue-based mode as "scientific" option. Apply chromatic ordering as default for auto-assign and all recipes.
+- .NET proxy endpoint
+- Target detail page wired to suggestion engine
+- Search results page (target search → target detail)
+
+### Phase C — Guided Creation Flow
+- Orchestration: download → auto-mosaic (if multi-pointing) → auto-composite
+- All via job queue + SignalR with stage-by-stage progress
+- Smart default stretch/color settings (tuned per recipe)
+- Result screen with simple sliders (brightness, contrast, saturation)
+- PNG/JPEG export (existing pipeline)
+- "Open in Advanced Editor" escape hatch to existing viewer/wizard
+- Data automatically appears in My Library after creation
+
+### Phase D — Polish + Release Prep
+- Token enforcement across all touched components
+- Loading skeletons for home page and target detail
+- Error states (MAST down, download failures, composite failures)
+- Test the full flow end-to-end with all featured targets
+- Curate and verify featured targets produce good results
+- Update documentation for new architecture
+
+---
+
+## Open Questions
+
+1. ~~**Mosaic in guided flow v1?**~~ **ANSWERED: No, mosaic is required for v1.** MAST data shows multi-pointing is common even for iconic targets (Stephan's Quintet MIRI = 3-7 pointings, Tarantula Nebula = 2-3 pointings across both instruments, SMACS 0723 = 2 pointings on some filters). The guided flow must handle "download → auto-mosaic if needed → composite" as one seamless step.
+
+2. **Auth for home page?** Currently everything requires login. Should the discovery feed be public (drives adoption) with login required only for creating composites?
+
+3. **Pre-computed composites for featured targets?** Could ship with pre-generated thumbnails for featured targets so the home page looks rich immediately. Users create their own version when they click "Create."
+
+4. **Download storage management?** If many users create composites from popular targets, the same FITS files get downloaded repeatedly. Cache at the app level? Shared storage for popular targets?
+
+5. **How to handle targets with 100+ observations?** Some programs have massive observation sets (e.g., Stephan's Quintet = 292 obs). Need pagination and smart grouping on the target detail page.

--- a/docs/plans/job-queue-websocket-progress.md
+++ b/docs/plans/job-queue-websocket-progress.md
@@ -1,0 +1,319 @@
+# Job Queue + WebSocket Progress
+
+## Context
+
+All long-running operations use 500ms HTTP polling for progress. MAST downloads already have a job-based pattern (enqueue, poll, completion), but composite and mosaic generation are fully synchronous — the HTTP request blocks for up to 10 minutes. There's no server-push infrastructure.
+
+**Goal:** Replace polling with SignalR (WebSocket) push, make composite/mosaic generation async with job IDs, and unify all job tracking into one system.
+
+## Non-Goals
+
+- No Redis/RabbitMQ in this phase
+- No processing-engine WebSocket changes (stays HTTP-only)
+- No breaking changes to existing import endpoints until cleanup phase
+
+## Current State
+
+| Operation | Duration | Pattern | Progress |
+|-----------|----------|---------|----------|
+| MAST download | Minutes | Async job + polling | Byte-level, 500ms polls |
+| Composite gen | 2-60s | Synchronous HTTP | None (spinner) |
+| Mosaic gen | 10-60+s | Synchronous HTTP | None (spinner) |
+| Mosaic save | 10-60+s | Synchronous HTTP | None (spinner) |
+
+**Existing patterns to reuse:**
+- `ThumbnailQueue` + `ThumbnailBackgroundService` — proven `Channel<T>` + `BackgroundService` pattern (`Services/ThumbnailQueue.cs`, `Services/ThumbnailBackgroundService.cs`)
+- `ImportJobTracker` — singleton `ConcurrentDictionary<string, ImportJobStatus>` with 30-min cleanup, cancellation token support (`Services/ImportJobTracker.cs`)
+- `IStorageProvider` — storage abstraction with `WriteAsync`, `ReadStreamAsync`, `DeleteAsync`, `ListAsync` (`Services/Storage/IStorageProvider.cs`)
+- CORS already has `.AllowCredentials()` (required for SignalR)
+- MongoDB already in use (`jwst_data`, `users` collections) — no new infrastructure for adding a `jobs` collection
+- Processing engine downloads already use `asyncio.create_task()` background jobs
+
+## Hard Decisions (locked before coding)
+
+1. **Job ownership is mandatory** — every job stores `OwnerUserId`. Authorization checked on subscribe, status fetch, cancel, and result retrieval. Anonymous users only hit sync preview endpoints; async operations require authentication.
+2. **MongoDB persistence** — job metadata persisted to `jobs` collection. Survives restarts. In-memory `ConcurrentDictionary` remains as hot cache, MongoDB is the durable source of truth.
+3. **Results via IStorageProvider** — async job results written to `tmp/jobs/{jobId}/result.{ext}`, not raw filesystem paths. Cleanup via `ListAsync("tmp/jobs/")` + `DeleteAsync`.
+4. **Sync/async split is intent-based, not dimension-based** — preview endpoints (called by the preview button) stay synchronous. Export/download/save endpoints (called by export and save buttons) return `202 Accepted` with `{ jobId }`. The caller's intent determines the path, not an arbitrary width threshold. This is cleaner because processing time depends on channel count, file sizes, and engine load — not just output width.
+5. **Backpressure is explicit** — bounded channels; `TryWrite()` failure returns `429 Too Many Requests` with `Retry-After` header.
+6. **Compatibility first** — old import polling endpoints remain until Phase 6.
+7. **Result TTL extends on access** — completed jobs expire 30 minutes after last access (not after completion). Each `GET /api/jobs/{jobId}/result` resets the TTL. `ExpiresAt` is included in the `JobCompleted` event so the frontend can display a countdown or warning. The reaper deletes both the job metadata and IStorageProvider artifacts when TTL passes.
+
+## Canonical Job Contract
+
+### JobStatus (API DTO)
+
+**Core fields (all job types):**
+- `JobId`, `JobType` (import/composite/mosaic), `State`, `Description`
+- `OwnerUserId`
+- `ProgressPercent` (0-100), `Stage`, `Message`
+- `Error` (null unless failed)
+- `CreatedAt`, `StartedAt`, `UpdatedAt`, `CompletedAt`, `ExpiresAt`
+- `CancelRequested`
+
+**Result fields (populated on completion):**
+- `ResultKind` — `blob` (binary file to download) or `data_id` (MongoDB record reference)
+- `ResultStorageKey` — IStorageProvider key for blob results
+- `ResultContentType` — MIME type (e.g., `image/png`)
+- `ResultFilename` — suggested download filename
+- `ResultDataId` — for mosaic save (references the saved data record)
+
+**Type-specific fields (stored in `Metadata` dictionary):**
+- Import jobs: `DownloadedBytes`, `TotalBytes`, `SpeedBytesPerSec`, `EtaSeconds`, `FileProgress`
+- Composite/mosaic: no extra fields needed initially
+
+**State machine:** `queued` → `running` → `completed` | `failed` | `cancelled`
+
+## Architecture
+
+```
+Frontend (React)
+    |
+    |-- SignalR WebSocket --> .NET Hub (push progress)
+    |                              |
+    +-- REST fallback -------> .NET Controllers
+                                   |
+                              JobTracker (unified, MongoDB-backed)
+                                   |
+                          +--------+--------+
+                          |        |        |
+                     Composite  Mosaic   Import
+                     Queue      Queue    (existing, adapted)
+                          |        |        |
+                     Background Background  Task.Run
+                     Service    Service    (existing)
+                          |        |        |
+                          +--------+--------+
+                                   |
+                          Processing Engine (HTTP, unchanged)
+```
+
+**Key decisions:**
+- **SignalR groups** (`job-{jobId}`) — multiple tabs work, reconnection requests `JobSnapshot`
+- **Hub events:** `JobProgress`, `JobCompleted`, `JobFailed`, `JobSnapshot` (full state on reconnect)
+- **No new infrastructure** — MongoDB (existing) + in-memory channels. Redis backplane is one line if horizontal scaling is ever needed
+- **Processing engine unchanged** — stays HTTP-only. Backend is the sole WebSocket hub
+- **Graceful degradation** — `useJobProgress` hook tries SignalR first, falls back to 500ms polling
+- **Startup reconciliation** — on server start, mark any `queued`/`running` jobs in MongoDB as `failed` with reason `service_restart`
+- **Cancellation asymmetry** — MAST imports support real cancellation (processing engine has cancel endpoint). Composite/mosaic cancel means "don't deliver the result" — the background service checks `CancelRequested` before calling the processing engine, and again after the call returns (to skip storage write). The processing engine computation may still run to completion if cancel arrives mid-processing
+
+## API + Hub Contracts
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/jobs` | GET | List caller's jobs (filtered by status, type). Safety net for page refresh |
+| `/api/jobs/{jobId}` | GET | Unified job status (polling fallback) |
+| `/api/jobs/{jobId}/cancel` | POST | Cancel any cancellable job |
+| `/api/jobs/{jobId}/result` | GET | Stream blob result (authorized, resets TTL) |
+| `/hubs/job-progress` | SignalR | WebSocket push |
+
+Hub client methods: `SubscribeToJob(jobId)`, `UnsubscribeFromJob(jobId)`
+Hub server events: `JobProgress`, `JobCompleted`, `JobFailed`, `JobSnapshot`
+
+## Implementation Notes
+
+**Docker/proxy WebSocket config:** If Docker Compose has a reverse proxy (nginx, traefik) in front of the .NET API, it needs WebSocket passthrough (`Upgrade` and `Connection` headers). Verify during Phase 1 — if it's direct port forwarding, no action needed.
+
+**Import backpressure gap:** Import jobs stay as `Task.Run` (existing) and don't go through `Channel<T>`. The processing engine is the natural bottleneck for imports. This is an accepted inconsistency — not worth the migration cost in this phase.
+
+**Structured logging:** Every job lifecycle event should be logged with structured fields: `Job {JobId} created by {UserId}, type={JobType}`, `Job {JobId} completed in {Duration}ms`, `Job {JobId} failed: {Error}`. Queue depth logged on enqueue/dequeue for observability.
+
+## Implementation Phases
+
+### Phase 1: SignalR Infrastructure (PR)
+Purely additive — no behavioral changes.
+
+**Backend (new):**
+- `Hubs/JobProgressHub.cs` — hub with `[Authorize]`, `SubscribeToJob(jobId)`, `UnsubscribeFromJob(jobId)`. Ownership guard on subscribe. Server pushes `JobProgress`, `JobCompleted`, `JobFailed`, `JobSnapshot` to groups
+- `Services/IJobProgressNotifier.cs` + `JobProgressNotifier.cs` — wraps `IHubContext<JobProgressHub>`, provides `NotifyProgressAsync()`, `NotifyCompletedAsync()`, `NotifyFailedAsync()`, `SendSnapshotAsync()`
+- `Models/JobProgressModels.cs` — `JobProgressUpdate`, `JobCompletionUpdate`, `JobFailureUpdate`, `JobSnapshotUpdate`
+
+**Backend (modify):**
+- `Program.cs` — `builder.Services.AddSignalR()`, `app.MapHub<JobProgressHub>("/hubs/job-progress")`, register `IJobProgressNotifier`, add JWT `OnMessageReceived` handler to extract token from query string for hub route
+- `JwstDataAnalysis.API.csproj` — SignalR is built into .NET 10, likely no extra package needed
+
+**Frontend (new):**
+- `src/services/signalRService.ts` — connection manager with auto-reconnect, `subscribeToJob()` returns unsubscribe function. **Token must be fetched dynamically** via `accessTokenFactory: () => getAccessToken()` on each connection/reconnect — do NOT capture the token once at creation time (it may expire during long-running jobs)
+- `src/types/JobTypes.ts` — `JobProgressUpdate`, `JobCompletionUpdate`, `JobFailureUpdate`, `JobSnapshotUpdate` types
+
+**Frontend (modify):**
+- `package.json` — add `@microsoft/signalr`
+
+**Tests (this phase):**
+- Hub connection with valid JWT succeeds
+- Hub connection without JWT is rejected
+- `SubscribeToJob` with non-owned jobId is rejected
+- `JobProgressNotifier` sends to correct SignalR group
+- Verify WebSocket connects through Docker networking (manual: devtools Network tab)
+
+### Phase 2: Unified Job Tracker (PR)
+Generalize `ImportJobTracker` into universal `JobTracker`. MongoDB-backed with in-memory cache. Ownership enforced. Pushes to SignalR on every state change.
+
+**Backend (new):**
+- `Services/IJobTracker.cs` — `CreateJob(type, description, userId)`, `UpdateProgress()`, `UpdateByteProgress()`, `CompleteJob()`, `FailJob()`, `CancelJob()`, `GetJob(jobId, userId)` (authorized), `GetJobsForUser(userId, status?, type?)` (list endpoint backing)
+- `Services/JobTracker.cs` — `ConcurrentDictionary` hot cache + MongoDB `jobs` collection as durable store. Injects `IJobProgressNotifier`, auto-pushes on mutation. 30-min TTL after last access (not after completion). Background reaper cleans expired jobs + IStorageProvider artifacts
+- `Controllers/JobsController.cs` — `GET /api/jobs` (list, filtered by owner + optional status/type query params), `GET /api/jobs/{jobId}` (status), `POST /api/jobs/{jobId}/cancel`, `GET /api/jobs/{jobId}/result` (stream blob, resets TTL). All endpoints check job ownership
+- `Models/JobStatus.cs` — unified status model per canonical contract above
+- Startup reconciliation: `IHostedService` that marks `queued`/`running` MongoDB jobs as `failed` on boot
+
+**Backend (modify):**
+- `ImportJobTracker.cs` — becomes thin dual-write adapter: writes to both old in-memory tracker AND new `IJobTracker` with `jobType = "import"`. Existing callers unchanged
+- `Program.cs` — register `IJobTracker` as singleton, register reaper background service
+
+**Tests (this phase):**
+- `JobTracker` CRUD: create, update progress, complete, fail, cancel
+- MongoDB persistence: create job, restart (clear in-memory cache), verify job loads from MongoDB
+- Startup reconciliation: seed `running` job in MongoDB, trigger reconciliation, verify it's marked `failed`
+- Ownership enforcement: `GetJob` with wrong userId returns null/403
+- `GET /api/jobs` returns only caller's jobs, respects status/type filters
+- Result TTL: verify `ExpiresAt` resets on result access
+- Reaper: verify expired jobs + storage artifacts are cleaned up
+
+**Docs (this phase):**
+- `key-files.md` — add `JobsController`, `JobTracker`, `IJobTracker`, `JobStatus`, `JobProgressNotifier`, `JobProgressHub`
+- `backend-development.md` — add to controllers/services list, add `/api/jobs` endpoints
+- `architecture.md` — update Backend Service Layer diagram with JobTracker + queues
+- `quick-reference.md` — add `/api/jobs`, `/api/jobs/{jobId}`, `/api/jobs/{jobId}/cancel`, `/api/jobs/{jobId}/result`
+
+### Phase 3: MAST Frontend Migration (PR)
+Migrate both polling consumers (WhatsNewPanel + MastSearch) in one PR — they use identical polling patterns and the same hook.
+
+**Frontend (new):**
+- `src/hooks/useJobProgress.ts` — React hook: tries SignalR subscription, falls back to polling `GET /api/jobs/{jobId}` at 500ms. Handles `JobSnapshot` on reconnect. Returns `{ progress, error, isComplete, cancel }`. On failure/cancel, surfaces error state for the component to render (toast, inline error, etc.)
+
+**Frontend (modify):**
+- `WhatsNewPanel.tsx` — replace polling loop with `useJobProgress(jobId)`
+- `MastSearch.tsx` — replace 3 inline polling loops with `useJobProgress(jobId)`. Covers single import, resume, cancel, and bulk import flows. Progress modal UI unchanged
+
+**Backend:** No changes needed — Phase 2's dual-write adapter already pushes on every update.
+
+**Tests (this phase):**
+- `useJobProgress` hook: subscribes via SignalR, receives progress updates
+- `useJobProgress` hook: falls back to polling when SignalR unavailable
+- `useJobProgress` hook: handles reconnect with `JobSnapshot` catch-up
+
+### Phase 4: Async Composite Generation (PR)
+Make composite exports non-blocking. Previews stay synchronous.
+
+**Backend (new):**
+- `Services/CompositeQueue.cs` — bounded `Channel<CompositeJobItem>(10)` (same pattern as `ThumbnailQueue`). `TryWrite()` failure -> 429
+- `Services/CompositeBackgroundService.cs` — reads queue, checks `CancelRequested` before calling processing engine, calls existing `CompositeService.GenerateNChannelCompositeAsync()`, checks `CancelRequested` again after return (skip storage write if cancelled), writes result via `IStorageProvider` to `tmp/jobs/{jobId}/result.{format}`, updates `IJobTracker`
+
+**Backend (modify):**
+- `CompositeController.cs`:
+  - Preview endpoint — stays synchronous (existing behavior unchanged)
+  - Export endpoint — returns `202 Accepted` with `{ jobId }`, enqueues to `CompositeQueue`
+  - Result retrieval via `JobsController.GetResult` (no separate endpoint needed)
+- `Program.cs` — register queue + background service
+
+**Frontend (modify):**
+- `compositeService.ts` — handle dual response (blob for sync preview, JSON with jobId for async export)
+- `CompositePreviewStep.tsx` — preview unchanged; export shows progress via `useJobProgress`, fetches result from `/api/jobs/{jobId}/result` on completion. Error/cancel states shown inline in the export modal
+
+**Tests (this phase):**
+- Export returns 202 with jobId
+- Preview stays synchronous (returns image bytes directly)
+- Queue-full returns 429 with Retry-After header
+- Background service writes result to IStorageProvider on completion
+- Cancelled job: background service skips storage write
+- `GET /api/jobs/{jobId}/result` streams the stored blob
+
+**Docs (this phase):**
+- `backend-development.md` — update composite endpoint docs (sync preview + async export)
+- `quick-reference.md` — update composite endpoints
+
+### Phase 5: Async Mosaic Generation (PR)
+Same pattern as Phase 4 for mosaics.
+
+**Backend (new):**
+- `Services/MosaicQueue.cs` — bounded `Channel<MosaicJobItem>(10)`
+- `Services/MosaicBackgroundService.cs` — reads queue, checks `CancelRequested`, calls existing `MosaicService` methods, checks `CancelRequested` after return
+
+**Backend (modify):**
+- `MosaicController.cs`:
+  - `POST /api/mosaic/generate` — sync for preview, async for export
+  - `POST /api/mosaic/generate-and-save` — always async (heavy operation). Returns 202 + jobId. Completion result includes `ResultDataId` (the saved data record)
+  - Result retrieval via `JobsController.GetResult`
+- `Program.cs` — register queue + background service
+
+**Frontend (modify):**
+- `mosaicService.ts` — handle dual response
+- `MosaicPreviewStep.tsx` — async save shows progress, notifies on completion with saved data ID. Error/cancel states shown inline
+
+**Tests (this phase):**
+- Generate-and-save returns 202 with jobId
+- Preview stays synchronous
+- Completion includes `ResultDataId` for saved mosaic
+- Queue-full returns 429
+
+**Docs (this phase):**
+- `backend-development.md` — update mosaic endpoint docs (sync preview + async export/save)
+- `quick-reference.md` — update mosaic endpoints
+
+### Phase 6: Cleanup + Polish (PR)
+- Remove dead polling code from `MastSearch.tsx`, `WhatsNewPanel.tsx`
+- Remove `ImportJobTracker` dual-write adapter — `IJobTracker` is now the sole source of truth (only if parity is validated; otherwise defer)
+- Add connection status indicator in app header (connected/reconnecting/disconnected)
+- Mark old `GET /api/mast/import-progress/{jobId}` as `[Obsolete]` in Swagger
+- Handle edge cases: browser sleep (SignalR auto-reconnects + `JobSnapshot` catch-up), server restart (startup reconciliation already handles this)
+
+**Docs (this phase):**
+- `architecture.md` — final diagram update showing SignalR + job system
+- `frontend-development.md` — document `useJobProgress` hook, `signalRService`, connection lifecycle
+- `desktop-requirements.md` — note WebSocket requirement
+- `development-plan.md` — mark completed tasks
+
+## New Files Summary
+
+**Backend (~13 new files):**
+- `Hubs/JobProgressHub.cs`
+- `Services/IJobTracker.cs`, `Services/JobTracker.cs`
+- `Services/IJobProgressNotifier.cs`, `Services/JobProgressNotifier.cs`
+- `Services/JobReaperBackgroundService.cs`
+- `Services/StartupReconciliationService.cs`
+- `Services/CompositeQueue.cs`, `Services/CompositeBackgroundService.cs`
+- `Services/MosaicQueue.cs`, `Services/MosaicBackgroundService.cs`
+- `Controllers/JobsController.cs`
+- `Models/JobProgressModels.cs`, `Models/JobStatus.cs`
+
+**Frontend (~3 new files):**
+- `src/services/signalRService.ts`
+- `src/hooks/useJobProgress.ts`
+- `src/types/JobTypes.ts`
+
+## Risk
+
+| Phase | Risk | Mitigation |
+|-------|------|------------|
+| 1 | Low | Purely additive SignalR setup, nothing changes behavior |
+| 2 | Low | Additive job tracker + MongoDB collection. Import adapter is dual-write (old + new) |
+| 3 | Low-Medium | Both polling consumers migrated. Polling fallback active if SignalR fails |
+| 4 | Medium | Sync->async for composite. Preview stays sync. Export path is new |
+| 5 | Medium | Sync->async for mosaic. Same pattern as Phase 4 |
+| 6 | Low | Removing dead code + adapter teardown |
+
+Each phase is a separate PR. Revert any single phase without affecting others. System works at every phase boundary because old polling endpoints are preserved until Phase 6.
+
+## Go/No-Go Criteria
+
+Before merging Phase 6 (final cleanup), all of these must pass:
+- [ ] Authorization tests pass for hub subscribe, job status, job result, and cancel
+- [ ] Startup reconciliation marks in-flight jobs as failed on restart
+- [ ] Async composite export: 202 -> progress -> result download (end-to-end)
+- [ ] Async mosaic save: 202 -> progress -> saved data ID returned (end-to-end)
+- [ ] Queue-full returns 429 with Retry-After
+- [ ] No regression in import resume/cancel workflows
+- [ ] Polling fallback works when SignalR connection is unavailable
+- [ ] Result TTL extends on access, reaper cleans expired results
+- [ ] Job list endpoint returns correct jobs for authenticated user
+- [ ] All documentation updated per phase (not deferred)
+
+## Verification
+
+After each phase:
+1. Run full compliance check (`/compliance-check`)
+2. Phase 1: verify WebSocket connection opens in browser devtools (Network -> WS), JWT auth works on hub, Docker proxy passes WebSocket traffic
+3. Phase 3: WhatsNewPanel + MastSearch import progress arrives via WebSocket (no polling in Network tab)
+4. Phase 4: composite export returns 202, progress streams via WebSocket, result downloads correctly
+5. Phase 5: mosaic export returns 202, generate-and-save returns saved data ID on completion
+6. Phase 6: verify no `setInterval` polling calls remain in frontend code

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,3 +43,7 @@ nav:
       - Database Models: standards/database-models.md
       - Docker Deployment: standards/docker-deployment.md
       - Development Workflow: standards/development-workflow.md
+    - Plans:
+      - Guided Discovery Experience: plans/guided-discovery-experience.md
+      - Color Mapping Research: plans/color-mapping-research.md
+      - Job Queue & WebSocket Progress: plans/job-queue-websocket-progress.md


### PR DESCRIPTION
## Summary
Track v1 planning documents in git and add them to the mkdocs documentation site under a new **Plans** section.

## Why
These plans were living as untracked files. Getting them into git means they're versioned, searchable, and visible on the docs site for reference during implementation.

## Type of Change
- [x] Documentation

## Changes Made
- Added `docs/plans/guided-discovery-experience.md` — full v1 design (discovery page, target detail, guided creation flow, my library, phased implementation)
- Added `docs/plans/color-mapping-research.md` — analysis of NASA's chromatic ordering vs our wavelength-to-hue mapping, prompted by the Cranium Nebula release
- Added `docs/plans/job-queue-websocket-progress.md` — existing job queue/SignalR migration plan
- Updated `mkdocs.yml` — new Plans nav section with all three documents

## Test Plan
- [x] Pre-commit checks pass
- [ ] Verify docs site renders: `mkdocs serve` → navigate to Plans section
- [ ] Confirm all three plan pages load and render markdown correctly

## Documentation Checklist
- [x] mkdocs.yml updated with new nav entries
- [ ] No new controllers/services/endpoints (docs-only change)
- [ ] No tech-debt changes

## Tech Debt Impact
- [x] No tech debt impact

## Risk & Rollback
Risk: None — docs-only change, no code modified.
Rollback: Revert commit.

## Quality Checklist
- [x] Changes match the intent of the PR title
- [x] No unrelated changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)