### PR TITLE
fix: filter proprietary MAST data from searches and recipes

### DIFF
--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -90,6 +90,7 @@ function toObservationInputs(observations: MastObservationResult[]): Observation
       filter: obs.filters,
       instrument: obs.instrument_name,
       observationId: obs.obs_id,
+      tObsRelease: obs.t_obs_release,
     });
   }
   return inputs;

--- a/frontend/jwst-frontend/src/pages/TargetDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.tsx
@@ -24,6 +24,7 @@ function toObservationInputs(observations: MastObservationResult[]): Observation
       filter: obs.filters,
       instrument: obs.instrument_name,
       observationId: obs.obs_id,
+      tObsRelease: obs.t_obs_release,
     });
   }
   return inputs;

--- a/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
+++ b/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
@@ -23,6 +23,7 @@ export interface ObservationInput {
   instrument: string;
   wavelengthUm?: number;
   observationId?: string;
+  tObsRelease?: number;
 }
 
 /** A composite recipe suggestion from the recipe engine */

--- a/processing-engine/app/discovery/models.py
+++ b/processing-engine/app/discovery/models.py
@@ -10,6 +10,11 @@ class ObservationInput(BaseModel):
     instrument: str = Field(..., description="Instrument name (e.g. NIRCAM)")
     wavelength_um: float | None = Field(default=None, description="Wavelength in micrometers")
     observation_id: str | None = Field(default=None, description="MAST observation ID")
+    t_obs_release: float | None = Field(
+        default=None,
+        description="Data release date in Modified Julian Date. "
+        "If set and in the future, the observation is still proprietary.",
+    )
 
 
 class SuggestRecipesRequest(BaseModel):

--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -6,10 +6,15 @@ ranked composite recipes with chromatic-ordered color assignments.
 """
 
 import logging
+from datetime import UTC, datetime
 
 from app.composite.color_mapping import chromatic_order_hues, hue_to_rgb_weights
 
 from .models import ObservationInput, Recipe
+
+
+# MJD epoch: November 17, 1858
+_MJD_EPOCH = datetime(1858, 11, 17, tzinfo=UTC)
 
 
 logger = logging.getLogger(__name__)
@@ -116,6 +121,19 @@ def generate_recipes(observations: list[ObservationInput]) -> list[Recipe]:
     Returns:
         Ranked list of Recipe objects.
     """
+    if not observations:
+        return []
+
+    # Filter out proprietary observations (Option B safety net)
+    today_mjd = (datetime.now(UTC) - _MJD_EPOCH).days
+    public_observations = [
+        obs for obs in observations if obs.t_obs_release is None or obs.t_obs_release <= today_mjd
+    ]
+    if len(public_observations) < len(observations):
+        dropped = len(observations) - len(public_observations)
+        logger.info(f"Filtered {dropped} proprietary observation(s) from recipe input")
+    observations = public_observations
+
     if not observations:
         return []
 

--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -9,7 +9,7 @@ import logging
 import os
 import re
 from collections.abc import Callable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import quote
 
@@ -24,6 +24,14 @@ ProgressCallback = Callable[[str, int, int], None]  # (filename, current, total)
 
 # MAST download base for converting mast: URIs to HTTPS URLs
 _MAST_DOWNLOAD_BASE = "https://mast.stsci.edu/api/v0.1/Download/file"
+
+# MJD (Modified Julian Date) epoch: November 17, 1858
+_MJD_EPOCH = datetime(1858, 11, 17, tzinfo=UTC)
+
+
+def _today_mjd() -> int:
+    """Return today's date as Modified Julian Date (integer days)."""
+    return (datetime.now(UTC) - _MJD_EPOCH).days
 
 
 def _convert_mast_uris(rows: list[dict[str, Any]]) -> None:
@@ -182,6 +190,7 @@ class MastService:
         radius: float = 0.2,
         _filters: dict[str, Any] | None = None,
         calib_level: list[int] | None = None,
+        exclude_proprietary: bool = True,
     ) -> list[dict[str, Any]]:
         """
         Search MAST by target name (e.g., 'NGC 1234', 'Carina Nebula').
@@ -219,13 +228,16 @@ class MastService:
             )
 
             # Step 2: Query MAST with coordinate box filter (much faster than query_object)
-            obs_table = Observations.query_criteria(
-                obs_collection="JWST",
-                s_ra=[coord.ra.deg - radius, coord.ra.deg + radius],
-                s_dec=[coord.dec.deg - radius, coord.dec.deg + radius],
-                calib_level=calib_level,
-                pagesize=self.DEFAULT_PAGE_SIZE,
-            )
+            query_params: dict[str, Any] = {
+                "obs_collection": "JWST",
+                "s_ra": [coord.ra.deg - radius, coord.ra.deg + radius],
+                "s_dec": [coord.dec.deg - radius, coord.dec.deg + radius],
+                "calib_level": calib_level,
+                "pagesize": self.DEFAULT_PAGE_SIZE,
+            }
+            if exclude_proprietary:
+                query_params["t_obs_release"] = [0, _today_mjd()]
+            obs_table = Observations.query_criteria(**query_params)
 
             logger.info(f"Found {len(obs_table)} JWST observations")
             return self._table_to_dict_list(obs_table)
@@ -239,6 +251,7 @@ class MastService:
         dec: float,
         radius: float = 0.2,
         calib_level: list[int] | None = None,
+        exclude_proprietary: bool = True,
     ) -> list[dict[str, Any]]:
         """
         Search MAST by RA/Dec coordinates.
@@ -262,13 +275,16 @@ class MastService:
             )
 
             # Use query_criteria instead of query_region to support calib_level filter
-            obs_table = Observations.query_criteria(
-                obs_collection="JWST",
-                s_ra=[ra - radius, ra + radius],
-                s_dec=[dec - radius, dec + radius],
-                calib_level=calib_level,
-                pagesize=self.DEFAULT_PAGE_SIZE,
-            )
+            query_params: dict[str, Any] = {
+                "obs_collection": "JWST",
+                "s_ra": [ra - radius, ra + radius],
+                "s_dec": [dec - radius, dec + radius],
+                "calib_level": calib_level,
+                "pagesize": self.DEFAULT_PAGE_SIZE,
+            }
+            if exclude_proprietary:
+                query_params["t_obs_release"] = [0, _today_mjd()]
+            obs_table = Observations.query_criteria(**query_params)
 
             logger.info(f"Found {len(obs_table)} JWST observations")
             return self._table_to_dict_list(obs_table)
@@ -277,7 +293,7 @@ class MastService:
             raise
 
     def search_by_observation_id(
-        self, obs_id: str, calib_level: list[int] | None = None
+        self, obs_id: str, calib_level: list[int] | None = None, exclude_proprietary: bool = True
     ) -> list[dict[str, Any]]:
         """
         Search MAST by observation ID.
@@ -304,6 +320,8 @@ class MastService:
             # Only add calib_level filter if specified (observation ID searches default to all levels)
             if calib_level:
                 query_params["calib_level"] = calib_level
+            if exclude_proprietary:
+                query_params["t_obs_release"] = [0, _today_mjd()]
 
             obs_table = Observations.query_criteria(**query_params)
             logger.info(f"Found {len(obs_table)} observations")
@@ -313,7 +331,10 @@ class MastService:
             raise
 
     def search_by_program_id(
-        self, program_id: str, calib_level: list[int] | None = None
+        self,
+        program_id: str,
+        calib_level: list[int] | None = None,
+        exclude_proprietary: bool = True,
     ) -> list[dict[str, Any]]:
         """
         Search MAST by program/proposal ID.
@@ -331,12 +352,15 @@ class MastService:
                 calib_level = [3]
 
             logger.info(f"Searching MAST for program ID: {program_id}, calib_level: {calib_level}")
-            obs_table = Observations.query_criteria(
-                proposal_id=program_id,
-                obs_collection="JWST",
-                calib_level=calib_level,
-                pagesize=self.DEFAULT_PAGE_SIZE,
-            )
+            query_params: dict[str, Any] = {
+                "proposal_id": program_id,
+                "obs_collection": "JWST",
+                "calib_level": calib_level,
+                "pagesize": self.DEFAULT_PAGE_SIZE,
+            }
+            if exclude_proprietary:
+                query_params["t_obs_release"] = [0, _today_mjd()]
+            obs_table = Observations.query_criteria(**query_params)
             logger.info(f"Found {len(obs_table)} observations")
             return self._table_to_dict_list(obs_table)
         except Exception as e:
@@ -360,13 +384,8 @@ class MastService:
         """
         try:
             # Calculate MJD date range
-            # MJD (Modified Julian Date) epoch is November 17, 1858
-            MJD_EPOCH = datetime(1858, 11, 17, tzinfo=UTC)
-            today = datetime.now(UTC)
-            start_date = today - timedelta(days=days_back)
-
-            min_mjd = (start_date - MJD_EPOCH).days
-            max_mjd = (today - MJD_EPOCH).days
+            max_mjd = _today_mjd()
+            min_mjd = max_mjd - days_back
 
             logger.info(
                 f"Searching MAST for recent releases: {days_back} days back, MJD range [{min_mjd}, {max_mjd}]"

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -1,7 +1,10 @@
 """Tests for the discovery recipe engine."""
 
+from datetime import UTC, datetime, timedelta
+
 from app.discovery.models import ObservationInput
 from app.discovery.recipe_engine import (
+    _MJD_EPOCH,
     build_color_mapping,
     generate_recipes,
     hue_to_hex,
@@ -255,3 +258,57 @@ class TestGenerateRecipes:
         recipes = generate_recipes(obs)
         names = [r.name for r in recipes]
         assert not any("Broadband" in n for n in names)
+
+
+class TestProprietaryFiltering:
+    """Tests for filtering proprietary (unreleased) observations."""
+
+    def _future_mjd(self, days_ahead: int = 365) -> float:
+        """Return an MJD value in the future."""
+        return (datetime.now(UTC) + timedelta(days=days_ahead) - _MJD_EPOCH).days
+
+    def _past_mjd(self, days_ago: int = 365) -> float:
+        """Return an MJD value in the past."""
+        return (datetime.now(UTC) - timedelta(days=days_ago) - _MJD_EPOCH).days
+
+    def test_proprietary_observations_excluded(self):
+        """Observations with future t_obs_release should be filtered out."""
+        obs = [
+            ObservationInput(filter="F444W", instrument="NIRCAM", t_obs_release=self._future_mjd()),
+            ObservationInput(filter="F200W", instrument="NIRCAM", t_obs_release=self._past_mjd()),
+        ]
+        recipes = generate_recipes(obs)
+        assert len(recipes) == 1
+        assert recipes[0].filters == ["F200W"]
+
+    def test_all_proprietary_returns_empty(self):
+        """If all observations are proprietary, return no recipes."""
+        obs = [
+            ObservationInput(filter="F444W", instrument="NIRCAM", t_obs_release=self._future_mjd()),
+            ObservationInput(filter="F200W", instrument="NIRCAM", t_obs_release=self._future_mjd()),
+        ]
+        recipes = generate_recipes(obs)
+        assert recipes == []
+
+    def test_none_release_date_treated_as_public(self):
+        """Observations without t_obs_release should be treated as public."""
+        obs = [
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        assert len(recipes) >= 1
+        assert set(recipes[0].filters) == {"F200W", "F444W"}
+
+    def test_mixed_public_and_no_release_date(self):
+        """Mix of explicit public dates and None should all pass through."""
+        obs = [
+            ObservationInput(filter="F444W", instrument="NIRCAM", t_obs_release=self._past_mjd()),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F090W", instrument="NIRCAM", t_obs_release=self._future_mjd()),
+        ]
+        recipes = generate_recipes(obs)
+        all_recipe = recipes[0]
+        assert "F090W" not in all_recipe.filters
+        assert "F444W" in all_recipe.filters
+        assert "F200W" in all_recipe.filters


### PR DESCRIPTION
## Summary
Prevent users from encountering HTTP 401 download errors when JWST data is still under proprietary access periods. Implements dual-layer filtering: at MAST query time (Option A) and as a safety net in the recipe engine (Option B).

## Why
Users hitting "Carina Nebula" on staging got 401 errors because program jw05408 data is still proprietary. MAST returns these observations in search results, but downloads fail because the data hasn't been publicly released yet. The `t_obs_release` MJD field indicates when data becomes public.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Added `exclude_proprietary: bool = True` parameter to all 4 MAST search methods (`search_by_target`, `search_by_coordinates`, `search_by_observation_id`, `search_by_program_id`)
- Each method now adds `t_obs_release=[0, _today_mjd()]` filter to MAST query criteria when enabled, ensuring only publicly released data is returned
- Added shared `_MJD_EPOCH` constant and `_today_mjd()` helper; refactored `search_recent_releases` to use it
- Added `t_obs_release` field to `ObservationInput` model (Python + TypeScript)
- Added proprietary filtering at the top of `generate_recipes()` — drops observations with future release dates before recipe generation
- Updated `toObservationInputs()` in both `TargetDetail.tsx` and `GuidedCreate.tsx` to pass `t_obs_release` through

## Test Plan
- [x] All 33 recipe engine tests pass (4 new proprietary filtering tests)
- [x] All 835 frontend tests pass
- [ ] Deploy to staging and search for a target with mixed public/proprietary data — proprietary observations should not appear
- [ ] Verify recipe generation works correctly with only public observations

## Documentation Checklist
- [x] No new controllers/services/endpoints — existing ones modified
- [ ] `docs/tech-debt.md` modified? N/A

## Tech Debt Impact
- [x] Reduces tech debt (removes a class of runtime errors)

## Risk & Rollback
Risk: Low — additive filtering with sensible defaults. All search methods default to `exclude_proprietary=True` so no API changes needed.
Rollback: Revert this PR. Proprietary observations will appear again but won't cause data loss.

## Quality Checklist
- [x] No hardcoded secrets or credentials
- [x] Error handling is appropriate
- [x] No unnecessary dependencies added
- [x] Code follows existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)