### PR TITLE
fix: send job snapshot on SignalR subscribe to prevent composite timeout

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Hubs/JobProgressHubTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Hubs/JobProgressHubTests.cs
@@ -23,10 +23,13 @@ public class JobProgressHubTests : IDisposable
     private readonly Mock<IGroupManager> mockGroups = new();
     private readonly Mock<ILogger<JobProgressHub>> mockLogger = new();
     private readonly Mock<IJobTracker> mockJobTracker = new();
+    private readonly Mock<IHubCallerClients> mockClients = new();
+    private readonly Mock<ISingleClientProxy> mockCallerProxy = new();
     private readonly JobProgressHub sut;
 
     public JobProgressHubTests()
     {
+        mockClients.Setup(c => c.Caller).Returns(mockCallerProxy.Object);
         sut = new JobProgressHub(mockLogger.Object, mockJobTracker.Object);
     }
 
@@ -39,6 +42,33 @@ public class JobProgressHubTests : IDisposable
         await sut.SubscribeToJob("job-123");
 
         mockGroups.Verify(g => g.AddToGroupAsync("conn-1", "job-job-123", default), Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeToJob_SendsSnapshotToCaller()
+    {
+        SetupHubContext("user-1");
+        SetupJobOwnership("job-123", "user-1", state: JobStates.Running, progressPercent: 10, stage: "generating", message: "Generating composite image...");
+
+        JobSnapshotUpdate? capturedSnapshot = null;
+        mockCallerProxy
+            .Setup(c => c.SendCoreAsync("JobSnapshot", It.IsAny<object?[]>(), default))
+            .Callback<string, object?[], CancellationToken>((_, args, _) =>
+            {
+                if (args.Length > 0)
+                {
+                    capturedSnapshot = args[0] as JobSnapshotUpdate;
+                }
+            })
+            .Returns(Task.CompletedTask);
+
+        await sut.SubscribeToJob("job-123");
+
+        capturedSnapshot.Should().NotBeNull();
+        capturedSnapshot!.JobId.Should().Be("job-123");
+        capturedSnapshot.State.Should().Be(JobStates.Running);
+        capturedSnapshot.ProgressPercent.Should().Be(10);
+        capturedSnapshot.Stage.Should().Be("generating");
     }
 
     [Fact]
@@ -140,6 +170,7 @@ public class JobProgressHubTests : IDisposable
 
         typeof(Hub).GetProperty("Context")!.SetValue(sut, mockContext.Object);
         typeof(Hub).GetProperty("Groups")!.SetValue(sut, mockGroups.Object);
+        typeof(Hub).GetProperty("Clients")!.SetValue(sut, mockClients.Object);
 
         SetupJobOwnership("job-789", "user-sub-1");
 
@@ -154,11 +185,19 @@ public class JobProgressHubTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private void SetupJobOwnership(string jobId, string userId)
+    private void SetupJobOwnership(string jobId, string userId, string state = JobStates.Queued, int progressPercent = 0, string? stage = null, string? message = null)
     {
         mockJobTracker
             .Setup(t => t.GetJobAsync(jobId, userId))
-            .ReturnsAsync(new JobStatus { JobId = jobId, OwnerUserId = userId });
+            .ReturnsAsync(new JobStatus
+            {
+                JobId = jobId,
+                OwnerUserId = userId,
+                State = state,
+                ProgressPercent = progressPercent,
+                Stage = stage,
+                Message = message,
+            });
     }
 
     private void SetupHubContext(string? userId, string connectionId = "conn-1")
@@ -178,8 +217,9 @@ public class JobProgressHubTests : IDisposable
             mockContext.Setup(c => c.User).Returns((ClaimsPrincipal?)null);
         }
 
-        // Use reflection to set Hub.Context and Hub.Groups (they're set by SignalR normally)
+        // Use reflection to set Hub.Context, Hub.Groups, and Hub.Clients (they're set by SignalR normally)
         typeof(Hub).GetProperty("Context")!.SetValue(sut, mockContext.Object);
         typeof(Hub).GetProperty("Groups")!.SetValue(sut, mockGroups.Object);
+        typeof(Hub).GetProperty("Clients")!.SetValue(sut, mockClients.Object);
     }
 }

--- a/backend/JwstDataAnalysis.API/Hubs/JobProgressHub.cs
+++ b/backend/JwstDataAnalysis.API/Hubs/JobProgressHub.cs
@@ -46,6 +46,32 @@ namespace JwstDataAnalysis.API.Hubs
 
             await Groups.AddToGroupAsync(Context.ConnectionId, $"job-{jobId}");
             LogSubscribed(jobId, userId);
+
+            // Send a snapshot of the current job state so the client catches up
+            // on any progress events it missed before subscribing (race condition fix).
+            var snapshot = new Models.JobSnapshotUpdate
+            {
+                JobId = job.JobId,
+                JobType = job.JobType,
+                State = job.State,
+                Description = job.Description,
+                ProgressPercent = job.ProgressPercent,
+                Stage = job.Stage,
+                Message = job.Message,
+                Error = job.Error,
+                CancelRequested = job.CancelRequested,
+                CreatedAt = job.CreatedAt,
+                StartedAt = job.StartedAt,
+                UpdatedAt = job.UpdatedAt,
+                CompletedAt = job.CompletedAt,
+                ExpiresAt = job.ExpiresAt,
+                ResultKind = job.ResultKind,
+                ResultContentType = job.ResultContentType,
+                ResultFilename = job.ResultFilename,
+                ResultDataId = job.ResultDataId,
+                Metadata = job.Metadata,
+            };
+            await Clients.Caller.SendAsync("JobSnapshot", snapshot);
         }
 
         /// <summary>

--- a/frontend/jwst-frontend/src/hooks/useJobProgress.ts
+++ b/frontend/jwst-frontend/src/hooks/useJobProgress.ts
@@ -293,7 +293,7 @@ export function subscribeToJobProgress(
         };
         callbacks.onFailed?.(timeoutStatus);
       },
-      2 * 60 * 1000
+      10 * 60 * 1000
     );
   }
 


### PR DESCRIPTION
## Summary

Fix SignalR race condition that caused "No progress updates received (SignalR timeout)" during composite generation for large multi-filter targets.

## Why

When a user starts composite processing (e.g., 8-filter PMR 1), the backend sends a 10% progress event immediately via SignalR. However, the frontend's SignalR subscription is established *after* the API call returns, so the 10% event is lost. With no events arriving, the 2-minute safety timeout fires — even though the composite is still processing normally on the backend.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Changes Made

- **Backend**: `JobProgressHub.SubscribeToJob` now sends a `JobSnapshot` with the current job state immediately after adding the client to the SignalR group, so clients always catch up on missed events
- **Frontend**: Increased the SignalR-only safety timeout from 2 minutes to 10 minutes in `useJobProgress.ts`, matching the HTTP polling timeout — large composites can legitimately take several minutes
- **Tests**: Added `SubscribeToJob_SendsSnapshotToCaller` test verifying the snapshot is sent with correct job state; updated test fixture to mock `IHubCallerClients`

## Test Plan

- [x] Backend builds with 0 warnings (`dotnet build --warnaserror`)
- [x] Backend tests pass (763 passed, 0 skipped)
- [x] Frontend tests pass (835 passed)
- [ ] Manual: Navigate to guided create for a multi-filter target (e.g., PMR 1), complete downloads, verify composite processes to completion without timeout
- [ ] Manual: Verify SignalR progress updates appear in the UI during composite generation

## Documentation Checklist

- [x] No new API endpoints or controllers
- [ ] N/A — docs/tech-debt.md not modified

## Tech Debt Impact

- [x] Reduces tech debt (explain below)

Eliminates a known race condition in the SignalR subscription flow. The snapshot-on-subscribe pattern is more robust and prevents similar issues for any future job types.

## Risk & Rollback

Risk: Low — the snapshot is a read-only operation that sends existing job state to the caller. The timeout increase is a safety net change.

Rollback: Revert this commit to restore previous behavior.

## Quality Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated for changes
- [x] No console.log or debug code left behind