### PR TITLE
fix: address Phase B review findings

### DIFF
--- a/frontend/jwst-frontend/src/utils/wavelengthUtils.ts
+++ b/frontend/jwst-frontend/src/utils/wavelengthUtils.ts
@@ -12,6 +12,7 @@ import {
 /**
  * Known JWST filter wavelengths in micrometers
  * Source: JWST documentation
+ * Keep in sync with processing-engine/app/discovery/recipe_engine.py:FILTER_WAVELENGTHS
  */
 const FILTER_WAVELENGTHS: Record<string, number> = {
   // NIRCam Short Wavelength filters

--- a/processing-engine/app/discovery/models.py
+++ b/processing-engine/app/discovery/models.py
@@ -39,7 +39,10 @@ class Recipe(BaseModel):
     filters: list[str] = Field(..., description="Filter names in this recipe")
     color_mapping: dict[str, str] = Field(..., description="Filter name to hex color")
     instruments: list[str] = Field(..., description="Instruments used")
-    requires_mosaic: bool = Field(default=False, description="Whether mosaic is needed")
+    requires_mosaic: bool = Field(
+        default=False,
+        description="Whether mosaic is needed (placeholder — spatial overlap detection not yet implemented)",
+    )
     estimated_time_seconds: int = Field(default=30, description="Estimated processing time")
     observation_ids: list[str] | None = Field(default=None, description="Observation IDs to use")
 

--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -14,7 +14,8 @@ from .models import ObservationInput, Recipe
 
 logger = logging.getLogger(__name__)
 
-# Known JWST filter wavelengths (micrometers) — mirrors frontend FILTER_WAVELENGTHS
+# Known JWST filter wavelengths (micrometers)
+# Keep in sync with frontend/jwst-frontend/src/utils/wavelengthUtils.ts:FILTER_WAVELENGTHS
 FILTER_WAVELENGTHS: dict[str, float] = {
     "F070W": 0.704,
     "F090W": 0.901,


### PR DESCRIPTION
## Summary
Addresses the 2 should-fix items from the reviewer's PR #491 code review.

## Why
The reviewer flagged two maintenance concerns: duplicate wavelength tables without cross-references, and `requires_mosaic` being described as functional when it's actually a placeholder.

## Type of Change
- [x] Bug fix

## Changes Made
- Add cross-reference comments between Python `FILTER_WAVELENGTHS` and TypeScript `FILTER_WAVELENGTHS` tables
- Document `requires_mosaic` field as a placeholder (spatial overlap detection not yet implemented)

## Test Plan
- [x] Comment-only changes — no behavioral impact

## Documentation Checklist
- [x] N/A — inline code comments only

## Tech Debt Impact
- [x] Reduces existing tech debt

## Risk & Rollback
Risk: None — comments only.
Rollback: Revert commit.

## Quality Checklist
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)