### PR TITLE
fix: wait for wizard stepper in composite E2E tests

### DIFF
--- a/frontend/jwst-frontend/e2e/composite-wizard.spec.ts
+++ b/frontend/jwst-frontend/e2e/composite-wizard.spec.ts
@@ -24,7 +24,7 @@ test.describe('Composite wizard', () => {
 
   test('displays 2-step wizard stepper', async ({ page }) => {
     await page.getByRole('button', { name: /Composite/i }).click();
-    await expect(page.locator('.composite-page')).toBeVisible();
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 10_000 });
 
     const steps = page.locator('.wizard-stepper .wizard-step');
     await expect(steps).toHaveCount(2);
@@ -34,9 +34,8 @@ test.describe('Composite wizard', () => {
 
   test('shows channel lanes on step 1', async ({ page }) => {
     await page.getByRole('button', { name: /Composite/i }).click();
-    await expect(page.locator('.composite-page')).toBeVisible();
+    await expect(page.locator('.channel-lanes')).toBeVisible({ timeout: 10_000 });
 
-    await expect(page.locator('.channel-lanes')).toBeVisible();
     // Should have at least the default channel lanes (RGB preset starts with 3)
     const lanes = page.locator('.channel-lane');
     expect(await lanes.count()).toBeGreaterThanOrEqual(1);
@@ -54,7 +53,7 @@ test.describe('Composite wizard', () => {
 
   test('navigates between steps (forward and back)', async ({ page }) => {
     await page.getByRole('button', { name: /Composite/i }).click();
-    await expect(page.locator('.composite-page')).toBeVisible();
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 10_000 });
 
     // Next should be disabled without images assigned
     const nextBtn = page.locator('.wizard-footer .btn-wizard.btn-primary');


### PR DESCRIPTION
## Summary
Fixes 3 failing E2E tests in `composite-wizard.spec.ts` by waiting for the wizard stepper to render instead of the loading state.

## Why
The CompositePage shows a "Loading images..." state while fetching data asynchronously. The loading div shares the `.composite-page` class, so the tests' `await expect(page.locator('.composite-page')).toBeVisible()` was passing immediately during the loading state — before the wizard stepper existed in the DOM.

## Type of Change
- [x] Bug fix

## Changes Made
- Changed 3 tests to wait for `.wizard-stepper` or `.channel-lanes` visibility (with 10s timeout) instead of `.composite-page`, ensuring the async image fetch has completed before asserting on wizard elements

## Test Plan
- [x] Run `npx playwright test --project=chromium e2e/composite-wizard.spec.ts` — all 6 tests pass (previously 3 failed)
- [x] Run full E2E suite to verify no regressions

## Documentation Checklist
- [x] No documentation updates needed (test-only fix)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — E2E test changes only, no production code modified.
Rollback: Revert commit.

## Quality Checklist
- [x] Changes are minimal and focused
- [x] No unrelated changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)