### PR TITLE
fix: set data directory ownership for container user in server-setup

### DIFF
--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -62,7 +62,9 @@ fi
 
 # --- Create data directory ----------------------------------------------------
 mkdir -p "$APP_DIR/data/mast"
-ok "Data directory ready"
+# Containers run as uid/gid 1001 (appuser/appgroup) — ensure they can write
+sudo chown -R 1001:1001 "$APP_DIR/data"
+ok "Data directory ready (owned by container user 1001)"
 
 # --- Environment File --------------------------------------------------------
 ENV_FILE="$APP_DIR/docker/.env"


### PR DESCRIPTION
## Summary
Fix PermissionError on first EC2 deployment by setting data directory ownership to uid 1001.

## Why
Containers run as non-root `appuser` (uid 1001). The data directory created by `mkdir` is owned by `ec2-user`, so the processing engine crashes with `PermissionError: [Errno 13] Permission denied: '/app/data/mast/.download_state'` on first boot.

## Type of Change
- [x] Bug fix

## Changes Made
- Added `sudo chown -R 1001:1001` for the data directory in `server-setup.sh`

## Test Plan
- [x] Verified fix resolves the issue on live EC2 instance (staging server)

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: None — only affects new deployments.
Rollback: Revert the one-line change.

## Quality Checklist
- [x] Code follows project conventions
- [x] No security concerns