### PR TITLE
fix: add SignalR /hubs proxy to nginx staging and production configs

### DIFF
--- a/frontend/jwst-frontend/nginx-ssl.conf
+++ b/frontend/jwst-frontend/nginx-ssl.conf
@@ -93,6 +93,23 @@ server {
         proxy_read_timeout 300s;
     }
 
+    # Proxy SignalR hub to backend (WebSocket required for real-time progress)
+    location /hubs {
+        proxy_pass http://backend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket upgrade — required for SignalR
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Long timeout for persistent connections
+        proxy_read_timeout 3600s;
+    }
+
     # Error pages
     error_page 500 502 503 504 /50x.html;
     location = /50x.html {

--- a/frontend/jwst-frontend/nginx-staging.conf
+++ b/frontend/jwst-frontend/nginx-staging.conf
@@ -43,6 +43,23 @@ server {
         proxy_read_timeout 300s;
     }
 
+    # Proxy SignalR hub to backend (WebSocket required for real-time progress)
+    location /hubs {
+        proxy_pass http://backend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket upgrade — required for SignalR
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Long timeout for persistent connections
+        proxy_read_timeout 3600s;
+    }
+
     error_page 500 502 503 504 /50x.html;
     location = /50x.html {
         root /usr/share/nginx/html;


### PR DESCRIPTION
## Summary
Add `/hubs` location block to nginx staging and production configs to proxy SignalR WebSocket connections to the backend.

## Why
SignalR connects to `/hubs/job-progress` for real-time job progress updates. The nginx configs only proxied `/api`, so SignalR negotiate/connect requests hit the SPA fallback (`try_files → index.html`) instead of reaching the backend. This caused the guided create flow to appear stuck at "Loading files" — the composite job completed server-side but the frontend never received the completion event.

## Type of Change
- [x] Bug fix

## Changes Made
- Added `location /hubs` proxy block in `nginx-staging.conf` with WebSocket upgrade headers and 1-hour read timeout for persistent connections
- Added matching `location /hubs` block in `nginx-ssl.conf` (production) to prevent the same issue when SSL is enabled

## Test Plan
- [x] Deployed fix to staging server (staging server), restarted frontend
- [ ] Re-test guided create flow: Discovery → M16 → Create Composite → verify progress updates and completion

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: None — adds a new proxy route, doesn't change existing behavior.
Rollback: Remove the `/hubs` location blocks from both nginx configs.

## Quality Checklist
- [x] Code follows project conventions
- [x] No security concerns