### PR TITLE
feat: add auth badge to recipe cards and cache MAST target searches

### DIFF
--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.css
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.css
@@ -95,6 +95,18 @@
   color: var(--color-warning);
 }
 
+.recipe-card-auth {
+  font-weight: 500;
+}
+
+.recipe-card-auth-login {
+  color: var(--color-warning);
+}
+
+.recipe-card-auth-ready {
+  color: var(--color-success, #34d399);
+}
+
 .recipe-card-cta {
   display: inline-flex;
   align-items: center;

--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { useAuth } from '../../context/useAuth';
 import type { CompositeRecipe } from '../../types/DiscoveryTypes';
 import './RecipeCard.css';
 
@@ -19,6 +20,7 @@ function formatTime(seconds: number): string {
  * color bars, and a CTA to start creation.
  */
 export function RecipeCard({ recipe, targetName, isRecommended }: RecipeCardProps) {
+  const { isAuthenticated } = useAuth();
   const createUrl = `/create?target=${encodeURIComponent(targetName)}&recipe=${encodeURIComponent(recipe.name)}`;
 
   return (
@@ -58,6 +60,12 @@ export function RecipeCard({ recipe, targetName, isRecommended }: RecipeCardProp
             <span className="recipe-card-dot">&middot;</span>
             <span className="recipe-card-mosaic">Mosaic needed</span>
           </>
+        )}
+        <span className="recipe-card-dot">&middot;</span>
+        {isAuthenticated ? (
+          <span className="recipe-card-auth recipe-card-auth-ready">Ready</span>
+        ) : (
+          <span className="recipe-card-auth recipe-card-auth-login">Login required</span>
         )}
       </div>
 

--- a/processing-engine/app/mast/routes.py
+++ b/processing-engine/app/mast/routes.py
@@ -71,10 +71,20 @@ MAST_SEARCH_TIMEOUT = int(os.environ.get("MAST_SEARCH_TIMEOUT", "120"))
 _recent_releases_cache: dict[str, tuple[float, dict]] = {}
 RECENT_RELEASES_CACHE_TTL = 300  # 5 minutes in seconds
 
+# In-memory cache for target searches (5 minute TTL)
+_target_search_cache: dict[str, tuple[float, MastSearchResponse]] = {}
+TARGET_SEARCH_CACHE_TTL = 300  # 5 minutes in seconds
+
 
 def _get_cache_key(days_back: int, instrument: str | None, limit: int, offset: int) -> str:
     """Generate a cache key for recent releases requests."""
     return f"{days_back}:{instrument or 'all'}:{limit}:{offset}"
+
+
+def _get_target_cache_key(target_name: str, radius: float, calib_level: list[int] | None) -> str:
+    """Generate a cache key for target search requests."""
+    cl = ",".join(str(c) for c in sorted(calib_level)) if calib_level else "default"
+    return f"{target_name.strip().lower()}:{radius}:{cl}"
 
 
 def _get_from_cache(cache_key: str) -> dict | None:
@@ -106,6 +116,16 @@ def _set_cache(cache_key: str, data: dict) -> None:
 async def search_by_target(request: MastTargetSearchRequest):
     """Search MAST by target name (e.g., 'NGC 1234', 'Carina Nebula')."""
     try:
+        # Check cache first
+        cache_key = _get_target_cache_key(request.target_name, request.radius, request.calib_level)
+        if cache_key in _target_search_cache:
+            cached_time, cached_response = _target_search_cache[cache_key]
+            if time.time() - cached_time < TARGET_SEARCH_CACHE_TTL:
+                logger.info(f"Target search cache HIT for: {request.target_name}")
+                return cached_response
+            else:
+                del _target_search_cache[cache_key]
+
         # Run synchronous MAST call in thread pool with timeout
         results = await asyncio.wait_for(
             asyncio.to_thread(
@@ -117,7 +137,7 @@ async def search_by_target(request: MastTargetSearchRequest):
             ),
             timeout=MAST_SEARCH_TIMEOUT,
         )
-        return MastSearchResponse(
+        response = MastSearchResponse(
             search_type="target",
             query_params={
                 "target_name": request.target_name,
@@ -128,6 +148,16 @@ async def search_by_target(request: MastTargetSearchRequest):
             result_count=len(results),
             timestamp=datetime.now(UTC).isoformat(),
         )
+
+        # Cache the response
+        _target_search_cache[cache_key] = (time.time(), response)
+        # Evict old entries
+        if len(_target_search_cache) > 100:
+            oldest = sorted(_target_search_cache, key=lambda k: _target_search_cache[k][0])
+            for k in oldest[:50]:
+                del _target_search_cache[k]
+
+        return response
     except asyncio.TimeoutError:
         logger.error(
             f"Target search timed out after {MAST_SEARCH_TIMEOUT}s for: {request.target_name}"


### PR DESCRIPTION
## Summary
- Recipe cards now show auth status badge ("Login required" / "Ready")
- MAST target searches are cached in-memory for 5 minutes on the backend

## Why
Users need to know upfront whether they'll need to sign in before starting a composite. Additionally, repeated visits to the same target page trigger redundant MAST API calls, adding unnecessary latency.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Added `useAuth` hook to `RecipeCard` component to display auth status in the meta row
- Added CSS styles for auth badge states (warning color for login required, green for ready)
- Added 5-minute in-memory cache for MAST target search results in `mast/routes.py`, using the same pattern as the existing recent releases cache

## Test Plan
- [x] Browse a target page while logged out → recipe cards show "Login required" in warning color
- [x] Browse a target page while logged in → recipe cards show "Ready" in green
- [x] Visit the same target twice within 5 minutes → second load is near-instant (cache hit logged in backend)
- [x] 835 frontend tests pass, TypeScript compiles clean

## Documentation Checklist
- [x] No new controllers, services, or endpoints added
- [x] No documentation updates needed

## Tech Debt Impact
- [x] Reduces tech debt — adds caching that was missing for a common operation

## Risk & Rollback
Risk: Low — badge is display-only, cache has 5-minute TTL with automatic eviction.
Rollback: Revert commit.

## Quality Checklist
- [x] Code follows project conventions
- [x] Tests pass locally
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)