### PR TITLE
fix: show active stage indicator during composite processing

### DIFF
--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
@@ -27,6 +27,7 @@ function getStages(
   requiresMosaic: boolean,
   phase: 'mosaic' | 'composite',
   isComplete: boolean,
+  progressPercent: number,
   progressStage?: string
 ): StageIndicator[] {
   const stages: StageIndicator[] = [];
@@ -43,12 +44,40 @@ function getStages(
   const compositeDone = isComplete;
   const compositeActive = phase === 'composite' && !isComplete;
 
+  // The backend sends known stage names (Loading, ColorMapping, Finalizing) when
+  // available. Otherwise it sends a single "generating" stage at progress=10 and
+  // then completes. When exact stages aren't available, infer: once the job has
+  // started (any progress), mark "Loading files" done and show the next stage active.
+  const hasExactStage =
+    progressStage === 'Loading' ||
+    progressStage === 'ColorMapping' ||
+    progressStage === 'Finalizing';
+  const jobStarted = progressPercent > 0 || !!progressStage;
+
+  let loadingDone: boolean;
+  let colorMappingDone: boolean;
+  let colorMappingActive: boolean;
+  let finalizingActive: boolean;
+
+  if (hasExactStage) {
+    loadingDone = progressStage !== 'Loading';
+    colorMappingDone = progressStage === 'Finalizing';
+    colorMappingActive = progressStage === 'ColorMapping';
+    finalizingActive = progressStage === 'Finalizing';
+  } else {
+    // No granular stages — show "color mapping" as active once the job has started
+    loadingDone = jobStarted;
+    colorMappingDone = false;
+    colorMappingActive = jobStarted;
+    finalizingActive = false;
+  }
+
   stages.push({
     label: 'Loading files',
     status:
-      compositeDone || (compositeActive && progressStage && progressStage !== 'Loading')
+      compositeDone || (compositeActive && loadingDone)
         ? 'done'
-        : compositeActive && (!progressStage || progressStage === 'Loading')
+        : compositeActive
           ? 'active'
           : 'pending',
   });
@@ -56,20 +85,16 @@ function getStages(
   stages.push({
     label: 'Applying color mapping',
     status:
-      compositeDone || (compositeActive && progressStage === 'Finalizing')
+      compositeDone || (compositeActive && colorMappingDone)
         ? 'done'
-        : compositeActive && progressStage === 'ColorMapping'
+        : compositeActive && colorMappingActive
           ? 'active'
           : 'pending',
   });
 
   stages.push({
     label: 'Final adjustments',
-    status: compositeDone
-      ? 'done'
-      : compositeActive && progressStage === 'Finalizing'
-        ? 'active'
-        : 'pending',
+    status: compositeDone ? 'done' : compositeActive && finalizingActive ? 'active' : 'pending',
   });
 
   return stages;
@@ -88,7 +113,13 @@ export function ProcessStep({
   isComplete,
   onRetry,
 }: ProcessStepProps) {
-  const stages = getStages(requiresMosaic, phase, isComplete, progress?.stage);
+  const stages = getStages(
+    requiresMosaic,
+    phase,
+    isComplete,
+    progress?.progress ?? 0,
+    progress?.stage
+  );
 
   return (
     <div className="process-step" role="status" aria-live="polite">


### PR DESCRIPTION
## Summary
Fix the process step (step 2) in guided create so it shows an active pulsing indicator on the current processing stage instead of leaving all stages as pending circles.

## Why
After "Loading files" completed, "Applying color mapping" and "Final adjustments" both showed empty pending circles with no active indicator — making it look like processing had stalled. The root cause: the backend sends `stage="generating"` but the frontend expected exact stage names (`Loading`, `ColorMapping`, `Finalizing`) that are never sent.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Refactor `getStages()` in `ProcessStep.tsx` to accept `progressPercent` in addition to `progressStage`
- When the backend sends known stage names (`Loading`/`ColorMapping`/`Finalizing`), use them directly (forward-compatible)
- When unknown stage names are received (current behavior: `"generating"`), infer the active stage: once the job has started, mark "Loading files" as done and "Applying color mapping" as active with the pulsing animation

## Test Plan
- [x] ESLint clean, 835 tests pass
- [ ] Navigate to guided create, start a composite
- [ ] Step 2: verify "Loading files" shows as active (pulsing blue dot) initially
- [ ] Once backend sends progress update: "Loading files" shows checkmark, "Applying color mapping" shows pulsing blue dot
- [ ] On completion: all three stages show green checkmarks, advances to Result step

## Documentation Checklist
- [x] No new controllers, services, or endpoints — no doc updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — single component change, isolated to the Process step UI indicator logic. No backend changes.
Rollback: Revert this commit.

## Quality Checklist
- [x] Code follows project style guidelines
- [x] No TypeScript errors
- [x] All 835 tests pass
- [x] Forward-compatible: if backend adds granular stage names later, they'll be used automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)