### PR TITLE
fix: handle missing colorMapping in guided create composite flow

### DIFF
--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -14,6 +14,7 @@ import type { ImportJobStatus, MastObservationResult } from '../types/MastTypes'
 import type { CompositeRecipe, ObservationInput } from '../types/DiscoveryTypes';
 import type { NChannelConfigPayload, OverallAdjustments } from '../types/CompositeTypes';
 import { DEFAULT_CHANNEL_PARAMS, DEFAULT_OVERALL_ADJUSTMENTS } from '../types/CompositeTypes';
+import { chromaticOrderHues, hueToHex } from '../utils/wavelengthUtils';
 import './GuidedCreate.css';
 
 type FlowStep = 1 | 2 | 3;
@@ -44,16 +45,24 @@ function hexToHue(hex: string): number {
 
 /**
  * Build NChannelConfigPayload array from recipe + imported data mappings.
+ * Falls back to chromatic-ordered colors if colorMapping is missing.
  */
 function buildChannelPayloads(
   recipe: CompositeRecipe,
   filterDataMap: Map<string, string[]>
 ): NChannelConfigPayload[] {
+  // Build fallback color mapping if the API response didn't include one
+  const colorMapping =
+    recipe.colorMapping ??
+    Object.fromEntries(
+      recipe.filters.map((f, i) => [f, hueToHex(chromaticOrderHues(recipe.filters.length)[i])])
+    );
+
   const payloads: NChannelConfigPayload[] = [];
   for (const filter of recipe.filters) {
     const dataIds = filterDataMap.get(filter.toUpperCase()) ?? [];
     if (dataIds.length === 0) continue;
-    const hexColor = recipe.colorMapping[filter] ?? '#ffffff';
+    const hexColor = colorMapping[filter] ?? '#ffffff';
     payloads.push({
       dataIds,
       color: { hue: hexToHue(hexColor) },

--- a/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
+++ b/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
@@ -30,7 +30,7 @@ export interface CompositeRecipe {
   name: string;
   rank: number;
   filters: string[];
-  colorMapping: Record<string, string>;
+  colorMapping?: Record<string, string>;
   instruments: string[];
   requiresMosaic: boolean;
   estimatedTimeSeconds: number;


### PR DESCRIPTION
## Summary
Fixes crash in guided composite creation when `recipe.colorMapping` is undefined. The error manifested as `Cannot read properties of undefined (reading 'F090W')` during the Process step.

## Why
`buildChannelPayloads` accessed `recipe.colorMapping[filter]` without null-checking. While the API normally returns `colorMapping`, it can be undefined during transient backend issues (e.g., Docker rebuild mid-request) or serialization edge cases. The crash prevented retry from working.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Added fallback color generation in `buildChannelPayloads` — when `colorMapping` is missing, generates chromatic-ordered colors from the filter list (same algorithm as the Python recipe engine)
- Made `CompositeRecipe.colorMapping` optional in the TypeScript type to match runtime reality
- `RecipeCard` already used optional chaining; no change needed there

## Test Plan
- [x] `npx tsc --noEmit` passes — no type errors
- [x] `npm run lint` passes — 0 errors
- [x] All 831 unit tests pass
- [x] Verified guided create flow loads successfully at `/create?target=M16&recipe=9-filter%20MIRI/IMAGE+NIRCAM/IMAGE`

## Documentation Checklist
- [x] No documentation updates needed (bug fix in existing component)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — adds a fallback path, does not change the happy path behavior. When `colorMapping` is present (normal case), behavior is identical.
Rollback: Revert the commit.

## Quality Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)