### PR TITLE
feat: enrich session blog with headlines, tags, excerpts, and commit messages

### DIFF
--- a/docs/blog/MILESTONES.md
+++ b/docs/blog/MILESTONES.md
@@ -50,4 +50,4 @@ Dates flagged for narrative enrichment. Edit the post and replace
 - **2026-03-01** — Architecture day (16 PRs: feat: sidebar split layout for guided create result step; feat: add rotation con)
 - **2026-03-02** — Architecture day (7 PRs: fix: add missing authorization checks for issues #565-#570; fix: add missing aut)
 
-Generated: 2026-03-02 10:51
+Generated: 2026-03-02 12:18

--- a/docs/blog/posts/2025-06-28.md
+++ b/docs/blog/posts/2025-06-28.md
@@ -3,6 +3,9 @@ date:
   created: 2025-06-28
 categories:
   - Development
+tags:
+  - frontend
+  - infrastructure
 authors:
   - shanon
 ---
@@ -11,7 +14,18 @@ authors:
 
 <!-- generated -->
 
-## Commits: 6
+**adds sln and updates markdown files; more markdown warnings removed; fixes markdown warnings** — frontend, infrastructure
+
+<!-- more -->
+
+## Commits
+
+- adds sln and updates markdown files
+- more markdown warnings removed
+- fixes markdown warnings
+- removed version from the docker file
+- Update jwst-frontend submodule pointer
+- Initial commit: clean start for Astronomy project
 
 ---
-*Generated from GitHub data.*
+*6 commits across this session.*

--- a/docs/blog/posts/2025-07-04.md
+++ b/docs/blog/posts/2025-07-04.md
@@ -11,7 +11,15 @@ authors:
 
 <!-- generated -->
 
-## Commits: 3
+**docs: add security note about development credentials and best practices for secrets; chore: update submodule and processing engine dependencies; fix: add build dependencies and update scientific package versions for compatibility**
+
+<!-- more -->
+
+## Commits
+
+- docs: add security note about development credentials and best practices for secrets
+- chore: update submodule and processing engine dependencies
+- fix: add build dependencies and update scientific package versions for compatibility
 
 ---
-*Generated from GitHub data.*
+*3 commits across this session.*

--- a/docs/blog/posts/2025-07-05.md
+++ b/docs/blog/posts/2025-07-05.md
@@ -3,6 +3,8 @@ date:
   created: 2025-07-05
 categories:
   - Development
+tags:
+  - frontend
 authors:
   - shanon
 ---
@@ -11,7 +13,17 @@ authors:
 
 <!-- generated -->
 
-## Commits: 5
+**fix: update frontend submodule with cross-browser compatible meta tags; Fix MD013 (line length) warnings in main README.md and update markdown compliance in all rule and doc files; Fix MD013 (line length) warnings in main README.md** — frontend
+
+<!-- more -->
+
+## Commits
+
+- fix: update frontend submodule with cross-browser compatible meta tags
+- Fix MD013 (line length) warnings in main README.md and update markdown compliance in all rule and doc files
+- Fix MD013 (line length) warnings in main README.md
+- Fix and recreate all Cursor .mdc rule files with valid structure and content
+- Add comprehensive Cursor rules for JWST project development
 
 ---
-*Generated from GitHub data.*
+*5 commits across this session.*

--- a/docs/blog/posts/2025-07-13.md
+++ b/docs/blog/posts/2025-07-13.md
@@ -3,6 +3,9 @@ date:
   created: 2025-07-13
 categories:
   - Development
+tags:
+  - api
+  - database
 authors:
   - shanon
 ---
@@ -11,7 +14,14 @@ authors:
 
 <!-- generated -->
 
-## Commits: 2
+**Fix nullable reference type error in GetStatisticsAsync; Phase 2: Enhanced Data Models and API Endpoints** — api, database
+
+<!-- more -->
+
+## Commits
+
+- Fix nullable reference type error in GetStatisticsAsync
+- Phase 2: Enhanced Data Models and API Endpoints
 
 ---
-*Generated from GitHub data.*
+*2 commits across this session.*

--- a/docs/blog/posts/2026-01-12.md
+++ b/docs/blog/posts/2026-01-12.md
@@ -4,6 +4,8 @@ date:
 categories:
   - Development
   - Feature
+tags:
+  - mast-data
 authors:
   - shanon
 ---
@@ -11,6 +13,10 @@ authors:
 # Session: January 12, 2026
 
 <!-- generated -->
+
+**1 feature** — mast-data
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -20,10 +26,11 @@ authors:
 
 ## Issues
 
-- **Opened**: [#1](https://github.com/Snoww3d/jwst-data-analysis/issues/1), [#2](https://github.com/Snoww3d/jwst-data-analysis/issues/2), [#3](https://github.com/Snoww3d/jwst-data-analysis/issues/3)
-- **Closed**: None
+**Opened:**
 
-## Commits: 15
+- [#1](https://github.com/Snoww3d/jwst-data-analysis/issues/1) — Implement actual image processing algorithms
+- [#2](https://github.com/Snoww3d/jwst-data-analysis/issues/2) — Implement spectral analysis tools
+- [#3](https://github.com/Snoww3d/jwst-data-analysis/issues/3) — Processing job queue system
 
 ---
-*Generated from GitHub data.*
+*15 commits across this session.*

--- a/docs/blog/posts/2026-01-13.md
+++ b/docs/blog/posts/2026-01-13.md
@@ -3,6 +3,9 @@ date:
   created: 2026-01-13
 categories:
   - Feature
+tags:
+  - imaging
+  - viewer
 authors:
   - shanon
 ---
@@ -11,11 +14,13 @@ authors:
 
 <!-- generated -->
 
+**1 feature** — imaging, viewer
+
+<!-- more -->
+
 ## Pull Requests Merged
 
 - **[#6](https://github.com/Snoww3d/jwst-data-analysis/pull/6)** feat: Advanced FITS Viewer with ZScale and Color Maps
 
-## Commits: 10
-
 ---
-*Generated from GitHub data.*
+*10 commits across this session.*

--- a/docs/blog/posts/2026-01-14.md
+++ b/docs/blog/posts/2026-01-14.md
@@ -4,6 +4,9 @@ date:
 categories:
   - Feature
   - Bug Fix
+tags:
+  - infrastructure
+  - mast-data
 authors:
   - shanon
 ---
@@ -11,6 +14,10 @@ authors:
 # Session: January 14, 2026
 
 <!-- generated -->
+
+**1 feature, 2 fixes** — infrastructure, mast-data
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -31,7 +38,5 @@ authors:
     - Fix API response to include Metadata field (required for grouping feature)
     - Add Docker verification documentation
 
-## Commits: 8
-
 ---
-*Generated from GitHub data.*
+*8 commits across this session.*

--- a/docs/blog/posts/2026-01-20.md
+++ b/docs/blog/posts/2026-01-20.md
@@ -3,6 +3,8 @@ date:
   created: 2026-01-20
 categories:
   - Feature
+tags:
+  - viewer
 authors:
   - shanon
 ---
@@ -10,6 +12,10 @@ authors:
 # Session: January 20, 2026
 
 <!-- generated -->
+
+**1 feature** — viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -19,7 +25,5 @@ authors:
     - Implement lineage tree visualization in frontend showing processing pipeline relationships
     - Add API endpoints for querying lineage data and migrating existing records
 
-## Commits: 2
-
 ---
-*Generated from GitHub data.*
+*2 commits across this session.*

--- a/docs/blog/posts/2026-01-21.md
+++ b/docs/blog/posts/2026-01-21.md
@@ -4,6 +4,11 @@ date:
 categories:
   - Documentation
   - Feature
+tags:
+  - ci
+  - docs
+  - mast-data
+  - viewer
 authors:
   - shanon
 ---
@@ -11,6 +16,10 @@ authors:
 # Session: January 21, 2026
 
 <!-- generated -->
+
+**2 features, 1 docs** — ci, docs, mast-data, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -36,7 +45,5 @@ authors:
     - Implement async file-by-file downloads to avoid timeout issues
     - Add progress polling from frontend to backend to processing engine
 
-## Commits: 6
-
 ---
-*Generated from GitHub data.*
+*6 commits across this session.*

--- a/docs/blog/posts/2026-01-22.md
+++ b/docs/blog/posts/2026-01-22.md
@@ -4,6 +4,10 @@ date:
 categories:
   - Documentation
   - Feature
+tags:
+  - ci
+  - docs
+  - viewer
 authors:
   - shanon
 ---
@@ -11,6 +15,10 @@ authors:
 # Session: January 22, 2026
 
 <!-- generated -->
+
+**2 features, 2 docs** — ci, docs, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -41,7 +49,5 @@ authors:
     - Extend backend and frontend models with astronomical fields
     - Style metadata with colored badges (purple for target, green for instrument)
 
-## Commits: 10
-
 ---
-*Generated from GitHub data.*
+*10 commits across this session.*

--- a/docs/blog/posts/2026-01-27.md
+++ b/docs/blog/posts/2026-01-27.md
@@ -3,6 +3,9 @@ date:
   created: 2026-01-27
 categories:
   - Feature
+tags:
+  - job-queue
+  - mast-data
 authors:
   - shanon
 ---
@@ -10,6 +13,10 @@ authors:
 # Session: January 27, 2026
 
 <!-- generated -->
+
+**2 features** — job-queue, mast-data
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -27,7 +34,5 @@ authors:
     - Remove hardcoded 10-minute timeout - downloads now run until complete or cancelled
     - Make download settings configurable (poll interval, base path) via appsettings.json
 
-## Commits: 8
-
 ---
-*Generated from GitHub data.*
+*8 commits across this session.*

--- a/docs/blog/posts/2026-01-28.md
+++ b/docs/blog/posts/2026-01-28.md
@@ -11,6 +11,10 @@ authors:
 
 <!-- generated -->
 
+**1 feature**
+
+<!-- more -->
+
 ## Pull Requests Merged
 
 - **[#20](https://github.com/Snoww3d/jwst-data-analysis/pull/20)** feat: Add observation date display and sort by download date
@@ -19,7 +23,5 @@ authors:
     - **Add default sorting by upload date** (newest first) across all data retrieval methods
     - **Display observation and download dates** in the dashboard lineage view
 
-## Commits: 14
-
 ---
-*Generated from GitHub data.*
+*14 commits across this session.*

--- a/docs/blog/posts/2026-01-29.md
+++ b/docs/blog/posts/2026-01-29.md
@@ -6,6 +6,13 @@ categories:
   - Feature
   - Bug Fix
   - Refactoring
+tags:
+  - ci
+  - docs
+  - export
+  - mast-data
+  - security
+  - viewer
 authors:
   - shanon
 ---
@@ -13,6 +20,10 @@ authors:
 # Session: January 29, 2026
 
 <!-- generated -->
+
+**4 features, 12 fixes, 4 docs, 1 refactor** — ci, docs, export, mast-data, security, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -139,7 +150,5 @@ authors:
     - Creates a collapsible StretchControls panel in the image viewer UI
     - Implements 500ms debouncing to prevent request flooding during slider adjustments
 
-## Commits: 42
-
 ---
-*Generated from GitHub data.*
+*42 commits across this session.*

--- a/docs/blog/posts/2026-01-30.md
+++ b/docs/blog/posts/2026-01-30.md
@@ -5,6 +5,11 @@ categories:
   - Feature
   - Bug Fix
   - Refactoring
+tags:
+  - job-queue
+  - mast-data
+  - ui
+  - viewer
 authors:
   - shanon
 ---
@@ -12,6 +17,10 @@ authors:
 # Session: January 30, 2026
 
 <!-- generated -->
+
+**6 features, 1 fix, 1 refactor** — job-queue, mast-data, ui, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -68,7 +77,5 @@ authors:
     - When users change stretch function (ZScale → Asinh → Linear, etc.) or adjust gamma/black point/white point, the histogram updates to reflect the actual displayed distribution
     - Histogram updates are synchronized with preview image updates (uses committed stretchParams after 500ms debounce)
 
-## Commits: 31
-
 ---
-*Generated from GitHub data.*
+*31 commits across this session.*

--- a/docs/blog/posts/2026-01-31.md
+++ b/docs/blog/posts/2026-01-31.md
@@ -7,6 +7,16 @@ categories:
   - Documentation
   - Feature
   - Testing
+tags:
+  - auth
+  - ci
+  - code-quality
+  - dependencies
+  - docs
+  - infrastructure
+  - security
+  - testing
+  - ui
 authors:
   - shanon
 ---
@@ -14,6 +24,10 @@ authors:
 # Session: January 31, 2026
 
 <!-- generated -->
+
+**1 feature, 2 fixes, 4 docs, 1 test, 6 maintenance, 7 dep updates** — auth, ci, code-quality, dependencies, docs, infrastructure, security, testing, ui
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -132,7 +146,5 @@ authors:
     - Integrate test execution into CI pipeline
     - Disable CodeQL until repo is public (added Task #37 to track)
 
-## Commits: 61
-
 ---
-*Generated from GitHub data.*
+*61 commits across this session.*

--- a/docs/blog/posts/2026-02-01.md
+++ b/docs/blog/posts/2026-02-01.md
@@ -6,6 +6,12 @@ categories:
   - Documentation
   - Feature
   - Refactoring
+tags:
+  - ci
+  - docs
+  - e2e-tests
+  - infrastructure
+  - viewer
 authors:
   - shanon
 ---
@@ -13,6 +19,10 @@ authors:
 # Session: February 1, 2026
 
 <!-- generated -->
+
+**5 features, 2 docs, 1 refactor, 1 maintenance** — ci, docs, e2e-tests, infrastructure, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -47,7 +57,5 @@ authors:
 
 - **[#94](https://github.com/Snoww3d/jwst-data-analysis/pull/94)** docs: Task #38 completion docs and workflow improvements
 
-## Commits: 42
-
 ---
-*Generated from GitHub data.*
+*42 commits across this session.*

--- a/docs/blog/posts/2026-02-02.md
+++ b/docs/blog/posts/2026-02-02.md
@@ -7,6 +7,13 @@ categories:
   - Feature
   - Bug Fix
   - Development
+tags:
+  - ci
+  - docs
+  - export
+  - mast-data
+  - security
+  - viewer
 authors:
   - shanon
 ---
@@ -14,6 +21,10 @@ authors:
 # Session: February 2, 2026
 
 <!-- generated -->
+
+**1 feature, 1 fix, 9 docs, 2 maintenance** — ci, docs, export, mast-data, security, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -125,7 +136,5 @@ authors:
     - Configure ASP.NET Core ForwardedHeaders for reverse proxy support
     - Add comprehensive security headers to both dev and prod nginx configs
 
-## Commits: 22
-
 ---
-*Generated from GitHub data.*
+*22 commits across this session.*

--- a/docs/blog/posts/2026-02-03.md
+++ b/docs/blog/posts/2026-02-03.md
@@ -6,6 +6,14 @@ categories:
   - Documentation
   - Feature
   - Bug Fix
+tags:
+  - auth
+  - ci
+  - code-quality
+  - docs
+  - export
+  - imaging
+  - mast-data
 authors:
   - shanon
 ---
@@ -13,6 +21,10 @@ authors:
 # Session: February 3, 2026
 
 <!-- generated -->
+
+**4 features, 4 fixes, 8 docs, 1 maintenance** — auth, ci, code-quality, docs, export, imaging, mast-data
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -87,7 +99,5 @@ authors:
     - Add `[AllowAnonymous]` attribute to read-only MAST search endpoints to fix 401 Unauthorized errors for unauthenticated users
     - Aligns with project API documentation: "Read operations (GET) allow anonymous access"
 
-## Commits: 51
-
 ---
-*Generated from GitHub data.*
+*51 commits across this session.*

--- a/docs/blog/posts/2026-02-04.md
+++ b/docs/blog/posts/2026-02-04.md
@@ -6,6 +6,16 @@ categories:
   - Feature
   - Bug Fix
   - Performance
+tags:
+  - auth
+  - ci
+  - docs
+  - guided-wizard
+  - imaging
+  - job-queue
+  - mast-data
+  - ui
+  - viewer
 authors:
   - shanon
 ---
@@ -13,6 +23,10 @@ authors:
 # Session: February 4, 2026
 
 <!-- generated -->
+
+**9 features, 6 fixes, 8 docs** — auth, ci, docs, guided-wizard, imaging, job-queue, mast-data, ui, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -160,7 +174,5 @@ authors:
     - Each row shows shortened observation ID, progress bar (amber), percentage, file count, and a Resume button
     - Clicking Resume removes the job from the panel and delegates to the existing `ha...
 
-## Commits: 70
-
 ---
-*Generated from GitHub data.*
+*70 commits across this session.*

--- a/docs/blog/posts/2026-02-05.md
+++ b/docs/blog/posts/2026-02-05.md
@@ -5,6 +5,12 @@ categories:
   - Documentation
   - Feature
   - Bug Fix
+tags:
+  - docs
+  - imaging
+  - infrastructure
+  - security
+  - ui
 authors:
   - shanon
 ---
@@ -12,6 +18,10 @@ authors:
 # Session: February 5, 2026
 
 <!-- generated -->
+
+**4 features, 9 fixes, 3 docs** — docs, imaging, infrastructure, security, ui
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -108,7 +118,5 @@ authors:
     - **Sort by recency**: Downloads sorted newest-first using `startedAt` timestamp
     - **Dismiss with cleanup**: Each download has a dismiss button (✕) that asks whether to also delete completed files
 
-## Commits: 21
-
 ---
-*Generated from GitHub data.*
+*21 commits across this session.*

--- a/docs/blog/posts/2026-02-06.md
+++ b/docs/blog/posts/2026-02-06.md
@@ -4,6 +4,9 @@ date:
 categories:
   - Documentation
   - Bug Fix
+tags:
+  - auth
+  - docs
 authors:
   - shanon
 ---
@@ -11,6 +14,10 @@ authors:
 # Session: February 6, 2026
 
 <!-- generated -->
+
+**1 fix, 1 docs** — auth, docs
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -25,7 +32,5 @@ authors:
     - Mark tech debt #88 (token refresh retry) as resolved in `docs/tech-debt.md` with PR #171 reference
     - Update quick stats in `CLAUDE.md`: 41 resolved / 40 remaining
 
-## Commits: 33
-
 ---
-*Generated from GitHub data.*
+*33 commits across this session.*

--- a/docs/blog/posts/2026-02-07.md
+++ b/docs/blog/posts/2026-02-07.md
@@ -5,6 +5,16 @@ categories:
   - Documentation
   - Feature
   - Bug Fix
+tags:
+  - ci
+  - code-quality
+  - docs
+  - export
+  - imaging
+  - infrastructure
+  - job-queue
+  - ui
+  - viewer
 authors:
   - shanon
 ---
@@ -12,6 +22,10 @@ authors:
 # Session: February 7, 2026
 
 <!-- generated -->
+
+**7 features, 6 fixes, 7 docs** — ci, code-quality, docs, export, imaging, infrastructure, job-queue, ui, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -152,7 +166,5 @@ authors:
     - Move tech debt #77 (SA1202) and #78 (SA1204) to resolved (PR #209)
     - Update stats: 53 resolved, 35 remaining
 
-## Commits: 63
-
 ---
-*Generated from GitHub data.*
+*63 commits across this session.*

--- a/docs/blog/posts/2026-02-08.md
+++ b/docs/blog/posts/2026-02-08.md
@@ -7,6 +7,19 @@ categories:
   - Documentation
   - Feature
   - Bug Fix
+tags:
+  - auth
+  - ci
+  - code-quality
+  - dependencies
+  - docs
+  - export
+  - guided-wizard
+  - imaging
+  - mast-data
+  - security
+  - ui
+  - viewer
 authors:
   - shanon
 ---
@@ -14,6 +27,10 @@ authors:
 # Session: February 8, 2026
 
 <!-- generated -->
+
+**8 features, 5 fixes, 2 docs, 2 maintenance, 18 dep updates** — auth, ci, code-quality, dependencies, docs, export, guided-wizard, imaging, mast-data, security, ui, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -168,7 +185,5 @@ authors:
 
     *Large WCS mosaics can exceed practical browser transfer size and fail the current download-then-upload workflow. Saving directly on the backend returns a reusable `dataId` for composer and keeps the flow reliable for big outputs.*
 
-## Commits: 36
-
 ---
-*Generated from GitHub data.*
+*36 commits across this session.*

--- a/docs/blog/posts/2026-02-09.md
+++ b/docs/blog/posts/2026-02-09.md
@@ -5,6 +5,12 @@ categories:
   - Maintenance
   - Documentation
   - Bug Fix
+tags:
+  - auth
+  - ci
+  - docs
+  - e2e-tests
+  - infrastructure
 authors:
   - shanon
 ---
@@ -12,6 +18,10 @@ authors:
 # Session: February 9, 2026
 
 <!-- generated -->
+
+**2 fixes, 2 docs, 6 maintenance** — auth, ci, docs, e2e-tests, infrastructure
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -79,7 +89,5 @@ authors:
 
     *The e2e test suite had 10 persistent failures caused by mismatches between what the app renders and what tests expect. All failures are real discrepancies — no tests were weakened or skipped.*
 
-## Commits: 25
-
 ---
-*Generated from GitHub data.*
+*25 commits across this session.*

--- a/docs/blog/posts/2026-02-10.md
+++ b/docs/blog/posts/2026-02-10.md
@@ -3,6 +3,8 @@ date:
   created: 2026-02-10
 categories:
   - Bug Fix
+tags:
+  - ui
 authors:
   - shanon
 ---
@@ -10,6 +12,10 @@ authors:
 # Session: February 10, 2026
 
 <!-- generated -->
+
+**2 fixes** — ui
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -25,7 +31,5 @@ authors:
 
     *The last remaining e2e test failure: browser's native `type="email"` validation blocks form submission before React's `handleSubmit` fires, so the custom error "Please enter a valid email address" never appears.*
 
-## Commits: 0
-
 ---
-*Generated from GitHub data.*
+*0 commits across this session.*

--- a/docs/blog/posts/2026-02-11.md
+++ b/docs/blog/posts/2026-02-11.md
@@ -3,6 +3,9 @@ date:
   created: 2026-02-11
 categories:
   - Bug Fix
+tags:
+  - ci
+  - e2e-tests
 authors:
   - shanon
 ---
@@ -10,6 +13,10 @@ authors:
 # Session: February 11, 2026
 
 <!-- generated -->
+
+**2 fixes** — ci, e2e-tests
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -27,7 +34,5 @@ authors:
 
     *The E2E job currently runs `npx playwright install --with-deps chromium` on each execution, which adds several minutes to repeat runs.*
 
-## Commits: 7
-
 ---
-*Generated from GitHub data.*
+*7 commits across this session.*

--- a/docs/blog/posts/2026-02-12.md
+++ b/docs/blog/posts/2026-02-12.md
@@ -5,6 +5,12 @@ categories:
   - Maintenance
   - Feature
   - Bug Fix
+tags:
+  - auth
+  - imaging
+  - infrastructure
+  - security
+  - ui
 authors:
   - shanon
 ---
@@ -12,6 +18,10 @@ authors:
 # Session: February 12, 2026
 
 <!-- generated -->
+
+**4 features, 5 fixes, 1 maintenance** — auth, imaging, infrastructure, security, ui
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -80,10 +90,51 @@ authors:
 
 ## Issues
 
-- **Opened**: [#250](https://github.com/Snoww3d/jwst-data-analysis/issues/250), [#251](https://github.com/Snoww3d/jwst-data-analysis/issues/251), [#252](https://github.com/Snoww3d/jwst-data-analysis/issues/252), [#253](https://github.com/Snoww3d/jwst-data-analysis/issues/253), [#254](https://github.com/Snoww3d/jwst-data-analysis/issues/254), [#255](https://github.com/Snoww3d/jwst-data-analysis/issues/255), [#256](https://github.com/Snoww3d/jwst-data-analysis/issues/256), [#257](https://github.com/Snoww3d/jwst-data-analysis/issues/257), [#258](https://github.com/Snoww3d/jwst-data-analysis/issues/258), [#259](https://github.com/Snoww3d/jwst-data-analysis/issues/259), [#260](https://github.com/Snoww3d/jwst-data-analysis/issues/260), [#261](https://github.com/Snoww3d/jwst-data-analysis/issues/261), [#262](https://github.com/Snoww3d/jwst-data-analysis/issues/262), [#263](https://github.com/Snoww3d/jwst-data-analysis/issues/263), [#264](https://github.com/Snoww3d/jwst-data-analysis/issues/264), [#265](https://github.com/Snoww3d/jwst-data-analysis/issues/265), [#266](https://github.com/Snoww3d/jwst-data-analysis/issues/266), [#267](https://github.com/Snoww3d/jwst-data-analysis/issues/267), [#268](https://github.com/Snoww3d/jwst-data-analysis/issues/268), [#269](https://github.com/Snoww3d/jwst-data-analysis/issues/269), [#270](https://github.com/Snoww3d/jwst-data-analysis/issues/270), [#271](https://github.com/Snoww3d/jwst-data-analysis/issues/271), [#272](https://github.com/Snoww3d/jwst-data-analysis/issues/272), [#273](https://github.com/Snoww3d/jwst-data-analysis/issues/273), [#274](https://github.com/Snoww3d/jwst-data-analysis/issues/274), [#275](https://github.com/Snoww3d/jwst-data-analysis/issues/275), [#276](https://github.com/Snoww3d/jwst-data-analysis/issues/276), [#277](https://github.com/Snoww3d/jwst-data-analysis/issues/277), [#278](https://github.com/Snoww3d/jwst-data-analysis/issues/278), [#279](https://github.com/Snoww3d/jwst-data-analysis/issues/279), [#280](https://github.com/Snoww3d/jwst-data-analysis/issues/280), [#281](https://github.com/Snoww3d/jwst-data-analysis/issues/281), [#282](https://github.com/Snoww3d/jwst-data-analysis/issues/282), [#283](https://github.com/Snoww3d/jwst-data-analysis/issues/283), [#284](https://github.com/Snoww3d/jwst-data-analysis/issues/284), [#285](https://github.com/Snoww3d/jwst-data-analysis/issues/285), [#286](https://github.com/Snoww3d/jwst-data-analysis/issues/286), [#287](https://github.com/Snoww3d/jwst-data-analysis/issues/287), [#288](https://github.com/Snoww3d/jwst-data-analysis/issues/288)
-- **Closed**: [#280](https://github.com/Snoww3d/jwst-data-analysis/issues/280)
+**Opened:**
 
-## Commits: 14
+- [#250](https://github.com/Snoww3d/jwst-data-analysis/issues/250) — Proper Job Queue for Background Tasks
+- [#251](https://github.com/Snoww3d/jwst-data-analysis/issues/251) — FITS TypeScript Interfaces
+- [#252](https://github.com/Snoww3d/jwst-data-analysis/issues/252) — Add API Documentation (OpenAPI/Swagger)
+- [#253](https://github.com/Snoww3d/jwst-data-analysis/issues/253) — Add Demo Mode / Sample Data
+- [#254](https://github.com/Snoww3d/jwst-data-analysis/issues/254) — Add Browser/Environment Compatibility Documentation
+- [#255](https://github.com/Snoww3d/jwst-data-analysis/issues/255) — Re-enable CodeQL Security Analysis
+- [#256](https://github.com/Snoww3d/jwst-data-analysis/issues/256) — Configure Structured Logging (JSON)
+- [#257](https://github.com/Snoww3d/jwst-data-analysis/issues/257) — Set up MCP Servers
+- [#258](https://github.com/Snoww3d/jwst-data-analysis/issues/258) — Configure Husky Git Hooks
+- [#259](https://github.com/Snoww3d/jwst-data-analysis/issues/259) — Generate and Host OpenAPI Spec
+- [#260](https://github.com/Snoww3d/jwst-data-analysis/issues/260) — Add JWST GWCS Support for WCS Coordinates
+- [#261](https://github.com/Snoww3d/jwst-data-analysis/issues/261) — Split Large Documentation Files to Reduce Context Window Usage
+- [#262](https://github.com/Snoww3d/jwst-data-analysis/issues/262) — Refresh Tokens Stored in Plaintext
+- [#263](https://github.com/Snoww3d/jwst-data-analysis/issues/263) — SA1402 — File May Only Contain Single Type
+- [#264](https://github.com/Snoww3d/jwst-data-analysis/issues/264) — SA1649 — File Name Should Match First Type Name
+- [#265](https://github.com/Snoww3d/jwst-data-analysis/issues/265) — CA1805 — Don't Initialize to Default Value
+- [#266](https://github.com/Snoww3d/jwst-data-analysis/issues/266) — SA1316 — Tuple Element Names Should Use Correct Casing
+- [#267](https://github.com/Snoww3d/jwst-data-analysis/issues/267) — SA1500 — Braces Should Not Share Line
+- [#268](https://github.com/Snoww3d/jwst-data-analysis/issues/268) — SA1117 — Parameters on Same or Separate Lines
+- [#269](https://github.com/Snoww3d/jwst-data-analysis/issues/269) — SA1116 — Split Parameters Should Start After Declaration
+- [#270](https://github.com/Snoww3d/jwst-data-analysis/issues/270) — SA1113 — Comma on Same Line as Previous Parameter
+- [#271](https://github.com/Snoww3d/jwst-data-analysis/issues/271) — SA1001 — Commas Should Be Spaced Correctly
+- [#272](https://github.com/Snoww3d/jwst-data-analysis/issues/272) — Incomplete Downloads Panel UX Improvements
+- [#273](https://github.com/Snoww3d/jwst-data-analysis/issues/273) — Require PR Approving Reviews on Branch Protection
+- [#274](https://github.com/Snoww3d/jwst-data-analysis/issues/274) — Add Test Coverage — Frontend & Processing Engine
+- [#275](https://github.com/Snoww3d/jwst-data-analysis/issues/275) — Add Application Logging and Monitoring Hooks
+- [#276](https://github.com/Snoww3d/jwst-data-analysis/issues/276) — Add Docker Image Publishing
+- [#277](https://github.com/Snoww3d/jwst-data-analysis/issues/277) — Create Release Process and Changelog
+- [#278](https://github.com/Snoww3d/jwst-data-analysis/issues/278) — Enable GitHub Branch Protection on Main
+- [#279](https://github.com/Snoww3d/jwst-data-analysis/issues/279) — Revisit Export Filename Pattern
+- [#280](https://github.com/Snoww3d/jwst-data-analysis/issues/280) — Environment Variables with Credentials
+- [#281](https://github.com/Snoww3d/jwst-data-analysis/issues/281) — No Network Isolation Between Services
+- [#282](https://github.com/Snoww3d/jwst-data-analysis/issues/282) — Missing CSRF Protection
+- [#283](https://github.com/Snoww3d/jwst-data-analysis/issues/283) — Overly Permissive TypeScript Types
+- [#284](https://github.com/Snoww3d/jwst-data-analysis/issues/284) — Expand Desktop Requirements to Implementation-Ready Specification
+- [#285](https://github.com/Snoww3d/jwst-data-analysis/issues/285) — Streamline Documentation-Only PR Workflow
+- [#286](https://github.com/Snoww3d/jwst-data-analysis/issues/286) — E2E Export Tests Skipped — No Seed Data in CI
+- [#287](https://github.com/Snoww3d/jwst-data-analysis/issues/287) — Optimize CodeQL CI with Path Filtering and Caching
+- [#288](https://github.com/Snoww3d/jwst-data-analysis/issues/288) — Composite Preview Performance — Architecture Rework
+
+**Closed:**
+
+- [#280](https://github.com/Snoww3d/jwst-data-analysis/issues/280) — Environment Variables with Credentials
 
 ---
-*Generated from GitHub data.*
+*14 commits across this session.*

--- a/docs/blog/posts/2026-02-13.md
+++ b/docs/blog/posts/2026-02-13.md
@@ -8,6 +8,15 @@ categories:
   - Bug Fix
   - Refactoring
   - Testing
+tags:
+  - auth
+  - ci
+  - docs
+  - e2e-tests
+  - export
+  - job-queue
+  - testing
+  - ui
 authors:
   - shanon
 ---
@@ -15,6 +24,10 @@ authors:
 # Session: February 13, 2026
 
 <!-- generated -->
+
+**2 features, 2 fixes, 1 docs, 3 refactors, 1 test, 4 maintenance** — auth, ci, docs, e2e-tests, export, job-queue, testing, ui
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -98,10 +111,27 @@ authors:
 
 ## Issues
 
-- **Opened**: [#298](https://github.com/Snoww3d/jwst-data-analysis/issues/298), [#301](https://github.com/Snoww3d/jwst-data-analysis/issues/301), [#302](https://github.com/Snoww3d/jwst-data-analysis/issues/302), [#303](https://github.com/Snoww3d/jwst-data-analysis/issues/303), [#304](https://github.com/Snoww3d/jwst-data-analysis/issues/304), [#305](https://github.com/Snoww3d/jwst-data-analysis/issues/305), [#306](https://github.com/Snoww3d/jwst-data-analysis/issues/306), [#317](https://github.com/Snoww3d/jwst-data-analysis/issues/317)
-- **Closed**: [#255](https://github.com/Snoww3d/jwst-data-analysis/issues/255), [#278](https://github.com/Snoww3d/jwst-data-analysis/issues/278), [#286](https://github.com/Snoww3d/jwst-data-analysis/issues/286), [#287](https://github.com/Snoww3d/jwst-data-analysis/issues/287), [#298](https://github.com/Snoww3d/jwst-data-analysis/issues/298), [#302](https://github.com/Snoww3d/jwst-data-analysis/issues/302), [#305](https://github.com/Snoww3d/jwst-data-analysis/issues/305), [#306](https://github.com/Snoww3d/jwst-data-analysis/issues/306)
+**Opened:**
 
-## Commits: 17
+- [#298](https://github.com/Snoww3d/jwst-data-analysis/issues/298) — fix: SeedDataService should assign Admin role to admin user
+- [#301](https://github.com/Snoww3d/jwst-data-analysis/issues/301) — fix: ImageViewer shows no metadata for mosaic-generated FITS files
+- [#302](https://github.com/Snoww3d/jwst-data-analysis/issues/302) — refactor: split JwstDataDashboard into separate view components
+- [#303](https://github.com/Snoww3d/jwst-data-analysis/issues/303) — refactor: extract shared MapToDataResponse and path resolution helpers
+- [#304](https://github.com/Snoww3d/jwst-data-analysis/issues/304) — test: add unit tests for ThumbnailService
+- [#305](https://github.com/Snoww3d/jwst-data-analysis/issues/305) — refactor: replace emoji indicators with SVG icons
+- [#306](https://github.com/Snoww3d/jwst-data-analysis/issues/306) — refactor: replace fire-and-forget Task.Run with proper background task queue
+- [#317](https://github.com/Snoww3d/jwst-data-analysis/issues/317) — Thumbnail generation fails for large FITS files (413 Request Entity Too Large)
+
+**Closed:**
+
+- [#255](https://github.com/Snoww3d/jwst-data-analysis/issues/255) — Re-enable CodeQL Security Analysis
+- [#278](https://github.com/Snoww3d/jwst-data-analysis/issues/278) — Enable GitHub Branch Protection on Main
+- [#286](https://github.com/Snoww3d/jwst-data-analysis/issues/286) — E2E Export Tests Skipped — No Seed Data in CI
+- [#287](https://github.com/Snoww3d/jwst-data-analysis/issues/287) — Optimize CodeQL CI with Path Filtering and Caching
+- [#298](https://github.com/Snoww3d/jwst-data-analysis/issues/298) — fix: SeedDataService should assign Admin role to admin user
+- [#302](https://github.com/Snoww3d/jwst-data-analysis/issues/302) — refactor: split JwstDataDashboard into separate view components
+- [#305](https://github.com/Snoww3d/jwst-data-analysis/issues/305) — refactor: replace emoji indicators with SVG icons
+- [#306](https://github.com/Snoww3d/jwst-data-analysis/issues/306) — refactor: replace fire-and-forget Task.Run with proper background task queue
 
 ---
-*Generated from GitHub data.*
+*17 commits across this session.*

--- a/docs/blog/posts/2026-02-14.md
+++ b/docs/blog/posts/2026-02-14.md
@@ -7,6 +7,18 @@ categories:
   - Documentation
   - Feature
   - Bug Fix
+tags:
+  - auth
+  - ci
+  - code-quality
+  - dependencies
+  - docs
+  - guided-wizard
+  - imaging
+  - infrastructure
+  - mast-data
+  - ui
+  - viewer
 authors:
   - shanon
 ---
@@ -14,6 +26,10 @@ authors:
 # Session: February 14, 2026
 
 <!-- generated -->
+
+**8 features, 10 fixes, 1 docs, 2 maintenance, 12 dep updates** — auth, ci, code-quality, dependencies, docs, guided-wizard, imaging, infrastructure, mast-data, ui, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -171,10 +187,21 @@ authors:
 
 ## Issues
 
-- **Opened**: [#319](https://github.com/Snoww3d/jwst-data-analysis/issues/319), [#326](https://github.com/Snoww3d/jwst-data-analysis/issues/326), [#347](https://github.com/Snoww3d/jwst-data-analysis/issues/347), [#348](https://github.com/Snoww3d/jwst-data-analysis/issues/348), [#357](https://github.com/Snoww3d/jwst-data-analysis/issues/357)
-- **Closed**: [#288](https://github.com/Snoww3d/jwst-data-analysis/issues/288), [#301](https://github.com/Snoww3d/jwst-data-analysis/issues/301), [#317](https://github.com/Snoww3d/jwst-data-analysis/issues/317), [#319](https://github.com/Snoww3d/jwst-data-analysis/issues/319), [#326](https://github.com/Snoww3d/jwst-data-analysis/issues/326)
+**Opened:**
 
-## Commits: 30
+- [#319](https://github.com/Snoww3d/jwst-data-analysis/issues/319) — fix: MAST Sync bulk import duplicate key error (500)
+- [#326](https://github.com/Snoww3d/jwst-data-analysis/issues/326) — [Feature] Improve target search for name variants (Crab Nebula / NGC 3132 / NGC-3132)
+- [#347](https://github.com/Snoww3d/jwst-data-analysis/issues/347) — chore: migrate eslint 9 → 10
+- [#348](https://github.com/Snoww3d/jwst-data-analysis/issues/348) — chore: migrate pytest-asyncio 0.23 → 1.x
+- [#357](https://github.com/Snoww3d/jwst-data-analysis/issues/357) — Refine RGB composite default stretch and background neutralization
+
+**Closed:**
+
+- [#288](https://github.com/Snoww3d/jwst-data-analysis/issues/288) — Composite Preview Performance — Architecture Rework
+- [#301](https://github.com/Snoww3d/jwst-data-analysis/issues/301) — fix: ImageViewer shows no metadata for mosaic-generated FITS files
+- [#317](https://github.com/Snoww3d/jwst-data-analysis/issues/317) — Thumbnail generation fails for large FITS files (413 Request Entity Too Large)
+- [#319](https://github.com/Snoww3d/jwst-data-analysis/issues/319) — fix: MAST Sync bulk import duplicate key error (500)
+- [#326](https://github.com/Snoww3d/jwst-data-analysis/issues/326) — [Feature] Improve target search for name variants (Crab Nebula / NGC 3132 / NGC-3132)
 
 ---
-*Generated from GitHub data.*
+*30 commits across this session.*

--- a/docs/blog/posts/2026-02-15.md
+++ b/docs/blog/posts/2026-02-15.md
@@ -7,6 +7,12 @@ categories:
   - Bug Fix
   - Refactoring
   - Testing
+tags:
+  - docs
+  - e2e-tests
+  - guided-wizard
+  - imaging
+  - testing
 authors:
   - shanon
 ---
@@ -14,6 +20,10 @@ authors:
 # Session: February 15, 2026
 
 <!-- generated -->
+
+**2 features, 5 fixes, 2 docs, 1 refactor, 1 test** — docs, e2e-tests, guided-wizard, imaging, testing
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -91,10 +101,9 @@ authors:
 
 ## Issues
 
-- **Opened**: [#372](https://github.com/Snoww3d/jwst-data-analysis/issues/372)
-- **Closed**: None
+**Opened:**
 
-## Commits: 6
+- [#372](https://github.com/Snoww3d/jwst-data-analysis/issues/372) — test: add WCS-enabled FITS fixture for E2E WCS grid toggle test
 
 ---
-*Generated from GitHub data.*
+*6 commits across this session.*

--- a/docs/blog/posts/2026-02-16.md
+++ b/docs/blog/posts/2026-02-16.md
@@ -5,6 +5,15 @@ categories:
   - Feature
   - Bug Fix
   - Testing
+tags:
+  - auth
+  - e2e-tests
+  - guided-wizard
+  - imaging
+  - infrastructure
+  - mast-data
+  - security
+  - testing
 authors:
   - shanon
 ---
@@ -12,6 +21,10 @@ authors:
 # Session: February 16, 2026
 
 <!-- generated -->
+
+**6 features, 3 fixes, 1 test** — auth, e2e-tests, guided-wizard, imaging, infrastructure, mast-data, security, testing
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -79,10 +92,15 @@ authors:
 
 ## Issues
 
-- **Opened**: [#375](https://github.com/Snoww3d/jwst-data-analysis/issues/375), [#377](https://github.com/Snoww3d/jwst-data-analysis/issues/377), [#379](https://github.com/Snoww3d/jwst-data-analysis/issues/379)
-- **Closed**: [#379](https://github.com/Snoww3d/jwst-data-analysis/issues/379)
+**Opened:**
 
-## Commits: 12
+- [#375](https://github.com/Snoww3d/jwst-data-analysis/issues/375) — UI/UX improvements for JWST filter presets dropdown
+- [#377](https://github.com/Snoww3d/jwst-data-analysis/issues/377) — fix: validate-before-pr-create.sh hook matched body text and failed in worktrees
+- [#379](https://github.com/Snoww3d/jwst-data-analysis/issues/379) — test: add comprehensive MAST download E2E coverage
+
+**Closed:**
+
+- [#379](https://github.com/Snoww3d/jwst-data-analysis/issues/379) — test: add comprehensive MAST download E2E coverage
 
 ---
-*Generated from GitHub data.*
+*12 commits across this session.*

--- a/docs/blog/posts/2026-02-17.md
+++ b/docs/blog/posts/2026-02-17.md
@@ -7,6 +7,16 @@ categories:
   - Feature
   - Bug Fix
   - Refactoring
+tags:
+  - auth
+  - code-quality
+  - docs
+  - guided-wizard
+  - imaging
+  - infrastructure
+  - mast-data
+  - ui
+  - viewer
 authors:
   - shanon
 ---
@@ -14,6 +24,10 @@ authors:
 # Session: February 17, 2026
 
 <!-- generated -->
+
+**6 features, 9 fixes, 2 docs, 1 refactor, 1 maintenance** — auth, code-quality, docs, guided-wizard, imaging, infrastructure, mast-data, ui, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -142,10 +156,13 @@ authors:
 
 ## Issues
 
-- **Opened**: [#403](https://github.com/Snoww3d/jwst-data-analysis/issues/403)
-- **Closed**: [#403](https://github.com/Snoww3d/jwst-data-analysis/issues/403)
+**Opened:**
 
-## Commits: 19
+- [#403](https://github.com/Snoww3d/jwst-data-analysis/issues/403) — Auth token expires during long-running operations, logging user out
+
+**Closed:**
+
+- [#403](https://github.com/Snoww3d/jwst-data-analysis/issues/403) — Auth token expires during long-running operations, logging user out
 
 ---
-*Generated from GitHub data.*
+*19 commits across this session.*

--- a/docs/blog/posts/2026-02-18.md
+++ b/docs/blog/posts/2026-02-18.md
@@ -4,6 +4,8 @@ date:
 categories:
   - Maintenance
   - Feature
+tags:
+  - code-quality
 authors:
   - shanon
 ---
@@ -11,6 +13,10 @@ authors:
 # Session: February 18, 2026
 
 <!-- generated -->
+
+**1 feature, 4 maintenance** — code-quality
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -46,10 +52,15 @@ authors:
 
 ## Issues
 
-- **Opened**: None
-- **Closed**: [#265](https://github.com/Snoww3d/jwst-data-analysis/issues/265), [#266](https://github.com/Snoww3d/jwst-data-analysis/issues/266), [#267](https://github.com/Snoww3d/jwst-data-analysis/issues/267), [#268](https://github.com/Snoww3d/jwst-data-analysis/issues/268), [#269](https://github.com/Snoww3d/jwst-data-analysis/issues/269), [#270](https://github.com/Snoww3d/jwst-data-analysis/issues/270), [#271](https://github.com/Snoww3d/jwst-data-analysis/issues/271)
+**Closed:**
 
-## Commits: 5
+- [#265](https://github.com/Snoww3d/jwst-data-analysis/issues/265) — CA1805 — Don't Initialize to Default Value
+- [#266](https://github.com/Snoww3d/jwst-data-analysis/issues/266) — SA1316 — Tuple Element Names Should Use Correct Casing
+- [#267](https://github.com/Snoww3d/jwst-data-analysis/issues/267) — SA1500 — Braces Should Not Share Line
+- [#268](https://github.com/Snoww3d/jwst-data-analysis/issues/268) — SA1117 — Parameters on Same or Separate Lines
+- [#269](https://github.com/Snoww3d/jwst-data-analysis/issues/269) — SA1116 — Split Parameters Should Start After Declaration
+- [#270](https://github.com/Snoww3d/jwst-data-analysis/issues/270) — SA1113 — Comma on Same Line as Previous Parameter
+- [#271](https://github.com/Snoww3d/jwst-data-analysis/issues/271) — SA1001 — Commas Should Be Spaced Correctly
 
 ---
-*Generated from GitHub data.*
+*5 commits across this session.*

--- a/docs/blog/posts/2026-02-21.md
+++ b/docs/blog/posts/2026-02-21.md
@@ -5,6 +5,10 @@ categories:
   - Maintenance
   - Development
   - Testing
+tags:
+  - code-quality
+  - dependencies
+  - testing
 authors:
   - shanon
 ---
@@ -12,6 +16,10 @@ authors:
 # Session: February 21, 2026
 
 <!-- generated -->
+
+**1 test, 1 maintenance, 4 dep updates** — code-quality, dependencies, testing
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -53,10 +61,14 @@ authors:
 
 ## Issues
 
-- **Opened**: [#425](https://github.com/Snoww3d/jwst-data-analysis/issues/425)
-- **Closed**: [#304](https://github.com/Snoww3d/jwst-data-analysis/issues/304), [#377](https://github.com/Snoww3d/jwst-data-analysis/issues/377)
+**Opened:**
 
-## Commits: 6
+- [#425](https://github.com/Snoww3d/jwst-data-analysis/issues/425) — chore: add retry logic for Docker image pulls in E2E CI
+
+**Closed:**
+
+- [#304](https://github.com/Snoww3d/jwst-data-analysis/issues/304) — test: add unit tests for ThumbnailService
+- [#377](https://github.com/Snoww3d/jwst-data-analysis/issues/377) — fix: validate-before-pr-create.sh hook matched body text and failed in worktrees
 
 ---
-*Generated from GitHub data.*
+*6 commits across this session.*

--- a/docs/blog/posts/2026-02-22.md
+++ b/docs/blog/posts/2026-02-22.md
@@ -6,6 +6,12 @@ categories:
   - Development
   - Feature
   - Refactoring
+tags:
+  - auth
+  - ci
+  - code-quality
+  - dependencies
+  - mast-data
 authors:
   - shanon
 ---
@@ -13,6 +19,10 @@ authors:
 # Session: February 22, 2026
 
 <!-- generated -->
+
+**1 feature, 2 refactors, 8 maintenance, 1 dep update** — auth, ci, code-quality, dependencies, mast-data
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -94,10 +104,21 @@ authors:
 
 ## Issues
 
-- **Opened**: [#433](https://github.com/Snoww3d/jwst-data-analysis/issues/433)
-- **Closed**: [#3](https://github.com/Snoww3d/jwst-data-analysis/issues/3), [#252](https://github.com/Snoww3d/jwst-data-analysis/issues/252), [#257](https://github.com/Snoww3d/jwst-data-analysis/issues/257), [#262](https://github.com/Snoww3d/jwst-data-analysis/issues/262), [#273](https://github.com/Snoww3d/jwst-data-analysis/issues/273), [#274](https://github.com/Snoww3d/jwst-data-analysis/issues/274), [#281](https://github.com/Snoww3d/jwst-data-analysis/issues/281), [#282](https://github.com/Snoww3d/jwst-data-analysis/issues/282), [#347](https://github.com/Snoww3d/jwst-data-analysis/issues/347)
+**Opened:**
 
-## Commits: 13
+- [#433](https://github.com/Snoww3d/jwst-data-analysis/issues/433) — Add CI coverage thresholds — starting with Python
+
+**Closed:**
+
+- [#3](https://github.com/Snoww3d/jwst-data-analysis/issues/3) — Processing job queue system
+- [#252](https://github.com/Snoww3d/jwst-data-analysis/issues/252) — Add API Documentation (OpenAPI/Swagger)
+- [#257](https://github.com/Snoww3d/jwst-data-analysis/issues/257) — Set up MCP Servers
+- [#262](https://github.com/Snoww3d/jwst-data-analysis/issues/262) — Refresh Tokens Stored in Plaintext
+- [#273](https://github.com/Snoww3d/jwst-data-analysis/issues/273) — Require PR Approving Reviews on Branch Protection
+- [#274](https://github.com/Snoww3d/jwst-data-analysis/issues/274) — Add Test Coverage — Frontend & Processing Engine
+- [#281](https://github.com/Snoww3d/jwst-data-analysis/issues/281) — No Network Isolation Between Services
+- [#282](https://github.com/Snoww3d/jwst-data-analysis/issues/282) — Missing CSRF Protection
+- [#347](https://github.com/Snoww3d/jwst-data-analysis/issues/347) — chore: migrate eslint 9 → 10
 
 ---
-*Generated from GitHub data.*
+*13 commits across this session.*

--- a/docs/blog/posts/2026-02-23.md
+++ b/docs/blog/posts/2026-02-23.md
@@ -6,6 +6,14 @@ categories:
   - Feature
   - Bug Fix
   - Testing
+tags:
+  - auth
+  - ci
+  - code-quality
+  - dependencies
+  - job-queue
+  - mast-data
+  - testing
 authors:
   - shanon
 ---
@@ -13,6 +21,10 @@ authors:
 # Session: February 23, 2026
 
 <!-- generated -->
+
+**3 features, 1 fix, 5 tests, 2 maintenance** — auth, ci, code-quality, dependencies, job-queue, mast-data, testing
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -85,10 +97,50 @@ authors:
 
 ## Issues
 
-- **Opened**: [#442](https://github.com/Snoww3d/jwst-data-analysis/issues/442), [#443](https://github.com/Snoww3d/jwst-data-analysis/issues/443), [#444](https://github.com/Snoww3d/jwst-data-analysis/issues/444), [#445](https://github.com/Snoww3d/jwst-data-analysis/issues/445), [#446](https://github.com/Snoww3d/jwst-data-analysis/issues/446), [#447](https://github.com/Snoww3d/jwst-data-analysis/issues/447), [#448](https://github.com/Snoww3d/jwst-data-analysis/issues/448), [#449](https://github.com/Snoww3d/jwst-data-analysis/issues/449), [#450](https://github.com/Snoww3d/jwst-data-analysis/issues/450), [#451](https://github.com/Snoww3d/jwst-data-analysis/issues/451), [#452](https://github.com/Snoww3d/jwst-data-analysis/issues/452), [#453](https://github.com/Snoww3d/jwst-data-analysis/issues/453), [#454](https://github.com/Snoww3d/jwst-data-analysis/issues/454), [#455](https://github.com/Snoww3d/jwst-data-analysis/issues/455), [#456](https://github.com/Snoww3d/jwst-data-analysis/issues/456), [#457](https://github.com/Snoww3d/jwst-data-analysis/issues/457), [#458](https://github.com/Snoww3d/jwst-data-analysis/issues/458), [#459](https://github.com/Snoww3d/jwst-data-analysis/issues/459), [#460](https://github.com/Snoww3d/jwst-data-analysis/issues/460), [#461](https://github.com/Snoww3d/jwst-data-analysis/issues/461)
-- **Closed**: [#1](https://github.com/Snoww3d/jwst-data-analysis/issues/1), [#2](https://github.com/Snoww3d/jwst-data-analysis/issues/2), [#250](https://github.com/Snoww3d/jwst-data-analysis/issues/250), [#251](https://github.com/Snoww3d/jwst-data-analysis/issues/251), [#260](https://github.com/Snoww3d/jwst-data-analysis/issues/260), [#263](https://github.com/Snoww3d/jwst-data-analysis/issues/263), [#264](https://github.com/Snoww3d/jwst-data-analysis/issues/264), [#272](https://github.com/Snoww3d/jwst-data-analysis/issues/272), [#275](https://github.com/Snoww3d/jwst-data-analysis/issues/275), [#276](https://github.com/Snoww3d/jwst-data-analysis/issues/276), [#277](https://github.com/Snoww3d/jwst-data-analysis/issues/277), [#279](https://github.com/Snoww3d/jwst-data-analysis/issues/279), [#283](https://github.com/Snoww3d/jwst-data-analysis/issues/283), [#284](https://github.com/Snoww3d/jwst-data-analysis/issues/284), [#348](https://github.com/Snoww3d/jwst-data-analysis/issues/348), [#375](https://github.com/Snoww3d/jwst-data-analysis/issues/375), [#433](https://github.com/Snoww3d/jwst-data-analysis/issues/433), [#444](https://github.com/Snoww3d/jwst-data-analysis/issues/444), [#445](https://github.com/Snoww3d/jwst-data-analysis/issues/445)
+**Opened:**
 
-## Commits: 12
+- [#442](https://github.com/Snoww3d/jwst-data-analysis/issues/442) — security: missing CanModifyData checks on mutation endpoints (IDOR)
+- [#443](https://github.com/Snoww3d/jwst-data-analysis/issues/443) — security: destructive observation-wide operations not owner/admin-gated
+- [#444](https://github.com/Snoww3d/jwst-data-analysis/issues/444) — security: migration endpoints callable by any authenticated user
+- [#445](https://github.com/Snoww3d/jwst-data-analysis/issues/445) — security: ownership spoofing via client-supplied UserId on create
+- [#446](https://github.com/Snoww3d/jwst-data-analysis/issues/446) — security: private thumbnail access bypass via AllowAnonymous
+- [#447](https://github.com/Snoww3d/jwst-data-analysis/issues/447) — security: import-job endpoints not bound to requesting user
+- [#448](https://github.com/Snoww3d/jwst-data-analysis/issues/448) — security: mosaic/analysis endpoints lack per-object authorization (cross-tenant IDOR)
+- [#449](https://github.com/Snoww3d/jwst-data-analysis/issues/449) — security: python-multipart pinned at vulnerable version 0.0.6
+- [#450](https://github.com/Snoww3d/jwst-data-analysis/issues/450) — security: path traversal in non-chunked MAST download (obs_id in filesystem path)
+- [#451](https://github.com/Snoww3d/jwst-data-analysis/issues/451) — security: resumable dismissal can delete paths without base-path guard
+- [#452](https://github.com/Snoww3d/jwst-data-analysis/issues/452) — security: JWT secret has insecure placeholder default
+- [#453](https://github.com/Snoww3d/jwst-data-analysis/issues/453) — security: open proxy trust enables rate limit bypass via X-Forwarded-For spoofing
+- [#454](https://github.com/Snoww3d/jwst-data-analysis/issues/454) — security: seeded credentials in code can run outside dev environment
+- [#455](https://github.com/Snoww3d/jwst-data-analysis/issues/455) — security: records default to public visibility
+- [#456](https://github.com/Snoww3d/jwst-data-analysis/issues/456) — security: tokens stored in localStorage (XSS token-theft risk)
+- [#457](https://github.com/Snoww3d/jwst-data-analysis/issues/457) — security: CSP allows unsafe-inline and unsafe-eval
+- [#458](https://github.com/Snoww3d/jwst-data-analysis/issues/458) — security: auth debug logs persisted client-side and exposed on window
+- [#459](https://github.com/Snoww3d/jwst-data-analysis/issues/459) — security: internal exception details returned to clients
+- [#460](https://github.com/Snoww3d/jwst-data-analysis/issues/460) — security: public data responses expose owner UserId
+- [#461](https://github.com/Snoww3d/jwst-data-analysis/issues/461) — security: frontend dev dependency audit shows 18 high vulnerabilities
+
+**Closed:**
+
+- [#1](https://github.com/Snoww3d/jwst-data-analysis/issues/1) — Implement actual image processing algorithms
+- [#2](https://github.com/Snoww3d/jwst-data-analysis/issues/2) — Implement spectral analysis tools
+- [#250](https://github.com/Snoww3d/jwst-data-analysis/issues/250) — Proper Job Queue for Background Tasks
+- [#251](https://github.com/Snoww3d/jwst-data-analysis/issues/251) — FITS TypeScript Interfaces
+- [#260](https://github.com/Snoww3d/jwst-data-analysis/issues/260) — Add JWST GWCS Support for WCS Coordinates
+- [#263](https://github.com/Snoww3d/jwst-data-analysis/issues/263) — SA1402 — File May Only Contain Single Type
+- [#264](https://github.com/Snoww3d/jwst-data-analysis/issues/264) — SA1649 — File Name Should Match First Type Name
+- [#272](https://github.com/Snoww3d/jwst-data-analysis/issues/272) — Incomplete Downloads Panel UX Improvements
+- [#275](https://github.com/Snoww3d/jwst-data-analysis/issues/275) — Add Application Logging and Monitoring Hooks
+- [#276](https://github.com/Snoww3d/jwst-data-analysis/issues/276) — Add Docker Image Publishing
+- [#277](https://github.com/Snoww3d/jwst-data-analysis/issues/277) — Create Release Process and Changelog
+- [#279](https://github.com/Snoww3d/jwst-data-analysis/issues/279) — Revisit Export Filename Pattern
+- [#283](https://github.com/Snoww3d/jwst-data-analysis/issues/283) — Overly Permissive TypeScript Types
+- [#284](https://github.com/Snoww3d/jwst-data-analysis/issues/284) — Expand Desktop Requirements to Implementation-Ready Specification
+- [#348](https://github.com/Snoww3d/jwst-data-analysis/issues/348) — chore: migrate pytest-asyncio 0.23 → 1.x
+- [#375](https://github.com/Snoww3d/jwst-data-analysis/issues/375) — UI/UX improvements for JWST filter presets dropdown
+- [#433](https://github.com/Snoww3d/jwst-data-analysis/issues/433) — Add CI coverage thresholds — starting with Python
+- [#444](https://github.com/Snoww3d/jwst-data-analysis/issues/444) — security: migration endpoints callable by any authenticated user
+- [#445](https://github.com/Snoww3d/jwst-data-analysis/issues/445) — security: ownership spoofing via client-supplied UserId on create
 
 ---
-*Generated from GitHub data.*
+*12 commits across this session.*

--- a/docs/blog/posts/2026-02-24.md
+++ b/docs/blog/posts/2026-02-24.md
@@ -5,6 +5,15 @@ categories:
   - Feature
   - Bug Fix
   - Testing
+tags:
+  - auth
+  - ci
+  - code-quality
+  - dependencies
+  - e2e-tests
+  - imaging
+  - testing
+  - viewer
 authors:
   - shanon
 ---
@@ -12,6 +21,10 @@ authors:
 # Session: February 24, 2026
 
 <!-- generated -->
+
+**2 features, 4 fixes, 4 tests** — auth, ci, code-quality, dependencies, e2e-tests, imaging, testing, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -77,7 +90,5 @@ authors:
 
     *Backend lint (`dotnet build --warnaserror`) was failing with 41 SA/CA warnings. These were masked by build caching in prior compliance checks.*
 
-## Commits: 9
-
 ---
-*Generated from GitHub data.*
+*9 commits across this session.*

--- a/docs/blog/posts/2026-02-25.md
+++ b/docs/blog/posts/2026-02-25.md
@@ -5,6 +5,13 @@ categories:
   - Documentation
   - Feature
   - Bug Fix
+tags:
+  - docs
+  - export
+  - imaging
+  - infrastructure
+  - job-queue
+  - mast-data
 authors:
   - shanon
 ---
@@ -12,6 +19,10 @@ authors:
 # Session: February 25, 2026
 
 <!-- generated -->
+
+**4 features, 3 fixes, 1 docs** — docs, export, imaging, infrastructure, job-queue, mast-data
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -67,7 +78,5 @@ authors:
 
     *PR #482 incorrectly marked this task as fully complete. The infrastructure (SignalR hub, unified job tracker, queue pattern) and two migrations (MAST imports, composite exports) are done, but mosaic generation and mosaic save-as-FITS still use synchronous HTTP.*
 
-## Commits: 10
-
 ---
-*Generated from GitHub data.*
+*10 commits across this session.*

--- a/docs/blog/posts/2026-02-26.md
+++ b/docs/blog/posts/2026-02-26.md
@@ -5,6 +5,14 @@ categories:
   - Documentation
   - Feature
   - Bug Fix
+tags:
+  - ci
+  - docs
+  - export
+  - guided-wizard
+  - imaging
+  - job-queue
+  - ui
 authors:
   - shanon
 ---
@@ -12,6 +20,10 @@ authors:
 # Session: February 26, 2026
 
 <!-- generated -->
+
+**5 features, 4 fixes, 4 docs** — ci, docs, export, guided-wizard, imaging, job-queue, ui
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -98,7 +110,5 @@ authors:
 
     *ASP.NET serializes response fields as camelCase (`colorMapping`, `requiresMosaic`, `estimatedTimeSeconds`) but the frontend `CompositeRecipe` type used snake_case (`color_mapping`, `requires_mosaic`, `estimated_time_seconds`). This caused `RecipeCard` to crash accessing undefined properties when ren...*
 
-## Commits: 13
-
 ---
-*Generated from GitHub data.*
+*13 commits across this session.*

--- a/docs/blog/posts/2026-02-27.md
+++ b/docs/blog/posts/2026-02-27.md
@@ -4,6 +4,11 @@ date:
 categories:
   - Feature
   - Bug Fix
+tags:
+  - auth
+  - e2e-tests
+  - guided-wizard
+  - imaging
 authors:
   - shanon
 ---
@@ -11,6 +16,10 @@ authors:
 # Session: February 27, 2026
 
 <!-- generated -->
+
+**2 features, 7 fixes** — auth, e2e-tests, guided-wizard, imaging
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -69,7 +78,5 @@ authors:
 
     *After PR #504 converted the wizards from modals to pages, three issues emerged: 1. Footers were pushed below the viewport because `app-shell` used block flow instead of flex 2. The modal-era styling (heavy borders, padding, box-shadow) wasted space in a full-page layout 3. The right padding was miss...*
 
-## Commits: 12
-
 ---
-*Generated from GitHub data.*
+*12 commits across this session.*

--- a/docs/blog/posts/2026-02-28.md
+++ b/docs/blog/posts/2026-02-28.md
@@ -7,6 +7,18 @@ categories:
   - Documentation
   - Feature
   - Bug Fix
+tags:
+  - auth
+  - ci
+  - code-quality
+  - dependencies
+  - docs
+  - e2e-tests
+  - guided-wizard
+  - imaging
+  - infrastructure
+  - job-queue
+  - mast-data
 authors:
   - shanon
 ---
@@ -14,6 +26,10 @@ authors:
 # Session: February 28, 2026
 
 <!-- generated -->
+
+**6 features, 12 fixes, 3 docs, 1 maintenance, 12 dep updates** — auth, ci, code-quality, dependencies, docs, e2e-tests, guided-wizard, imaging, infrastructure, job-queue, mast-data
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -176,10 +192,15 @@ authors:
 
 ## Issues
 
-- **Opened**: [#529](https://github.com/Snoww3d/jwst-data-analysis/issues/529), [#537](https://github.com/Snoww3d/jwst-data-analysis/issues/537)
-- **Closed**: [#529](https://github.com/Snoww3d/jwst-data-analysis/issues/529), [#537](https://github.com/Snoww3d/jwst-data-analysis/issues/537)
+**Opened:**
 
-## Commits: 36
+- [#529](https://github.com/Snoww3d/jwst-data-analysis/issues/529) — bug: recipe engine suggests composites for spectral-only observations (NIRSPEC/IFU)
+- [#537](https://github.com/Snoww3d/jwst-data-analysis/issues/537) — Skip login gate in GuidedCreate when data already exists in library
+
+**Closed:**
+
+- [#529](https://github.com/Snoww3d/jwst-data-analysis/issues/529) — bug: recipe engine suggests composites for spectral-only observations (NIRSPEC/IFU)
+- [#537](https://github.com/Snoww3d/jwst-data-analysis/issues/537) — Skip login gate in GuidedCreate when data already exists in library
 
 ---
-*Generated from GitHub data.*
+*36 commits across this session.*

--- a/docs/blog/posts/2026-03-01.md
+++ b/docs/blog/posts/2026-03-01.md
@@ -6,6 +6,15 @@ categories:
   - Feature
   - Bug Fix
   - Refactoring
+tags:
+  - auth
+  - docs
+  - guided-wizard
+  - imaging
+  - infrastructure
+  - mast-data
+  - ui
+  - viewer
 authors:
   - shanon
 ---
@@ -13,6 +22,10 @@ authors:
 # Session: March 1, 2026
 
 <!-- generated -->
+
+**4 features, 5 fixes, 5 docs, 2 refactors** — auth, docs, guided-wizard, imaging, infrastructure, mast-data, ui, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -116,7 +129,5 @@ authors:
 
     *The stacked layout required scrolling past the preview image to reach controls. This made it hard to see the effect of adjustments (brightness, contrast, channel colors) while interacting with the sliders.*
 
-## Commits: 11
-
 ---
-*Generated from GitHub data.*
+*11 commits across this session.*

--- a/docs/blog/posts/2026-03-02.md
+++ b/docs/blog/posts/2026-03-02.md
@@ -4,6 +4,13 @@ date:
 categories:
   - Maintenance
   - Bug Fix
+tags:
+  - auth
+  - e2e-tests
+  - export
+  - guided-wizard
+  - security
+  - viewer
 authors:
   - shanon
 ---
@@ -11,6 +18,10 @@ authors:
 # Session: March 2, 2026
 
 <!-- generated -->
+
+**5 fixes, 2 maintenance** — auth, e2e-tests, export, guided-wizard, security, viewer
+
+<!-- more -->
 
 ## Pull Requests Merged
 
@@ -58,10 +69,34 @@ authors:
 
 ## Issues
 
-- **Opened**: [#565](https://github.com/Snoww3d/jwst-data-analysis/issues/565), [#566](https://github.com/Snoww3d/jwst-data-analysis/issues/566), [#567](https://github.com/Snoww3d/jwst-data-analysis/issues/567), [#568](https://github.com/Snoww3d/jwst-data-analysis/issues/568), [#569](https://github.com/Snoww3d/jwst-data-analysis/issues/569), [#570](https://github.com/Snoww3d/jwst-data-analysis/issues/570), [#571](https://github.com/Snoww3d/jwst-data-analysis/issues/571), [#572](https://github.com/Snoww3d/jwst-data-analysis/issues/572)
-- **Closed**: [#442](https://github.com/Snoww3d/jwst-data-analysis/issues/442), [#443](https://github.com/Snoww3d/jwst-data-analysis/issues/443), [#446](https://github.com/Snoww3d/jwst-data-analysis/issues/446), [#447](https://github.com/Snoww3d/jwst-data-analysis/issues/447), [#448](https://github.com/Snoww3d/jwst-data-analysis/issues/448), [#449](https://github.com/Snoww3d/jwst-data-analysis/issues/449), [#450](https://github.com/Snoww3d/jwst-data-analysis/issues/450), [#451](https://github.com/Snoww3d/jwst-data-analysis/issues/451), [#565](https://github.com/Snoww3d/jwst-data-analysis/issues/565), [#566](https://github.com/Snoww3d/jwst-data-analysis/issues/566), [#567](https://github.com/Snoww3d/jwst-data-analysis/issues/567), [#568](https://github.com/Snoww3d/jwst-data-analysis/issues/568), [#569](https://github.com/Snoww3d/jwst-data-analysis/issues/569), [#570](https://github.com/Snoww3d/jwst-data-analysis/issues/570), [#572](https://github.com/Snoww3d/jwst-data-analysis/issues/572)
+**Opened:**
 
-## Commits: 8
+- [#565](https://github.com/Snoww3d/jwst-data-analysis/issues/565) — fix: DataManagementController.Search omits SharedWith from access filter
+- [#566](https://github.com/Snoww3d/jwst-data-analysis/issues/566) — fix: MAST import resume endpoint lacks ownership check
+- [#567](https://github.com/Snoww3d/jwst-data-analysis/issues/567) — fix: resumable downloads endpoint returns all users' jobs
+- [#568](https://github.com/Snoww3d/jwst-data-analysis/issues/568) — fix: resumable download dismiss endpoint lacks ownership check
+- [#569](https://github.com/Snoww3d/jwst-data-analysis/issues/569) — fix: refresh-metadata endpoints lack ownership check
+- [#570](https://github.com/Snoww3d/jwst-data-analysis/issues/570) — fix: export download endpoint lacks ownership check on export files
+- [#571](https://github.com/Snoww3d/jwst-data-analysis/issues/571) — refactor: deduplicate IsDataAccessible between AnalysisController and JwstDataController
+- [#572](https://github.com/Snoww3d/jwst-data-analysis/issues/572) — feat: allow anonymous mosaic generation for public data (guided wizard)
+
+**Closed:**
+
+- [#442](https://github.com/Snoww3d/jwst-data-analysis/issues/442) — security: missing CanModifyData checks on mutation endpoints (IDOR)
+- [#443](https://github.com/Snoww3d/jwst-data-analysis/issues/443) — security: destructive observation-wide operations not owner/admin-gated
+- [#446](https://github.com/Snoww3d/jwst-data-analysis/issues/446) — security: private thumbnail access bypass via AllowAnonymous
+- [#447](https://github.com/Snoww3d/jwst-data-analysis/issues/447) — security: import-job endpoints not bound to requesting user
+- [#448](https://github.com/Snoww3d/jwst-data-analysis/issues/448) — security: mosaic/analysis endpoints lack per-object authorization (cross-tenant IDOR)
+- [#449](https://github.com/Snoww3d/jwst-data-analysis/issues/449) — security: python-multipart pinned at vulnerable version 0.0.6
+- [#450](https://github.com/Snoww3d/jwst-data-analysis/issues/450) — security: path traversal in non-chunked MAST download (obs_id in filesystem path)
+- [#451](https://github.com/Snoww3d/jwst-data-analysis/issues/451) — security: resumable dismissal can delete paths without base-path guard
+- [#565](https://github.com/Snoww3d/jwst-data-analysis/issues/565) — fix: DataManagementController.Search omits SharedWith from access filter
+- [#566](https://github.com/Snoww3d/jwst-data-analysis/issues/566) — fix: MAST import resume endpoint lacks ownership check
+- [#567](https://github.com/Snoww3d/jwst-data-analysis/issues/567) — fix: resumable downloads endpoint returns all users' jobs
+- [#568](https://github.com/Snoww3d/jwst-data-analysis/issues/568) — fix: resumable download dismiss endpoint lacks ownership check
+- [#569](https://github.com/Snoww3d/jwst-data-analysis/issues/569) — fix: refresh-metadata endpoints lack ownership check
+- [#570](https://github.com/Snoww3d/jwst-data-analysis/issues/570) — fix: export download endpoint lacks ownership check on export files
+- [#572](https://github.com/Snoww3d/jwst-data-analysis/issues/572) — feat: allow anonymous mosaic generation for public data (guided wizard)
 
 ---
-*Generated from GitHub data.*
+*8 commits across this session.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ theme:
 
 plugins:
   - search
+  - tags
   - blog:
       blog_dir: blog
       post_date_format: long

--- a/scripts/generate-session-blog.sh
+++ b/scripts/generate-session-blog.sh
@@ -91,13 +91,9 @@ filter_dates() {
   fi
 }
 
-# macOS-compatible date formatting
 format_date() {
   local date="$1"
-  if date -j -f "%Y-%m-%d" "$date" "+%B %-d, %Y" 2>/dev/null; then
-    return
-  fi
-  # Linux fallback
+  if date -j -f "%Y-%m-%d" "$date" "+%B %-d, %Y" 2>/dev/null; then return; fi
   date -d "$date" "+%B %-d, %Y" 2>/dev/null || echo "$date"
 }
 
@@ -136,7 +132,6 @@ get_categories() {
     [[ -z "$prefix" ]] && continue
     local cat
     cat=$(pr_prefix_to_category "$prefix")
-    # Deduplicate
     local found=false
     for s in "${seen[@]+"${seen[@]}"}"; do
       [[ "$s" == "$cat" ]] && found=true && break
@@ -146,6 +141,86 @@ get_categories() {
       echo "$cat"
     fi
   done <<< "$prefixes"
+}
+
+# --- Tag Extraction ---
+
+get_tags() {
+  local date="$1"
+  local pr_count="$2"
+
+  if [[ "$pr_count" -gt 0 ]]; then
+    jq -r --arg d "$date" '
+      [.[] | select(.mergedAt | startswith($d))] | [.[].title | ascii_downcase] as $t |
+      (if ($t | any(test("auth|jwt|token|login|credential"))) then ["auth"] else [] end) +
+      (if ($t | any(test("security|authorization|access.control|idor|bfla|traversal"))) then ["security"] else [] end) +
+      (if ($t | any(test("mosaic|composite|rgb|color.map|nchannel"))) then ["imaging"] else [] end) +
+      (if ($t | any(test("viewer|histogram|curves|stretch|level|canvas"))) then ["viewer"] else [] end) +
+      (if ($t | any(test("wizard|guided|discovery"))) then ["guided-wizard"] else [] end) +
+      (if ($t | any(test("docker|deploy|container|infra"))) then ["infrastructure"] else [] end) +
+      (if ($t | any(test("e2e|playwright"))) then ["e2e-tests"] else [] end) +
+      (if ($t | any(test("mast|import"))) then ["mast-data"] else [] end) +
+      (if ($t | any(test("export"))) then ["export"] else [] end) +
+      (if ($t | any(test("signalr|websocket|queue|job"))) then ["job-queue"] else [] end) +
+      (if ($t | any(test("deps|bump|dependabot"))) then ["dependencies"] else [] end) +
+      (if ($t | any(test("lint|format|eslint|prettier|ruff"))) then ["code-quality"] else [] end) +
+      (if ($t | any(test("ci|workflow|github.action"))) then ["ci"] else [] end) +
+      (if ($t | any(test("sidebar|panel|collaps|margin|layout|css|background"))) then ["ui"] else [] end) +
+      (if ($t | any(test("^test"))) then ["testing"] else [] end) +
+      (if ($t | any(test("^docs|readme|standard|contributing"))) then ["docs"] else [] end) |
+      unique | .[]
+    ' "$CACHE_DIR/prs.json" 2>/dev/null || true
+  else
+    # Pre-PR: extract tags from commit messages
+    local commit_msgs
+    commit_msgs=$(grep "|${date}|" "$CACHE_DIR/git-log.txt" | cut -d'|' -f3 | tr '[:upper:]' '[:lower:]' || true)
+    [[ -z "$commit_msgs" ]] && return
+    local tags=""
+    echo "$commit_msgs" | grep -qi "fits\|viewer\|image" && tags+="viewer"$'\n' || true
+    echo "$commit_msgs" | grep -qi "mongo\|database\|model" && tags+="database"$'\n' || true
+    echo "$commit_msgs" | grep -qi "docker\|container" && tags+="infrastructure"$'\n' || true
+    echo "$commit_msgs" | grep -qi "api\|endpoint\|controller" && tags+="api"$'\n' || true
+    echo "$commit_msgs" | grep -qi "auth\|login\|jwt" && tags+="auth"$'\n' || true
+    echo "$commit_msgs" | grep -qi "frontend\|react\|component" && tags+="frontend"$'\n' || true
+    echo "$commit_msgs" | grep -qi "test" && tags+="testing"$'\n' || true
+    echo "$commit_msgs" | grep -qi "mast\|import" && tags+="mast-data"$'\n' || true
+    if [[ -n "$tags" ]]; then
+      echo "$tags" | sort -u | grep -v '^$'
+    fi
+  fi
+}
+
+# --- Headline Generation ---
+
+get_headline() {
+  local date="$1"
+  local pr_count="$2"
+  local commit_count="$3"
+
+  if [[ "$pr_count" -gt 0 ]]; then
+    jq -r --arg d "$date" '
+      [.[] | select(.mergedAt | startswith($d))] |
+      (map(select(.title | test("^feat"))) | length) as $feat |
+      (map(select(.title | test("^fix"))) | length) as $fix |
+      (map(select(.title | test("^docs"))) | length) as $docs |
+      (map(select(.title | test("^refactor"))) | length) as $refactor |
+      (map(select(.title | test("^test"))) | length) as $tst |
+      (map(select(.title | (test("deps") or test("^Bump")))) | length) as $deps |
+      (map(select(.title | (test("^chore") and (test("deps") | not)))) | length) as $chore |
+      (
+        (if $feat > 0 then ["\($feat) feature" + (if $feat > 1 then "s" else "" end)] else [] end) +
+        (if $fix > 0 then ["\($fix) fix" + (if $fix > 1 then "es" else "" end)] else [] end) +
+        (if $docs > 0 then ["\($docs) docs"] else [] end) +
+        (if $refactor > 0 then ["\($refactor) refactor" + (if $refactor > 1 then "s" else "" end)] else [] end) +
+        (if $tst > 0 then ["\($tst) test" + (if $tst > 1 then "s" else "" end)] else [] end) +
+        (if $chore > 0 then ["\($chore) maintenance"] else [] end) +
+        (if $deps > 0 then ["\($deps) dep update" + (if $deps > 1 then "s" else "" end)] else [] end)
+      ) | join(", ")
+    ' "$CACHE_DIR/prs.json" 2>/dev/null || true
+  elif [[ "$commit_count" -gt 0 ]]; then
+    # Pre-PR: summarize from commit messages
+    grep "|${date}|" "$CACHE_DIR/git-log.txt" | cut -d'|' -f3 | sed 's/^[[:space:]]*//' | head -3 | tr '\n' '|' | sed 's/|$//' | sed 's/|/; /g'
+  fi
 }
 
 # --- Post Generation ---
@@ -163,9 +238,30 @@ generate_post() {
   local display_date
   display_date=$(format_date "$date")
 
-  # --- Gather data for this date ---
+  # --- Compute metrics ---
 
-  # PRs merged on this date (rich format with body excerpts)
+  local commit_count
+  commit_count=$(grep -c "|${date}|" "$CACHE_DIR/git-log.txt" || true)
+
+  local pr_count
+  pr_count=$(jq --arg d "$date" '[.[] | select(.mergedAt | startswith($d))] | length' "$CACHE_DIR/prs.json" 2>/dev/null || echo 0)
+
+  # --- Generate headline and tags ---
+
+  local headline
+  headline=$(get_headline "$date" "$pr_count" "$commit_count")
+
+  local tags_list
+  tags_list=$(get_tags "$date" "$pr_count")
+
+  local tag_inline=""
+  if [[ -n "$tags_list" ]]; then
+    tag_inline=$(echo "$tags_list" | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
+  fi
+
+  # --- Gather content ---
+
+  # PRs (rich format with body excerpts)
   local pr_content
   pr_content=$(jq -r --arg d "$date" '
     def extract_section(header):
@@ -192,49 +288,85 @@ generate_post() {
     ] | join("\n\n")
   ' "$CACHE_DIR/prs.json" 2>/dev/null || true)
 
-  # Issues opened on this date
+  # Issues opened (with titles)
   local issues_opened
   issues_opened=$(jq -r --arg d "$date" '
     [.[] | select(.createdAt | startswith($d))]
     | sort_by(.number)
-    | if length > 0 then [.[] | "[#\(.number)](\(.url))"] | join(", ") else "None" end
-  ' "$CACHE_DIR/issues.json" 2>/dev/null || echo "None")
+    | if length > 0 then
+        [.[] | "- [#\(.number)](\(.url)) — \(.title)"] | join("\n")
+      else "" end
+  ' "$CACHE_DIR/issues.json" 2>/dev/null || true)
 
-  # Issues closed on this date
+  # Issues closed (with titles)
   local issues_closed
   issues_closed=$(jq -r --arg d "$date" '
     [.[] | select(.closedAt != null and (.closedAt | startswith($d)))]
     | sort_by(.number)
-    | if length > 0 then [.[] | "[#\(.number)](\(.url))"] | join(", ") else "None" end
-  ' "$CACHE_DIR/issues.json" 2>/dev/null || echo "None")
+    | if length > 0 then
+        [.[] | "- [#\(.number)](\(.url)) — \(.title)"] | join("\n")
+      else "" end
+  ' "$CACHE_DIR/issues.json" 2>/dev/null || true)
 
-  # Commit count
-  local commit_count
-  commit_count=$(grep -c "|${date}|" "$CACHE_DIR/git-log.txt" || true)
+  # Commit messages (for pre-PR days)
+  local commit_messages=""
+  if [[ "$pr_count" -eq 0 && "$commit_count" -gt 0 ]]; then
+    commit_messages=$(grep "|${date}|" "$CACHE_DIR/git-log.txt" | cut -d'|' -f3 | sed 's/^[[:space:]]*//' | while IFS= read -r msg; do
+      echo "- ${msg}"
+    done)
+  fi
 
-  # Categories
+  # --- Build frontmatter ---
+
   local categories_yaml=""
   while IFS= read -r cat; do
     [[ -z "$cat" ]] && continue
     categories_yaml+="  - ${cat}"$'\n'
   done < <(get_categories "$date")
 
+  local tags_yaml=""
+  if [[ -n "$tags_list" ]]; then
+    while IFS= read -r tag; do
+      [[ -z "$tag" ]] && continue
+      tags_yaml+="  - ${tag}"$'\n'
+    done <<< "$tags_list"
+  fi
+
+  # Build headline line
+  local headline_line=""
+  if [[ -n "$headline" && -n "$tag_inline" ]]; then
+    headline_line="**${headline}** — ${tag_inline}"
+  elif [[ -n "$headline" ]]; then
+    headline_line="**${headline}**"
+  fi
+
   # --- Write post ---
 
-  cat > "$post_file" << POSTEOF
----
-date:
-  created: ${date}
-categories:
-${categories_yaml}authors:
-  - shanon
----
-
-# Session: ${display_date}
-
-<!-- generated -->
-
-POSTEOF
+  {
+    echo "---"
+    echo "date:"
+    echo "  created: ${date}"
+    echo "categories:"
+    printf '%s' "$categories_yaml"
+    if [[ -n "$tags_yaml" ]]; then
+      echo "tags:"
+      printf '%s' "$tags_yaml"
+    fi
+    echo "authors:"
+    echo "  - shanon"
+    echo "---"
+    echo ""
+    echo "# Session: ${display_date}"
+    echo ""
+    echo "<!-- generated -->"
+    echo ""
+    if [[ -n "$headline_line" ]]; then
+      echo "${headline_line}"
+      echo ""
+    fi
+    echo "<!-- more -->"
+    echo ""
+  } > "$post_file"
 
   # PRs section
   if [[ -n "$pr_content" ]]; then
@@ -244,23 +376,36 @@ POSTEOF
     echo "" >> "$post_file"
   fi
 
-  # Issues section
-  if [[ "$issues_opened" != "None" || "$issues_closed" != "None" ]]; then
-    echo "## Issues" >> "$post_file"
+  # Commit messages (pre-PR days)
+  if [[ -n "$commit_messages" ]]; then
+    echo "## Commits" >> "$post_file"
     echo "" >> "$post_file"
-    echo "- **Opened**: ${issues_opened}" >> "$post_file"
-    echo "- **Closed**: ${issues_closed}" >> "$post_file"
+    echo "$commit_messages" >> "$post_file"
     echo "" >> "$post_file"
   fi
 
-  # Commits section
-  echo "## Commits: ${commit_count}" >> "$post_file"
-  echo "" >> "$post_file"
-  echo "---" >> "$post_file"
-  echo "*Generated from GitHub data.*" >> "$post_file"
+  # Issues section
+  if [[ -n "$issues_opened" || -n "$issues_closed" ]]; then
+    echo "## Issues" >> "$post_file"
+    echo "" >> "$post_file"
+    if [[ -n "$issues_opened" ]]; then
+      echo "**Opened:**" >> "$post_file"
+      echo "" >> "$post_file"
+      echo "$issues_opened" >> "$post_file"
+      echo "" >> "$post_file"
+    fi
+    if [[ -n "$issues_closed" ]]; then
+      echo "**Closed:**" >> "$post_file"
+      echo "" >> "$post_file"
+      echo "$issues_closed" >> "$post_file"
+      echo "" >> "$post_file"
+    fi
+  fi
 
-  local pr_count
-  pr_count=$(jq --arg d "$date" '[.[] | select(.mergedAt | startswith($d))] | length' "$CACHE_DIR/prs.json" 2>/dev/null || echo 0)
+  # Stats footer
+  echo "---" >> "$post_file"
+  echo "*${commit_count} commits across this session.*" >> "$post_file"
+
   echo "  Generated: $date ($commit_count commits, $pr_count PRs)"
 }
 


### PR DESCRIPTION
## Summary

Five improvements to the session blog posts: auto-generated headlines with PR count summaries, topic tags for filtering, issue titles alongside links, `<!-- more -->` excerpt separators for a scannable blog index, and commit messages on pre-PR era posts.

## Why

The initial blog posts had raw data but lacked scannability. The blog index showed full posts (requiring endless scrolling), issues were just number links (unreadable without clicking), and the 4 early posts had no content beyond a commit count. These improvements make the blog actually useful as both a dev journal and portfolio showcase.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Add MkDocs Material `tags` plugin to `mkdocs.yml`
- Add `get_headline()` function — generates count-based summary (e.g., "5 fixes, 2 maintenance")
- Add `get_tags()` function — extracts topic tags from PR titles (auth, security, imaging, viewer, etc.) and commit messages for pre-PR days
- Add `<!-- more -->` excerpt separator after headline for scannable blog index
- Change issue format from bare `#N` links to `#N — Issue Title` with separate Opened/Closed sections
- Show commit messages as bullet list on pre-PR era posts (Jun-Jul 2025)
- Combine headline + tags into a bold summary line: `**5 fixes, 2 maintenance** — auth, security, viewer`
- Fix jq `as` binding issue in headline generation (use `map(select(...))` pattern)
- Fix `set -e` exit on empty tag list (restructure conditional return)
- Fix macOS `paste -sd` delimiter handling (use `tr`+`sed` instead)
- Regenerate all 43 posts with enriched format

## Test Plan

- [x] Run `./scripts/generate-session-blog.sh --date 2026-03-02` — headline shows "5 fixes, 2 maintenance" with tags
- [x] Run `./scripts/generate-session-blog.sh --date 2025-06-28` — pre-PR post shows commit messages + tags
- [x] Run `./scripts/generate-session-blog.sh --date 2025-07-04` — tagless pre-PR day generates without error
- [x] Run full backfill — all 43 posts generated successfully
- [x] Verify MkDocs builds with tags plugin (no errors)
- [x] Verify `http://localhost:8001/blog/` returns 200
- [x] Verify issue sections show titles alongside links
- [x] Verify `<!-- more -->` appears in generated posts

## Documentation Checklist

- [x] Updated `docs/key-files.md`? — N/A (this PR IS docs content)
- [ ] Updated `docs/standards/backend-development.md`? — N/A
- [ ] Updated `docs/architecture.md`? — N/A
- [ ] Updated `docs/quick-reference.md`? — N/A
- [ ] Updated `docs/development-plan.md`? — N/A
- [ ] Updated `docs/tech-debt.md`? — N/A

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt added (justified in summary)
- [ ] Tech debt reduced

## Risk & Rollback

Risk: Low — docs-only change, no impact on application functionality.

Rollback: Revert this PR. Run `./scripts/generate-session-blog.sh` from the previous version to regenerate posts without enrichments.

## Quality Checklist

- [x] Code follows project conventions
- [x] Changes are minimal and focused
- [x] No unnecessary refactoring included

🤖 Generated with [Claude Code](https://claude.com/claude-code)