### PR TITLE
fix: add pre-request token freshness check to prevent session expiry

### DIFF
--- a/frontend/jwst-frontend/src/services/apiClient.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.ts
@@ -211,6 +211,26 @@ export async function attemptTokenRefresh(): Promise<boolean> {
   }
 }
 
+/** Pre-flight buffer: refresh token if it expires within this window */
+const PRE_REQUEST_REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Check if the stored token is near expiry and proactively refresh it.
+ * This guards against Chrome throttling setTimeout in background tabs,
+ * which can cause the scheduled refresh to fire late or not at all.
+ */
+async function ensureTokenFresh(): Promise<void> {
+  const expiresAtStr = localStorage.getItem(STORAGE_KEYS.EXPIRES_AT);
+  const refreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
+  if (!expiresAtStr || !refreshToken) return;
+
+  const expiresAt = new Date(expiresAtStr).getTime();
+  if (expiresAt - PRE_REQUEST_REFRESH_BUFFER_MS <= Date.now()) {
+    authLog('Pre-request refresh: token near expiry, refreshing proactively');
+    await attemptTokenRefresh();
+  }
+}
+
 class ApiClient {
   private baseUrl: string;
 
@@ -230,6 +250,17 @@ class ApiClient {
       headers['Authorization'] = `Bearer ${token}`;
     }
     return headers;
+  }
+
+  /**
+   * Ensure token is fresh before making an authenticated request.
+   * No-op if no token is stored (unauthenticated request).
+   */
+  private async ensureFreshToken(): Promise<void> {
+    const hasToken = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
+    if (hasToken) {
+      await ensureTokenFresh();
+    }
   }
 
   /**
@@ -292,6 +323,7 @@ class ApiClient {
    * GET request
    */
   async get<T>(endpoint: string, options?: RequestOptions): Promise<T> {
+    await this.ensureFreshToken();
     const makeRequest = () =>
       fetch(this.buildUrl(endpoint), {
         method: 'GET',
@@ -310,6 +342,7 @@ class ApiClient {
    * POST request with JSON body
    */
   async post<T>(endpoint: string, data?: unknown, options?: RequestOptions): Promise<T> {
+    await this.ensureFreshToken();
     const makeRequest = () =>
       fetch(this.buildUrl(endpoint), {
         method: 'POST',
@@ -335,6 +368,7 @@ class ApiClient {
     formData: FormData,
     options?: RequestOptions
   ): Promise<T> {
+    await this.ensureFreshToken();
     const makeRequest = () =>
       fetch(this.buildUrl(endpoint), {
         method: 'POST',
@@ -353,6 +387,7 @@ class ApiClient {
    * PUT request with JSON body
    */
   async put<T>(endpoint: string, data?: unknown, options?: RequestOptions): Promise<T> {
+    await this.ensureFreshToken();
     const makeRequest = () =>
       fetch(this.buildUrl(endpoint), {
         method: 'PUT',
@@ -374,6 +409,7 @@ class ApiClient {
    * Includes automatic 401 retry with token refresh.
    */
   async getBlob(endpoint: string, options?: RequestOptions): Promise<Blob> {
+    await this.ensureFreshToken();
     const makeRequest = () =>
       fetch(this.buildUrl(endpoint), {
         method: 'GET',
@@ -416,6 +452,7 @@ class ApiClient {
    * DELETE request
    */
   async delete<T>(endpoint: string, options?: RequestOptions): Promise<T> {
+    await this.ensureFreshToken();
     const makeRequest = () =>
       fetch(this.buildUrl(endpoint), {
         method: 'DELETE',


### PR DESCRIPTION
## Summary

Adds a proactive token freshness check before every authenticated API request, preventing "Session expired" errors caused by Chrome throttling background tab timers.

## Why

Chrome aggressively throttles `setTimeout` in background tabs — timers can be delayed by minutes or suspended entirely. The auth flow relies on a `setTimeout`-based proactive refresh (scheduled 60s before token expiry), which silently fails when the tab is backgrounded. The user then gets a "Session expired — please log in again" toast mid-operation (e.g., during composite processing) because the token expired without being refreshed.

## Type of Change
- [x] fix (bug fix)

## Changes Made
- Added `ensureTokenFresh()` function in `apiClient.ts` that checks if the stored token is within 5 minutes of expiry and proactively refreshes it before sending the request
- Added `ensureFreshToken()` method to `ApiClient` class that gates on whether a token exists (no-op for unauthenticated requests)
- Called `ensureFreshToken()` at the top of every request method: `get`, `post`, `postFormData`, `put`, `getBlob`, `delete`
- Uses the existing `attemptTokenRefresh()` deduplication layer to prevent concurrent refreshes

## Test Plan
- [x] All 859 frontend unit tests pass
- [x] ESLint passes (warnings only, pre-existing)
- [ ] Log in, wait 55+ minutes, then perform an action — should silently refresh instead of showing "Session expired"
- [ ] Open app, switch to another tab for 55+ minutes, switch back and perform an action — should work without session expiry
- [ ] Verify unauthenticated flows (discovery browsing) are unaffected — `ensureFreshToken()` is a no-op when no token exists

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
Risk: Low — this is an additive check that runs before each request. If the token is fresh (the common case), it's a fast no-op (two localStorage reads). The 5-minute buffer is conservative and well within the 60-minute token lifetime.
Rollback: Revert the single commit.

## Quality Checklist
- [x] PR title uses conventional format (`feat: ...`, `fix: ...`, etc.)
- [x] Branch name follows `<type>/<short-description>` or `codex/...`
- [x] Code follows project coding standards
- [x] Linting/formatting checks pass locally
- [x] Relevant tests pass locally
- [x] All checks pass locally (build, lint, format, tests)