### PR TITLE
fix: auth race condition in guided create when all data cached

### DIFF
--- a/frontend/jwst-frontend/e2e/guided-create.spec.ts
+++ b/frontend/jwst-frontend/e2e/guided-create.spec.ts
@@ -192,7 +192,7 @@ async function mockFullPipelineToResultStep(page: Page): Promise<void> {
 
       if (pollCount === 3) {
         // Deliver the SubscribeToJob completion + JobCompleted event together
-        const subscribeCompletion = JSON.stringify({ type: 3, invocationId: '1' });
+        const subscribeCompletion = JSON.stringify({ type: 3, invocationId: '0' });
         const jobCompleted = JSON.stringify({
           type: 1,
           target: 'JobCompleted',

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -254,7 +254,12 @@ export function GuidedCreate() {
           // All data exists — skip download, go straight to composite
           filterDataMapRef.current = existingFilterData;
           setDownloadComplete(true);
-          startProcessing(matched);
+          if (isAuthenticated) {
+            startProcessing(matched);
+          } else {
+            // Auth not loaded yet — defer until useAuth resolves
+            setPendingObs({ observations: [], matched });
+          }
         } else if (existingFilterData.size > 0) {
           // Some data exists — pre-populate map, only download the rest
           filterDataMapRef.current = existingFilterData;
@@ -288,10 +293,15 @@ export function GuidedCreate() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- isAuthenticated handled by separate effect
   }, [target, recipeName, retryCount]);
 
-  // When user authenticates after page load, start pending downloads
+  // When user authenticates after page load, start pending work
   useEffect(() => {
     if (isAuthenticated && pendingObs) {
-      startDownloads(pendingObs.observations, pendingObs.matched);
+      if (pendingObs.observations.length === 0) {
+        // All data already available — go straight to processing
+        startProcessing(pendingObs.matched);
+      } else {
+        startDownloads(pendingObs.observations, pendingObs.matched);
+      }
       setPendingObs(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- startDownloads is stable closure


### PR DESCRIPTION
## Summary

Fixes auth race condition in the guided create wizard that caused E2E test failures and would affect real users when all FITS data is already cached.

## Why

When all FITS data for a recipe is already cached (no downloads needed), `startProcessing()` was called immediately during `resolveRecipe` — before `useAuth()` had loaded `isAuthenticated` from localStorage. This caused the code to take the anonymous/sync path (`/api/composite/nchannel`) instead of the authenticated async path (`/api/composite/export-nchannel`), resulting in "N-channel composite generation failed" errors.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test update
- [ ] Configuration/infrastructure change

## Changes Made

- Gate the "all data available" shortcut in `GuidedCreate.tsx` on `isAuthenticated`, deferring via `setPendingObs()` when auth hasn't loaded yet
- Update the `pendingObs` useEffect to handle the deferred case (empty observations array → call `startProcessing` instead of `startDownloads`)
- Fix SignalR mock `invocationId` from `'1'` to `'0'` to match actual client behavior in E2E tests

## Test Plan

- [x] All 19 guided-create E2E tests pass locally (were 8 failing before fix)
- [x] All 859 frontend unit tests pass
- [ ] Verify guided create wizard completes successfully in browser for a cached target
- [ ] Verify guided create wizard still works for uncached targets (download path)

## Documentation Checklist

- [x] No new endpoints or API changes
- [ ] `docs/key-files.md` updated
- [ ] `docs/standards/backend-development.md` updated
- [ ] `docs/architecture.md` updated
- [ ] `docs/quick-reference.md` updated

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt added (explain below)
- [ ] Tech debt reduced (explain below)

## Risk & Rollback

Risk: Low — changes are confined to the guided create page's auth-gating logic, using the same `pendingObs` deferral pattern already in place for the download path.

Rollback: Revert the single commit. The only impact would be guided create failing when data is already cached (the pre-existing bug).

## Quality Checklist

- [x] Code follows project conventions
- [x] No console.log or debug artifacts
- [x] Error states handled appropriately
- [x] No hardcoded values that should be configurable
- [x] Changes are minimal and focused

Closes #559