### PR TITLE
fix: exclude spectral observations from composite pipeline

### DIFF
--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -91,6 +91,7 @@ function toObservationInputs(observations: MastObservationResult[]): Observation
       instrument: obs.instrument_name,
       observationId: obs.obs_id,
       tObsRelease: obs.t_obs_release,
+      dataProductType: obs.dataproduct_type,
     });
   }
   return inputs;

--- a/frontend/jwst-frontend/src/pages/TargetDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.tsx
@@ -25,6 +25,7 @@ function toObservationInputs(observations: MastObservationResult[]): Observation
       instrument: obs.instrument_name,
       observationId: obs.obs_id,
       tObsRelease: obs.t_obs_release,
+      dataProductType: obs.dataproduct_type,
     });
   }
   return inputs;

--- a/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
+++ b/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
@@ -24,6 +24,7 @@ export interface ObservationInput {
   wavelengthUm?: number;
   observationId?: string;
   tObsRelease?: number;
+  dataProductType?: string;
 }
 
 /** A composite recipe suggestion from the recipe engine */

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -412,13 +412,22 @@ async def generate_nchannel_composite(request: NChannelCompositeRequest):
                 local_paths = [resolve_fits_path(fp) for fp in ch_config.file_paths]
                 logger.info(f"Loading channel {ch_name}: {len(local_paths)} file(s)")
 
-                try:
-                    file_data = [
-                        downscale_for_composite(*load_fits_2d_with_wcs(p), max_pixels=input_budget)
-                        for p in local_paths
-                    ]
-                except ValueError as e:
-                    raise HTTPException(status_code=400, detail=str(e)) from e
+                file_data = []
+                for p in local_paths:
+                    try:
+                        file_data.append(
+                            downscale_for_composite(
+                                *load_fits_2d_with_wcs(p), max_pixels=input_budget
+                            )
+                        )
+                    except ValueError as e:
+                        logger.warning(f"Skipping non-image file {p}: {e}")
+
+                if not file_data:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"No usable image data for channel {ch_name}",
+                    )
 
                 if len(file_data) == 1:
                     raw_channels[ch_name] = file_data[0]

--- a/processing-engine/app/discovery/models.py
+++ b/processing-engine/app/discovery/models.py
@@ -15,6 +15,11 @@ class ObservationInput(BaseModel):
         description="Data release date in Modified Julian Date. "
         "If set and in the future, the observation is still proprietary.",
     )
+    dataproduct_type: str | None = Field(
+        default=None,
+        description="MAST data product type (e.g. 'image', 'spectrum'). "
+        "Spectral observations are excluded from composite recipes.",
+    )
 
 
 class SuggestRecipesRequest(BaseModel):

--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -124,6 +124,20 @@ def generate_recipes(observations: list[ObservationInput]) -> list[Recipe]:
     if not observations:
         return []
 
+    # Filter out spectral observations (no 2D image data for composites)
+    image_observations = [
+        obs
+        for obs in observations
+        if obs.dataproduct_type is None or obs.dataproduct_type.lower() != "spectrum"
+    ]
+    if len(image_observations) < len(observations):
+        dropped = len(observations) - len(image_observations)
+        logger.info(f"Filtered {dropped} spectral observation(s) from recipe input")
+    observations = image_observations
+
+    if not observations:
+        return []
+
     # Filter out proprietary observations (Option B safety net)
     today_mjd = (datetime.now(UTC) - _MJD_EPOCH).days
     public_observations = [

--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -676,11 +676,15 @@ class MastService:
             logger.error(f"Failed to get product count: {e}")
             return 0
 
+    # Spectral file suffixes that have no 2D image data and crash the composite engine
+    SPECTRAL_SUFFIXES = ("_x1d", "_x1dints", "_c1d")
+
     def get_download_urls(
         self,
         obs_id: str,
         product_type: str = "SCIENCE",
         calib_level: list[int] | None = None,
+        exclude_spectral: bool = True,
     ) -> list[dict[str, Any]]:
         """
         Get direct download URLs for observation products.
@@ -716,6 +720,21 @@ class MastService:
                 logger.info(
                     f"Filtered to {len(filtered)} products with calib_level in {calib_level}"
                 )
+
+            # Exclude spectral file products (no 2D image data)
+            if exclude_spectral and len(filtered) > 0:
+                pre_count = len(filtered)
+                spectral_mask = [
+                    not any(
+                        str(p["productFilename"]).rsplit(".fits", 1)[0].endswith(suffix)
+                        for suffix in self.SPECTRAL_SUFFIXES
+                    )
+                    for p in filtered
+                ]
+                filtered = filtered[spectral_mask]
+                dropped = pre_count - len(filtered)
+                if dropped > 0:
+                    logger.info(f"Excluded {dropped} spectral product(s) from download URLs")
 
             if len(filtered) == 0:
                 logger.warning(f"No {product_type} FITS products found for {obs_id}")

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -312,3 +312,40 @@ class TestProprietaryFiltering:
         assert "F090W" not in all_recipe.filters
         assert "F444W" in all_recipe.filters
         assert "F200W" in all_recipe.filters
+
+
+class TestSpectralFiltering:
+    """Tests for filtering spectral (non-image) observations."""
+
+    def test_spectral_observations_excluded(self):
+        """Observations with dataproduct_type='spectrum' should be filtered out."""
+        obs = [
+            ObservationInput(filter="G140H", instrument="NIRSPEC", dataproduct_type="spectrum"),
+            ObservationInput(filter="G235H", instrument="NIRSPEC", dataproduct_type="spectrum"),
+        ]
+        recipes = generate_recipes(obs)
+        assert recipes == []
+
+    def test_mixed_image_and_spectral(self):
+        """Only image observations should produce recipes; spectral ones excluded."""
+        obs = [
+            ObservationInput(filter="F444W", instrument="NIRCAM", dataproduct_type="image"),
+            ObservationInput(filter="F200W", instrument="NIRCAM", dataproduct_type="image"),
+            ObservationInput(filter="G140H", instrument="NIRSPEC", dataproduct_type="spectrum"),
+        ]
+        recipes = generate_recipes(obs)
+        assert len(recipes) >= 1
+        all_filters = {f for r in recipes for f in r.filters}
+        assert "G140H" not in all_filters
+        assert "F444W" in all_filters
+        assert "F200W" in all_filters
+
+    def test_none_dataproduct_type_treated_as_image(self):
+        """Observations without dataproduct_type should pass through (backward compat)."""
+        obs = [
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        assert len(recipes) >= 1
+        assert set(recipes[0].filters) == {"F200W", "F444W"}


### PR DESCRIPTION
## Summary
Spectral observations (NIRSpec `_x1d.fits` files) have no 2D image data and crash the composite engine with `BadRequest - No image data found in FITS file`. This PR filters them out at three defensive layers.

## Why
When a target has NIRSpec spectroscopic observations, the system tries to build composites from 1D spectral table files, crashing the composite engine. This affects any target with mixed imaging + spectroscopic data.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- **Recipe engine** (primary fix): filter out observations with `dataproduct_type="spectrum"` before generating composite recipes, same pattern as the existing proprietary filtering
- **MAST download**: exclude spectral file suffixes (`_x1d`, `_x1dints`, `_c1d`) from `get_download_urls()` via a new `exclude_spectral` parameter (defaults to `True`)
- **Composite engine** (safety net): per-file error handling when loading channel files — skip non-image FITS files with a warning instead of crashing the entire request
- **Frontend**: pass `dataProductType` from MAST observation data through to the recipe engine in both `TargetDetail.tsx` and `GuidedCreate.tsx`

## Test Plan
- [x] `test_spectral_observations_excluded` — all-spectral observations return empty recipes
- [x] `test_mixed_image_and_spectral` — only image observations produce recipes, spectral excluded
- [x] `test_none_dataproduct_type_treated_as_image` — backward compat: None passes through
- [ ] Browse a target with NIRSpec observations → no composite recipes for spectral-only filters
- [ ] Browse a target with NIRCam + NIRSpec → NIRCam recipes work, NIRSpec excluded
- [ ] Generate a composite from a NIRCam target → no "No image data" errors

## Documentation Checklist
- [x] No new controllers, services, or endpoints added
- [x] No new API parameters affecting public docs (internal filtering only)

## Tech Debt Impact
- [x] Reduces tech debt — adds defensive filtering that was missing

## Risk & Rollback
Risk: Low — additive filtering at three layers, each independently safe. Existing observations with `dataproduct_type=None` pass through unchanged.
Rollback: Revert commit. No data migration needed.

## Quality Checklist
- [x] Code follows project conventions
- [x] Tests pass locally (36 recipe engine tests, 835 frontend tests)
- [x] TypeScript compiles clean
- [x] Pre-commit hooks pass (ESLint, Prettier, Ruff)

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)