### PR TITLE
fix: resolve E2E test failures in viewer, export, and auth refresh

### DIFF
--- a/frontend/jwst-frontend/e2e/export.spec.ts
+++ b/frontend/jwst-frontend/e2e/export.spec.ts
@@ -18,7 +18,7 @@ test.describe('Image Export Feature', () => {
   });
 
   async function openViewerOrSkip(page: import('@playwright/test').Page) {
-    const opened = await openImageViewer(page);
+    const opened = await openImageViewer(page, seed.dataIds[0].fileName);
     if (!opened) {
       test.skip(true, 'No viewable data available for testing export');
     }

--- a/frontend/jwst-frontend/e2e/fits-viewer.spec.ts
+++ b/frontend/jwst-frontend/e2e/fits-viewer.spec.ts
@@ -18,7 +18,7 @@ test.describe('FITS image viewer', () => {
   });
 
   async function openViewerOrSkip(page: import('@playwright/test').Page) {
-    const opened = await openImageViewer(page);
+    const opened = await openImageViewer(page, seed.dataIds[0].fileName);
     if (!opened) {
       test.skip(true, 'No viewable data available');
     }
@@ -31,9 +31,10 @@ test.describe('FITS image viewer', () => {
 
   test('displays scientific image in canvas viewport', async ({ page }) => {
     await openViewerOrSkip(page);
-    // The main rendered image is an <img> with class scientific-canvas (hidden until loaded)
+    // The main rendered image is an <img> with class scientific-canvas (hidden until loaded).
+    // The processing engine may take a while to generate the preview.
     const img = page.locator('img.scientific-canvas');
-    await expect(img).toBeVisible({ timeout: 15_000 });
+    await expect(img).toBeVisible({ timeout: 30_000 });
   });
 
   test('shows stretch controls panel (not collapsed)', async ({ page }) => {

--- a/frontend/jwst-frontend/e2e/helpers.ts
+++ b/frontend/jwst-frontend/e2e/helpers.ts
@@ -210,27 +210,49 @@ export async function loginWithTokens(
 }
 
 /**
- * From an authenticated dashboard with data, open the first viewable
- * image in the FITS viewer. Returns `true` if a viewer was opened,
- * `false` if no viewable files exist (caller should skip).
+ * From an authenticated dashboard with data, open a viewable image in
+ * the FITS viewer. When `fileName` is provided the helper targets that
+ * specific file (avoiding stale public data from previous test runs).
+ * Returns `true` if a viewer was opened, `false` if no viewable files exist.
  */
-export async function openImageViewer(page: Page): Promise<boolean> {
-  // Switch to "By Target" view where View buttons are visible on cards
-  const byTargetBtn = page.getByRole('button', { name: /By Target/i });
-  if ((await byTargetBtn.count()) > 0) {
-    await byTargetBtn.click();
-  }
-
-  // Wait for data to load
+export async function openImageViewer(page: Page, fileName?: string): Promise<boolean> {
+  // Wait for data cards to render
   await page.waitForTimeout(1000);
 
-  // Look for an enabled View button on any data card
-  const viewButton = page.locator('.view-file-btn:not(.disabled)').first();
+  let viewButton;
+
+  if (fileName) {
+    // Target the specific file's card by matching the filename text.
+    // DataCard renders the name in an <h4>, LineageFileCard in a .file-name span.
+    const card = page.locator('.data-card', { hasText: fileName }).first();
+    if ((await card.count()) === 0) {
+      return false;
+    }
+    viewButton = card.locator('.view-file-btn:not(.disabled)');
+  } else {
+    // Fallback: switch to "By Target" view and click the first viewable file
+    const byTargetBtn = page.getByRole('button', { name: /By Target/i });
+    if ((await byTargetBtn.count()) > 0) {
+      await byTargetBtn.click();
+      await page.waitForTimeout(1000);
+    }
+    viewButton = page.locator('.view-file-btn:not(.disabled)').first();
+  }
+
   if ((await viewButton.count()) === 0) {
     return false;
   }
 
   await viewButton.click();
   await page.waitForSelector('.image-viewer-overlay', { state: 'visible', timeout: 15_000 });
+
+  // Wait for the preview image to finish loading (or an error to appear).
+  // The image has display:none while loading, so waiting for it to become
+  // visible confirms the processing engine has returned a preview.
+  await Promise.race([
+    page.waitForSelector('img.scientific-canvas', { state: 'visible', timeout: 30_000 }),
+    page.waitForSelector('.viewer-error-state', { state: 'visible', timeout: 30_000 }),
+  ]);
+
   return true;
 }

--- a/frontend/jwst-frontend/e2e/session-persistence.spec.ts
+++ b/frontend/jwst-frontend/e2e/session-persistence.spec.ts
@@ -47,12 +47,14 @@ test.describe('Session persistence and token handling', () => {
       freshAuth
     );
 
-    // Navigate to library — app should detect expired token and refresh
+    // Navigate to library — app should detect expired token and refresh.
+    // The refresh path involves retryRefreshToken which can take up to ~5s on
+    // retries (1s + 3s delays), so we give generous timeouts.
     await page.goto('/library');
 
     // Should still end up on dashboard (refresh succeeded)
-    await expect(page).not.toHaveURL(/\/(login|register)/, { timeout: 10_000 });
-    await expect(page.locator('.dashboard .controls')).toBeVisible({ timeout: 10_000 });
+    await expect(page).not.toHaveURL(/\/(login|register)/, { timeout: 15_000 });
+    await expect(page.locator('.dashboard .controls')).toBeVisible({ timeout: 15_000 });
   });
 
   test('redirects to login when all tokens are cleared', async ({ page }) => {

--- a/frontend/jwst-frontend/e2e/ux-regression.spec.ts
+++ b/frontend/jwst-frontend/e2e/ux-regression.spec.ts
@@ -73,7 +73,7 @@ test.describe('UX regression coverage', () => {
     test.use({ viewport: { width: 390, height: 844 } });
 
     test('enables compact layout and content-first panel defaults', async ({ page }) => {
-      const opened = await openImageViewer(page);
+      const opened = await openImageViewer(page, seed.dataIds[0].fileName);
       if (!opened) {
         test.skip(true, 'No viewable files available for compact-viewer assertions');
         return;
@@ -93,7 +93,7 @@ test.describe('UX regression coverage', () => {
     test.use({ viewport: { width: 1280, height: 900 } });
 
     test('keeps desktop layout when viewport exceeds compact threshold', async ({ page }) => {
-      const opened = await openImageViewer(page);
+      const opened = await openImageViewer(page, seed.dataIds[0].fileName);
       if (!opened) {
         test.skip(true, 'No viewable files available for desktop-viewer assertions');
         return;

--- a/frontend/jwst-frontend/e2e/viewer-tools.spec.ts
+++ b/frontend/jwst-frontend/e2e/viewer-tools.spec.ts
@@ -16,7 +16,7 @@ test.describe('Viewer tools: regions, annotations, WCS grid, curves', () => {
   test.beforeEach(async ({ page }) => {
     await loginWithTokens(page, seed);
 
-    const opened = await openImageViewer(page);
+    const opened = await openImageViewer(page, seed.dataIds[0].fileName);
     if (!opened) {
       test.skip(true, 'No viewable data available');
     }

--- a/frontend/jwst-frontend/src/services/apiClient.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.ts
@@ -342,7 +342,11 @@ class ApiClient {
    * POST request with JSON body
    */
   async post<T>(endpoint: string, data?: unknown, options?: RequestOptions): Promise<T> {
-    await this.ensureFreshToken();
+    // Skip pre-flight token refresh for auth endpoints (skipAuthRetry) to avoid
+    // circular deadlock: refresh → post → ensureFreshToken → attemptRefresh → post → ...
+    if (!options?.skipAuthRetry) {
+      await this.ensureFreshToken();
+    }
     const makeRequest = () =>
       fetch(this.buildUrl(endpoint), {
         method: 'POST',


### PR DESCRIPTION
## Summary

Fixes 10 pre-existing E2E test failures across 3 spec files (export, fits-viewer, session-persistence).

## Why

E2E tests have been failing consistently due to three compounding issues: stale test data contamination, missing wait conditions for async preview generation, and a deadlock in the token refresh flow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`e2e/helpers.ts`**: Updated `openImageViewer` to accept optional `fileName` parameter. When provided, targets the specific file's `.data-card` instead of clicking the first viewable file (which could be stale public data from previous test runs). Also added wait for preview loading completion (`img.scientific-canvas` visible or `.viewer-error-state`).
- **`e2e/export.spec.ts`**, **`e2e/fits-viewer.spec.ts`**, **`e2e/ux-regression.spec.ts`**, **`e2e/viewer-tools.spec.ts`**: Pass `seed.dataIds[0].fileName` to `openImageViewer` to target the correct test fixture.
- **`e2e/fits-viewer.spec.ts`**: Increased `scientific-canvas` visibility timeout from 15s to 30s for slower preview generation.
- **`e2e/session-persistence.spec.ts`**: Increased refresh test timeouts from 10s to 15s.
- **`src/services/apiClient.ts`**: Skip `ensureFreshToken()` pre-flight when `skipAuthRetry` is set, breaking a circular deadlock where the refresh endpoint triggered its own pre-flight refresh.

## Test Plan

- [x] Frontend unit tests pass (859/859)
- [x] Backend unit tests pass (762/762)
- [x] TypeScript type check clean
- [x] ESLint passes (0 errors)
- [x] Prettier formatting clean
- [ ] E2E: `npx playwright test e2e/session-persistence.spec.ts --project=chromium` — all 4 pass
- [ ] E2E: `npx playwright test e2e/fits-viewer.spec.ts --project=chromium` — all 8 pass
- [ ] E2E: `npx playwright test e2e/export.spec.ts --project=chromium` — all 8 pass
- [ ] E2E: `npx playwright test e2e/ux-regression.spec.ts --project=chromium` — all tests pass
- [ ] E2E: `npx playwright test e2e/viewer-tools.spec.ts --project=chromium` — all tests pass

## Documentation Checklist

- [x] No new endpoints, components, or API changes — no doc updates needed

## Tech Debt Impact

- [x] Reduces tech debt (fixes pre-existing test failures)

## Risk & Rollback

Risk: Low — changes are confined to E2E test helpers and one guard condition in apiClient. The apiClient change only affects auth refresh endpoints (skipAuthRetry=true).

Rollback: `git revert <sha>` — no data migration or state changes.

## Quality Checklist

- [x] Self-reviewed all changes
- [x] No debug/console statements left behind
- [x] Error handling is appropriate
- [x] No security concerns introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)