### PR TITLE
feat: add NASA/STScI thumbnail images to featured targets

### DIFF
--- a/backend/JwstDataAnalysis.API/Configuration/featured-targets.json
+++ b/backend/JwstDataAnalysis.API/Configuration/featured-targets.json
@@ -7,6 +7,7 @@
     "instruments": ["NIRCam"],
     "filterCount": 6,
     "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/07/STScI-01GA6KKWG229B16K4Q38CH3BXS.png?w=600",
     "mastSearchParams": {
       "target": "Carina Nebula",
       "instrument": "NIRCAM",
@@ -21,6 +22,7 @@
     "instruments": ["NIRCam", "MIRI"],
     "filterCount": 8,
     "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/10/STScI-01GGF8H15VZ09MET9HFBRQX4S3.png?w=600",
     "mastSearchParams": {
       "target": "M16",
       "instrument": "NIRCAM",
@@ -35,6 +37,7 @@
     "instruments": ["NIRCam", "MIRI"],
     "filterCount": 6,
     "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/07/STScI-01G8GZQ3ZFJRD8YF8YZWMAXCE3.png?w=600",
     "mastSearchParams": {
       "target": "NGC 3132",
       "instrument": "NIRCAM",
@@ -49,6 +52,7 @@
     "instruments": ["NIRCam", "MIRI"],
     "filterCount": 7,
     "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/07/STScI-01G8H49RQ0E48YDM8WKW9PP5XS.png?w=600",
     "mastSearchParams": {
       "target": "Stephan's Quintet",
       "instrument": "NIRCAM",
@@ -63,6 +67,7 @@
     "instruments": ["NIRCam"],
     "filterCount": 6,
     "compositePotential": "good",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/07/STScI-01G8H1K2BCNATEZSKVRN9Z69SR.png?w=600",
     "mastSearchParams": {
       "target": "SMACS 0723",
       "instrument": "NIRCAM",
@@ -77,6 +82,7 @@
     "instruments": ["NIRCam", "MIRI"],
     "filterCount": 8,
     "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/09/STScI-01GA76Q01D09HFEV174SVMQDMV.png?w=600",
     "mastSearchParams": {
       "target": "NGC 2070",
       "instrument": "NIRCAM",
@@ -91,6 +97,7 @@
     "instruments": ["NIRCam", "MIRI"],
     "filterCount": 5,
     "compositePotential": "good",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/08/STScI-01G9G4J23CDPVNGCYDJRZTTJQN.png?w=600",
     "mastSearchParams": {
       "target": "Cartwheel",
       "instrument": "NIRCAM",
@@ -105,6 +112,7 @@
     "instruments": ["NIRCam"],
     "filterCount": 3,
     "compositePotential": "limited",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/10/STScI-01HCX1B69H5ZEF6S18S0F6PM1V.png?w=600",
     "mastSearchParams": {
       "target": "Jupiter",
       "instrument": "NIRCAM",
@@ -119,6 +127,7 @@
     "instruments": ["NIRCam", "MIRI"],
     "filterCount": 8,
     "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/12/STScI-01HGGZBZ1WK06H9NMB5WZTZPXD.png?w=600",
     "mastSearchParams": {
       "target": "Cas A",
       "instrument": "NIRCAM",
@@ -133,6 +142,7 @@
     "instruments": ["NIRCam"],
     "filterCount": 5,
     "compositePotential": "good",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/07/STScI-01H44AVB69N1P8RAEJ12NW2RB2.png?w=600",
     "mastSearchParams": {
       "target": "Rho Oph",
       "instrument": "NIRCAM",
@@ -147,6 +157,7 @@
     "instruments": ["MIRI"],
     "filterCount": 4,
     "compositePotential": "limited",
+    "thumbnail": "https://cdn.esawebb.org/archives/images/wallpaper1/potm2208a.jpg",
     "mastSearchParams": {
       "target": "M74",
       "instrument": "MIRI",
@@ -161,6 +172,7 @@
     "instruments": ["NIRCam", "MIRI"],
     "filterCount": 6,
     "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2024/04/STScI-01HV4CG0EACM1MC07E10X19KNX.png?w=600",
     "mastSearchParams": {
       "target": "Horsehead",
       "instrument": "NIRCAM",
@@ -175,6 +187,7 @@
     "instruments": ["NIRCam", "MIRI"],
     "filterCount": 6,
     "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/10/STScI-01HBBMF6GFYQG7ECGX1WD3W92B.png?w=600",
     "mastSearchParams": {
       "target": "M1",
       "instrument": "NIRCAM",


### PR DESCRIPTION
## Summary
Add official JWST thumbnail URLs to all 13 featured targets on the discovery home page.

## Why
The featured target cards showed placeholder gradient backgrounds with a telescope icon instead of real images. The `FeaturedTarget` model already supports a `thumbnail` field and `TargetCard.tsx` renders it — the data just wasn't populated.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Changes Made
- Add `thumbnail` URLs to all 13 entries in `featured-targets.json`
- 12 targets use NASA's dynamic image service (`assets.science.nasa.gov/dynamicimage/...?w=600`) for 600px-wide thumbnails
- 1 target (Phantom Galaxy) uses ESA's CDN (`cdn.esawebb.org`) since it was an ESA Picture of the Month release
- All URLs verified: HTTP 200, CORS enabled (`access-control-allow-origin: *`), public/no-auth

## Test Plan
- [x] `curl` verified all 13 URLs return HTTP 200
- [x] Verified CORS headers allow cross-origin loading
- [x] Backend API returns thumbnails: `curl localhost:5001/api/discovery/featured`
- [ ] Open `http://localhost:3000/` — all 13 featured target cards show real JWST images
- [ ] Scroll down to confirm lazy loading works (images below fold load on scroll)
- [ ] Verify `onError` fallback: if a URL were to fail, card falls back to placeholder icon

## Documentation Checklist
- [x] No new controllers, services, or endpoints — no doc updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: None — config-only change. If any NASA/STScI URL goes offline, the `onError` handler in `TargetCard.tsx` hides the broken image and the gradient placeholder remains visible.
Rollback: Revert this commit to restore placeholder backgrounds.

## Quality Checklist
- [x] No code changes, only JSON config
- [x] 763 backend tests pass
- [x] All URLs are official NASA/STScI/ESA public resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)