### PR TITLE
fix: suppress CA1869 in test-only JsonSerializerOptions

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/DiscoveryServiceAliasTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/DiscoveryServiceAliasTests.cs
@@ -16,6 +16,8 @@ using Moq;
 
 namespace JwstDataAnalysis.API.Tests.Services;
 
+#pragma warning disable CA1869 // Cache and reuse JsonSerializerOptions — test code only
+
 /// <summary>
 /// Unit tests for DiscoveryService.ResolveTargetAlias.
 /// </summary>


### PR DESCRIPTION
## Summary
Suppresses CA1869 analyzer warning in `DiscoveryServiceAliasTests` where `JsonSerializerOptions` is instantiated once during test setup to write a fixture JSON file.

## Why
The `--warnaserror` local compliance build failed on this warning introduced by PR #498. CI doesn't use `--warnaserror` so it passed there, but local compliance checks caught it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Added `#pragma warning disable CA1869` at file scope in `DiscoveryServiceAliasTests.cs` with comment explaining test-only usage

## Test Plan
- [x] `dotnet build --warnaserror` passes locally
- [x] All 762 backend tests pass

## Documentation Checklist
- [x] No documentation updates needed (single-line pragma in test file)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback

Risk: None — pragma only affects one test file, no runtime behavior change.
Rollback: Revert the commit.

## Quality Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)