### PR TITLE
feat: make discovery pages public, gate auth at download action

### DIFF
--- a/frontend/jwst-frontend/src/App.tsx
+++ b/frontend/jwst-frontend/src/App.tsx
@@ -14,18 +14,25 @@ import {
 /**
  * Root App component with routing.
  *
- * Public routes: /login, /register
- * Protected routes (wrapped in SharedLayout with persistent header + nav):
- *   / — Discovery home (featured targets + search)
- *   /library — My Library (the existing dashboard, relocated)
- *   /target/:name — Target detail (observations + suggested composites)
- *   /create — Guided creation flow (download → process → result)
+ * Public routes: /login, /register, and discovery/browse pages
+ * Protected routes: /library (requires login)
+ *
+ * The SharedLayout (header + nav) wraps all authenticated and public pages.
+ * GuidedCreate gates the import action itself, not the page load.
  */
 function App() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
+      {/* Public discovery pages — no login required to browse */}
+      <Route element={<SharedLayout />}>
+        <Route index element={<DiscoveryHome />} />
+        <Route path="target/:name" element={<TargetDetail />} />
+        <Route path="create" element={<GuidedCreate />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Route>
+      {/* Protected pages — login required */}
       <Route
         element={
           <ProtectedRoute>
@@ -33,11 +40,7 @@ function App() {
           </ProtectedRoute>
         }
       >
-        <Route index element={<DiscoveryHome />} />
         <Route path="library" element={<MyLibrary />} />
-        <Route path="target/:name" element={<TargetDetail />} />
-        <Route path="create" element={<GuidedCreate />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>
   );

--- a/frontend/jwst-frontend/src/components/UserMenu.css
+++ b/frontend/jwst-frontend/src/components/UserMenu.css
@@ -175,6 +175,28 @@
   background: var(--color-error-subtle);
 }
 
+/* Sign-in link for anonymous users */
+.header-login-link {
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
+  padding: 0 16px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary) !important;
+  font-size: 0.9rem;
+  text-decoration: none !important;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.header-login-link:hover {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: var(--accent-primary);
+}
+
 /* Hide on small screens, show only avatar */
 @media (max-width: 640px) {
   .user-name {

--- a/frontend/jwst-frontend/src/components/UserMenu.test.tsx
+++ b/frontend/jwst-frontend/src/components/UserMenu.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 const mockLogout = vi.fn();
 
@@ -24,6 +26,10 @@ vi.mock('../context/useAuth', () => ({
 
 import { UserMenu } from './UserMenu';
 
+function renderWithRouter(ui: ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
 describe('UserMenu', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,7 +42,7 @@ describe('UserMenu', () => {
   });
 
   it('renders user avatar with initials "TU" from "Test User"', () => {
-    render(<UserMenu />);
+    renderWithRouter(<UserMenu />);
 
     // The trigger avatar shows initials
     const avatars = screen.getAllByText('TU');
@@ -44,13 +50,13 @@ describe('UserMenu', () => {
   });
 
   it('shows user display name', () => {
-    render(<UserMenu />);
+    renderWithRouter(<UserMenu />);
 
     expect(screen.getByText('Test User')).toBeInTheDocument();
   });
 
   it('clicking trigger opens dropdown', () => {
-    render(<UserMenu />);
+    renderWithRouter(<UserMenu />);
 
     // Dropdown should not be visible initially
     expect(screen.queryByText('test@example.com')).not.toBeInTheDocument();
@@ -64,7 +70,7 @@ describe('UserMenu', () => {
   });
 
   it('dropdown shows email and organization', () => {
-    render(<UserMenu />);
+    renderWithRouter(<UserMenu />);
 
     // Open dropdown
     const trigger = screen.getByRole('button', { expanded: false });
@@ -75,7 +81,7 @@ describe('UserMenu', () => {
   });
 
   it('clicking Sign Out calls logout', () => {
-    render(<UserMenu />);
+    renderWithRouter(<UserMenu />);
 
     // Open dropdown
     const trigger = screen.getByRole('button', { expanded: false });
@@ -87,7 +93,7 @@ describe('UserMenu', () => {
   });
 
   it('escape key closes dropdown', () => {
-    render(<UserMenu />);
+    renderWithRouter(<UserMenu />);
 
     // Open dropdown
     const trigger = screen.getByRole('button', { expanded: false });
@@ -103,10 +109,11 @@ describe('UserMenu', () => {
     expect(screen.queryByText('test@example.com')).not.toBeInTheDocument();
   });
 
-  it('returns null when user is null', () => {
+  it('shows Sign In link when user is null', () => {
     mockUser = null;
 
-    const { container } = render(<UserMenu />);
-    expect(container.innerHTML).toBe('');
+    renderWithRouter(<UserMenu />);
+    expect(screen.getByText('Sign In')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 });

--- a/frontend/jwst-frontend/src/components/UserMenu.tsx
+++ b/frontend/jwst-frontend/src/components/UserMenu.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useRef, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../context/useAuth';
 import './UserMenu.css';
 
@@ -40,7 +41,13 @@ export function UserMenu() {
   }, []);
 
   if (!user) {
-    return null;
+    return (
+      <div className="user-menu">
+        <Link to="/login" className="nav-link header-login-link">
+          Sign In
+        </Link>
+      </div>
+    );
   }
 
   // Get initials for avatar

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.css
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.css
@@ -71,6 +71,59 @@
   border-radius: var(--radius-sm);
 }
 
+/* Auth gate — shown when user needs to sign in to start creating */
+.guided-create-auth-gate {
+  padding: 40px 20px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  text-align: center;
+}
+
+.guided-create-auth-gate > p {
+  margin: 0 0 8px;
+  color: var(--text-primary);
+  font-size: 1.05rem;
+}
+
+.guided-create-auth-hint {
+  color: var(--text-secondary) !important;
+  font-size: 0.875rem !important;
+  margin-bottom: 24px !important;
+}
+
+.guided-create-auth-cta {
+  display: inline-flex;
+  align-items: center;
+  height: 40px;
+  padding: 0 28px;
+  background: var(--accent-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    background var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.guided-create-auth-cta:hover {
+  background: var(--accent-hover, var(--accent-primary));
+  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
+}
+
+.guided-create-auth-register {
+  margin-top: 16px !important;
+  font-size: 0.85rem !important;
+  color: var(--text-secondary) !important;
+}
+
+.guided-create-auth-register a {
+  color: var(--accent-primary);
+}
+
 @media (max-width: 768px) {
   .guided-create h2 {
     font-size: 1.375rem;

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useSearchParams, Link } from 'react-router-dom';
+import { useSearchParams, Link, useLocation } from 'react-router-dom';
 import { WizardStepper } from '../components/wizard/WizardStepper';
 import { DownloadStep } from '../components/guided/DownloadStep';
 import { ProcessStep } from '../components/guided/ProcessStep';
@@ -8,6 +8,7 @@ import { searchByTarget, startImport } from '../services/mastService';
 import { suggestRecipes } from '../services/discoveryService';
 import { exportNChannelCompositeAsync, getCompositeToken } from '../services/compositeService';
 import { subscribeToJobProgress } from '../hooks/useJobProgress';
+import { useAuth } from '../context/useAuth';
 import { API_BASE_URL } from '../config/api';
 import type { ImportJobStatus, MastObservationResult } from '../types/MastTypes';
 import type { CompositeRecipe, ObservationInput } from '../types/DiscoveryTypes';
@@ -112,6 +113,8 @@ export function GuidedCreate() {
   const [searchParams] = useSearchParams();
   const target = searchParams.get('target') ?? '';
   const recipeName = searchParams.get('recipe') ?? '';
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const location = useLocation();
 
   // Flow state
   const [currentStep, setCurrentStep] = useState<FlowStep>(1);
@@ -155,7 +158,13 @@ export function GuidedCreate() {
     };
   }, []);
 
-  // Step 0: Resolve recipe from target name
+  // Resolved observations awaiting auth to start downloads
+  const [pendingObs, setPendingObs] = useState<{
+    observations: MastObservationResult[];
+    matched: CompositeRecipe;
+  } | null>(null);
+
+  // Step 0: Resolve recipe from target name (all public endpoints — no auth needed)
   useEffect(() => {
     if (!target || !recipeName) {
       setInitError('Missing target or recipe parameters.');
@@ -205,7 +214,12 @@ export function GuidedCreate() {
           return;
         }
 
-        startDownloads(relevantObs, matched);
+        // Gate on auth: if logged in, start immediately. Otherwise, stash for later.
+        if (isAuthenticated) {
+          startDownloads(relevantObs, matched);
+        } else {
+          setPendingObs({ observations: relevantObs, matched });
+        }
       } catch (err) {
         if (controller.signal.aborted) return;
         setInitError(err instanceof Error ? err.message : 'Failed to resolve recipe.');
@@ -214,7 +228,17 @@ export function GuidedCreate() {
 
     resolveRecipe();
     return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- isAuthenticated handled by separate effect
   }, [target, recipeName]);
+
+  // When user authenticates after page load, start pending downloads
+  useEffect(() => {
+    if (isAuthenticated && pendingObs) {
+      startDownloads(pendingObs.observations, pendingObs.matched);
+      setPendingObs(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- startDownloads is stable closure
+  }, [isAuthenticated, pendingObs]);
 
   /**
    * Start importing MAST observations in parallel.
@@ -511,6 +535,40 @@ export function GuidedCreate() {
           >
             Go Back
           </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Auth gate: recipe resolved but user not logged in
+  if (pendingObs && !isAuthenticated && !authLoading) {
+    return (
+      <div className="guided-create">
+        <div className="guided-create-back">
+          <Link to={`/target/${encodeURIComponent(target)}`} className="back-link">
+            &larr; Back to {target}
+          </Link>
+        </div>
+        <h2>Create Composite</h2>
+        <div className="guided-create-auth-gate">
+          <p>Sign in to create a composite image of {target}.</p>
+          <p className="guided-create-auth-hint">
+            {pendingObs.matched.filters.length} filters will be downloaded and combined using the{' '}
+            {pendingObs.matched.name} recipe.
+          </p>
+          <Link
+            to="/login"
+            state={{ from: location.pathname + location.search }}
+            className="guided-create-auth-cta"
+          >
+            Sign In to Continue
+          </Link>
+          <p className="guided-create-auth-register">
+            Don&apos;t have an account?{' '}
+            <Link to="/register" state={{ from: location.pathname + location.search }}>
+              Register
+            </Link>
+          </p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Make Discovery, Target Detail, and Guided Create pages publicly accessible without login. Auth is only required when the user initiates a download — a sign-in gate intercepts at that point with redirect-back support.

## Why

Previously all routes were wrapped in `ProtectedRoute`, forcing login just to browse targets. Users should be able to explore and view target details without creating an account. Auth is only needed when an action increases server storage (downloading files).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **App.tsx**: Split routes into public (Discovery, Target Detail, Guided Create) and protected (Library) groups. Public routes use `SharedLayout` directly; Library stays wrapped in `ProtectedRoute`.
- **GuidedCreate.tsx**: Added `useAuth` hook and `pendingObs` state. When recipe resolves but user isn't authenticated, observations are stashed and an auth gate is rendered. After login, a separate `useEffect` detects auth + pending obs and triggers downloads.
- **GuidedCreate.css**: Auth gate styles (`.guided-create-auth-gate`, sign-in CTA, register hint).
- **UserMenu.tsx**: When `user` is null, render a "Sign In" `<Link>` instead of nothing, so anonymous users see a login option in the header.
- **UserMenu.css**: `.header-login-link` styles matching the existing nav aesthetic.
- **UserMenu.test.tsx**: Updated tests for anonymous behavior (expects "Sign In" link), added `MemoryRouter` wrapper for `<Link>` support.

## Test Plan

- [x] All 831 frontend unit tests pass
- [ ] Visit `/` without logging in — Discovery page loads, targets visible
- [ ] Click a target — Target Detail loads without redirect to login
- [ ] Click "Create Composite" on a target — Guided Create loads, recipe resolves, auth gate shown
- [ ] Auth gate shows filter count, recipe name, "Sign In to Continue" button, register link
- [ ] Click "Sign In to Continue" → redirected to `/login` with `from` state set
- [ ] After login → redirected back to Guided Create, downloads start automatically
- [ ] Visit `/library` without login → redirected to `/login`
- [ ] Header shows "Sign In" link when logged out, user avatar dropdown when logged in

## Documentation Checklist

- [x] No new controllers, services, or endpoints — no doc updates needed

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — frontend-only routing change. No backend changes.
Rollback: Revert commit to restore `ProtectedRoute` wrapper on all routes.

## Quality Checklist

- [x] Code follows project conventions
- [x] Tests updated for changed behavior
- [x] No security implications (backend endpoints retain their own `[Authorize]` attributes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)