### PR TITLE
fix: prevent OOM crash in 8-channel composite generation

### DIFF
--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -2,6 +2,7 @@
 FastAPI routes for RGB composite image generation.
 """
 
+import gc
 import io
 import logging
 import os
@@ -282,12 +283,30 @@ def reproject_channels_to_common_wcs(
         raise ValueError(f"Could not determine common WCS for RGB channels: {e}") from e
 
     total_pixels = shape_out[0] * shape_out[1]
-    if total_pixels > max_reproject_pixels:
-        raise ValueError(
-            f"Composite output would be {total_pixels:,} pixels "
-            f"(max {max_reproject_pixels:,}). "
-            f"Shape: {shape_out[1]}x{shape_out[0]}"
+    num_channels = len(channels)
+    total_reproject_budget = total_pixels * num_channels
+
+    # Adaptive downscaling: treat max_reproject_pixels as a total budget
+    # across all channels. For 3 channels each gets ~21M px (full quality);
+    # for 8 channels each gets ~8M px (automatically reduced). The final
+    # output is resized to request dimensions anyway, so quality loss is minimal.
+    if total_reproject_budget > max_reproject_pixels:
+        target_per_channel = max_reproject_pixels // num_channels
+        factor = (target_per_channel / total_pixels) ** 0.5
+        shape_out = (int(shape_out[0] * factor), int(shape_out[1] * factor))
+        wcs_out.wcs.cdelt /= factor
+        wcs_out.wcs.crpix *= factor
+        total_pixels = shape_out[0] * shape_out[1]
+        logger.info(
+            f"Downscaled output grid to {shape_out[1]}x{shape_out[0]} "
+            f"for {num_channels} channels (budget: {max_reproject_pixels:,} px total)"
         )
+
+    est_mb = num_channels * total_pixels * 8 / (1024 * 1024)
+    logger.info(
+        f"Reprojecting {num_channels} channels to "
+        f"{shape_out[1]}x{shape_out[0]} (est. {est_mb:.0f} MB)"
+    )
 
     reprojected_channels: dict[str, np.ndarray] = {}
     for channel_name, (data, wcs) in channels.items():
@@ -299,6 +318,8 @@ def reproject_channels_to_common_wcs(
         reprojected = np.nan_to_num(reprojected, nan=0.0, posinf=0.0, neginf=0.0)
         reprojected[footprint == 0] = 0.0
         reprojected_channels[channel_name] = reprojected
+        del footprint
+        gc.collect()
 
     return reprojected_channels, shape_out
 
@@ -421,11 +442,12 @@ async def generate_nchannel_composite(request: NChannelCompositeRequest):
                 error_msg = str(e)
                 if "Could not determine common WCS" in error_msg:
                     raise HTTPException(status_code=400, detail=error_msg) from e
-                if "pixels" in error_msg and "max" in error_msg:
-                    raise HTTPException(status_code=413, detail=error_msg) from e
                 raise HTTPException(
                     status_code=500, detail=f"Composite reprojection failed: {e}"
                 ) from e
+
+            del raw_channels
+            gc.collect()
 
             logger.info(f"Reprojected {n} channels to common WCS grid: {target_shape}")
             _cache.put(cache_key, reprojected_channels)


### PR DESCRIPTION
## Summary
Fixes SIGKILL OOM crash when generating an 8-channel composite (e.g. Pillars of Creation from guided create). The processing engine was silently killed by the OS when `reproject_channels_to_common_wcs()` tried to reproject all 8 channels onto a ~4000x4000 grid simultaneously, exceeding available memory.

## Why
With 8 channels (two NIRCam at ~16M pixels, six MIRI), peak memory during reprojection reached 4-5 GB — too much for the Docker container's ~8 GB share. The user saw "An error occurred while sending the request" with no traceback or useful error message, and the container restarted 6 times.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Replace hard pixel-limit error with **adaptive output grid scaling** that treats `MAX_COMPOSITE_REPROJECT_PIXELS` (64M) as a total budget across all channels rather than a per-grid limit
  - 3 channels: ~21M px each (full quality preserved, no downscaling)
  - 8 channels: ~8M px each (~2828×2828, automatically reduced)
  - Final output is resized to `request.width × request.height` anyway, so quality loss is minimal
- Add `gc.collect()` after each channel reprojection and `del footprint` to free ~128 MB per iteration
- Release `raw_channels` dict after reprojection completes to free pre-reproject input arrays
- Add memory diagnostics logging (estimated MB, grid dimensions, channel count)
- Remove now-unnecessary 413 error path (adaptive scaling handles it gracefully)

## Test Plan
- [x] `ruff check` and `ruff format --check` pass
- [x] `pytest` — 815 tests pass
- [ ] Navigate to guided create for PMR 1 (Pillars of Creation) → complete download → Step 2 Process should complete without crash
- [ ] Check `docker logs jwst-processing` for:
  - `"Downscaled output grid to NxN for 8 channels"` (adaptive scaling triggered)
  - `"Reprojecting 8 channels to NxN (est. N MB)"` (reasonable estimate)
  - `"N-channel composite generated"` (success)
- [ ] Regression: test a 3-channel composite from library → should work at full resolution (no downscaling triggered)

## Documentation Checklist
- [x] No new controllers, services, or endpoints — no doc updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — changes are isolated to the composite reprojection path. The adaptive scaling is a strict improvement over the previous hard error. 3-channel composites are unaffected (budget is only consumed when `channels × pixels > 64M`).

Rollback: Revert this commit. The previous behavior (hard error at 64M pixels per grid) returns.

## Quality Checklist
- [x] Code compiles/runs without errors
- [x] Edge cases considered (single channel, 3 channels under budget, many channels over budget)
- [x] No hardcoded values — uses existing `MAX_COMPOSITE_REPROJECT_PIXELS` env var
- [x] Logging added for observability