### PR TITLE
fix: align discovery frontend types with backend camelCase serialization

### DIFF
--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
@@ -31,7 +31,7 @@ export function RecipeCard({ recipe, targetName, isRecommended }: RecipeCardProp
           <span key={filter} className="recipe-filter-chip">
             <span
               className="recipe-filter-swatch"
-              style={{ backgroundColor: recipe.color_mapping[filter] || '#666' }}
+              style={{ backgroundColor: recipe.colorMapping[filter] || '#666' }}
             />
             {filter}
           </span>
@@ -43,7 +43,7 @@ export function RecipeCard({ recipe, targetName, isRecommended }: RecipeCardProp
           <div
             key={filter}
             className="recipe-color-bar-segment"
-            style={{ backgroundColor: recipe.color_mapping[filter] || '#666' }}
+            style={{ backgroundColor: recipe.colorMapping[filter] || '#666' }}
             title={filter}
           />
         ))}
@@ -52,8 +52,8 @@ export function RecipeCard({ recipe, targetName, isRecommended }: RecipeCardProp
       <div className="recipe-card-meta">
         <span>{recipe.instruments.join(' + ')}</span>
         <span className="recipe-card-dot">&middot;</span>
-        <span>{formatTime(recipe.estimated_time_seconds)}</span>
-        {recipe.requires_mosaic && (
+        <span>{formatTime(recipe.estimatedTimeSeconds)}</span>
+        {recipe.requiresMosaic && (
           <>
             <span className="recipe-card-dot">&middot;</span>
             <span className="recipe-card-mosaic">Mosaic needed</span>

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -52,7 +52,7 @@ function buildChannelPayloads(
   for (const filter of recipe.filters) {
     const dataIds = filterDataMap.get(filter.toUpperCase()) ?? [];
     if (dataIds.length === 0) continue;
-    const hexColor = recipe.color_mapping[filter] ?? '#ffffff';
+    const hexColor = recipe.colorMapping[filter] ?? '#ffffff';
     payloads.push({
       dataIds,
       color: { hue: hexToHue(hexColor) },
@@ -79,7 +79,7 @@ function toObservationInputs(observations: MastObservationResult[]): Observation
     inputs.push({
       filter: obs.filters,
       instrument: obs.instrument_name,
-      observation_id: obs.obs_id,
+      observationId: obs.obs_id,
     });
   }
   return inputs;
@@ -180,7 +180,7 @@ export function GuidedCreate() {
         // Get recipe suggestions
         const inputs = toObservationInputs(observations);
         const recipeResponse = await suggestRecipes(
-          { target_name: target, observations: inputs },
+          { targetName: target, observations: inputs },
           controller.signal
         );
         if (controller.signal.aborted) return;
@@ -513,7 +513,7 @@ export function GuidedCreate() {
           <ProcessStep
             targetName={target}
             recipeName={recipeName}
-            requiresMosaic={recipe?.requires_mosaic ?? false}
+            requiresMosaic={recipe?.requiresMosaic ?? false}
             phase={processPhase}
             progress={processProgress}
             error={processError}

--- a/frontend/jwst-frontend/src/pages/TargetDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.tsx
@@ -23,7 +23,7 @@ function toObservationInputs(observations: MastObservationResult[]): Observation
     inputs.push({
       filter: obs.filters,
       instrument: obs.instrument_name,
-      observation_id: obs.obs_id,
+      observationId: obs.obs_id,
     });
   }
   return inputs;
@@ -76,7 +76,7 @@ export function TargetDetail() {
         }
 
         const recipeResponse = await suggestRecipes(
-          { target_name: displayName, observations: inputs },
+          { targetName: displayName, observations: inputs },
           controller.signal
         );
 

--- a/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
+++ b/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
@@ -21,8 +21,8 @@ export type FeaturedTargetsResponse = FeaturedTarget[];
 export interface ObservationInput {
   filter: string;
   instrument: string;
-  wavelength_um?: number;
-  observation_id?: string;
+  wavelengthUm?: number;
+  observationId?: string;
 }
 
 /** A composite recipe suggestion from the recipe engine */
@@ -30,17 +30,17 @@ export interface CompositeRecipe {
   name: string;
   rank: number;
   filters: string[];
-  color_mapping: Record<string, string>;
+  colorMapping: Record<string, string>;
   instruments: string[];
-  requires_mosaic: boolean;
-  estimated_time_seconds: number;
-  observation_ids?: string[];
+  requiresMosaic: boolean;
+  estimatedTimeSeconds: number;
+  observationIds?: string[];
 }
 
 /** Target metadata returned with recipe suggestions */
 export interface TargetInfo {
   name?: string;
-  common_name?: string;
+  commonName?: string;
   ra?: number;
   dec?: number;
   category?: string;
@@ -48,7 +48,7 @@ export interface TargetInfo {
 
 /** Request body for POST /api/discovery/suggest-recipes */
 export interface SuggestRecipesRequest {
-  target_name?: string;
+  targetName?: string;
   observations: ObservationInput[];
 }
 


### PR DESCRIPTION
## Summary
Fix black screen on target detail page caused by frontend/backend JSON field naming mismatch.

## Why
ASP.NET serializes response fields as camelCase (`colorMapping`, `requiresMosaic`, `estimatedTimeSeconds`) but the frontend `CompositeRecipe` type used snake_case (`color_mapping`, `requires_mosaic`, `estimated_time_seconds`). This caused `RecipeCard` to crash accessing undefined properties when rendering recipe suggestions.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Updated `CompositeRecipe` type fields from snake_case to camelCase (`colorMapping`, `requiresMosaic`, `estimatedTimeSeconds`, `observationIds`)
- Updated `ObservationInput` type fields (`wavelengthUm`, `observationId`)
- Updated `SuggestRecipesRequest` type field (`targetName`)
- Updated `TargetInfo` type field (`commonName`)
- Updated all usages in `RecipeCard`, `TargetDetail`, and `GuidedCreate`

## Test Plan
- [x] All 831 frontend tests pass
- [ ] Navigate to target detail page (e.g. Carina Nebula) — recipe cards render with color swatches
- [ ] Verify color bar and filter chips display correctly
- [ ] Click "Create This Composite" — guided create flow initializes

## Documentation Checklist
- [x] No new controllers/services/endpoints added

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — only frontend type definitions and their usages changed. Backend is unmodified.
Rollback: Revert the commit.

## Quality Checklist
- [x] Code follows project conventions
- [x] Tests pass
- [x] No hardcoded secrets

Closes the target detail black screen issue (companion to #495).

🤖 Generated with [Claude Code](https://claude.com/claude-code)