### PR TITLE
fix: include calibration level 2 in .NET MAST search defaults

### DIFF
--- a/backend/JwstDataAnalysis.API/Models/MastModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/MastModels.cs
@@ -28,9 +28,9 @@ namespace JwstDataAnalysis.API.Models
 
         /// <summary>
         /// Gets or sets the calibration levels to include (1=minimally processed, 2=calibrated, 3=combined/mosaic).
-        /// Default: [3] for Level 3 only.
+        /// Default: [2, 3] for Level 2 (calibrated) and Level 3 (combined/mosaic).
         /// </summary>
-        public List<int>? CalibLevel { get; set; } = [3];
+        public List<int>? CalibLevel { get; set; } = [2, 3];
     }
 
     public class MastCoordinateSearchRequest
@@ -48,9 +48,9 @@ namespace JwstDataAnalysis.API.Models
 
         /// <summary>
         /// Gets or sets the calibration levels to include (1=minimally processed, 2=calibrated, 3=combined/mosaic).
-        /// Default: [3] for Level 3 only.
+        /// Default: [2, 3] for Level 2 (calibrated) and Level 3 (combined/mosaic).
         /// </summary>
-        public List<int>? CalibLevel { get; set; } = [3];
+        public List<int>? CalibLevel { get; set; } = [2, 3];
     }
 
     public class MastObservationSearchRequest
@@ -73,9 +73,9 @@ namespace JwstDataAnalysis.API.Models
 
         /// <summary>
         /// Gets or sets the calibration levels to include (1=minimally processed, 2=calibrated, 3=combined/mosaic).
-        /// Default: [3] for Level 3 only.
+        /// Default: [2, 3] for Level 2 (calibrated) and Level 3 (combined/mosaic).
         /// </summary>
-        public List<int>? CalibLevel { get; set; } = [3];
+        public List<int>? CalibLevel { get; set; } = [2, 3];
     }
 
     public class MastRecentReleasesRequest


### PR DESCRIPTION
## Summary
Fixes the .NET backend MAST search DTOs to default `CalibLevel` to `[2, 3]` instead of `[3]`, matching the Python fix in PR #551.

## Why
PR #551 changed the Python `calib_level` default from `[3]` to `[2, 3]` to include Level 2 (calibrated) data. However, the .NET DTOs (`MastModels.cs`) still defaulted to `[3]` and explicitly passed this to the Python engine, overriding the Python default. Targets like Carina Nebula that only have Level 2 data continued to return 0 results.

## Type of Change
- [x] Bug fix

## Changes Made
- Updated `MastTargetSearchRequest.CalibLevel` default from `[3]` to `[2, 3]`
- Updated `MastCoordinateSearchRequest.CalibLevel` default from `[3]` to `[2, 3]`
- Updated `MastProgramSearchRequest.CalibLevel` default from `[3]` to `[2, 3]`

## Test Plan
- [x] Backend tests pass (762/762)
- [x] Verified via API: `POST /api/mast/search/target {"targetName": "Carina Nebula"}` now returns 6 results (previously 0)
- [ ] Navigate to `/target/Carina%20Nebula` in the UI and confirm observations load

## Documentation Checklist
- [x] No documentation changes needed (internal default change)
- [ ] `docs/tech-debt.md` updated

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — only changes default search filter breadth. Targets with Level 3 data will now also return Level 2 results (more data, not less).
Rollback: Revert this commit to restore Level 3-only default.

## Quality Checklist
- [x] Changes match the .NET conventions in the codebase
- [x] No security implications
- [x] Backend tests pass