### PR TITLE
fix: cap download speed display and add GB formatting tier

### DIFF
--- a/frontend/jwst-frontend/src/components/guided/DownloadStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/DownloadStep.tsx
@@ -17,7 +17,8 @@ interface DownloadStepProps {
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
 const NO_PRODUCTS_PREFIX = 'NO_PRODUCTS:';
@@ -136,11 +137,13 @@ export function DownloadStep({
               </span>
             )}
             {progress?.stage && <span className="download-step-stage">{progress.stage}</span>}
-            {progress?.speedBytesPerSec != null && progress.speedBytesPerSec > 0 && (
-              <span className="download-step-speed">
-                {formatBytes(progress.speedBytesPerSec)}/s
-              </span>
-            )}
+            {progress?.speedBytesPerSec != null &&
+              progress.speedBytesPerSec > 0 &&
+              progress.speedBytesPerSec < 10 * 1024 * 1024 * 1024 && (
+                <span className="download-step-speed">
+                  {formatBytes(progress.speedBytesPerSec)}/s
+                </span>
+              )}
           </p>
 
           {fileProgress.length > 0 && (


### PR DESCRIPTION
## Summary
Fixes absurd download speed display (e.g. "3173269.6 MB/s") caused by cached files completing near-instantly and `formatBytes()` lacking a GB tier.

## Why
The `SpeedTracker` sliding window produces extreme byte/sec values when files complete from cache with near-zero elapsed time. Combined with `formatBytes()` only handling up to MB, users saw nonsensical multi-million MB/s speeds.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Added GB tier to `formatBytes()` in `DownloadStep.tsx` — values >= 1 GB now display as "X.X GB" instead of enormous MB numbers
- Capped speed display at 10 GB/s — speeds above this threshold are measurement artifacts from cached files, so the speed indicator is hidden entirely

## Test Plan
- [x] Run guided create flow with a target that has cached data
- [x] Verify speed shows reasonable values (KB/s or MB/s range)
- [x] Verify speed indicator hides when cached files produce extreme values
- [x] Verify `formatBytes()` correctly formats values in GB range

## Documentation Checklist
- [x] No new endpoints, components, or architectural changes

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — display-only change in a single component, no behavioral changes.
Rollback: Revert the single commit.

## Quality Checklist
- [x] Code follows project conventions
- [x] No new warnings introduced
- [x] All existing tests pass