### PR TITLE
fix: remove overflow hidden that prevents library dashboard scrolling

### DIFF
--- a/frontend/jwst-frontend/src/pages/MyLibrary.css
+++ b/frontend/jwst-frontend/src/pages/MyLibrary.css
@@ -2,7 +2,6 @@
   background-color: var(--bg-elevated);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
-  overflow: hidden;
 }
 
 .library-loading {


### PR DESCRIPTION
## Summary
Removes `overflow: hidden` from `.my-library` container which was clipping all child content and preventing the library dashboard page from scrolling.

## Why
The library dashboard stopped scrolling after PR #490 introduced `overflow: hidden` on the `.my-library` wrapper. The scroll chain is `.app-shell` (overflow: hidden) → `.app-main` (overflow-y: auto, scroll container) → `.my-library` (overflow: hidden — clips content so `.app-main` never sees overflow).

## Type of Change
- [x] Bug fix

## Changes Made
- Removed `overflow: hidden` from `.my-library` in `MyLibrary.css` — the property was originally added for `border-radius` clipping but it prevents the parent `.app-main` scroll container from detecting overflowing content

## Test Plan
- [x] Open `http://localhost:3000/library` with enough saved items to exceed viewport height
- [x] Verify the page scrolls normally (mouse wheel, trackpad, scrollbar)
- [x] Verify the border-radius on the `.my-library` container still renders correctly

## Documentation Checklist
- [x] No documentation updates needed (CSS-only bug fix)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — single CSS property removal, no logic changes.
Rollback: Revert commit, re-add `overflow: hidden` to `.my-library`.

## Quality Checklist
- [x] Changes are minimal and focused
- [x] No unrelated changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)