### PR TITLE
fix: exclude coverage directory from Vite file watcher

### DIFF
--- a/frontend/jwst-frontend/vite.config.ts
+++ b/frontend/jwst-frontend/vite.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
   server: {
     port: 3000,
     strictPort: true,  // Fail fast if port 3000 is unavailable
-    host: true  // Required for Docker
+    host: true,  // Required for Docker
+    watch: {
+      ignored: ['**/coverage/**', '**/node_modules/**']
+    }
   },
   build: {
     outDir: 'dist'


### PR DESCRIPTION
## Summary

Prevents Vite's HMR file watcher from picking up vitest coverage output files, which caused continuous page reloads in Docker.

## Why

Running `npx vitest run --coverage` generates HTML files in the `coverage/` directory. Since this directory is volume-mounted into the Docker frontend container, Vite detects the new files as changes and triggers page reloads. Each reload aborts in-flight API fetches, so the app never finishes loading.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test update
- [ ] Configuration/infrastructure change

## Changes Made

- Add `watch.ignored` to Vite server config to exclude `**/coverage/**` and `**/node_modules/**` from file watching

## Test Plan

- [x] Run `npx vitest run --coverage` locally, verify Docker frontend does not reload
- [x] Verify Discover page loads featured targets after coverage run
- [x] All 859 frontend unit tests pass

## Documentation Checklist

- [x] No new endpoints or API changes
- [ ] `docs/key-files.md` updated
- [ ] `docs/standards/backend-development.md` updated
- [ ] `docs/architecture.md` updated
- [ ] `docs/quick-reference.md` updated

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt added (explain below)
- [ ] Tech debt reduced (explain below)

## Risk & Rollback

Risk: Minimal — only affects Vite dev server file watching config.

Rollback: Revert the single commit.

## Quality Checklist

- [x] Code follows project conventions
- [x] No console.log or debug artifacts
- [x] Error states handled appropriately
- [x] No hardcoded values that should be configurable
- [x] Changes are minimal and focused