### PR TITLE
fix: use Simbad-resolvable names for featured target searches

### DIFF
--- a/backend/JwstDataAnalysis.API/Configuration/featured-targets.json
+++ b/backend/JwstDataAnalysis.API/Configuration/featured-targets.json
@@ -69,7 +69,7 @@
     "compositePotential": "good",
     "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/07/STScI-01G8H1K2BCNATEZSKVRN9Z69SR.png?w=600",
     "mastSearchParams": {
-      "target": "SMACS 0723",
+      "target": "SMACS J0723.3-7327",
       "instrument": "NIRCAM",
       "productLevel": "2b"
     }
@@ -99,7 +99,7 @@
     "compositePotential": "good",
     "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/08/STScI-01G9G4J23CDPVNGCYDJRZTTJQN.png?w=600",
     "mastSearchParams": {
-      "target": "Cartwheel",
+      "target": "Cartwheel Galaxy",
       "instrument": "NIRCAM",
       "productLevel": "2b"
     }
@@ -129,7 +129,7 @@
     "compositePotential": "great",
     "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/12/STScI-01HGGZBZ1WK06H9NMB5WZTZPXD.png?w=600",
     "mastSearchParams": {
-      "target": "Cas A",
+      "target": "Cassiopeia A",
       "instrument": "NIRCAM",
       "productLevel": "2b"
     }
@@ -144,7 +144,7 @@
     "compositePotential": "good",
     "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/07/STScI-01H44AVB69N1P8RAEJ12NW2RB2.png?w=600",
     "mastSearchParams": {
-      "target": "Rho Oph",
+      "target": "Rho Ophiuchi",
       "instrument": "NIRCAM",
       "productLevel": "2b"
     }
@@ -174,7 +174,7 @@
     "compositePotential": "great",
     "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2024/04/STScI-01HV4CG0EACM1MC07E10X19KNX.png?w=600",
     "mastSearchParams": {
-      "target": "Horsehead",
+      "target": "Horsehead Nebula",
       "instrument": "NIRCAM",
       "productLevel": "2b"
     }


### PR DESCRIPTION
## Summary
Fix featured target cards failing to resolve when clicked by using canonical astronomical names that Simbad/NED can look up.

## Why
Several featured targets used abbreviated names in `mastSearchParams.target` that Simbad cannot resolve (e.g., "Cartwheel" instead of "Cartwheel Galaxy"). When users click these cards, the target detail page fails because `SkyCoord.from_name()` can't find coordinates for the abbreviated name. The variant generator only handles formatting differences (spaces, hyphens), not missing words.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Updated `featured-targets.json` `mastSearchParams.target` values:
  - "Cartwheel" → "Cartwheel Galaxy"
  - "Cas A" → "Cassiopeia A"
  - "Rho Oph" → "Rho Ophiuchi"
  - "Horsehead" → "Horsehead Nebula"
  - "SMACS 0723" → "SMACS J0723.3-7327"

## Test Plan
- [x] Backend builds and all 763 tests pass
- [ ] Click each updated featured target card on staging and verify the target detail page loads successfully
- [ ] Verify alias resolution still works (e.g., searching "Cas A" manually should still resolve via catalogId alias)

## Documentation Checklist
- [x] No new controllers/services/endpoints
- [ ] `docs/tech-debt.md` modified? N/A

## Tech Debt Impact
- [x] Reduces tech debt (fixes broken featured targets)

## Risk & Rollback
Risk: Low — config-only change to a single JSON file.
Rollback: Revert this PR.

## Quality Checklist
- [x] No hardcoded secrets or credentials
- [x] Error handling is appropriate
- [x] No unnecessary dependencies added
- [x] Code follows existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)