### PR TITLE
refactor: simplify anonymous composite code and fix review findings

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -2140,7 +2140,7 @@ namespace JwstDataAnalysis.API.Controllers
                     var usable = records.Where(r =>
                         !r.IsArchived
                         && !string.IsNullOrEmpty(r.FilePath)
-                        && r.ProcessingLevel is "L2a" or "L2b" or "L3").ToList();
+                        && r.ProcessingLevel is ProcessingLevels.Level2a or ProcessingLevels.Level2b or ProcessingLevels.Level3).ToList();
 
                     if (usable.Count > 0)
                     {

--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
@@ -49,11 +49,11 @@ export function RecipeCard({ recipe, targetName, isRecommended, observations }: 
   useEffect(() => {
     if (obsIds.length === 0) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
 
-    checkDataAvailability(obsIds)
+    checkDataAvailability(obsIds, controller.signal)
       .then((result) => {
-        if (cancelled) return;
+        if (controller.signal.aborted) return;
 
         // Check if every filter in the recipe has available data
         const recipeFilters = new Set(recipe.filters.map((f) => f.toUpperCase()));
@@ -70,13 +70,13 @@ export function RecipeCard({ recipe, targetName, isRecommended, observations }: 
         setDataReady(allReady);
       })
       .catch(() => {
-        /* availability check failed — default to not ready */
+        /* availability check failed or aborted — default to not ready */
       });
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
-  }, [obsIds, recipe.filters]);
+  }, [obsIds]); // obsIds already derives from recipe.filters via useMemo
 
   const showReady = dataReady || isAuthenticated;
 

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -29,6 +29,13 @@ const WIZARD_STEPS = [
   { number: 3, label: 'Result' },
 ];
 
+const COMPOSITE_OUTPUT = {
+  outputFormat: 'png' as const,
+  quality: 95,
+  width: 2000,
+  height: 2000,
+};
+
 /**
  * Convert a hex color string (#rrggbb) to a hue value (0-360).
  */
@@ -159,6 +166,15 @@ export function GuidedCreate() {
   const filterDataMapRef = useRef<Map<string, string[]>>(new Map());
   const abortRef = useRef<AbortController | null>(null);
   const previewUrlRef = useRef<string | null>(null);
+
+  /** Apply a composite result blob as the preview image. */
+  function applyBlobPreview(blob: Blob) {
+    setCompositeBlob(blob);
+    if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    const url = URL.createObjectURL(blob);
+    previewUrlRef.current = url;
+    setPreviewUrl(url);
+  }
 
   // Cleanup on unmount — capture ref handles created during lifecycle
   useEffect(() => {
@@ -425,10 +441,10 @@ export function GuidedCreate() {
         // Authenticated: use async job queue with SignalR progress
         const { jobId } = await exportNChannelCompositeAsync(
           channels,
-          'png',
-          95,
-          2000,
-          2000,
+          COMPOSITE_OUTPUT.outputFormat,
+          COMPOSITE_OUTPUT.quality,
+          COMPOSITE_OUTPUT.width,
+          COMPOSITE_OUTPUT.height,
           DEFAULT_OVERALL_ADJUSTMENTS
         );
 
@@ -443,13 +459,7 @@ export function GuidedCreate() {
 
               try {
                 const blob = await apiClient.getBlob(`/api/jobs/${jobId}/result`);
-                setCompositeBlob(blob);
-
-                if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
-
-                const url = URL.createObjectURL(blob);
-                previewUrlRef.current = url;
-                setPreviewUrl(url);
+                applyBlobPreview(blob);
                 setCurrentStep(3);
               } catch (err) {
                 setProcessError(
@@ -467,24 +477,13 @@ export function GuidedCreate() {
         subscriptionsRef.current.push(sub);
       } else {
         // Anonymous: use synchronous endpoint (AllowAnonymous)
-        const request = {
+        const blob = await generateNChannelComposite({
           channels,
           overall: DEFAULT_OVERALL_ADJUSTMENTS,
-          outputFormat: 'png' as const,
-          quality: 95,
-          width: 2000,
-          height: 2000,
-        };
-
-        const blob = await generateNChannelComposite(request);
+          ...COMPOSITE_OUTPUT,
+        });
         setProcessComplete(true);
-        setCompositeBlob(blob);
-
-        if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
-
-        const url = URL.createObjectURL(blob);
-        previewUrlRef.current = url;
-        setPreviewUrl(url);
+        applyBlobPreview(blob);
         setCurrentStep(3);
       }
     } catch (err) {
@@ -507,10 +506,10 @@ export function GuidedCreate() {
         // Authenticated: use async job queue
         const { jobId } = await exportNChannelCompositeAsync(
           channels,
-          'png',
-          95,
-          2000,
-          2000,
+          COMPOSITE_OUTPUT.outputFormat,
+          COMPOSITE_OUTPUT.quality,
+          COMPOSITE_OUTPUT.width,
+          COMPOSITE_OUTPUT.height,
           overall
         );
 
@@ -523,13 +522,7 @@ export function GuidedCreate() {
             onCompleted: async () => {
               try {
                 const blob = await apiClient.getBlob(`/api/jobs/${jobId}/result`);
-                setCompositeBlob(blob);
-
-                if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
-
-                const url = URL.createObjectURL(blob);
-                previewUrlRef.current = url;
-                setPreviewUrl(url);
+                applyBlobPreview(blob);
               } catch (err) {
                 setExportError(err instanceof Error ? err.message : 'Failed to apply adjustments.');
               } finally {
@@ -547,23 +540,12 @@ export function GuidedCreate() {
         subscriptionsRef.current.push(sub);
       } else {
         // Anonymous: use synchronous endpoint
-        const request = {
+        const blob = await generateNChannelComposite({
           channels,
           overall,
-          outputFormat: 'png' as const,
-          quality: 95,
-          width: 2000,
-          height: 2000,
-        };
-
-        const blob = await generateNChannelComposite(request);
-        setCompositeBlob(blob);
-
-        if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
-
-        const url = URL.createObjectURL(blob);
-        previewUrlRef.current = url;
-        setPreviewUrl(url);
+          ...COMPOSITE_OUTPUT,
+        });
+        applyBlobPreview(blob);
         setIsExporting(false);
       }
     } catch (err) {

--- a/frontend/jwst-frontend/src/services/jwstDataService.ts
+++ b/frontend/jwst-frontend/src/services/jwstDataService.ts
@@ -221,11 +221,14 @@ export async function getCubeInfo(dataId: string): Promise<CubeInfoResponse> {
  * @param observationIds - List of MAST obs_id strings to check
  */
 export async function checkDataAvailability(
-  observationIds: string[]
+  observationIds: string[],
+  signal?: AbortSignal
 ): Promise<DataAvailabilityResponse> {
-  return apiClient.post<DataAvailabilityResponse>('/api/jwstdata/check-availability', {
-    observationIds,
-  });
+  return apiClient.post<DataAvailabilityResponse>(
+    '/api/jwstdata/check-availability',
+    { observationIds },
+    signal ? { signal } : undefined
+  );
 }
 
 // Export as named object for convenience


### PR DESCRIPTION
## Summary
Code quality cleanup from `/simplify` review of PRs #538 and #539 (anonymous access feature). Extracts duplicated patterns, uses proper constants, and fixes a missing fetch abort.

## Why
The anonymous composite feature introduced duplicated blob-to-preview-URL logic (4 copies), hard-coded composite dimensions in multiple places, string literals instead of existing constants, and a missing fetch abort that left HTTP requests in-flight after component unmount.

## Type of Change
- [x] Refactoring (no functional changes)

## Changes Made
- Extract `applyBlobPreview()` helper in GuidedCreate to consolidate 4 duplicated blob→objectURL→preview blocks
- Extract `COMPOSITE_OUTPUT` constant for shared output format, quality, width, and height values
- Use `ProcessingLevels.Level2a`/`Level2b`/`Level3` constants instead of string literals in `CheckDataAvailability`
- Add `AbortController` to RecipeCard's availability check `useEffect` (was using a boolean flag without aborting the fetch)
- Remove redundant `recipe.filters` from RecipeCard `useEffect` dependency array (already derived via `useMemo` → `obsIds`)
- Add optional `signal` parameter to `checkDataAvailability` service function

## Test Plan
- [x] Backend builds with 0 warnings (`dotnet build --warnaserror`)
- [x] Backend tests pass (763 passed)
- [x] Frontend lint passes (0 errors)
- [x] Frontend type check passes (`tsc --noEmit`)
- [x] Frontend tests pass (835 passed)
- [ ] Verify anonymous composite flow still works (GuidedCreate → skip download → generate composite)
- [ ] Verify RecipeCard "Ready" badge still appears for targets with existing data

## Documentation Checklist
- [x] No new endpoints, services, or components — no doc updates needed

## Tech Debt Impact
- [x] Reduces tech debt (removes duplication, uses proper constants)

## Risk & Rollback
Risk: Low — pure refactoring, no behavioral changes. All existing tests pass.
Rollback: Revert the single commit.

## Quality Checklist
- [x] No hardcoded secrets or credentials
- [x] Error handling maintained (no changes to error paths)
- [x] No new dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)