### PR TITLE
feat: use NASA/STScI discrete color palette for composite presets

### DIFF
--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -161,7 +161,7 @@ export function hueToColorName(hue: number): string {
     [120, 'Green'],
     [180, 'Cyan'],
     [240, 'Blue'],
-    [270, 'Purple'],
+    [280, 'Purple'],
     [300, 'Magenta'],
     [330, 'Rose'],
   ];

--- a/frontend/jwst-frontend/src/utils/filterPresets.ts
+++ b/frontend/jwst-frontend/src/utils/filterPresets.ts
@@ -10,7 +10,7 @@ import {
   createDefaultNChannel,
   DEFAULT_CHANNEL_PARAMS,
 } from '../types/CompositeTypes';
-import { wavelengthToHue } from './wavelengthUtils';
+import { chromaticOrderHues } from './wavelengthUtils';
 
 export type PresetInstrument = 'NIRCam' | 'MIRI' | 'Mixed';
 
@@ -131,12 +131,12 @@ export function getPresetsByInstrument(): Map<PresetInstrument, FilterPreset[]> 
 
 /**
  * Create NChannelState[] from a preset definition.
- * Each filter becomes one channel with hue derived from wavelength.
+ * Each filter gets a color from the NASA/STScI discrete palette.
  */
 export function createChannelsFromPreset(preset: FilterPreset): NChannelState[] {
-  return preset.filters.map((f) => {
-    const hue = wavelengthToHue(f.wavelengthUm);
-    const channel = createDefaultNChannel(hue);
+  const hues = chromaticOrderHues(preset.filters.length);
+  return preset.filters.map((f, i) => {
+    const channel = createDefaultNChannel(hues[i]);
     channel.label = f.name;
     channel.wavelengthUm = f.wavelengthUm;
     channel.params = { ...DEFAULT_CHANNEL_PARAMS };

--- a/frontend/jwst-frontend/src/utils/wavelengthUtils.test.ts
+++ b/frontend/jwst-frontend/src/utils/wavelengthUtils.test.ts
@@ -179,27 +179,32 @@ describe('getFilterLabel', () => {
 });
 
 describe('chromaticOrderHues', () => {
-  it('returns [0] for single filter', () => {
+  it('returns [0] for single filter (Red)', () => {
     expect(chromaticOrderHues(1)).toEqual([0]);
   });
 
-  it('returns [240, 0] for two filters', () => {
+  it('returns Blue, Red for two filters', () => {
     expect(chromaticOrderHues(2)).toEqual([240, 0]);
   });
 
-  it('returns [240, 120, 0] for three filters', () => {
-    const hues = chromaticOrderHues(3);
-    expect(hues[0]).toBeCloseTo(240);
-    expect(hues[1]).toBeCloseTo(120);
-    expect(hues[2]).toBeCloseTo(0);
+  it('returns Blue, Green, Red for three filters', () => {
+    expect(chromaticOrderHues(3)).toEqual([240, 120, 0]);
   });
 
-  it('returns four evenly-spaced hues', () => {
-    const hues = chromaticOrderHues(4);
-    expect(hues[0]).toBeCloseTo(240);
-    expect(hues[1]).toBeCloseTo(160);
-    expect(hues[2]).toBeCloseTo(80);
-    expect(hues[3]).toBeCloseTo(0);
+  it('returns Blue, Green, Orange, Red for four filters (NASA convention)', () => {
+    expect(chromaticOrderHues(4)).toEqual([240, 120, 30, 0]);
+  });
+
+  it('returns Purple, Blue, Green, Orange, Red for five filters', () => {
+    expect(chromaticOrderHues(5)).toEqual([280, 240, 120, 30, 0]);
+  });
+
+  it('returns six NASA palette colors for six filters', () => {
+    expect(chromaticOrderHues(6)).toEqual([280, 240, 120, 60, 30, 0]);
+  });
+
+  it('returns all seven NASA palette colors for seven filters', () => {
+    expect(chromaticOrderHues(7)).toEqual([280, 240, 180, 120, 60, 30, 0]);
   });
 
   it('produces monotonically decreasing hues', () => {
@@ -211,13 +216,23 @@ describe('chromaticOrderHues', () => {
     }
   });
 
-  it('all hues are in [0, 240]', () => {
+  it('all hues are in [0, 280]', () => {
     for (const n of [1, 2, 3, 5, 8, 10]) {
       const hues = chromaticOrderHues(n);
       for (const h of hues) {
         expect(h).toBeGreaterThanOrEqual(0);
-        expect(h).toBeLessThanOrEqual(240);
+        expect(h).toBeLessThanOrEqual(280);
       }
+    }
+  });
+
+  it('handles N > 7 by interpolating extras', () => {
+    const hues = chromaticOrderHues(9);
+    expect(hues).toHaveLength(9);
+    expect(hues[0]).toBe(280); // First palette entry
+    expect(hues[hues.length - 1]).toBe(0); // Last palette entry
+    for (let i = 0; i < hues.length - 1; i++) {
+      expect(hues[i]).toBeGreaterThan(hues[i + 1]);
     }
   });
 

--- a/frontend/jwst-frontend/src/utils/wavelengthUtils.ts
+++ b/frontend/jwst-frontend/src/utils/wavelengthUtils.ts
@@ -197,19 +197,78 @@ export function getFilterLabel(data: JwstDataModel): string {
 }
 
 /**
- * Assign evenly-spaced hues from blue (240) to red (0) for N filters.
+ * NASA/STScI discrete color palette for JWST composites.
+ * Matches the convention used in official NASA press releases:
+ * shortest wavelength → blue end, longest → red end.
+ * Hue values correspond to HSV color wheel degrees.
+ */
+const NASA_PALETTE: ReadonlyArray<{ name: string; hue: number }> = [
+  { name: 'Purple', hue: 280 },
+  { name: 'Blue', hue: 240 },
+  { name: 'Cyan', hue: 180 },
+  { name: 'Green', hue: 120 },
+  { name: 'Yellow', hue: 60 },
+  { name: 'Orange', hue: 30 },
+  { name: 'Red', hue: 0 },
+];
+
+/**
+ * For N filters, select the optimal subset from the NASA palette that
+ * maximizes visual distinction. Based on actual NASA/STScI practice.
+ */
+const NASA_PALETTE_INDICES: Record<number, number[]> = {
+  1: [6], // Red
+  2: [1, 6], // Blue, Red
+  3: [1, 3, 6], // Blue, Green, Red
+  4: [1, 3, 5, 6], // Blue, Green, Orange, Red
+  5: [0, 1, 3, 5, 6], // Purple, Blue, Green, Orange, Red
+  6: [0, 1, 3, 4, 5, 6], // Purple, Blue, Green, Yellow, Orange, Red
+  7: [0, 1, 2, 3, 4, 5, 6], // All seven
+};
+
+/**
+ * Assign hues from the NASA/STScI discrete color palette for N filters.
  *
- * Implements chromatic ordering as used by STScI image processors for
- * NASA press releases. Filters should be sorted by wavelength ascending
- * before calling — the first gets blue, the last gets red.
+ * Implements the chromatic ordering convention used in official NASA
+ * press releases (e.g. Cranium Nebula, Pillars of Creation). Filters
+ * should be sorted by wavelength ascending before calling — the first
+ * gets the shortest-wavelength color, the last gets red.
+ *
+ * For 1-7 filters, uses hand-picked subsets that match NASA practice.
+ * For 8+ filters, uses all 7 palette colors plus evenly interpolated
+ * extras between adjacent entries.
  *
  * @param n - Number of filters (must be >= 1)
- * @returns Array of N hue angles from 240 (blue) to 0 (red)
+ * @returns Array of N hue angles, ordered from blue/purple to red
  */
 export function chromaticOrderHues(n: number): number[] {
   if (n < 1) throw new Error('Need at least 1 filter for chromatic ordering');
-  if (n === 1) return [0]; // Single filter → red
-  return Array.from({ length: n }, (_, i) => 240 * (1 - i / (n - 1)));
+
+  const indices = NASA_PALETTE_INDICES[n];
+  if (indices) {
+    return indices.map((i) => NASA_PALETTE[i].hue);
+  }
+
+  // N > 7: use all 7 palette hues plus interpolated extras
+  const base = NASA_PALETTE.map((p) => p.hue);
+  const result: number[] = [];
+  const extras = n - 7;
+  // Distribute extra hues into the widest gaps between palette entries
+  const gaps = base.slice(0, -1).map((h, i) => ({ idx: i, span: h - base[i + 1] }));
+  gaps.sort((a, b) => b.span - a.span);
+  const insertions = new Map<number, number>();
+  for (let e = 0; e < extras; e++) {
+    const gap = gaps[e % gaps.length];
+    insertions.set(gap.idx, (insertions.get(gap.idx) ?? 0) + 1);
+  }
+  for (let i = 0; i < base.length; i++) {
+    result.push(base[i]);
+    const count = insertions.get(i) ?? 0;
+    for (let j = 1; j <= count; j++) {
+      result.push(base[i] - ((base[i] - base[i + 1]) * j) / (count + 1));
+    }
+  }
+  return result;
 }
 
 /**

--- a/processing-engine/app/composite/color_mapping.py
+++ b/processing-engine/app/composite/color_mapping.py
@@ -68,20 +68,47 @@ def wavelength_to_hue(wavelength_um: float) -> float:
     return hue
 
 
-def chromatic_order_hues(n: int) -> list[float]:
-    """Assign evenly-spaced hues from blue (240) to red (0) for N filters.
+NASA_PALETTE: list[tuple[str, float]] = [
+    ("Purple", 280.0),
+    ("Blue", 240.0),
+    ("Cyan", 180.0),
+    ("Green", 120.0),
+    ("Yellow", 60.0),
+    ("Orange", 30.0),
+    ("Red", 0.0),
+]
+"""NASA/STScI discrete color palette for JWST composites.
+Matches the convention used in official NASA press releases:
+shortest wavelength → blue end, longest → red end."""
 
-    This implements the relative chromatic ordering used by STScI image
-    processors (e.g. DePasquale) for NASA press releases. Filters are
-    assumed to be sorted by wavelength ascending before calling this
-    function — the first filter gets blue, the last gets red, and middle
-    filters are evenly spaced between.
+_NASA_PALETTE_INDICES: dict[int, list[int]] = {
+    1: [6],  # Red
+    2: [1, 6],  # Blue, Red
+    3: [1, 3, 6],  # Blue, Green, Red
+    4: [1, 3, 5, 6],  # Blue, Green, Orange, Red
+    5: [0, 1, 3, 5, 6],  # Purple, Blue, Green, Orange, Red
+    6: [0, 1, 3, 4, 5, 6],  # Purple, Blue, Green, Yellow, Orange, Red
+    7: [0, 1, 2, 3, 4, 5, 6],  # All seven
+}
+
+
+def chromatic_order_hues(n: int) -> list[float]:
+    """Assign hues from the NASA/STScI discrete color palette for N filters.
+
+    Implements the chromatic ordering convention used in official NASA
+    press releases (e.g. Cranium Nebula, Pillars of Creation). Filters
+    are assumed to be sorted by wavelength ascending before calling —
+    the first filter gets the shortest-wavelength color, the last gets red.
+
+    For 1-7 filters, uses hand-picked subsets that match NASA practice.
+    For 8+ filters, uses all 7 palette hues plus evenly interpolated
+    extras between adjacent entries.
 
     Args:
         n: Number of filters (must be >= 1).
 
     Returns:
-        List of N hue angles in degrees, from 240 (blue) down to 0 (red).
+        List of N hue angles in degrees, ordered from blue/purple to red.
 
     Raises:
         ValueError: If n < 1.
@@ -89,11 +116,28 @@ def chromatic_order_hues(n: int) -> list[float]:
     if n < 1:
         raise ValueError("Need at least 1 filter for chromatic ordering")
 
-    if n == 1:
-        return [0.0]  # Single filter → red
+    indices = _NASA_PALETTE_INDICES.get(n)
+    if indices is not None:
+        return [NASA_PALETTE[i][1] for i in indices]
 
-    # Evenly space from 240 (blue) to 0 (red)
-    return [240.0 * (1.0 - i / (n - 1)) for i in range(n)]
+    # N > 7: use all 7 palette hues plus interpolated extras
+    base = [h for _, h in NASA_PALETTE]
+    extras = n - 7
+    gaps = sorted(
+        [(i, base[i] - base[i + 1]) for i in range(len(base) - 1)],
+        key=lambda x: -x[1],
+    )
+    insertions: dict[int, int] = {}
+    for e in range(extras):
+        gap_idx = gaps[e % len(gaps)][0]
+        insertions[gap_idx] = insertions.get(gap_idx, 0) + 1
+    result: list[float] = []
+    for i, h in enumerate(base):
+        result.append(h)
+        count = insertions.get(i, 0)
+        for j in range(1, count + 1):
+            result.append(h - (h - base[i + 1]) * j / (count + 1))
+    return result
 
 
 def rgb_to_hsl(rgb: NDArray) -> tuple[NDArray, NDArray, NDArray]:

--- a/processing-engine/tests/test_color_mapping.py
+++ b/processing-engine/tests/test_color_mapping.py
@@ -117,37 +117,39 @@ class TestWavelengthToHue:
 
 
 class TestChromaticOrderHues:
-    """Tests for chromatic_order_hues."""
+    """Tests for chromatic_order_hues (NASA discrete palette)."""
 
     def test_single_filter_returns_red(self):
         assert chromatic_order_hues(1) == [0.0]
 
     def test_two_filters_blue_red(self):
-        hues = chromatic_order_hues(2)
-        assert hues == [240.0, 0.0]
+        assert chromatic_order_hues(2) == [240.0, 0.0]
 
     def test_three_filters_blue_green_red(self):
-        hues = chromatic_order_hues(3)
-        assert hues[0] == pytest.approx(240.0)
-        assert hues[1] == pytest.approx(120.0)
-        assert hues[2] == pytest.approx(0.0)
+        assert chromatic_order_hues(3) == [240.0, 120.0, 0.0]
 
-    def test_four_filters(self):
-        hues = chromatic_order_hues(4)
-        assert hues[0] == pytest.approx(240.0)
-        assert hues[1] == pytest.approx(160.0)
-        assert hues[2] == pytest.approx(80.0)
-        assert hues[3] == pytest.approx(0.0)
+    def test_four_filters_nasa_convention(self):
+        """4-filter: Blue, Green, Orange, Red (matches NASA Cranium Nebula)."""
+        assert chromatic_order_hues(4) == [240.0, 120.0, 30.0, 0.0]
 
-    def test_six_filters_evenly_spaced(self):
-        hues = chromatic_order_hues(6)
-        assert len(hues) == 6
-        assert hues[0] == pytest.approx(240.0)
-        assert hues[-1] == pytest.approx(0.0)
-        # Check even spacing
-        spacing = hues[0] - hues[1]
-        for i in range(1, len(hues) - 1):
-            assert hues[i] - hues[i + 1] == pytest.approx(spacing)
+    def test_five_filters(self):
+        """5-filter: Purple, Blue, Green, Orange, Red."""
+        assert chromatic_order_hues(5) == [280.0, 240.0, 120.0, 30.0, 0.0]
+
+    def test_six_filters(self):
+        """6-filter: Purple, Blue, Green, Yellow, Orange, Red."""
+        assert chromatic_order_hues(6) == [280.0, 240.0, 120.0, 60.0, 30.0, 0.0]
+
+    def test_seven_filters_full_palette(self):
+        """7-filter: All NASA palette colors."""
+        assert chromatic_order_hues(7) == [280.0, 240.0, 180.0, 120.0, 60.0, 30.0, 0.0]
+
+    def test_eight_filters_interpolates(self):
+        """N>7: interpolates extras between widest gaps."""
+        hues = chromatic_order_hues(8)
+        assert len(hues) == 8
+        assert hues[0] == 280.0
+        assert hues[-1] == 0.0
 
     def test_monotonically_decreasing(self):
         for n in [2, 3, 4, 5, 6, 7, 8]:
@@ -159,7 +161,7 @@ class TestChromaticOrderHues:
         for n in range(1, 11):
             hues = chromatic_order_hues(n)
             for h in hues:
-                assert 0.0 <= h <= 240.0, f"Hue {h} out of range at n={n}"
+                assert 0.0 <= h <= 280.0, f"Hue {h} out of range at n={n}"
 
     def test_zero_raises(self):
         with pytest.raises(ValueError, match="at least 1"):


### PR DESCRIPTION
## Summary

Replace the evenly-spaced hue interpolation for composite color assignments with NASA/STScI's discrete 7-color palette (Purple, Blue, Cyan, Green, Yellow, Orange, Red). This matches the color convention used in official NASA press releases for JWST imagery.

## Why

Our previous approach distributed hues evenly across 0-240°, which produced arbitrary colors that didn't match NASA's published conventions. Users familiar with NASA imagery (Cranium Nebula, Pillars of Creation, etc.) expect the standard palette: Blue for shortest wavelength, Red for longest, with specific intermediate colors.

## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Changes Made

- Added `NASA_PALETTE` constant (7 named colors with hue angles) in both frontend (`wavelengthUtils.ts`) and backend (`color_mapping.py`)
- Added `NASA_PALETTE_INDICES` lookup tables for optimal N-color subsets (1-7 filters) matching NASA practice
- Updated `chromaticOrderHues()` (TS) and `chromatic_order_hues()` (Python) to use the discrete palette instead of evenly-spaced interpolation
- For N > 7 filters, all 7 palette colors are used plus extras interpolated into the widest gaps
- Updated `createChannelsFromPreset()` in `filterPresets.ts` to use `chromaticOrderHues()` instead of per-filter `wavelengthToHue()`
- Updated `hueToColorName()` Purple entry from 270° to 280° to match NASA palette
- Updated all related tests in both frontend and backend

## Test Plan

- [x] Frontend unit tests pass (835 tests) — `chromaticOrderHues` tests rewritten for NASA palette values
- [x] Python unit tests pass — `test_color_mapping.py` updated for new palette
- [x] Frontend lint, format, and type checks pass
- [x] Python ruff lint and format pass
- [ ] Visual verification: Open composite wizard with a 4-filter preset, confirm colors are Blue, Green, Orange, Red (not arbitrary hues)
- [ ] Visual verification: Guided create flow assigns correct NASA colors to filters

## Documentation Checklist

- [x] No new API endpoints or controllers
- [ ] N/A — docs/tech-debt.md not modified

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Adds tech debt (explain below)
- [ ] Reduces tech debt (explain below)

## Risk & Rollback

Risk: Low — color values only, no behavioral or API changes. Existing composites in the database retain their original colors; only new composites use the updated palette.

Rollback: Revert this commit to restore evenly-spaced hue interpolation.

## Quality Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated for changes
- [x] No console.log or debug code left behind
- [x] Frontend and backend palette definitions are synchronized