### PR TITLE
feat: session blog creative overhaul with narrative structure

### DIFF
--- a/.claude/commands/enrich-blog.md
+++ b/.claude/commands/enrich-blog.md
@@ -1,0 +1,104 @@
+# Enrich Blog Posts with Slack Journal
+
+Enrich generated session blog posts with a "Developer Journal" section synthesized from Slack messages.
+
+## Arguments
+
+- `--date YYYY-MM-DD` — enrich a single date
+- `--from YYYY-MM-DD --to YYYY-MM-DD` — enrich a date range
+- `--all` — enrich all eligible posts
+
+Parse `$ARGUMENTS` for these flags.
+
+## Process
+
+### 1. Identify Target Posts
+
+Find blog posts in `docs/blog/posts/` matching the date range. A post is eligible if:
+- It contains `<!-- generated -->` (not yet enriched)
+- It does NOT contain `<!-- enriched -->` (already done → skip)
+
+If no dates specified via arguments, prompt the user to choose.
+
+### 2. Fetch Slack Data
+
+For each target date, use the Slack MCP tools to read messages from both channels:
+
+- **Primary channel**: `C28RB6LGM` (#programming-crap) — project updates, debugging stories, screenshots, architecture discussions
+- **Secondary channel**: `C064NSLUK19` (#artificial-intelligence) — AI tool discussions, Claude Code usage, workflow experiments
+
+Use `mcp__claude_ai_Slack__slack_read_channel` for each channel, filtering to the target date.
+
+Cache raw Slack data to `docs/blog/.cache/slack-journal.json` keyed by date to avoid re-fetching. Check the cache before calling Slack tools.
+
+### 3. Generate Developer Journal Section
+
+From Shanon's messages on that date, classify and synthesize into a narrative paragraph or two covering:
+
+- **Intent/motivation** — what was the session about? ("Intended to just test the deployment script...")
+- **Technical decisions** — architecture choices, tradeoffs ("Considered Lambda orchestration, landed on SQS...")
+- **Debugging stories** — problems hit and solved ("Hit Docker disk space issues...")
+- **Screenshots** — note what images were shared, infer content from surrounding messages ("Shared a screenshot of the composite result")
+- **Social context** — how friend interactions influenced decisions (see Privacy Rules below)
+
+Write in narrative voice (third person or first person matching the blog tone). Keep it 2-5 paragraphs max.
+
+If there are no relevant Shanon messages for a date (only friend messages, or no messages at all), skip that date — leave it as `<!-- generated -->`.
+
+### 4. Insert into Post
+
+Insert the Developer Journal section into the post file:
+- Location: after `<!-- more -->`, before the first `## Highlights` or `## What Changed` or `## Commits`
+- Format:
+
+```markdown
+## Developer Journal
+
+[synthesized narrative paragraphs]
+
+```
+
+### 5. Update Marker
+
+Replace `<!-- generated -->` with `<!-- enriched -->` in the post file.
+
+This prevents Layer 1 (`generate-session-blog.sh`) from overwriting the enriched content on re-run.
+
+## Privacy Rules (CRITICAL — must follow exactly)
+
+- **NEVER quote friends directly** — always summarize: "A friend tested the staging URL and gave feedback about the signup requirement, which led to implementing anonymous access"
+- **NEVER include friends' names or usernames** — use "a friend", "friends", "someone in the channel"
+- **Shanon's messages**: paraphrase in narrative voice, don't dump raw quotes. Capture the intent and energy, not verbatim text.
+- **No timestamps** in output — just narrative flow
+- **No Slack links** in output
+- **Screenshots/images**: note that an image was shared and infer what it showed from surrounding context ("Shared the composite result showing all 8 NIRCam channels mapped to the NASA palette")
+- **Bot messages**: ignore completely
+- **Reactions/emoji**: can mention general sentiment ("the result got positive reactions") but don't list specific emoji
+
+## Edge Cases
+
+- **No Slack data for a date** → skip, leave as `<!-- generated -->`
+- **Only friend messages** (Shanon posted nothing) → skip
+- **Pre-PR dates** (2025-06-28 through 2025-07-13) → enrich if data exists, insert before `## Commits`
+- **Already enriched** (`<!-- enriched -->` marker) → skip with a note
+- **Slack MCP unavailable** → report error, don't modify any files
+
+## Example Output
+
+```markdown
+## Developer Journal
+
+Intended to just test the deployment script, but wound up fixing a cascade of staging issues. The SignalR proxy was missing from nginx — composite processing appeared stuck because WebSocket connections were falling through to the SPA fallback.
+
+Shared the staging URL with friends for the first real external test. Feedback about the mandatory signup requirement led to implementing anonymous access for users who just want to browse existing composites. A friend's suggestion to show auth badges on recipe cards made it into the same session.
+
+Hit Docker disk space issues on the dev machine midway through — had to clear build cache to keep going. The 8-channel Pillars of Creation composite was the stress test that surfaced the OOM crash.
+```
+
+## Verification
+
+After enriching, confirm:
+1. The `<!-- enriched -->` marker is present
+2. The Developer Journal section is properly placed
+3. No friend names/usernames leaked
+4. Re-running `./scripts/generate-session-blog.sh` skips enriched posts

--- a/docs/blog/MILESTONES.md
+++ b/docs/blog/MILESTONES.md
@@ -50,4 +50,4 @@ Dates flagged for narrative enrichment. Edit the post and replace
 - **2026-03-01** — Architecture day (16 PRs: feat: sidebar split layout for guided create result step; feat: add rotation con)
 - **2026-03-02** — Architecture day (7 PRs: fix: add missing authorization checks for issues #565-#570; fix: add missing aut)
 
-Generated: 2026-03-02 12:18
+Generated: 2026-03-02 14:23

--- a/docs/blog/posts/2025-06-28.md
+++ b/docs/blog/posts/2025-06-28.md
@@ -14,18 +14,19 @@ authors:
 
 <!-- generated -->
 
-**adds sln and updates markdown files; more markdown warnings removed; fixes markdown warnings** — frontend, infrastructure
+Project inception day. Initial repository setup, Docker configuration, and frontend submodule integration.
 
 <!-- more -->
 
 ## Commits
 
-- adds sln and updates markdown files
-- more markdown warnings removed
-- fixes markdown warnings
-- removed version from the docker file
-- Update jwst-frontend submodule pointer
-- Initial commit: clean start for Astronomy project
+- `b1ab8f1` adds sln and updates markdown files
+- `1a58352` more markdown warnings removed
+- `eccda21` fixes markdown warnings
+- `e1cd9a9` removed version from the docker file
+- `a9b2285` Update jwst-frontend submodule pointer
+- `8d67007` Initial commit: clean start for Astronomy project
 
 ---
-*6 commits across this session.*
+6 commits.
+*Next: July 4, 2025*

--- a/docs/blog/posts/2025-07-04.md
+++ b/docs/blog/posts/2025-07-04.md
@@ -11,15 +11,16 @@ authors:
 
 <!-- generated -->
 
-**docs: add security note about development credentials and best practices for secrets; chore: update submodule and processing engine dependencies; fix: add build dependencies and update scientific package versions for compatibility**
+Early development — 3 commits before the PR workflow was established.
 
 <!-- more -->
 
 ## Commits
 
-- docs: add security note about development credentials and best practices for secrets
-- chore: update submodule and processing engine dependencies
-- fix: add build dependencies and update scientific package versions for compatibility
+- `9a56fb5` docs: add security note about development credentials and best practices for secrets
+- `54afe3e` chore: update submodule and processing engine dependencies
+- `d4e98ff` fix: add build dependencies and update scientific package versions for compatibility
 
 ---
-*3 commits across this session.*
+3 commits.
+*Next: July 5, 2025*

--- a/docs/blog/posts/2025-07-05.md
+++ b/docs/blog/posts/2025-07-05.md
@@ -13,17 +13,18 @@ authors:
 
 <!-- generated -->
 
-**fix: update frontend submodule with cross-browser compatible meta tags; Fix MD013 (line length) warnings in main README.md and update markdown compliance in all rule and doc files; Fix MD013 (line length) warnings in main README.md** — frontend
+Early development — 5 commits before the PR workflow was established.
 
 <!-- more -->
 
 ## Commits
 
-- fix: update frontend submodule with cross-browser compatible meta tags
-- Fix MD013 (line length) warnings in main README.md and update markdown compliance in all rule and doc files
-- Fix MD013 (line length) warnings in main README.md
-- Fix and recreate all Cursor .mdc rule files with valid structure and content
-- Add comprehensive Cursor rules for JWST project development
+- `9dde651` fix: update frontend submodule with cross-browser compatible meta tags
+- `67549db` Fix MD013 (line length) warnings in main README.md and update markdown compliance in all rule and doc files
+- `a359a22` Fix MD013 (line length) warnings in main README.md
+- `fec3609` Fix and recreate all Cursor .mdc rule files with valid structure and content
+- `f258e69` Add comprehensive Cursor rules for JWST project development
 
 ---
-*5 commits across this session.*
+5 commits.
+*Next: July 13, 2025*

--- a/docs/blog/posts/2025-07-13.md
+++ b/docs/blog/posts/2025-07-13.md
@@ -14,14 +14,15 @@ authors:
 
 <!-- generated -->
 
-**Fix nullable reference type error in GetStatisticsAsync; Phase 2: Enhanced Data Models and API Endpoints** — api, database
+Early development — 2 commits before the PR workflow was established.
 
 <!-- more -->
 
 ## Commits
 
-- Fix nullable reference type error in GetStatisticsAsync
-- Phase 2: Enhanced Data Models and API Endpoints
+- `3e75d7c` Fix nullable reference type error in GetStatisticsAsync
+- `17f626e` Phase 2: Enhanced Data Models and API Endpoints
 
 ---
-*2 commits across this session.*
+2 commits.
+*Next: January 12, 2026 — Feature/archive files, add bulk import for existing MAST files*

--- a/docs/blog/posts/2026-01-12.md
+++ b/docs/blog/posts/2026-01-12.md
@@ -5,6 +5,7 @@ categories:
   - Development
   - Feature
 tags:
+  - astronomy-data
   - mast-data
 authors:
   - shanon
@@ -14,15 +15,19 @@ authors:
 
 <!-- generated -->
 
-**1 feature** — mast-data
+The project restarts with a proper PR workflow. First pull requests merged, CI pipeline established.
 
 <!-- more -->
 
-## Pull Requests Merged
+## What Changed
 
-- **[#4](https://github.com/Snoww3d/jwst-data-analysis/pull/4)** Feature/archive files
+### Features (1)
 
-- **[#5](https://github.com/Snoww3d/jwst-data-analysis/pull/5)** feat: add bulk import for existing MAST files
+- [#5](https://github.com/Snoww3d/jwst-data-analysis/pull/5) add bulk import for existing MAST files
+
+### Other (1)
+
+- [#4](https://github.com/Snoww3d/jwst-data-analysis/pull/4) Feature/archive files
 
 ## Issues
 
@@ -33,4 +38,5 @@ authors:
 - [#3](https://github.com/Snoww3d/jwst-data-analysis/issues/3) — Processing job queue system
 
 ---
-*15 commits across this session.*
+15 commits across 2 pull requests.
+*Next: January 13, 2026 — Advanced FITS Viewer with ZScale and Color Maps*

--- a/docs/blog/posts/2026-01-13.md
+++ b/docs/blog/posts/2026-01-13.md
@@ -4,6 +4,7 @@ date:
 categories:
   - Feature
 tags:
+  - astronomy-data
   - imaging
   - viewer
 authors:
@@ -14,13 +15,16 @@ authors:
 
 <!-- generated -->
 
-**1 feature** — imaging, viewer
+A focused session with a single pull request.
 
 <!-- more -->
 
-## Pull Requests Merged
+## What Changed
 
-- **[#6](https://github.com/Snoww3d/jwst-data-analysis/pull/6)** feat: Advanced FITS Viewer with ZScale and Color Maps
+### Features (1)
+
+- [#6](https://github.com/Snoww3d/jwst-data-analysis/pull/6) Advanced FITS Viewer with ZScale and Color Maps
 
 ---
-*10 commits across this session.*
+10 commits across 1 pull request.
+*Next: January 14, 2026 — Convert MAST Modified Julian Date to readable date..., Add pagination to MAST search results, Include Metadata in API response and add Docker ve...*

--- a/docs/blog/posts/2026-01-14.md
+++ b/docs/blog/posts/2026-01-14.md
@@ -5,6 +5,7 @@ categories:
   - Feature
   - Bug Fix
 tags:
+  - astronomy-data
   - infrastructure
   - mast-data
 authors:
@@ -15,28 +16,35 @@ authors:
 
 <!-- generated -->
 
-**1 feature, 2 fixes** — infrastructure, mast-data
+Productive session with 3 pull requests: 1 feature, 2 fixes.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#7](https://github.com/Snoww3d/jwst-data-analysis/pull/7)** fix: Convert MAST Modified Julian Date to readable dates
+### [#9](https://github.com/Snoww3d/jwst-data-analysis/pull/9) Include Metadata in API response and add Docker verification docs
 
-    - Fix dates displaying as 12/31/1969 in MAST search results
-    - MAST API returns dates as Modified Julian Date (MJD) numbers, not ISO strings
-    - Updated `formatDate()` to detect and convert MJD values properly
+- Fix API response to include Metadata field (required for grouping feature)
+- Add Docker verification documentation
 
-- **[#8](https://github.com/Snoww3d/jwst-data-analysis/pull/8)** feat: Add pagination to MAST search results
 
-    - Add pagination to MAST search results panel
-    - Increase query limit from 10 to 500 results
-    - Fix dates showing as future dates (was using release date instead of observation date)
+### [#8](https://github.com/Snoww3d/jwst-data-analysis/pull/8) Add pagination to MAST search results
 
-- **[#9](https://github.com/Snoww3d/jwst-data-analysis/pull/9)** fix: Include Metadata in API response and add Docker verification docs
+- Add pagination to MAST search results panel
+- Increase query limit from 10 to 500 results
+- Fix dates showing as future dates (was using release date instead of observation date)
 
-    - Fix API response to include Metadata field (required for grouping feature)
-    - Add Docker verification documentation
+## What Changed
+
+### Features (1)
+
+- [#8](https://github.com/Snoww3d/jwst-data-analysis/pull/8) Add pagination to MAST search results
+
+### Bug Fixes (2)
+
+- [#7](https://github.com/Snoww3d/jwst-data-analysis/pull/7) Convert MAST Modified Julian Date to readable dates
+- [#9](https://github.com/Snoww3d/jwst-data-analysis/pull/9) Include Metadata in API response and add Docker verification docs
 
 ---
-*8 commits across this session.*
+8 commits across 3 pull requests.
+*Next: January 20, 2026 — Add JWST processing level tracking and lineage tre...*

--- a/docs/blog/posts/2026-01-20.md
+++ b/docs/blog/posts/2026-01-20.md
@@ -13,17 +13,24 @@ authors:
 
 <!-- generated -->
 
-**1 feature** — viewer
+A focused session with a single pull request.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#10](https://github.com/Snoww3d/jwst-data-analysis/pull/10)** feat: Add JWST processing level tracking and lineage tree view
+### [#10](https://github.com/Snoww3d/jwst-data-analysis/pull/10) Add JWST processing level tracking and lineage tree view
 
-    - Add JWST processing level tracking (L1/L2a/L2b/L3) based on filename suffixes
-    - Implement lineage tree visualization in frontend showing processing pipeline relationships
-    - Add API endpoints for querying lineage data and migrating existing records
+- Add JWST processing level tracking (L1/L2a/L2b/L3) based on filename suffixes
+- Implement lineage tree visualization in frontend showing processing pipeline relationships
+- Add API endpoints for querying lineage data and migrating existing records
+
+## What Changed
+
+### Features (1)
+
+- [#10](https://github.com/Snoww3d/jwst-data-analysis/pull/10) Add JWST processing level tracking and lineage tree view
 
 ---
-*2 commits across this session.*
+2 commits across 1 pull request.
+*Next: January 21, 2026 — Update instruction files with lineage feature and ..., Add processing level filter to dashboard, Add MAST import progress indicator with async down...*

--- a/docs/blog/posts/2026-01-21.md
+++ b/docs/blog/posts/2026-01-21.md
@@ -5,6 +5,7 @@ categories:
   - Documentation
   - Feature
 tags:
+  - astronomy-data
   - ci
   - docs
   - mast-data
@@ -17,33 +18,36 @@ authors:
 
 <!-- generated -->
 
-**2 features, 1 docs** — ci, docs, mast-data, viewer
+Productive session with 3 pull requests: 2 features, 1 docs.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#11](https://github.com/Snoww3d/jwst-data-analysis/pull/11)** docs: Update instruction files with lineage feature and fix inconsistencies
+### [#13](https://github.com/Snoww3d/jwst-data-analysis/pull/13) Add MAST import progress indicator with async downloads
 
-    - Add lineage API endpoints and processing level tracking documentation
-    - Update CLAUDE.md with lineage view in component hierarchy
-    - Add Processing Level Tracking section to development-plan.md
-    - Fix git workflow in backend-development.md (now requires PRs)
-    - Add MastController, DataManagementController to backend docs
-    - Add MastSearch component and lineage types to frontend docs
-    - Update phase s...
+- Add visual progress bar for MAST import operations with real-time updates
+- Implement async file-by-file downloads to avoid timeout issues
+- Add progress polling from frontend to backend to processing engine
 
-- **[#12](https://github.com/Snoww3d/jwst-data-analysis/pull/12)** feat: Add processing level filter to dashboard
 
-    - Add dropdown filter to filter data by processing level (L1, L2a, L2b, L3, Unknown)
-    - Allows users to see only files at a specific level (e.g., Level 3 Combined files)
-    - Filter works in combination with existing data type filter and search
+### [#12](https://github.com/Snoww3d/jwst-data-analysis/pull/12) Add processing level filter to dashboard
 
-- **[#13](https://github.com/Snoww3d/jwst-data-analysis/pull/13)** feat: Add MAST import progress indicator with async downloads
+- Add dropdown filter to filter data by processing level (L1, L2a, L2b, L3, Unknown)
+- Allows users to see only files at a specific level (e.g., Level 3 Combined files)
+- Filter works in combination with existing data type filter and search
 
-    - Add visual progress bar for MAST import operations with real-time updates
-    - Implement async file-by-file downloads to avoid timeout issues
-    - Add progress polling from frontend to backend to processing engine
+## What Changed
+
+### Features (2)
+
+- [#12](https://github.com/Snoww3d/jwst-data-analysis/pull/12) Add processing level filter to dashboard
+- [#13](https://github.com/Snoww3d/jwst-data-analysis/pull/13) Add MAST import progress indicator with async downloads
+
+### Documentation (1)
+
+- [#11](https://github.com/Snoww3d/jwst-data-analysis/pull/11) Update instruction files with lineage feature and fix inconsistencies
 
 ---
-*6 commits across this session.*
+6 commits across 3 pull requests.
+*Next: January 22, 2026 — Add chunked downloads with resume capability and F..., Add CI check requirement to git workflow, Update documentation for chunked downloads and FIT...*

--- a/docs/blog/posts/2026-01-22.md
+++ b/docs/blog/posts/2026-01-22.md
@@ -5,6 +5,7 @@ categories:
   - Documentation
   - Feature
 tags:
+  - astronomy-data
   - ci
   - docs
   - viewer
@@ -16,38 +17,38 @@ authors:
 
 <!-- generated -->
 
-**2 features, 2 docs** — ci, docs, viewer
+Productive session with 4 pull requests: 2 features, 2 docs.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#14](https://github.com/Snoww3d/jwst-data-analysis/pull/14)** feat: Add chunked downloads with resume capability and FITS file type indicators
+### [#17](https://github.com/Snoww3d/jwst-data-analysis/pull/17) Display target name and instrument in lineage view
 
-    - **Chunked Downloads**: Implement HTTP Range header support for downloading large FITS files in 5MB chunks with parallel downloads (3 concurrent files)
-    - **Resume Capability**: Add state persistence and resume functionality for interrupted downloads
-    - **FITS File Type Indicators**: Show visual badges indicating whether files are viewable images or non-viewable tables
-    - **Improved Error Handling**...
+- Add target name and instrument display to lineage view headers
+- Extract target_name from MAST observation metadata during import
+- Extend backend and frontend models with astronomical fields
+- Style metadata with colored badges (purple for target, green for instrument)
 
-- **[#15](https://github.com/Snoww3d/jwst-data-analysis/pull/15)** docs: Add CI check requirement to git workflow
 
-    - Add explicit requirement to check CI tests before merging PRs
-    - Add `gh pr checks` command to workflow steps
-    - Clarify that merge should only happen after CI passes
+### [#14](https://github.com/Snoww3d/jwst-data-analysis/pull/14) Add chunked downloads with resume capability and FITS file type indicators
 
-- **[#16](https://github.com/Snoww3d/jwst-data-analysis/pull/16)** docs: Update documentation for chunked downloads and FITS viewer features
+- **Chunked Downloads**: Implement HTTP Range header support for downloading large FITS files in 5MB chunks with parallel downloads (3 concurrent files)
+- **Resume Capability**: Add state persistence and resume functionality for interrupted downloads
+- **FITS File Type Indicators**: Show visual badg...
 
-    Updates all project documentation to reflect recently implemented features:
-    - Chunked downloads with HTTP Range headers and resume capability
-    - FITS file type detection and viewer improvements
-    - Byte-level progress tracking with speed and ETA
+## What Changed
 
-- **[#17](https://github.com/Snoww3d/jwst-data-analysis/pull/17)** feat: Display target name and instrument in lineage view
+### Features (2)
 
-    - Add target name and instrument display to lineage view headers
-    - Extract target_name from MAST observation metadata during import
-    - Extend backend and frontend models with astronomical fields
-    - Style metadata with colored badges (purple for target, green for instrument)
+- [#14](https://github.com/Snoww3d/jwst-data-analysis/pull/14) Add chunked downloads with resume capability and FITS file type indicators
+- [#17](https://github.com/Snoww3d/jwst-data-analysis/pull/17) Display target name and instrument in lineage view
+
+### Documentation (2)
+
+- [#15](https://github.com/Snoww3d/jwst-data-analysis/pull/15) Add CI check requirement to git workflow
+- [#16](https://github.com/Snoww3d/jwst-data-analysis/pull/16) Update documentation for chunked downloads and FITS viewer features
 
 ---
-*10 commits across this session.*
+10 commits across 4 pull requests.
+*Next: January 27, 2026 — Add image processing module foundation with photut..., Add import job cancellation and configurable downl...*

--- a/docs/blog/posts/2026-01-27.md
+++ b/docs/blog/posts/2026-01-27.md
@@ -14,25 +14,34 @@ authors:
 
 <!-- generated -->
 
-**2 features** — job-queue, mast-data
+A focused session — 2 features.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#18](https://github.com/Snoww3d/jwst-data-analysis/pull/18)** feat: Add image processing module foundation with photutils
+### [#19](https://github.com/Snoww3d/jwst-data-analysis/pull/19) Add import job cancellation and configurable download settings
 
-    - Implements Phase 1 of the image processing roadmap (Task #12)
-    - Adds `photutils` and `scikit-image` dependencies for astronomical image analysis
-    - Creates modular processing architecture with 6 specialized modules
-    - Includes comprehensive research document covering algorithms and design decisions
+- Add cancel endpoint (`POST /mast/import/cancel/{jobId}`) to abort active MAST imports
+- Implement graceful cancellation using CancellationTokens in ImportJobTracker
+- Remove hardcoded 10-minute timeout - downloads now run until complete or cancelled
+- Make download settings configurable (poll inte...
 
-- **[#19](https://github.com/Snoww3d/jwst-data-analysis/pull/19)** feat: Add import job cancellation and configurable download settings
 
-    - Add cancel endpoint (`POST /mast/import/cancel/{jobId}`) to abort active MAST imports
-    - Implement graceful cancellation using CancellationTokens in ImportJobTracker
-    - Remove hardcoded 10-minute timeout - downloads now run until complete or cancelled
-    - Make download settings configurable (poll interval, base path) via appsettings.json
+### [#18](https://github.com/Snoww3d/jwst-data-analysis/pull/18) Add image processing module foundation with photutils
+
+- Implements Phase 1 of the image processing roadmap (Task #12)
+- Adds `photutils` and `scikit-image` dependencies for astronomical image analysis
+- Creates modular processing architecture with 6 specialized modules
+- Includes comprehensive research document covering algorithms and design decisions
+
+## What Changed
+
+### Features (2)
+
+- [#18](https://github.com/Snoww3d/jwst-data-analysis/pull/18) Add image processing module foundation with photutils
+- [#19](https://github.com/Snoww3d/jwst-data-analysis/pull/19) Add import job cancellation and configurable download settings
 
 ---
-*8 commits across this session.*
+8 commits across 2 pull requests.
+*Next: January 28, 2026 — Add observation date display and sort by download ...*

--- a/docs/blog/posts/2026-01-28.md
+++ b/docs/blog/posts/2026-01-28.md
@@ -11,17 +11,24 @@ authors:
 
 <!-- generated -->
 
-**1 feature**
+A focused session with a single pull request.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#20](https://github.com/Snoww3d/jwst-data-analysis/pull/20)** feat: Add observation date display and sort by download date
+### [#20](https://github.com/Snoww3d/jwst-data-analysis/pull/20) Add observation date display and sort by download date
 
-    - **Fix MJD to DateTime conversion** for MAST imports - uses `t_min` field (observation start time) with proper MJD epoch (November 17, 1858)
-    - **Add default sorting by upload date** (newest first) across all data retrieval methods
-    - **Display observation and download dates** in the dashboard lineage view
+- **Fix MJD to DateTime conversion** for MAST imports - uses `t_min` field (observation start time) with proper MJD epoch (November 17, 1858)
+- **Add default sorting by upload date** (newest first) across all data retrieval methods
+- **Display observation and download dates** in the dashboard lineag...
+
+## What Changed
+
+### Features (1)
+
+- [#20](https://github.com/Snoww3d/jwst-data-analysis/pull/20) Add observation date display and sort by download date
 
 ---
-*14 commits across this session.*
+14 commits across 1 pull request.
+*Next: January 29, 2026 — Preserve all MAST metadata on import and add refre..., Update documentation for MAST metadata preservatio..., Add documentation update step to PR workflow*

--- a/docs/blog/posts/2026-01-29.md
+++ b/docs/blog/posts/2026-01-29.md
@@ -7,10 +7,12 @@ categories:
   - Bug Fix
   - Refactoring
 tags:
+  - astronomy-data
   - ci
   - docs
   - export
   - mast-data
+  - performance
   - security
   - viewer
 authors:
@@ -21,134 +23,59 @@ authors:
 
 <!-- generated -->
 
-**4 features, 12 fixes, 4 docs, 1 refactor** — ci, docs, export, mast-data, security, viewer
+A marathon session: 21 pull requests merged (4 features, 12 fixes, 4 docs, 1 refactor). Security hardening across the stack.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#21](https://github.com/Snoww3d/jwst-data-analysis/pull/21)** feat: Preserve all MAST metadata on import and add refresh functionality
+### [#41](https://github.com/Snoww3d/jwst-data-analysis/pull/41) Add interactive stretch and level controls to FITS viewer
 
-    - Previously only ~10 fields from MAST were saved during import (4 generic + 6 ImageMetadata fields)
-    - Now all ~30+ fields are preserved with `mast_` prefix in the Metadata dictionary
-    - Added "Refresh Metadata" button to fix existing imports that are missing metadata
+- Adds 7 stretch algorithms (zscale, asinh, log, sqrt, power, histogram equalization, linear) to the FITS preview
+- Adds gamma correction, black point, and white point controls for fine-tuning image display
+- Creates a collapsible StretchControls panel in the image viewer UI
+- Implements 500ms debou...
 
-- **[#22](https://github.com/Snoww3d/jwst-data-analysis/pull/22)** docs: Update documentation for MAST metadata preservation feature
 
-    Updates all project documentation to reflect the new MAST metadata preservation feature merged in PR #21.
+### [#39](https://github.com/Snoww3d/jwst-data-analysis/pull/39) Server-side FITS preview with enhanced viewer UI
 
-- **[#23](https://github.com/Snoww3d/jwst-data-analysis/pull/23)** docs: Add documentation update step to PR workflow
+Replace slow client-side FITS parsing with fast server-side PNG generation.
 
-    Adds documentation updates as a required step in the PR workflow to ensure all features and changes are properly documented.
+## What Changed
 
-- **[#24](https://github.com/Snoww3d/jwst-data-analysis/pull/24)** docs: Include documentation updates in same PR
+### Features (4)
 
-    - Update Git Workflow to require documentation updates in same PR as code changes
-    - Removes separate docs PR step (old step 8)
-    - Adds documentation update guidance to step 2
-    - Simplifies workflow while keeping the reference table for what docs to update
+- [#21](https://github.com/Snoww3d/jwst-data-analysis/pull/21) Preserve all MAST metadata on import and add refresh functionality
+- [#37](https://github.com/Snoww3d/jwst-data-analysis/pull/37) Add centralized API service layer (Task #12)
+- [#39](https://github.com/Snoww3d/jwst-data-analysis/pull/39) Server-side FITS preview with enhanced viewer UI
+- [#41](https://github.com/Snoww3d/jwst-data-analysis/pull/41) Add interactive stretch and level controls to FITS viewer
 
-- **[#25](https://github.com/Snoww3d/jwst-data-analysis/pull/25)** docs: Add user review pause to Git Workflow
+### Bug Fixes (12)
 
-    - Add step 7: STOP for user review after CI passes
-    - Renumber merge step to 8 and cleanup step to 9
-    - Ensures user can review PR before merge happens
+- [#26](https://github.com/Snoww3d/jwst-data-analysis/pull/26) Path traversal protection in preview endpoint (Task #1)
+- [#27](https://github.com/Snoww3d/jwst-data-analysis/pull/27) Stream file downloads to prevent memory exhaustion (Task #2)
+- [#28](https://github.com/Snoww3d/jwst-data-analysis/pull/28) Escape regex patterns in MongoDB search to prevent ReDoS (Task #3)
+- [#29](https://github.com/Snoww3d/jwst-data-analysis/pull/29) Prevent path traversal in export download endpoint (Task #4)
+- [#30](https://github.com/Snoww3d/jwst-data-analysis/pull/30) Replace N+1 query with batch fetch in export endpoint (Task #5)
+- [#32](https://github.com/Snoww3d/jwst-data-analysis/pull/32) Add TypeScript interfaces for API responses (Task #7)
+- [#33](https://github.com/Snoww3d/jwst-data-analysis/pull/33) Centralize hardcoded API URLs in frontend (Task #8)
+- [#34](https://github.com/Snoww3d/jwst-data-analysis/pull/34) Use MongoDB aggregation for statistics to avoid memory exhaustion (Task #9)
+- [#35](https://github.com/Snoww3d/jwst-data-analysis/pull/35) Add MongoDB indexes for commonly queried fields (Task #10)
+- [#36](https://github.com/Snoww3d/jwst-data-analysis/pull/36) Add file content validation using magic bytes/signatures (Task #11)
+- [#38](https://github.com/Snoww3d/jwst-data-analysis/pull/38) Add mast_obs_id fallback for observation lookup/delete
+- [#40](https://github.com/Snoww3d/jwst-data-analysis/pull/40) Forward colormap and size parameters to processing engine
 
-- **[#26](https://github.com/Snoww3d/jwst-data-analysis/pull/26)** fix: Path traversal protection in preview endpoint (Task #1)
+### Refactoring (1)
 
-    Security fix for **critical** path traversal vulnerability in the `/preview/{data_id}` endpoint.
+- [#31](https://github.com/Snoww3d/jwst-data-analysis/pull/31) Extract duplicated import logic into shared helper (Task #6)
 
-- **[#27](https://github.com/Snoww3d/jwst-data-analysis/pull/27)** fix: Stream file downloads to prevent memory exhaustion (Task #2)
+### Documentation (4)
 
-    - Fix critical performance issue in file download endpoint (`GET /api/jwstdata/{id}/file`)
-    - Replace `ReadAllBytesAsync` (loads entire file to memory) with `FileStream` streaming
-    - Prevents denial of service from large FITS files (100MB+) exhausting server memory
-
-- **[#28](https://github.com/Snoww3d/jwst-data-analysis/pull/28)** fix: Escape regex patterns in MongoDB search to prevent ReDoS (Task #3)
-
-    - Escape user-provided search terms with `Regex.Escape()` before using in MongoDB regex filters
-    - Prevents Regular Expression Denial of Service (ReDoS) attacks via malicious regex patterns
-    - Applied fix to both `AdvancedSearchAsync` and `GetSearchCountAsync` methods
-
-- **[#29](https://github.com/Snoww3d/jwst-data-analysis/pull/29)** fix: Prevent path traversal in export download endpoint (Task #4)
-
-    - Add GUID validation to `exportId` parameter in `DownloadExport` endpoint to prevent path traversal attacks
-    - Add defense-in-depth check to ensure resolved file path is within the exports directory
-    - Add warning logging for invalid/malicious export ID attempts
-
-- **[#30](https://github.com/Snoww3d/jwst-data-analysis/pull/30)** fix: Replace N+1 query with batch fetch in export endpoint (Task #5)
-
-    - Add `GetManyAsync(IEnumerable<string> ids)` method to MongoDBService that fetches multiple records in a single database query using MongoDB's `$in` operator
-    - Update export endpoint to use batch fetch instead of looping through individual `GetAsync` calls
-
-- **[#31](https://github.com/Snoww3d/jwst-data-analysis/pull/31)** refactor: Extract duplicated import logic into shared helper (Task #6)
-
-    - Add `CreateRecordsForFilesAsync` helper method that consolidates record creation logic
-    - Update `ExecuteImportAsync`, `ExecuteResumedImportAsync`, and `CompleteImportFromExistingFilesAsync` to use shared helper
-    - Remove unused `BuildTags` helper method
-
-- **[#32](https://github.com/Snoww3d/jwst-data-analysis/pull/32)** fix: Add TypeScript interfaces for API responses (Task #7)
-
-    - Add `BulkImportResponse` interface for `/api/datamanagement/import/scan` endpoint responses
-    - Add `ApiErrorResponse` interface for generic error handling across API calls
-    - Add `MetadataRefreshAllResponse` interface for `/api/mast/refresh-metadata-all` endpoint
-    - Update `JwstDataDashboard.tsx` to use typed responses instead of implicit `any`
-
-- **[#33](https://github.com/Snoww3d/jwst-data-analysis/pull/33)** fix: Centralize hardcoded API URLs in frontend (Task #8)
-
-    - Create centralized API configuration at `src/config/api.ts`
-    - Replace 10 hardcoded `http://localhost:5001` URLs across 4 files
-    - Support `REACT_APP_API_URL` environment variable for production deployments
-
-- **[#34](https://github.com/Snoww3d/jwst-data-analysis/pull/34)** fix: Use MongoDB aggregation for statistics to avoid memory exhaustion (Task #9)
-
-    - Replace `GetStatisticsAsync()` implementation that loaded all documents into memory with efficient MongoDB aggregation pipelines
-    - Basic stats (count, sum, avg, min, max) computed in a single aggregation pipeline
-    - Separate `$group` pipelines for data type, status, format, and processing level distributions
-    - `$unwind` + `$group` + `$sort` + `$limit` pipeline for most common tags
-    - This prevents...
-
-- **[#35](https://github.com/Snoww3d/jwst-data-analysis/pull/35)** fix: Add MongoDB indexes for commonly queried fields (Task #10)
-
-    - Adds 11 MongoDB indexes during application startup for commonly queried fields
-    - Improves query performance for filtered searches, lineage queries, and text search
-    - Indexes created with `Background = true` to avoid blocking application startup
-
-- **[#36](https://github.com/Snoww3d/jwst-data-analysis/pull/36)** fix: Add file content validation using magic bytes/signatures (Task #11)
-
-    - Add `FileContentValidator` service that validates file content matches extension
-    - Prevents malicious files being uploaded with renamed extensions
-    - Validates binary files (FITS, PNG, JPEG, TIFF, GZ) using magic bytes
-    - Validates text files (JSON, CSV) using structure checking
-
-- **[#37](https://github.com/Snoww3d/jwst-data-analysis/pull/37)** feat: Add centralized API service layer (Task #12)
-
-    - Replace 15 inline fetch() calls across 4 components with a centralized service layer
-    - Add `ApiError` class for typed error handling with status codes
-    - Add `apiClient.ts` core HTTP client with automatic JSON handling
-    - Add `jwstDataService.ts` for JWST data operations
-    - Add `mastService.ts` for MAST search/import operations
-    - Update `App.tsx`, `JwstDataDashboard.tsx`, and `MastSearch.tsx` to us...
-
-- **[#38](https://github.com/Snoww3d/jwst-data-analysis/pull/38)** fix: Add mast_obs_id fallback for observation lookup/delete
-
-    Fixes delete observation failing with "No records found for observation" error.
-
-- **[#39](https://github.com/Snoww3d/jwst-data-analysis/pull/39)** feat: Server-side FITS preview with enhanced viewer UI
-
-    Replace slow client-side FITS parsing with fast server-side PNG generation.
-
-- **[#40](https://github.com/Snoww3d/jwst-data-analysis/pull/40)** fix: Forward colormap and size parameters to processing engine
-
-    - Fixed preview endpoint not forwarding `cmap`, `width`, and `height` query parameters to the Python processing engine
-    - Colormap changes in the viewer now take effect immediately
-
-- **[#41](https://github.com/Snoww3d/jwst-data-analysis/pull/41)** feat: Add interactive stretch and level controls to FITS viewer
-
-    - Adds 7 stretch algorithms (zscale, asinh, log, sqrt, power, histogram equalization, linear) to the FITS preview
-    - Adds gamma correction, black point, and white point controls for fine-tuning image display
-    - Creates a collapsible StretchControls panel in the image viewer UI
-    - Implements 500ms debouncing to prevent request flooding during slider adjustments
+- [#22](https://github.com/Snoww3d/jwst-data-analysis/pull/22) Update documentation for MAST metadata preservation feature
+- [#23](https://github.com/Snoww3d/jwst-data-analysis/pull/23) Add documentation update step to PR workflow
+- [#24](https://github.com/Snoww3d/jwst-data-analysis/pull/24) Include documentation updates in same PR
+- [#25](https://github.com/Snoww3d/jwst-data-analysis/pull/25) Add user review pause to Git Workflow
 
 ---
-*42 commits across this session.*
+42 commits across 21 pull requests.
+*Next: January 30, 2026 — Add delete/archive by processing level functionali..., Redesign FITS viewer header with observation title, Add observation title to dashboard Lineage and Gro...*

--- a/docs/blog/posts/2026-01-30.md
+++ b/docs/blog/posts/2026-01-30.md
@@ -6,6 +6,7 @@ categories:
   - Bug Fix
   - Refactoring
 tags:
+  - astronomy-data
   - job-queue
   - mast-data
   - ui
@@ -18,64 +19,45 @@ authors:
 
 <!-- generated -->
 
-**6 features, 1 fix, 1 refactor** — job-queue, mast-data, ui, viewer
+Productive session with 8 pull requests: 6 features, 1 fix, 1 refactor.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#42](https://github.com/Snoww3d/jwst-data-analysis/pull/42)** feat: Add delete/archive by processing level functionality
+### [#50](https://github.com/Snoww3d/jwst-data-analysis/pull/50) Histogram shows stretched values instead of raw data
 
-    - Add ability to delete or archive all files of a specific processing level within an observation
-    - Users can now delete all L1 raw files while keeping L2b calibrated and L3 combined images
-    - Archive (📦) and Delete (🗑️) buttons appear on each processing level header in Lineage view
+- Histogram panel now displays the distribution of **stretched** pixel values instead of raw FITS data
+- When users change stretch function (ZScale → Asinh → Linear, etc.) or adjust gamma/black point/white point, the histogram updates to reflect the actual displayed distribution
+- Histogram updates ...
 
-- **[#43](https://github.com/Snoww3d/jwst-data-analysis/pull/43)** refactor: Redesign FITS viewer header with observation title
 
-    - Add observation title (from mast_obs_title) to FITS viewer header
-    - Expand breadcrumbs to show target / instrument / filter
-    - Left-align title for cleaner visual hierarchy
-    - Delete unused AdvancedFitsViewer component and test
-    - Rename AdvancedFitsViewer.css to FitsViewer.css for clarity
+### [#48](https://github.com/Snoww3d/jwst-data-analysis/pull/48) Sync MAST Files now fetches metadata and processing levels
 
-- **[#44](https://github.com/Snoww3d/jwst-data-analysis/pull/44)** feat: Add observation title to dashboard Lineage and Grouped views
+- Combined "Import MAST Files" and "Refresh Metadata" buttons into single "Sync MAST Files" button
+- Updated `ScanAndImportFiles` endpoint to fetch MAST metadata for each observation group
+- Now properly populates both `Metadata` dictionary and `ImageInfo` fields during disk scan import
+- Automatica...
 
-    - Display `mast_obs_title` metadata in both Lineage and Grouped dashboard views
-    - Observation title appears first in metadata row with teal italic styling
-    - Grouped view adds new metadata row below observation ID header
-    - Gracefully handles missing obs_title by showing remaining metadata (target, instrument)
+## What Changed
 
-- **[#45](https://github.com/Snoww3d/jwst-data-analysis/pull/45)** feat: Add magma, inferno, and plasma colormaps for FITS viewer
+### Features (6)
 
-    - Add **magma** colormap (black → purple → pink → light yellow)
-    - Add **inferno** colormap (black → purple → orange → yellow)
-    - Add **plasma** colormap (purple → pink → orange → yellow)
-    - Rename 'heat' to 'hot' to match matplotlib naming convention
-    - Resolves tech debt item #16
+- [#42](https://github.com/Snoww3d/jwst-data-analysis/pull/42) Add delete/archive by processing level functionality
+- [#44](https://github.com/Snoww3d/jwst-data-analysis/pull/44) Add observation title to dashboard Lineage and Grouped views
+- [#45](https://github.com/Snoww3d/jwst-data-analysis/pull/45) Add magma, inferno, and plasma colormaps for FITS viewer
+- [#46](https://github.com/Snoww3d/jwst-data-analysis/pull/46) Add download job cleanup timer and cancel endpoint
+- [#47](https://github.com/Snoww3d/jwst-data-analysis/pull/47) A2 Histogram display panel with adjustable black/white points
+- [#50](https://github.com/Snoww3d/jwst-data-analysis/pull/50) Histogram shows stretched values instead of raw data
 
-- **[#46](https://github.com/Snoww3d/jwst-data-analysis/pull/46)** feat: Add download job cleanup timer and cancel endpoint
+### Bug Fixes (1)
 
-    - Run cleanup of old download state files on processing engine startup
-    - Run cleanup after each completed/cancelled download  
-    - Include cancelled downloads in cleanup (not just completed)
-    - Add `POST /mast/download/cancel/{job_id}` endpoint
-    - State files older than 7 days are automatically removed
-    - Orphaned `.part` files are also cleaned up
+- [#48](https://github.com/Snoww3d/jwst-data-analysis/pull/48) Sync MAST Files now fetches metadata and processing levels
 
-- **[#47](https://github.com/Snoww3d/jwst-data-analysis/pull/47)** feat: A2 Histogram display panel with adjustable black/white points
+### Refactoring (1)
 
-- **[#48](https://github.com/Snoww3d/jwst-data-analysis/pull/48)** fix: Sync MAST Files now fetches metadata and processing levels
-
-    - Combined "Import MAST Files" and "Refresh Metadata" buttons into single "Sync MAST Files" button
-    - Updated `ScanAndImportFiles` endpoint to fetch MAST metadata for each observation group
-    - Now properly populates both `Metadata` dictionary and `ImageInfo` fields during disk scan import
-    - Automatically refreshes metadata for existing files with missing TargetName or Unknown processing level
-
-- **[#50](https://github.com/Snoww3d/jwst-data-analysis/pull/50)** feat: Histogram shows stretched values instead of raw data
-
-    - Histogram panel now displays the distribution of **stretched** pixel values instead of raw FITS data
-    - When users change stretch function (ZScale → Asinh → Linear, etc.) or adjust gamma/black point/white point, the histogram updates to reflect the actual displayed distribution
-    - Histogram updates are synchronized with preview image updates (uses committed stretchParams after 500ms debounce)
+- [#43](https://github.com/Snoww3d/jwst-data-analysis/pull/43) Redesign FITS viewer header with observation title
 
 ---
-*31 commits across this session.*
+31 commits across 8 pull requests.
+*Next: January 31, 2026 — Add "What's New" panel to browse recent JWST relea..., Complete git history security audit (Task #35), Externalize credentials to environment variables (...*

--- a/docs/blog/posts/2026-01-31.md
+++ b/docs/blog/posts/2026-01-31.md
@@ -6,6 +6,7 @@ categories:
   - Development
   - Documentation
   - Feature
+  - Bug Fix
   - Testing
 tags:
   - auth
@@ -25,126 +26,64 @@ authors:
 
 <!-- generated -->
 
-**1 feature, 2 fixes, 4 docs, 1 test, 6 maintenance, 7 dep updates** — auth, ci, code-quality, dependencies, docs, infrastructure, security, testing, ui
+A marathon session: 23 pull requests merged (1 feature, 2 fixes, 4 docs, 1 test, 6 maintenance, 7 dependency updates). Security hardening across the stack.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#51](https://github.com/Snoww3d/jwst-data-analysis/pull/51)** feat: Add "What's New" panel to browse recent JWST releases
+### [#79](https://github.com/Snoww3d/jwst-data-analysis/pull/79) Add API rate limiting
 
-    - Adds a "What's New" panel to the dashboard that displays JWST observations recently released to the public on MAST
-    - Users can filter by time period (7/30/90 days) and instrument (NIRCAM, MIRI, NIRSPEC, NIRISS)
-    - Observation cards display thumbnails (from MAST jpegURL), target name, instrument, filter, exposure time, and release date
-    - Import functionality with progress tracking reuses existing ...
+- Add AspNetCoreRateLimit package for IP-based rate limiting
+- Configure sensible defaults to prevent abuse without impacting normal use
+- Development mode whitelists localhost/private IPs
 
-- **[#52](https://github.com/Snoww3d/jwst-data-analysis/pull/52)** docs: Complete git history security audit (Task #35)
 
-    - Complete security audit of git history for production readiness
-    - Scan for secrets, API keys, credentials, and sensitive files
-    - Update .gitignore with safety patterns to prevent future accidents
-    - Add production readiness tasks (#18-36) to tech debt tracking
+### [#78](https://github.com/Snoww3d/jwst-data-analysis/pull/78) Configure CORS for production
 
-- **[#53](https://github.com/Snoww3d/jwst-data-analysis/pull/53)** security: Externalize credentials to environment variables (Task #18)
+- Replace `AllowAnyOrigin()` with environment-configurable allowed origins
+- Add `CORS_ALLOWED_ORIGINS` environment variable (comma-separated)
+- Development mode defaults to localhost origins
+- Production mode requires explicit configuration
 
-    Remove hardcoded MongoDB credentials from docker-compose.yml and externalize all configuration to environment variables.
+## What Changed
 
-- **[#54](https://github.com/Snoww3d/jwst-data-analysis/pull/54)** docs: Add MIT License (Task #22)
+### Features (1)
 
-    Add MIT License to enable open source contribution and clarify terms of use.
+- [#51](https://github.com/Snoww3d/jwst-data-analysis/pull/51) Add "What's New" panel to browse recent JWST releases
 
-- **[#55](https://github.com/Snoww3d/jwst-data-analysis/pull/55)** docs: Add community documentation (Tasks #21, #23)
+### Bug Fixes (2)
 
-    Add essential open-source community documentation for public repository.
+- [#78](https://github.com/Snoww3d/jwst-data-analysis/pull/78) Configure CORS for production
+- [#79](https://github.com/Snoww3d/jwst-data-analysis/pull/79) Add API rate limiting
 
-- **[#56](https://github.com/Snoww3d/jwst-data-analysis/pull/56)** ci: Add security scanning and dependency automation (Task #26)
+### Testing (1)
 
-    - Add CodeQL security scanning workflow for JavaScript/TypeScript, C#, and Python
-    - Add Dependabot configuration for automated dependency updates
-    - Add Docker build verification job to CI workflow
+- [#84](https://github.com/Snoww3d/jwst-data-analysis/pull/84) Add backend test infrastructure (Task #27)
 
-- **[#57](https://github.com/Snoww3d/jwst-data-analysis/pull/57)** chore(deps): Bump actions/setup-dotnet from 4 to 5
+### Documentation (4)
 
-- **[#58](https://github.com/Snoww3d/jwst-data-analysis/pull/58)** chore(deps): Bump github/codeql-action from 3 to 4
+- [#52](https://github.com/Snoww3d/jwst-data-analysis/pull/52) Complete git history security audit (Task #35)
+- [#54](https://github.com/Snoww3d/jwst-data-analysis/pull/54) Add MIT License (Task #22)
+- [#55](https://github.com/Snoww3d/jwst-data-analysis/pull/55) Add community documentation (Tasks #21, #23)
+- [#82](https://github.com/Snoww3d/jwst-data-analysis/pull/82) Mark #35 (Review and Clean Git History) as resolved
 
-- **[#59](https://github.com/Snoww3d/jwst-data-analysis/pull/59)** chore(deps): Bump actions/setup-node from 4 to 6
+### Maintenance (6)
 
-- **[#60](https://github.com/Snoww3d/jwst-data-analysis/pull/60)** chore(deps): Bump actions/setup-python from 5 to 6
+- [#75](https://github.com/Snoww3d/jwst-data-analysis/pull/75) Update all dependencies to latest versions
+- [#76](https://github.com/Snoww3d/jwst-data-analysis/pull/76) Migrate frontend from Create React App to Vite
+- [#77](https://github.com/Snoww3d/jwst-data-analysis/pull/77) Upgrade numpy to 2.0.2 and dependencies
+- [#80](https://github.com/Snoww3d/jwst-data-analysis/pull/80) Add GitHub issue and PR templates
+- [#81](https://github.com/Snoww3d/jwst-data-analysis/pull/81) Separate dev and production Docker configs
+- [#83](https://github.com/Snoww3d/jwst-data-analysis/pull/83) Add linting and formatting configurations (Task #28)
 
-- **[#62](https://github.com/Snoww3d/jwst-data-analysis/pull/62)** chore(deps): Bump actions/checkout from 4 to 6
+**Dependencies** (7 updates: @types/node, actions/checkout, actions/setup-dotnet, actions/setup-node, actions/setup-python, aiofiles, github/codeql-action)
 
-- **[#63](https://github.com/Snoww3d/jwst-data-analysis/pull/63)** chore(deps): Bump @types/node from 16.18.126 to 25.1.0 in /frontend/jwst-frontend
+### Other (2)
 
-- **[#65](https://github.com/Snoww3d/jwst-data-analysis/pull/65)** chore(deps): Bump aiofiles from 23.2.1 to 25.1.0 in /processing-engine
-
-- **[#75](https://github.com/Snoww3d/jwst-data-analysis/pull/75)** chore: Update all dependencies to latest versions
-
-    Update all project dependencies to their latest versions with regression testing.
-
-- **[#76](https://github.com/Snoww3d/jwst-data-analysis/pull/76)** chore: Migrate frontend from Create React App to Vite
-
-    - Replace Create React App with Vite for faster builds and native TypeScript 5 support
-    - Update environment variables from `REACT_APP_*` to `VITE_*` prefix
-    - Fix TypeScript compatibility issues for cross-platform builds
-
-- **[#77](https://github.com/Snoww3d/jwst-data-analysis/pull/77)** chore: Upgrade numpy to 2.0.2 and dependencies
-
-    - Upgrades numpy from 1.26.2 to 2.0.2
-    - Updates dependent packages that had `numpy<2` constraints:
-      - scipy: 1.11.4 → 1.13.1
-      - pandas: 2.1.4 → 2.2.3
-      - astropy: 6.0.0 → 6.1.7
-      - matplotlib: 3.8.2 → 3.9.4
-    - Updates CI Python version from 3.9 to 3.12 (numpy 2.x requires Python 3.10+)
-
-- **[#78](https://github.com/Snoww3d/jwst-data-analysis/pull/78)** fix(security): Configure CORS for production
-
-    - Replace `AllowAnyOrigin()` with environment-configurable allowed origins
-    - Add `CORS_ALLOWED_ORIGINS` environment variable (comma-separated)
-    - Development mode defaults to localhost origins
-    - Production mode requires explicit configuration
-
-- **[#79](https://github.com/Snoww3d/jwst-data-analysis/pull/79)** fix(security): Add API rate limiting
-
-    - Add AspNetCoreRateLimit package for IP-based rate limiting
-    - Configure sensible defaults to prevent abuse without impacting normal use
-    - Development mode whitelists localhost/private IPs
-
-- **[#80](https://github.com/Snoww3d/jwst-data-analysis/pull/80)** chore: Add GitHub issue and PR templates
-
-    - Add bug report issue template
-    - Add feature request issue template
-    - Add template chooser config with links to docs and security policy
-    - Add PR template with type checklist
-
-- **[#81](https://github.com/Snoww3d/jwst-data-analysis/pull/81)** chore: Separate dev and production Docker configs
-
-    - Split docker-compose.yml into base + override files
-    - `docker-compose.override.yml`: Dev defaults (auto-loaded)
-    - `docker-compose.prod.yml`: Production overrides
-
-- **[#82](https://github.com/Snoww3d/jwst-data-analysis/pull/82)** docs: Mark #35 (Review and Clean Git History) as resolved
-
-    - Marks Task #35 (Review and Clean Git History) as resolved in tech-debt.md
-    - Updates resolved count from 24 to 25
-    - Updates remaining count from 12 to 11
-
-- **[#83](https://github.com/Snoww3d/jwst-data-analysis/pull/83)** chore: Add linting and formatting configurations (Task #28)
-
-    - Add comprehensive linting and formatting tools across all projects
-    - ESLint + Prettier for frontend (React/TypeScript)
-    - StyleCop + NetAnalyzers for backend (.NET)
-    - Ruff for processing engine (Python)
-    - CI integration with lint job running before build
-    - **Implement LoggerMessage source generators for high-performance logging**
-
-- **[#84](https://github.com/Snoww3d/jwst-data-analysis/pull/84)** test: Add backend test infrastructure (Task #27)
-
-    - Add xUnit test project for .NET backend with model validation tests
-    - Create test fixtures for sample data generation
-    - Add specification tests for MongoDBService and JwstDataController (skipped until DI refactor)
-    - Integrate test execution into CI pipeline
-    - Disable CodeQL until repo is public (added Task #37 to track)
+- [#53](https://github.com/Snoww3d/jwst-data-analysis/pull/53) Externalize credentials to environment variables (Task #18)
+- [#56](https://github.com/Snoww3d/jwst-data-analysis/pull/56) Add security scanning and dependency automation (Task #26)
 
 ---
-*61 commits across this session.*
+61 commits across 23 pull requests.
+*Next: February 1, 2026 — Implement Playwright and update agentic docs (Task..., Implement Zoomed Range View for Histogram (Task #1..., add test data generation and docs*

--- a/docs/blog/posts/2026-02-01.md
+++ b/docs/blog/posts/2026-02-01.md
@@ -7,10 +7,12 @@ categories:
   - Feature
   - Refactoring
 tags:
+  - astronomy-data
   - ci
   - docs
   - e2e-tests
   - infrastructure
+  - performance
   - viewer
 authors:
   - shanon
@@ -20,42 +22,44 @@ authors:
 
 <!-- generated -->
 
-**5 features, 2 docs, 1 refactor, 1 maintenance** — ci, docs, e2e-tests, infrastructure, viewer
+Productive session with 9 pull requests: 5 features, 2 docs, 1 refactor, 1 maintenance. Tackling stability and memory issues.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#85](https://github.com/Snoww3d/jwst-data-analysis/pull/85)** feat: Implement Playwright and update agentic docs (Task #39)
+### [#86](https://github.com/Snoww3d/jwst-data-analysis/pull/86) Implement Zoomed Range View for Histogram (Task #17)
 
-- **[#86](https://github.com/Snoww3d/jwst-data-analysis/pull/86)** feat: Implement Zoomed Range View for Histogram (Task #17)
 
-- **[#87](https://github.com/Snoww3d/jwst-data-analysis/pull/87)** feat: add test data generation and docs
+### [#91](https://github.com/Snoww3d/jwst-data-analysis/pull/91) add pixel coordinate and value display on hover in FITS viewer
 
-- **[#88](https://github.com/Snoww3d/jwst-data-analysis/pull/88)** feat: add documentation viewer with MkDocs
+- Add status bar to FITS viewer showing pixel coordinates, values, and WCS sky coordinates on hover
+- New `/pixeldata` endpoint returns downsampled pixel array with WCS parameters for client-side coordinate calculations
+- Instant response during mouse movement (no server calls per hover)
 
-- **[#90](https://github.com/Snoww3d/jwst-data-analysis/pull/90)** docs: clarify distinction between skills and workflows
+## What Changed
 
-    Clarifies the difference between **skills** (quick utilities) and **workflows** (development processes with PRs).
+### Features (5)
 
-- **[#91](https://github.com/Snoww3d/jwst-data-analysis/pull/91)** feat: add pixel coordinate and value display on hover in FITS viewer
+- [#85](https://github.com/Snoww3d/jwst-data-analysis/pull/85) Implement Playwright and update agentic docs (Task #39)
+- [#86](https://github.com/Snoww3d/jwst-data-analysis/pull/86) Implement Zoomed Range View for Histogram (Task #17)
+- [#87](https://github.com/Snoww3d/jwst-data-analysis/pull/87) add test data generation and docs
+- [#88](https://github.com/Snoww3d/jwst-data-analysis/pull/88) add documentation viewer with MkDocs
+- [#91](https://github.com/Snoww3d/jwst-data-analysis/pull/91) add pixel coordinate and value display on hover in FITS viewer
 
-    - Add status bar to FITS viewer showing pixel coordinates, values, and WCS sky coordinates on hover
-    - New `/pixeldata` endpoint returns downsampled pixel array with WCS parameters for client-side coordinate calculations
-    - Instant response during mouse movement (no server calls per hover)
+### Refactoring (1)
 
-- **[#92](https://github.com/Snoww3d/jwst-data-analysis/pull/92)** chore: add mandatory Docker verification to all workflows
+- [#93](https://github.com/Snoww3d/jwst-data-analysis/pull/93) extract IMongoDBService interface for DI (Task #38)
 
-    Updates all three workflow files to include mandatory Docker verification steps **before** creating PRs. This prevents integration issues from being discovered post-PR creation.
+### Documentation (2)
 
-- **[#93](https://github.com/Snoww3d/jwst-data-analysis/pull/93)** refactor: extract IMongoDBService interface for DI (Task #38)
+- [#90](https://github.com/Snoww3d/jwst-data-analysis/pull/90) clarify distinction between skills and workflows
+- [#94](https://github.com/Snoww3d/jwst-data-analysis/pull/94) Task #38 completion docs and workflow improvements
 
-    - Extract `IMongoDBService` interface from `MongoDBService` to enable proper dependency injection
-    - Add internal constructor for test injection via `InternalsVisibleTo`
-    - Enable 63 previously skipped unit tests that can now use mocked services
-    - All 116 tests now pass
+### Maintenance (1)
 
-- **[#94](https://github.com/Snoww3d/jwst-data-analysis/pull/94)** docs: Task #38 completion docs and workflow improvements
+- [#92](https://github.com/Snoww3d/jwst-data-analysis/pull/92) add mandatory Docker verification to all workflows
 
 ---
-*42 commits across this session.*
+42 commits across 9 pull requests.
+*Next: February 2, 2026 — extract shared filter builder to fix pagination co..., add GetSearchCountAsync fix to tech-debt.md and en..., mark A3 pixel coordinate display as complete*

--- a/docs/blog/posts/2026-02-02.md
+++ b/docs/blog/posts/2026-02-02.md
@@ -8,6 +8,7 @@ categories:
   - Bug Fix
   - Development
 tags:
+  - astronomy-data
   - ci
   - docs
   - export
@@ -22,119 +23,62 @@ authors:
 
 <!-- generated -->
 
-**1 feature, 1 fix, 9 docs, 2 maintenance** — ci, docs, export, mast-data, security, viewer
+A marathon session: 19 pull requests merged (1 feature, 1 fix, 9 docs, 2 maintenance). Security hardening across the stack.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#95](https://github.com/Snoww3d/jwst-data-analysis/pull/95)** fix: extract shared filter builder to fix pagination count mismatch (Task #2)
+### [#101](https://github.com/Snoww3d/jwst-data-analysis/pull/101) add PNG export to FITS viewer
 
-    - Fixed `GetSearchCountAsync` to apply all 9 filters that `AdvancedSearchAsync` uses, ensuring pagination counts match filtered results
-    - Extracted `BuildSearchFilter()` private method to eliminate code duplication and guarantee consistent filtering behavior
-    - Added 5 unit tests to verify correct count behavior with various filter combinations
+- Add PNG export button to FITS viewer that downloads current visualization with all settings applied
+- Generate meaningful filenames from MAST metadata (e.g., `jw02733-o001_nircam_f090w_2024-01-15_143022.png`)
+- Show loading spinner during export, disable button while image is loading
+- Update docu...
 
-- **[#96](https://github.com/Snoww3d/jwst-data-analysis/pull/96)** docs: add GetSearchCountAsync fix to tech-debt.md and enhance workflows
 
-    - Added Task #47 (GetSearchCountAsync incomplete filter logic fix from PR #95) to the Resolved table in `docs/tech-debt.md`
-    - Enhanced `fix-bug.md` and `create-feature.md` workflows to include `docs/tech-debt.md` in documentation checklists
+### [#95](https://github.com/Snoww3d/jwst-data-analysis/pull/95) extract shared filter builder to fix pagination count mismatch (Task #2)
 
-- **[#97](https://github.com/Snoww3d/jwst-data-analysis/pull/97)** docs: mark A3 pixel coordinate display as complete
+- Fixed `GetSearchCountAsync` to apply all 9 filters that `AdvancedSearchAsync` uses, ensuring pagination counts match filtered results
+- Extracted `BuildSearchFilter()` private method to eliminate code duplication and guarantee consistent filtering behavior
+- Added 5 unit tests to verify correct co...
 
-    - Mark A3 (Pixel coordinate and value display on hover) as complete in development-plan.md
-    - This feature was implemented in PR #91 but the checkbox was not updated
+## What Changed
 
-- **[#98](https://github.com/Snoww3d/jwst-data-analysis/pull/98)** chore: add git workflow protection to prevent direct pushes to main
+### Features (1)
 
-    - Add pre-push git hook that blocks direct pushes to `main` branch
-    - Add setup script (`scripts/setup-hooks.sh`) to install hooks
-    - Add warning boxes to all workflow files
-    - Strengthen CLAUDE.md git workflow section
+- [#101](https://github.com/Snoww3d/jwst-data-analysis/pull/101) add PNG export to FITS viewer
 
-    *Direct push to main today bypassed CI and user review. This adds multiple layers of protection: 1. **Documentation** - Explicit rules in CLAUDE.md and workflow files 2. **Technical** - Pre-push hook blocks the action locally*
+### Bug Fixes (1)
 
-- **[#99](https://github.com/Snoww3d/jwst-data-analysis/pull/99)** chore: enhance PR template with documentation checklist
+- [#95](https://github.com/Snoww3d/jwst-data-analysis/pull/95) extract shared filter builder to fix pagination count mismatch (Task #2)
 
-    Enhance the existing PR template with more specific documentation reminders.
+### Documentation (9)
 
-- **[#100](https://github.com/Snoww3d/jwst-data-analysis/pull/100)** docs: add Task #48 for GitHub branch protection
+- [#96](https://github.com/Snoww3d/jwst-data-analysis/pull/96) add GetSearchCountAsync fix to tech-debt.md and enhance workflows
+- [#97](https://github.com/Snoww3d/jwst-data-analysis/pull/97) mark A3 pixel coordinate display as complete
+- [#100](https://github.com/Snoww3d/jwst-data-analysis/pull/100) add Task #48 for GitHub branch protection
+- [#102](https://github.com/Snoww3d/jwst-data-analysis/pull/102) add Branch-First Rule to harden git workflow
+- [#103](https://github.com/Snoww3d/jwst-data-analysis/pull/103) add Task #49 for export filename pattern improvements
+- [#104](https://github.com/Snoww3d/jwst-data-analysis/pull/104) add No Dangling Changes Rule to git workflow
+- [#106](https://github.com/Snoww3d/jwst-data-analysis/pull/106) Enforce mandatory workflow usage for all changes
+- [#109](https://github.com/Snoww3d/jwst-data-analysis/pull/109) mark Task #50 (MongoDB password exposure) as verified false positive
+- [#111](https://github.com/Snoww3d/jwst-data-analysis/pull/111) add self-compliance check to all workflows
 
-    Add tech debt item to track enabling GitHub branch protection when the repo becomes public.
+### Maintenance (2)
 
-- **[#101](https://github.com/Snoww3d/jwst-data-analysis/pull/101)** feat: add PNG export to FITS viewer
+- [#98](https://github.com/Snoww3d/jwst-data-analysis/pull/98) add git workflow protection to prevent direct pushes to main
+- [#99](https://github.com/Snoww3d/jwst-data-analysis/pull/99) enhance PR template with documentation checklist
 
-    - Add PNG export button to FITS viewer that downloads current visualization with all settings applied
-    - Generate meaningful filenames from MAST metadata (e.g., `jw02733-o001_nircam_f090w_2024-01-15_143022.png`)
-    - Show loading spinner during export, disable button while image is loading
-    - Update documentation to fix outdated `AdvancedFitsViewer` references → `ImageViewer`
+### Other (6)
 
-- **[#102](https://github.com/Snoww3d/jwst-data-analysis/pull/102)** docs: add Branch-First Rule to harden git workflow
-
-    - Add explicit **Branch-First Rule** to Git Workflow section in CLAUDE.md
-    - Requires creating feature branch BEFORE any file edits (Edit, Write tools)
-    - Prevents accidental work on `main` branch
-
-- **[#103](https://github.com/Snoww3d/jwst-data-analysis/pull/103)** docs: add Task #49 for export filename pattern improvements
-
-    - Add Task #49 to track potential improvements to PNG export filename generation
-    - Update remaining task count (11 → 12)
-
-- **[#104](https://github.com/Snoww3d/jwst-data-analysis/pull/104)** docs: add No Dangling Changes Rule to git workflow
-
-    Add **No Dangling Changes Rule** to Git Workflow section requiring uncommitted changes to be resolved immediately after PR completion.
-
-- **[#105](https://github.com/Snoww3d/jwst-data-analysis/pull/105)** security: Add MCP server security policy
-
-    - Add MCP (Model Context Protocol) server security policy to CLAUDE.md
-    - Document that this project does NOT require MCP servers for core functionality
-    - Prohibit dangerous MCP tool permissions (mcp-add, mcp-config-set)
-    - Establish credential management policy (use Docker secrets, not embedded values)
-
-- **[#106](https://github.com/Snoww3d/jwst-data-analysis/pull/106)** docs: Enforce mandatory workflow usage for all changes
-
-    - Make workflow usage mandatory for ALL changes to tracked files
-    - Add workflow selection guide to help choose the correct workflow
-    - Clarify that "docs only" and "quick fixes" are not exceptions
-
-- **[#107](https://github.com/Snoww3d/jwst-data-analysis/pull/107)** security: add comprehensive security audit findings to tech debt
-
-    - Documents findings from comprehensive security audit across all application layers
-    - Adds 19 new security tasks (#50-#68) to `docs/tech-debt.md`
-    - Organizes issues by priority (Critical → High → Medium → Low)
-    - Includes file locations, code snippets, attack vectors, and fix approaches
-
-- **[#108](https://github.com/Snoww3d/jwst-data-analysis/pull/108)** security: fix path traversal vulnerability via obsId parameter (Task #51)
-
-    - Fixes critical path traversal vulnerability in `MastController.cs` where `obsId` URL parameters could be exploited to access files outside the download directory
-    - Adds format validation for JWST observation IDs using a regex pattern
-    - Adds defense-in-depth path validation to ensure resolved paths stay within the download base directory
-    - Adds security event logging for blocked path traversal at...
-
-- **[#109](https://github.com/Snoww3d/jwst-data-analysis/pull/109)** docs: mark Task #50 (MongoDB password exposure) as verified false positive
-
-    - Marks Task #50 as a verified false positive after investigation
-    - Updates resolved count (33→34)
-
-- **[#110](https://github.com/Snoww3d/jwst-data-analysis/pull/110)** security: fix SSRF risk in MAST URL construction (Task #52)
-
-    - Fix critical SSRF vulnerability in MAST URL construction where `data_uri` from API responses was interpolated without validation
-    - Add regex validation ensuring URIs match expected `mast:{collection}/product/{filename}` format
-    - Add URL encoding as defense-in-depth to neutralize any bypassed injection
-    - Add 38 security tests covering various attack vectors
-
-- **[#111](https://github.com/Snoww3d/jwst-data-analysis/pull/111)** docs: add self-compliance check to all workflows
-
-    Add a mandatory "Self-Compliance Check" step to all workflow files that requires displaying a verification table before creating PRs.
-
-- **[#112](https://github.com/Snoww3d/jwst-data-analysis/pull/112)** security: fix path traversal in chunked downloader filename (Task #53)
-
-    Fix critical path traversal vulnerability in chunked downloader where filenames from MAST API were used directly without sanitization.
-
-- **[#113](https://github.com/Snoww3d/jwst-data-analysis/pull/113)** security: add production-ready HTTPS/TLS support (Task #54, #63)
-
-    - Add production-ready HTTPS/TLS support with nginx TLS termination
-    - Configure ASP.NET Core ForwardedHeaders for reverse proxy support
-    - Add comprehensive security headers to both dev and prod nginx configs
+- [#105](https://github.com/Snoww3d/jwst-data-analysis/pull/105) Add MCP server security policy
+- [#107](https://github.com/Snoww3d/jwst-data-analysis/pull/107) add comprehensive security audit findings to tech debt
+- [#108](https://github.com/Snoww3d/jwst-data-analysis/pull/108) fix path traversal vulnerability via obsId parameter (Task #51)
+- [#110](https://github.com/Snoww3d/jwst-data-analysis/pull/110) fix SSRF risk in MAST URL construction (Task #52)
+- [#112](https://github.com/Snoww3d/jwst-data-analysis/pull/112) fix path traversal in chunked downloader filename (Task #53)
+- [#113](https://github.com/Snoww3d/jwst-data-analysis/pull/113) add production-ready HTTPS/TLS support (Task #54, #63)
 
 ---
-*22 commits across this session.*
+22 commits across 19 pull requests.
+*Next: February 3, 2026 — add desktop requirements specification document, add tech debt #70 for docs-only PR workflow optimi..., add tech debt #71 for context window optimization*

--- a/docs/blog/posts/2026-02-03.md
+++ b/docs/blog/posts/2026-02-03.md
@@ -7,6 +7,7 @@ categories:
   - Feature
   - Bug Fix
 tags:
+  - astronomy-data
   - auth
   - ci
   - code-quality
@@ -14,6 +15,7 @@ tags:
   - export
   - imaging
   - mast-data
+  - performance
 authors:
   - shanon
 ---
@@ -22,82 +24,56 @@ authors:
 
 <!-- generated -->
 
-**4 features, 4 fixes, 8 docs, 1 maintenance** — auth, ci, code-quality, docs, export, imaging, mast-data
+A marathon session: 17 pull requests merged (4 features, 4 fixes, 8 docs, 1 maintenance). Security hardening across the stack.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#114](https://github.com/Snoww3d/jwst-data-analysis/pull/114)** docs: add desktop requirements specification document
+### [#121](https://github.com/Snoww3d/jwst-data-analysis/pull/121) implement RGB composite generation backend (B1.1)
 
-- **[#115](https://github.com/Snoww3d/jwst-data-analysis/pull/115)** docs: add tech debt #70 for docs-only PR workflow optimization
+- Add new `/api/composite/generate` endpoint to create RGB composites from 3 FITS files
+- Implement composite module in processing engine with per-channel stretch controls
+- Support automatic dimension resampling when FITS files have different sizes
+- Include path traversal protection and comprehens...
 
-- **[#116](https://github.com/Snoww3d/jwst-data-analysis/pull/116)** docs: add tech debt #71 for context window optimization
 
-- **[#117](https://github.com/Snoww3d/jwst-data-analysis/pull/117)** feat: implement JWT authentication for all API endpoints (Task #55)
+### [#130](https://github.com/Snoww3d/jwst-data-analysis/pull/130) allow anonymous access to MAST search endpoints
 
-- **[#118](https://github.com/Snoww3d/jwst-data-analysis/pull/118)** docs: mark Task #55 as resolved (PR #117)
+- Add `[AllowAnonymous]` attribute to read-only MAST search endpoints to fix 401 Unauthorized errors for unauthenticated users
+- Aligns with project API documentation: "Read operations (GET) allow anonymous access"
 
-- **[#119](https://github.com/Snoww3d/jwst-data-analysis/pull/119)** docs: add compliance check reminder to workflow files
+## What Changed
 
-- **[#120](https://github.com/Snoww3d/jwst-data-analysis/pull/120)** docs: add auth review items to tech debt
+### Features (4)
 
-- **[#121](https://github.com/Snoww3d/jwst-data-analysis/pull/121)** feat: implement RGB composite generation backend (B1.1)
+- [#117](https://github.com/Snoww3d/jwst-data-analysis/pull/117) implement JWT authentication for all API endpoints (Task #55)
+- [#121](https://github.com/Snoww3d/jwst-data-analysis/pull/121) implement RGB composite generation backend (B1.1)
+- [#125](https://github.com/Snoww3d/jwst-data-analysis/pull/125) add PNG/JPEG export with format, quality, and resolution options (A4)
+- [#128](https://github.com/Snoww3d/jwst-data-analysis/pull/128) add 3D data cube navigator for MIRI IFU spectral cubes
 
-    - Add new `/api/composite/generate` endpoint to create RGB composites from 3 FITS files
-    - Implement composite module in processing engine with per-channel stretch controls
-    - Support automatic dimension resampling when FITS files have different sizes
-    - Include path traversal protection and comprehensive error handling
+### Bug Fixes (4)
 
-- **[#122](https://github.com/Snoww3d/jwst-data-analysis/pull/122)** docs: add Python linting to workflow quality checks
+- [#123](https://github.com/Snoww3d/jwst-data-analysis/pull/123) resolve all code analysis warnings and enforce zero warnings
+- [#124](https://github.com/Snoww3d/jwst-data-analysis/pull/124) Add memory limits to FITS processing endpoints (Tech Debt #56)
+- [#126](https://github.com/Snoww3d/jwst-data-analysis/pull/126) correct MkDocs nav paths and add missing pages
+- [#130](https://github.com/Snoww3d/jwst-data-analysis/pull/130) allow anonymous access to MAST search endpoints
 
-    Adds Python/ruff linting to the workflow quality checks to prevent CI lint failures like those encountered in PR #121.
+### Documentation (8)
 
-- **[#123](https://github.com/Snoww3d/jwst-data-analysis/pull/123)** fix: resolve all code analysis warnings and enforce zero warnings
+- [#114](https://github.com/Snoww3d/jwst-data-analysis/pull/114) add desktop requirements specification document
+- [#115](https://github.com/Snoww3d/jwst-data-analysis/pull/115) add tech debt #70 for docs-only PR workflow optimization
+- [#116](https://github.com/Snoww3d/jwst-data-analysis/pull/116) add tech debt #71 for context window optimization
+- [#118](https://github.com/Snoww3d/jwst-data-analysis/pull/118) mark Task #55 as resolved (PR #117)
+- [#119](https://github.com/Snoww3d/jwst-data-analysis/pull/119) add compliance check reminder to workflow files
+- [#120](https://github.com/Snoww3d/jwst-data-analysis/pull/120) add auth review items to tech debt
+- [#122](https://github.com/Snoww3d/jwst-data-analysis/pull/122) add Python linting to workflow quality checks
+- [#129](https://github.com/Snoww3d/jwst-data-analysis/pull/129) add /compliance-check skill
 
-    Resolves all ~450 StyleCop and CA code analysis warnings in the backend codebase and updates workflows to prevent regression.
+### Maintenance (1)
 
-- **[#124](https://github.com/Snoww3d/jwst-data-analysis/pull/124)** fix: Add memory limits to FITS processing endpoints (Tech Debt #56)
-
-    - Adds resource validation to prevent memory exhaustion (DoS) attacks in FITS processing
-    - Introduces two configurable limits: file size (2GB default) and array elements (100M pixels default)
-    - Protects `/preview/{data_id}`, `/histogram/{data_id}`, and `/pixeldata/{data_id}` endpoints
-
-- **[#125](https://github.com/Snoww3d/jwst-data-analysis/pull/125)** feat: add PNG/JPEG export with format, quality, and resolution options (A4)
-
-    Completes feature A4 (Export processed image as PNG/JPEG) with full format selection, quality control, and resolution presets.
-
-- **[#126](https://github.com/Snoww3d/jwst-data-analysis/pull/126)** fix: correct MkDocs nav paths and add missing pages
-
-    - Fixed broken nav links in MkDocs configuration that used incorrect `content/` prefix
-    - Created `docs/index.md` as the documentation homepage
-    - Copied workflow files to `docs/workflows/` (MkDocs requires files within docs_dir)
-    - Added missing pages (desktop-requirements.md, git-history-audit.md) to navigation
-
-- **[#127](https://github.com/Snoww3d/jwst-data-analysis/pull/127)** chore: upgrade Node.js from 18 to 22 LTS
-
-    - Upgrade Node.js from version 18 to 22 LTS across all Docker images and CI workflows
-    - Node.js 22 is the current LTS version with improved performance and modern JS features
-    - All frontend dependencies already support Node.js 22 (checked package-lock.json)
-
-- **[#128](https://github.com/Snoww3d/jwst-data-analysis/pull/128)** feat: add 3D data cube navigator for MIRI IFU spectral cubes
-
-    - Adds a cube navigator component to the FITS viewer for navigating wavelength/time slices in 3D data cubes
-    - Includes `/cubeinfo` API endpoint to fetch cube metadata (dimensions, wavelength WCS)
-    - Slider control with real-time preview updates as you scrub through slices
-    - Play/pause animation with configurable speed (1-10 FPS)
-    - Keyboard shortcuts for navigation (arrows, space, home/end)
-    - Wavele...
-
-- **[#129](https://github.com/Snoww3d/jwst-data-analysis/pull/129)** docs: add /compliance-check skill
-
-    - Add `/compliance-check` skill for automated pre-merge verification
-    - Add proactive usage note to CLAUDE.md so Claude runs it automatically before asking for merge review
-
-- **[#130](https://github.com/Snoww3d/jwst-data-analysis/pull/130)** fix: allow anonymous access to MAST search endpoints
-
-    - Add `[AllowAnonymous]` attribute to read-only MAST search endpoints to fix 401 Unauthorized errors for unauthenticated users
-    - Aligns with project API documentation: "Read operations (GET) allow anonymous access"
+- [#127](https://github.com/Snoww3d/jwst-data-analysis/pull/127) upgrade Node.js from 18 to 22 LTS
 
 ---
-*51 commits across this session.*
+51 commits across 17 pull requests.
+*Next: February 4, 2026 — add frontend authentication UI with login/register..., allow login with email address in addition to user..., add WCS Mosaic Generator (B2) to roadmap*

--- a/docs/blog/posts/2026-02-04.md
+++ b/docs/blog/posts/2026-02-04.md
@@ -7,6 +7,7 @@ categories:
   - Bug Fix
   - Performance
 tags:
+  - astronomy-data
   - auth
   - ci
   - docs
@@ -14,6 +15,7 @@ tags:
   - imaging
   - job-queue
   - mast-data
+  - performance
   - ui
   - viewer
 authors:
@@ -24,155 +26,62 @@ authors:
 
 <!-- generated -->
 
-**9 features, 6 fixes, 8 docs** — auth, ci, docs, guided-wizard, imaging, job-queue, mast-data, ui, viewer
+A marathon session: 24 pull requests merged (9 features, 6 fixes, 8 docs). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#131](https://github.com/Snoww3d/jwst-data-analysis/pull/131)** feat: add frontend authentication UI with login/register pages
+### [#145](https://github.com/Snoww3d/jwst-data-analysis/pull/145) add filter badge to dashboard cards for RGB composite selection
 
-    - Add complete authentication UI to the React frontend
-    - Login page with username/password form and error handling
-    - Registration page with form validation
-    - JWT token injection on all API requests
-    - Protected routes redirect unauthenticated users to login
-    - User menu dropdown with logout functionality
+- Display JWST filter name (e.g., F1130W, F770W) as a purple badge in card headers
+- Helps users quickly identify images from different filters when selecting 3 images for RGB composites
+- Badge shown in both By Target view (full size) and Lineage view (compact size)
+- Conditionally rendered only wh...
 
-- **[#132](https://github.com/Snoww3d/jwst-data-analysis/pull/132)** fix: allow login with email address in addition to username
 
-    - Fix login to accept either username or email address
-    - Users attempting to login with their email were getting 401 errors because the backend only looked up by username
-    - This is a common UX expectation - users often remember their email more readily
+### [#141](https://github.com/Snoww3d/jwst-data-analysis/pull/141) RGB Composite Creator wizard UI
 
-- **[#133](https://github.com/Snoww3d/jwst-data-analysis/pull/133)** docs: add WCS Mosaic Generator (B2) to roadmap
+Implements a 3-step wizard UI for creating false-color RGB composite images from 3 FITS files.
 
-    - Add B2: WCS Mosaic Generator epic to Phase 4 roadmap
-    - 6 implementation tasks (B2.1-B2.6) with proper dependencies
-    - Document key difference from RGB Composite feature
+## What Changed
 
-- **[#134](https://github.com/Snoww3d/jwst-data-analysis/pull/134)** docs: remove duplicated tech debt from CLAUDE.md
+### Features (9)
 
-    - Remove outdated tech debt section from CLAUDE.md that was listing resolved tasks as open
-    - Replace with reference to `docs/tech-debt.md` (the authoritative source)
-    - Saves ~24 lines and eliminates maintenance burden
+- [#131](https://github.com/Snoww3d/jwst-data-analysis/pull/131) add frontend authentication UI with login/register pages
+- [#141](https://github.com/Snoww3d/jwst-data-analysis/pull/141) RGB Composite Creator wizard UI
+- [#142](https://github.com/Snoww3d/jwst-data-analysis/pull/142) add calibration level filter to MAST search
+- [#144](https://github.com/Snoww3d/jwst-data-analysis/pull/144) replace Grouped view with By Target grouping
+- [#145](https://github.com/Snoww3d/jwst-data-analysis/pull/145) add filter badge to dashboard cards for RGB composite selection
+- [#147](https://github.com/Snoww3d/jwst-data-analysis/pull/147) enable parallel multi-observation downloads in MAST bulk import
+- [#148](https://github.com/Snoww3d/jwst-data-analysis/pull/148) Improve bulk import progress UI with distinguishable rows
+- [#153](https://github.com/Snoww3d/jwst-data-analysis/pull/153) show 'Imported' status for already-downloaded observations in MAST search
+- [#154](https://github.com/Snoww3d/jwst-data-analysis/pull/154) add resumable downloads panel to MAST search
 
-- **[#135](https://github.com/Snoww3d/jwst-data-analysis/pull/135)** docs: move MAST usage details to separate file
+### Bug Fixes (6)
 
-    - Extract detailed MAST content from CLAUDE.md to `docs/mast-usage.md`
-    - Replace 89 lines with 5-line summary + link
-    - No content lost - all details preserved in the new file
+- [#132](https://github.com/Snoww3d/jwst-data-analysis/pull/132) allow login with email address in addition to username
+- [#140](https://github.com/Snoww3d/jwst-data-analysis/pull/140) enable XML documentation for Swagger API descriptions
+- [#146](https://github.com/Snoww3d/jwst-data-analysis/pull/146) add 401 interceptor with automatic token refresh retry (Task #1)
+- [#149](https://github.com/Snoww3d/jwst-data-analysis/pull/149) Prevent duplicate FITS imports and improve error/auth debugging
+- [#150](https://github.com/Snoww3d/jwst-data-analysis/pull/150) add fallback token refresh for timing issues
+- [#152](https://github.com/Snoww3d/jwst-data-analysis/pull/152) prevent bulk import modal from closing when first job completes
 
-- **[#136](https://github.com/Snoww3d/jwst-data-analysis/pull/136)** docs: remove duplicated architecture and phase content
+### Documentation (8)
 
-    - Remove ASCII architecture diagram (17 lines) - `docs/architecture.md` has better Mermaid diagrams
-    - Condense phase status section (24 lines) - `docs/development-plan.md` has full details
+- [#133](https://github.com/Snoww3d/jwst-data-analysis/pull/133) add WCS Mosaic Generator (B2) to roadmap
+- [#134](https://github.com/Snoww3d/jwst-data-analysis/pull/134) remove duplicated tech debt from CLAUDE.md
+- [#135](https://github.com/Snoww3d/jwst-data-analysis/pull/135) move MAST usage details to separate file
+- [#136](https://github.com/Snoww3d/jwst-data-analysis/pull/136) remove duplicated architecture and phase content
+- [#137](https://github.com/Snoww3d/jwst-data-analysis/pull/137) condense Quick Start Commands with inline comments
+- [#138](https://github.com/Snoww3d/jwst-data-analysis/pull/138) condense API endpoints, keep frequently-used details
+- [#139](https://github.com/Snoww3d/jwst-data-analysis/pull/139) add XML documentation to API endpoints for Swagger
+- [#143](https://github.com/Snoww3d/jwst-data-analysis/pull/143) add calibration level filter documentation
 
-- **[#137](https://github.com/Snoww3d/jwst-data-analysis/pull/137)** docs: condense Quick Start Commands with inline comments
+### Other (1)
 
-    - Condense Quick Start Commands section using inline comments
-    - Fix duplicate "Build for production" line bug in Frontend section
-    - Reduce Service URLs to single line format
-
-- **[#138](https://github.com/Snoww3d/jwst-data-analysis/pull/138)** docs: condense API endpoints, keep frequently-used details
-
-    Condense API Endpoints section while keeping frequently-referenced details inline.
-
-- **[#139](https://github.com/Snoww3d/jwst-data-analysis/pull/139)** docs: add XML documentation to API endpoints for Swagger
-
-    - Add comprehensive XML documentation comments to undocumented API endpoints
-    - Improves Swagger/OpenAPI documentation for developers
-    - Ensures clear endpoint descriptions after CLAUDE.md API section was condensed
-
-- **[#140](https://github.com/Snoww3d/jwst-data-analysis/pull/140)** fix: enable XML documentation for Swagger API descriptions
-
-    - Enable XML documentation generation in the .csproj file
-    - Configure SwaggerGen to read from the generated XML documentation file
-    - Fix a few XML doc warnings (missing param tags)
-
-- **[#141](https://github.com/Snoww3d/jwst-data-analysis/pull/141)** feat: RGB Composite Creator wizard UI
-
-    Implements a 3-step wizard UI for creating false-color RGB composite images from 3 FITS files.
-
-- **[#142](https://github.com/Snoww3d/jwst-data-analysis/pull/142)** feat: add calibration level filter to MAST search
-
-    - Add calibration level filter to MAST search endpoints
-    - Default to Level 3 only (combined/mosaic images - highest quality, fewest results)
-    - Add toggle to show all calibration levels (1, 2, 3) for access to individual exposures
-    - **Import filtering**: Imports now only download files matching the searched calibration level
-
-- **[#143](https://github.com/Snoww3d/jwst-data-analysis/pull/143)** docs: add calibration level filter documentation
-
-    - Document the calibration level filter feature added in PR #142
-    - Add new "Calibration Levels" section explaining Level 1/2/3 data products
-    - Explain import filtering behavior (downloads respect selected level)
-    - Update Frontend Walkthrough to include the toggle step
-
-- **[#144](https://github.com/Snoww3d/jwst-data-analysis/pull/144)** feat: replace Grouped view with By Target grouping
-
-    - Replace the "Grouped" view mode (which grouped by MAST observation ID) with "By Target" view
-    - Groups observations by astronomical target name instead of observation ID
-    - Provides more distinct functionality from Lineage view
-    - Allows users to see all observations of the same astronomical object together (e.g., all NGC 3132 data from different filters/instruments)
-
-- **[#145](https://github.com/Snoww3d/jwst-data-analysis/pull/145)** feat: add filter badge to dashboard cards for RGB composite selection
-
-    - Display JWST filter name (e.g., F1130W, F770W) as a purple badge in card headers
-    - Helps users quickly identify images from different filters when selecting 3 images for RGB composites
-    - Badge shown in both By Target view (full size) and Lineage view (compact size)
-    - Conditionally rendered only when filter data exists
-
-- **[#146](https://github.com/Snoww3d/jwst-data-analysis/pull/146)** fix: add 401 interceptor with automatic token refresh retry (Task #1)
-
-    - Adds automatic 401 handling to apiClient that detects expired tokens and refreshes them
-    - Uses a shared promise to prevent multiple simultaneous refresh calls when several requests fail at once
-    - Retries the original request once with the new access token
-    - Auth endpoints use `skipAuthRetry` option to prevent infinite retry loops
-
-- **[#147](https://github.com/Snoww3d/jwst-data-analysis/pull/147)** feat: enable parallel multi-observation downloads in MAST bulk import
-
-    - Enable parallel downloading of multiple MAST observations (up to 3 concurrent)
-    - Add dedicated bulk import progress modal with multi-job tracking
-    - Improve bulk import performance by ~3x compared to sequential downloads
-
-- **[#148](https://github.com/Snoww3d/jwst-data-analysis/pull/148)** feat: Improve bulk import progress UI with distinguishable rows
-
-    - Add row numbers (1, 2, 3...) for quick identification of each download
-    - Extract unique observation ID suffix instead of truncating from start (e.g., `02101_nircam` instead of `...clear-f115w`)
-    - Show percentage as numeric value (e.g., "45%") next to progress bar
-    - Display download speed (MB/s) when available during active downloads
-    - Reorganize row layout for better visual distinction between j...
-
-- **[#149](https://github.com/Snoww3d/jwst-data-analysis/pull/149)** fix: Prevent duplicate FITS imports and improve error/auth debugging
-
-    - **Prevent duplicate imports**: Check if file already exists before creating database records
-    - **Show errors in UI**: Display error messages directly in bulk import rows (not just tooltip)
-    - **Persistent auth debugging**: Store auth logs in sessionStorage so they survive page redirects
-
-- **[#150](https://github.com/Snoww3d/jwst-data-analysis/pull/150)** fix: add fallback token refresh for timing issues
-
-    - Adds fallback token refresh mechanism that reads directly from localStorage when AuthContext's callback isn't registered yet
-    - Fixes 401 errors during bulk imports where API calls happen before the AuthContext useEffect runs
-    - Adds diagnostic logging for debugging token refresh timing
-
-- **[#151](https://github.com/Snoww3d/jwst-data-analysis/pull/151)** perf: optimize CI builds with parallel jobs and caching
-
-    Optimizes GitHub Actions CI workflow to reduce build times from ~3-4 minutes to ~1.5-2 minutes.
-
-- **[#152](https://github.com/Snoww3d/jwst-data-analysis/pull/152)** fix: prevent bulk import modal from closing when first job completes
-
-    Fixes bulk import modal unexpectedly closing when the first of multiple jobs reaches 100% completion.
-
-- **[#153](https://github.com/Snoww3d/jwst-data-analysis/pull/153)** feat: show 'Imported' status for already-downloaded observations in MAST search
-
-    Shows which observations have already been imported when browsing MAST search results, preventing accidental re-imports.
-
-- **[#154](https://github.com/Snoww3d/jwst-data-analysis/pull/154)** feat: add resumable downloads panel to MAST search
-
-    - Adds an "Incomplete Downloads" panel that appears at the top of the MAST search section when there are resumable import jobs
-    - Fetches resumable jobs from `GET /api/mast/import/resumable` on component mount
-    - Each row shows shortened observation ID, progress bar (amber), percentage, file count, and a Resume button
-    - Clicking Resume removes the job from the panel and delegates to the existing `ha...
+- [#151](https://github.com/Snoww3d/jwst-data-analysis/pull/151) optimize CI builds with parallel jobs and caching
 
 ---
-*70 commits across this session.*
+70 commits across 24 pull requests.
+*Next: February 5, 2026 — deduplicate resumable downloads panel by obs_id, Add input validation for numeric parameters (Tech ..., Add input validation on numeric parameters (Task #...*

--- a/docs/blog/posts/2026-02-05.md
+++ b/docs/blog/posts/2026-02-05.md
@@ -6,6 +6,7 @@ categories:
   - Feature
   - Bug Fix
 tags:
+  - astronomy-data
   - docs
   - imaging
   - infrastructure
@@ -19,104 +20,50 @@ authors:
 
 <!-- generated -->
 
-**4 features, 9 fixes, 3 docs** — docs, imaging, infrastructure, security, ui
+A marathon session: 16 pull requests merged (4 features, 9 fixes, 3 docs). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#155](https://github.com/Snoww3d/jwst-data-analysis/pull/155)** fix: deduplicate resumable downloads panel by obs_id
+### [#164](https://github.com/Snoww3d/jwst-data-analysis/pull/164) WCS Mosaic full-stack implementation (B2.2-B2.6)
 
-    - Fixes duplicate rows in the resumable downloads panel when multiple download attempts exist for the same observation
-    - Deduplicates by `obs_id` in `get_resumable_jobs()`, keeping the job with the most downloaded bytes
-    - Automatically cleans up stale duplicate state files to prevent re-accumulation
+Complete the WCS Mosaic epic (B2.2 through B2.6) with full-stack implementation for generating WCS-aligned mosaic images from multiple FITS files.
 
-- **[#156](https://github.com/Snoww3d/jwst-data-analysis/pull/156)** fix: Add input validation for numeric parameters (Tech Debt #57)
 
-    - Adds comprehensive input validation for `blackPoint`, `whitePoint`, `asinhA`, `bins`, `stretch`, and `cmap` parameters across all 4 endpoint locations
-    - Prevents DoS attacks (e.g., `bins=999999999` causing memory exhaustion) and unhandled exceptions from invalid stretch/cmap names
-    - Replaces silent fallback behavior with explicit HTTP 400 errors for invalid parameters
-    - Adds `httpx` test depende...
+### [#160](https://github.com/Snoww3d/jwst-data-analysis/pull/160) WCS mosaic engine with reproject library (B2.1)
 
-- **[#157](https://github.com/Snoww3d/jwst-data-analysis/pull/157)** fix: Add input validation on numeric parameters (Task #57)
+- Add `processing-engine/app/mosaic/` module for WCS-aware mosaic generation from multiple FITS files
+- Uses `reproject` library (`reproject_interp` + `reproject_and_coadd`) for celestial reprojection
+- Two new endpoints: `POST /mosaic/generate` (combine 2+ files into mosaic image) and `POST /mosaic...
 
-    - Add comprehensive range/allowlist validation to **preview**, **histogram**, and **pixeldata** endpoints in both backend (.NET) and processing engine (Python)
-    - Prevents DoS vectors (e.g., `bins=999999999` causing memory exhaustion) and unexpected behavior (e.g., invalid cmap/stretch silently falling back)
-    - Remove silent fallbacks in Python processing engine — invalid parameters now return expli...
+## What Changed
 
-- **[#158](https://github.com/Snoww3d/jwst-data-analysis/pull/158)** fix: validate dataId as MongoDB ObjectId before URL construction (Bug #60)
+### Features (4)
 
-    - Add `isValidObjectId()` utility that validates 24-char hex MongoDB ObjectId format
-    - Guard `ImageViewer` component — returns null if `dataId` is invalid, preventing all URL constructions (`window.open`, `<img src>`, `fetch`)
-    - Guard `jwstDataService` functions (`process`, `archive`, `unarchive`, `getPixelData`, `getCubeInfo`) — throw on invalid `dataId`
-    - Move Bug #60 from open to resolved in `d...
+- [#160](https://github.com/Snoww3d/jwst-data-analysis/pull/160) WCS mosaic engine with reproject library (B2.1)
+- [#164](https://github.com/Snoww3d/jwst-data-analysis/pull/164) WCS Mosaic full-stack implementation (B2.2-B2.6)
+- [#167](https://github.com/Snoww3d/jwst-data-analysis/pull/167) Agent Docker helper scripts
+- [#168](https://github.com/Snoww3d/jwst-data-analysis/pull/168) Region selection and statistics for FITS images (C2)
 
-- **[#159](https://github.com/Snoww3d/jwst-data-analysis/pull/159)** docs: Add agent coordination rules to CLAUDE.md
+### Bug Fixes (9)
 
-    - Add an **Agent Coordination** section to CLAUDE.md defining roles, file ownership, and branch conventions
-    - Prevents duplicate work (e.g., two agents both updating `docs/tech-debt.md`)
-    - Each agent reads CLAUDE.md at session start and knows their scope
+- [#155](https://github.com/Snoww3d/jwst-data-analysis/pull/155) deduplicate resumable downloads panel by obs_id
+- [#156](https://github.com/Snoww3d/jwst-data-analysis/pull/156) Add input validation for numeric parameters (Tech Debt #57)
+- [#157](https://github.com/Snoww3d/jwst-data-analysis/pull/157) Add input validation on numeric parameters (Task #57)
+- [#158](https://github.com/Snoww3d/jwst-data-analysis/pull/158) validate dataId as MongoDB ObjectId before URL construction (Bug #60)
+- [#162](https://github.com/Snoww3d/jwst-data-analysis/pull/162) Remove internal error details from HTTP responses (Bug #65)
+- [#165](https://github.com/Snoww3d/jwst-data-analysis/pull/165) add access control filtering for anonymous and user-scoped queries (Tasks #73, #74, #75)
+- [#166](https://github.com/Snoww3d/jwst-data-analysis/pull/166) Run Docker containers as non-root user (Task #58)
+- [#169](https://github.com/Snoww3d/jwst-data-analysis/pull/169) Bind all service ports to localhost only (Task #59)
+- [#170](https://github.com/Snoww3d/jwst-data-analysis/pull/170) Improve incomplete downloads UX (Task #89)
 
-- **[#160](https://github.com/Snoww3d/jwst-data-analysis/pull/160)** feat: WCS mosaic engine with reproject library (B2.1)
+### Documentation (3)
 
-    - Add `processing-engine/app/mosaic/` module for WCS-aware mosaic generation from multiple FITS files
-    - Uses `reproject` library (`reproject_interp` + `reproject_and_coadd`) for celestial reprojection
-    - Two new endpoints: `POST /mosaic/generate` (combine 2+ files into mosaic image) and `POST /mosaic/footprint` (WCS footprint polygons for preview)
-    - Follows existing `app/composite/` pattern exactly...
-
-- **[#161](https://github.com/Snoww3d/jwst-data-analysis/pull/161)** docs: update Bug #60 resolved PR reference to #158
-
-    - Update Bug #60 PR reference from #TBD to #158 in bugs.md
-
-- **[#162](https://github.com/Snoww3d/jwst-data-analysis/pull/162)** fix: Remove internal error details from HTTP responses (Bug #65)
-
-    - Removed `ex.Message` and raw processing engine `errorContent` from 23 HTTP error responses across 3 controllers
-    - Server-side logging already captures full error details for debugging — only the client-facing response is changed
-    - Affected controllers: `JwstDataController` (9 instances), `MastController` (12 instances), `CompositeController` (2 instances)
-
-- **[#163](https://github.com/Snoww3d/jwst-data-analysis/pull/163)** docs: Reorganize to 2-agent setup with isolated Docker stacks
-
-    - Consolidate from 3 agents to 2: **Agent 1** (Features), **Agent 2** (Tech Debt & Bug Fixes)
-    - Add `docker-compose.agent.yml` overlay so each agent runs its own isolated Docker stack on separate ports
-    - Reorder C-series image analysis tasks (region stats → blink mode → curves)
-    - Update current phase reference from Phase 3 to Phase 4
-
-- **[#164](https://github.com/Snoww3d/jwst-data-analysis/pull/164)** feat: WCS Mosaic full-stack implementation (B2.2-B2.6)
-
-    Complete the WCS Mosaic epic (B2.2 through B2.6) with full-stack implementation for generating WCS-aligned mosaic images from multiple FITS files.
-
-- **[#165](https://github.com/Snoww3d/jwst-data-analysis/pull/165)** fix: add access control filtering for anonymous and user-scoped queries (Tasks #73, #74, #75)
-
-- **[#166](https://github.com/Snoww3d/jwst-data-analysis/pull/166)** fix: Run Docker containers as non-root user (Task #58)
-
-    - Added non-root `USER` directives to all 4 Dockerfiles, eliminating root-level container execution
-    - Each container creates `appuser:appgroup` with consistent UID/GID 1001
-    - All build steps (apt-get, pip install, npm install) execute as root before the `USER` directive
-    - Required data directories are created and chowned before dropping privileges
-
-- **[#167](https://github.com/Snoww3d/jwst-data-analysis/pull/167)** feat: Agent Docker helper scripts
-
-    - `scripts/agent-docker.sh` — simple wrapper for agent Docker stack management (`up`, `down`, `logs`, `exec`, etc.)
-    - `scripts/agent-env-init.sh` — auto-generates `.env.agent*` files with correct port offsets
-    - Updated CLAUDE.md to reference the simpler commands
-
-- **[#168](https://github.com/Snoww3d/jwst-data-analysis/pull/168)** feat: Region selection and statistics for FITS images (C2)
-
-    - Interactive rectangle and ellipse region selection on FITS images via SVG overlay
-    - Real-time statistics computation (mean, median, std, min, max, sum, pixel count)
-    - Full-stack implementation across Processing Engine, Backend, and Frontend
-
-- **[#169](https://github.com/Snoww3d/jwst-data-analysis/pull/169)** fix: Bind all service ports to localhost only (Task #59)
-
-    - Bind all Docker service ports to `127.0.0.1` (localhost only) instead of `0.0.0.0` (all interfaces)
-    - Prevents MongoDB and other services from being accessible from other machines on the network
-    - Applied consistently across base, development override, and agent overlay compose files
-
-- **[#170](https://github.com/Snoww3d/jwst-data-analysis/pull/170)** fix: Improve incomplete downloads UX (Task #89)
-
-    - **Collapsible panel**: Incomplete Downloads section now defaults to collapsed with a chevron toggle
-    - **Sort by recency**: Downloads sorted newest-first using `startedAt` timestamp
-    - **Dismiss with cleanup**: Each download has a dismiss button (✕) that asks whether to also delete completed files
+- [#159](https://github.com/Snoww3d/jwst-data-analysis/pull/159) Add agent coordination rules to CLAUDE.md
+- [#161](https://github.com/Snoww3d/jwst-data-analysis/pull/161) update Bug #60 resolved PR reference to #158
+- [#163](https://github.com/Snoww3d/jwst-data-analysis/pull/163) Reorganize to 2-agent setup with isolated Docker stacks
 
 ---
-*21 commits across this session.*
+21 commits across 16 pull requests.
+*Next: February 6, 2026 — Add retry with backoff to token refresh (Tech Debt..., Mark tech debt #88 as resolved*

--- a/docs/blog/posts/2026-02-06.md
+++ b/docs/blog/posts/2026-02-06.md
@@ -15,22 +15,28 @@ authors:
 
 <!-- generated -->
 
-**1 fix, 1 docs** — auth, docs
+A focused session — 1 fix, 1 docs.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#171](https://github.com/Snoww3d/jwst-data-analysis/pull/171)** fix: Add retry with backoff to token refresh (Tech Debt #88)
+### [#171](https://github.com/Snoww3d/jwst-data-analysis/pull/171) Add retry with backoff to token refresh (Tech Debt #88)
 
-    - Adds retry logic (3 attempts, 1s/3s backoff) to all three token refresh paths: scheduled refresh, 401 handler, and fallback refresh
-    - Adds `AuthToast` component that shows warning notifications during retries and an error notification before logout
-    - Only logs the user out after all retries are exhausted, with a 1.5s delay so they see the error message
+- Adds retry logic (3 attempts, 1s/3s backoff) to all three token refresh paths: scheduled refresh, 401 handler, and fallback refresh
+- Adds `AuthToast` component that shows warning notifications during retries and an error notification before logout
+- Only logs the user out after all retries are ex...
 
-- **[#172](https://github.com/Snoww3d/jwst-data-analysis/pull/172)** docs: Mark tech debt #88 as resolved
+## What Changed
 
-    - Mark tech debt #88 (token refresh retry) as resolved in `docs/tech-debt.md` with PR #171 reference
-    - Update quick stats in `CLAUDE.md`: 41 resolved / 40 remaining
+### Bug Fixes (1)
+
+- [#171](https://github.com/Snoww3d/jwst-data-analysis/pull/171) Add retry with backoff to token refresh (Tech Debt #88)
+
+### Documentation (1)
+
+- [#172](https://github.com/Snoww3d/jwst-data-analysis/pull/172) Mark tech debt #88 as resolved
 
 ---
-*33 commits across this session.*
+33 commits across 2 pull requests.
+*Next: February 7, 2026 — Sort mosaic file selection by processing level (li..., Pin Docker image versions for reproducible builds ..., Image comparison/blink mode (C3)*

--- a/docs/blog/posts/2026-02-07.md
+++ b/docs/blog/posts/2026-02-07.md
@@ -6,6 +6,7 @@ categories:
   - Feature
   - Bug Fix
 tags:
+  - astronomy-data
   - ci
   - code-quality
   - docs
@@ -23,148 +24,54 @@ authors:
 
 <!-- generated -->
 
-**7 features, 6 fixes, 7 docs** — ci, code-quality, docs, export, imaging, infrastructure, job-queue, ui, viewer
+A marathon session: 20 pull requests merged (7 features, 6 fixes, 7 docs). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#173](https://github.com/Snoww3d/jwst-data-analysis/pull/173)** feat: Sort mosaic file selection by processing level (lineage order)
+### [#176](https://github.com/Snoww3d/jwst-data-analysis/pull/176) Disable seed users in production, refresh downloads panel, fix mosaic export button (#90, #91, #92)
 
-    - Sort the Mosaic Wizard file selection grid by JWST processing level (lineage order): L1 (raw/uncal) → L2a (rate/rateints) → L2b (calibrated) → L3 (combined) → unknown
-    - Add color-coded processing level badges next to each filename for visual grouping
-    - Secondary sort by filename within each level group
+Three independent quick fixes bundled into a single PR:
 
-- **[#174](https://github.com/Snoww3d/jwst-data-analysis/pull/174)** fix: Pin Docker image versions for reproducible builds (Task #62)
 
-    Resolves Tech Debt #62 — pins all Docker images to specific version tags for reproducible builds and supply chain security.
+### [#173](https://github.com/Snoww3d/jwst-data-analysis/pull/173) Sort mosaic file selection by processing level (lineage order)
 
-- **[#175](https://github.com/Snoww3d/jwst-data-analysis/pull/175)** feat: Image comparison/blink mode (C3)
+- Sort the Mosaic Wizard file selection grid by JWST processing level (lineage order): L1 (raw/uncal) → L2a (rate/rateints) → L2b (calibrated) → L3 (combined) → unknown
+- Add color-coded processing level badges next to each filename for visual grouping
+- Secondary sort by filename within each level ...
 
-    - Adds image comparison viewer with three modes: **blink** (toggle between two images), **side-by-side** (synchronized zoom/pan), and **opacity overlay** (slider to blend images)
-    - Adds image picker modal for selecting two viewable FITS images to compare
-    - Integrates into dashboard toolbar ("Compare" button) and ImageViewer header ("Compare with..." button)
+## What Changed
 
-- **[#176](https://github.com/Snoww3d/jwst-data-analysis/pull/176)** fix: Disable seed users in production, refresh downloads panel, fix mosaic export button (#90, #91, #92)
+### Features (7)
 
-    Three independent quick fixes bundled into a single PR:
+- [#173](https://github.com/Snoww3d/jwst-data-analysis/pull/173) Sort mosaic file selection by processing level (lineage order)
+- [#175](https://github.com/Snoww3d/jwst-data-analysis/pull/175) Image comparison/blink mode (C3)
+- [#178](https://github.com/Snoww3d/jwst-data-analysis/pull/178) Add interactive curves/levels adjustment to FITS viewer (C4)
+- [#180](https://github.com/Snoww3d/jwst-data-analysis/pull/180) Add WCS coordinate grid overlay to FITS viewer (D3)
+- [#181](https://github.com/Snoww3d/jwst-data-analysis/pull/181) Add annotation tools to FITS viewer (D5)
+- [#183](https://github.com/Snoww3d/jwst-data-analysis/pull/183) Add angular scale bar to FITS viewer (D4)
+- [#208](https://github.com/Snoww3d/jwst-data-analysis/pull/208) Add AVM metadata embedding on export (D6)
 
-- **[#177](https://github.com/Snoww3d/jwst-data-analysis/pull/177)** fix: Prevent concurrent resume of same download job (#66)
+### Bug Fixes (6)
 
-    - Fixes race condition where two concurrent resume requests for the same download job could corrupt state
-    - Adds `asyncio.Lock` + `set` guard to both resume paths (`start_chunked_download` with `resume_job_id` and `resume_download` endpoint)
-    - Returns HTTP 409 Conflict if a job is already being resumed
-    - Cleanup in `_run_chunked_download_job` finally block via `discard()`
+- [#174](https://github.com/Snoww3d/jwst-data-analysis/pull/174) Pin Docker image versions for reproducible builds (Task #62)
+- [#176](https://github.com/Snoww3d/jwst-data-analysis/pull/176) Disable seed users in production, refresh downloads panel, fix mosaic export button (#90, #91, #92)
+- [#177](https://github.com/Snoww3d/jwst-data-analysis/pull/177) Prevent concurrent resume of same download job (#66)
+- [#182](https://github.com/Snoww3d/jwst-data-analysis/pull/182) Resolve 14 pre-existing ESLint warnings
+- [#207](https://github.com/Snoww3d/jwst-data-analysis/pull/207) Resolve all backend build warnings (SA1516, CA1848)
+- [#209](https://github.com/Snoww3d/jwst-data-analysis/pull/209) Reorder backend members per StyleCop SA1202/SA1204 (Tech Debt #77+#78)
 
-- **[#178](https://github.com/Snoww3d/jwst-data-analysis/pull/178)** feat: Add interactive curves/levels adjustment to FITS viewer (C4)
+### Documentation (7)
 
-    - Adds a Photoshop/GIMP-style interactive curves editor to the FITS ImageViewer
-    - Natural cubic spline interpolation (Thomas algorithm) for smooth curve shaping
-    - 256-entry LUT applied via offscreen canvas overlay — zero cost when at default
-    - 4 built-in presets: Linear, Auto Contrast, High Contrast, Invert
-    - Interactive canvas: drag control points, double-click to add, right-click to remove
-    - Wor...
-
-- **[#179](https://github.com/Snoww3d/jwst-data-analysis/pull/179)** docs: Update tracking docs for session 2026-02-07
-
-    - Mark C2, C3, C4 complete in `docs/development-plan.md` (all C-series image analysis done)
-    - Mark #90, #91, #92 resolved in `docs/tech-debt.md` (PR #176)
-    - Move bug #66 to resolved in `docs/bugs.md` (PR #177)
-    - Update summary counts: 49 resolved / 32 remaining tech debt, 0 open bugs
-    - Update CLAUDE.md quick stats
-
-- **[#180](https://github.com/Snoww3d/jwst-data-analysis/pull/180)** feat: Add WCS coordinate grid overlay to FITS viewer (D3)
-
-    - Add toggleable RA/Dec coordinate grid overlay to the FITS image viewer
-    - Grid lines computed client-side using existing WCS parameters from `/pixeldata`
-    - Auto-scaling grid density from 3.6" to 45° based on field of view
-    - Edge labels in HMS/DMS format
-    - Grid button disabled when WCS data unavailable
-    - Add SVGSVGElement to ESLint browser globals, remove stale eslint-disable directives
-
-- **[#181](https://github.com/Snoww3d/jwst-data-analysis/pull/181)** feat: Add annotation tools to FITS viewer (D5)
-
-    - Add text labels, arrows, and circle/ellipse annotation tools to the FITS image viewer
-    - 5 color presets (white, cyan, yellow, red, green)
-    - Annotations stored in FITS coordinates and track with pan/zoom
-    - Click to select, Delete/Backspace to remove, Clear All button
-    - Mutual exclusion with region selection tools
-    - Add SVGSVGElement to ESLint browser globals
-
-- **[#182](https://github.com/Snoww3d/jwst-data-analysis/pull/182)** fix: Resolve 14 pre-existing ESLint warnings
-
-    - Resolve all 14 pre-existing ESLint warnings in the frontend codebase
-    - Add `eslint-disable` comments for intentional hook dependency patterns in composite wizard steps
-    - Suppress `react-refresh/only-export-components` for AuthContext (context must be co-located with provider)
-    - Replace `console.log` with `console.warn` in debug utilities (ESLint allows warn/error only)
-    - Remove unnecessary debug...
-
-- **[#183](https://github.com/Snoww3d/jwst-data-analysis/pull/183)** feat: Add angular scale bar to FITS viewer (D4)
-
-    - Add dynamic angular scale bar to the FITS viewer, positioned in the lower-right corner
-    - Scale bar automatically appears when WCS grid overlay is enabled
-    - Computes pixel scale from WCS CD matrix or CDELT values
-    - Snaps to "nice" angular values (0.1" to 10° range)
-    - Dynamically resizes based on current zoom level
-    - Formatted labels: arcsec, arcmin, or degrees depending on scale
-    - Styling matches...
-
-- **[#184](https://github.com/Snoww3d/jwst-data-analysis/pull/184)** docs: Update development plan for D3, D4, D5 completion
-
-    - Mark D3 (WCS Grid Overlay), D4 (Angular Scale Bar), D5 (Annotation Tools) as completed
-    - Reference merged PRs: #180, #183, #181
-
-- **[#185](https://github.com/Snoww3d/jwst-data-analysis/pull/185)** docs: Update CLAUDE.md with comprehensive current state
-
-- **[#204](https://github.com/Snoww3d/jwst-data-analysis/pull/204)** docs: Slim CLAUDE.md from 50KB to 26KB, add cloud session instructions
-
-    - **CLAUDE.md reduced from 992 lines (50KB) to 604 lines (26KB)** — nearly halved
-    - Moved Architecture Deep Dive (~200 lines) to compact summary + link to existing `docs/architecture.md`
-    - Moved Key Files Reference (~110 lines) to new `docs/key-files.md`
-    - Moved Common Patterns, API Reference, Troubleshooting, MAST usage (~90 lines) to new `docs/quick-reference.md`
-    - Added **"Cloud / Phone Session...
-
-- **[#205](https://github.com/Snoww3d/jwst-data-analysis/pull/205)** docs: Reorganize tech-debt.md into ordered sections
-
-    - Reorganized `docs/tech-debt.md` from scattered, unordered sections into two clean sections
-    - **Remaining Tasks (38)**: All unresolved items in numerical order with full detail
-    - **Resolved Tasks (51)**: Summary table in numerical order with PR references
-    - Corrected summary counts (was 50/31, now 51/38) and noted 3 items moved to bugs.md
-    - Reduced file from ~1150 lines to ~460 lines by condensin...
-
-- **[#206](https://github.com/Snoww3d/jwst-data-analysis/pull/206)** docs: Rewrite setup guide to match current project state
-
-    - Complete rewrite of `docs/setup-guide.md` — the old version was significantly outdated
-    - Added: default login credentials, docs server (port 8001), JWT auth details, rate limiting, resource limits, code quality tools, testing section
-    - Fixed: environment variables now match actual `.env.example`
-    - Removed: generic filler sections, redundant local MongoDB instructions, outdated config examples
-
-- **[#207](https://github.com/Snoww3d/jwst-data-analysis/pull/207)** fix: Resolve all backend build warnings (SA1516, CA1848)
-
-    - Fixed all backend build warnings so `dotnet build --warnaserror` passes cleanly
-    - SA1516: Added blank lines between properties in `AnalysisModels.cs` DTOs
-    - CA1848: Replaced 7 direct `logger.Log*()` calls with `[LoggerMessage]` source generators in `SeedDataService`, `MastService`, and `MastController`
-    - Also updated `/compliance-check` skill to include backend lint (`--warnaserror`) as a check
-
-- **[#208](https://github.com/Snoww3d/jwst-data-analysis/pull/208)** feat: Add AVM metadata embedding on export (D6)
-
-    - Implements D6: AVM (Astronomy Visualization Metadata) embedding in exported PNG/JPEG images
-    - AVM is an XMP-based standard that embeds astronomical provenance info (WCS coordinates, telescope, instrument, filter) into image metadata
-    - Completes the last remaining Phase 4 feature item
-
-- **[#209](https://github.com/Snoww3d/jwst-data-analysis/pull/209)** fix: Reorder backend members per StyleCop SA1202/SA1204 (Tech Debt #77+#78)
-
-    - Re-enable SA1202 and SA1204 StyleCop analyzers in `.editorconfig` (previously suppressed)
-    - Reorder class members in all 4 backend files to comply with member ordering rules:
-      - **SA1202**: Public members before private members
-      - **SA1204**: Static members before non-static members
-    - Zero logic changes — pure member reordering (624 insertions, 624 deletions)
-
-- **[#210](https://github.com/Snoww3d/jwst-data-analysis/pull/210)** docs: Update tracking docs for session 2026-02-07
-
-    - Mark D6 (AVM metadata embedding) complete in development plan (PR #208)
-    - Move tech debt #77 (SA1202) and #78 (SA1204) to resolved (PR #209)
-    - Update stats: 53 resolved, 35 remaining
+- [#179](https://github.com/Snoww3d/jwst-data-analysis/pull/179) Update tracking docs for session 2026-02-07
+- [#184](https://github.com/Snoww3d/jwst-data-analysis/pull/184) Update development plan for D3, D4, D5 completion
+- [#185](https://github.com/Snoww3d/jwst-data-analysis/pull/185) Update CLAUDE.md with comprehensive current state
+- [#204](https://github.com/Snoww3d/jwst-data-analysis/pull/204) Slim CLAUDE.md from 50KB to 26KB, add cloud session instructions
+- [#205](https://github.com/Snoww3d/jwst-data-analysis/pull/205) Reorganize tech-debt.md into ordered sections
+- [#206](https://github.com/Snoww3d/jwst-data-analysis/pull/206) Rewrite setup guide to match current project state
+- [#210](https://github.com/Snoww3d/jwst-data-analysis/pull/210) Update tracking docs for session 2026-02-07
 
 ---
-*63 commits across this session.*
+63 commits across 20 pull requests.
+*Next: February 8, 2026 — Make metadata sidebar panel collapsible, Guard curves canvas against crash during level adj..., Curves overlay disappears when switching from Line...*

--- a/docs/blog/posts/2026-02-08.md
+++ b/docs/blog/posts/2026-02-08.md
@@ -8,6 +8,7 @@ categories:
   - Feature
   - Bug Fix
 tags:
+  - astronomy-data
   - auth
   - ci
   - code-quality
@@ -17,6 +18,7 @@ tags:
   - guided-wizard
   - imaging
   - mast-data
+  - performance
   - security
   - ui
   - viewer
@@ -28,162 +30,57 @@ authors:
 
 <!-- generated -->
 
-**8 features, 5 fixes, 2 docs, 2 maintenance, 18 dep updates** — auth, ci, code-quality, dependencies, docs, export, guided-wizard, imaging, mast-data, security, ui, viewer
+A marathon session: 35 pull requests merged (8 features, 5 fixes, 2 docs, 2 maintenance, 18 dependency updates). Security hardening across the stack.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#186](https://github.com/Snoww3d/jwst-data-analysis/pull/186)** chore(deps): Bump actions/checkout from 4 to 6
+### [#227](https://github.com/Snoww3d/jwst-data-analysis/pull/227) add server-side FITS mosaic save flow
 
-- **[#187](https://github.com/Snoww3d/jwst-data-analysis/pull/187)** chore(deps): Bump actions/setup-dotnet from 4 to 5
+Add a server-side FITS mosaic save path so large mosaics can be generated and persisted without browser upload/download limits, and make FITS an explicit mosaic output format.
 
-- **[#188](https://github.com/Snoww3d/jwst-data-analysis/pull/188)** chore(deps): Bump actions/setup-node from 4 to 6
+*Large WCS mosaics can exceed practical browser transfer size and fail the current download-then-upload workflow. Saving directly on the backend returns a reusable `dataId` for composer and keeps the f...*
 
-- **[#189](https://github.com/Snoww3d/jwst-data-analysis/pull/189)** chore(deps): Bump actions/cache from 4 to 5
+### [#226](https://github.com/Snoww3d/jwst-data-analysis/pull/226) add target stage and instrument filters to mosaic selection
 
-- **[#190](https://github.com/Snoww3d/jwst-data-analysis/pull/190)** chore(deps): Bump requests from 2.31.0 to 2.32.5 in /processing-engine
+Adds quick dropdown filters to Mosaic Wizard Step 1 so users can narrow files by target, processing stage, and instrument before selecting files.
 
-- **[#191](https://github.com/Snoww3d/jwst-data-analysis/pull/191)** chore(deps): Bump actions/setup-python from 5 to 6
+*The file list gets large quickly. Adding dedicated filters (with Stage defaulted to L3) makes it much faster to build a useful selection for mosaic generation.*
 
-- **[#192](https://github.com/Snoww3d/jwst-data-analysis/pull/192)** chore(deps): Bump matplotlib from 3.9.4 to 3.10.8 in /processing-engine
+## What Changed
 
-- **[#193](https://github.com/Snoww3d/jwst-data-analysis/pull/193)** chore(deps): Bump fastapi from 0.104.1 to 0.128.4 in /processing-engine
+### Features (8)
 
-- **[#194](https://github.com/Snoww3d/jwst-data-analysis/pull/194)** chore(deps-dev): Bump vite from 6.4.1 to 7.3.1 in /frontend/jwst-frontend
+- [#211](https://github.com/Snoww3d/jwst-data-analysis/pull/211) Make metadata sidebar panel collapsible
+- [#217](https://github.com/Snoww3d/jwst-data-analysis/pull/217) Add JWST background image to auth pages
+- [#218](https://github.com/Snoww3d/jwst-data-analysis/pull/218) Show common filename prefix in MAST import file progress
+- [#221](https://github.com/Snoww3d/jwst-data-analysis/pull/221) per-channel RGB params and composite access control
+- [#222](https://github.com/Snoww3d/jwst-data-analysis/pull/222) add levels and curves controls to RGB composite wizard
+- [#223](https://github.com/Snoww3d/jwst-data-analysis/pull/223) improve mosaic wizard controls and export settings
+- [#226](https://github.com/Snoww3d/jwst-data-analysis/pull/226) add target stage and instrument filters to mosaic selection
+- [#227](https://github.com/Snoww3d/jwst-data-analysis/pull/227) add server-side FITS mosaic save flow
 
-- **[#195](https://github.com/Snoww3d/jwst-data-analysis/pull/195)** chore(deps): Bump ruff from 0.8.6 to 0.15.0 in /processing-engine
+### Bug Fixes (5)
 
-- **[#196](https://github.com/Snoww3d/jwst-data-analysis/pull/196)** chore(deps-dev): Bump @vitejs/plugin-react from 4.7.0 to 5.1.3 in /frontend/jwst-frontend
+- [#212](https://github.com/Snoww3d/jwst-data-analysis/pull/212) Guard curves canvas against crash during level adjustments
+- [#213](https://github.com/Snoww3d/jwst-data-analysis/pull/213) Curves overlay disappears when switching from Linear to preset
+- [#214](https://github.com/Snoww3d/jwst-data-analysis/pull/214) Add clock skew tolerance to JWT validation
+- [#215](https://github.com/Snoww3d/jwst-data-analysis/pull/215) Separate collapse state for Stretched and Raw Data histogram panels
+- [#216](https://github.com/Snoww3d/jwst-data-analysis/pull/216) Equal left/right margins on auth page form inputs
 
-- **[#197](https://github.com/Snoww3d/jwst-data-analysis/pull/197)** chore(deps): Bump pydantic from 2.5.0 to 2.12.5 in /processing-engine
+### Documentation (2)
 
-- **[#198](https://github.com/Snoww3d/jwst-data-analysis/pull/198)** chore(deps-dev): Bump jsdom from 26.1.0 to 28.0.0 in /frontend/jwst-frontend
+- [#219](https://github.com/Snoww3d/jwst-data-analysis/pull/219) add AGENTS guidance and align CLAUDE workflow
+- [#220](https://github.com/Snoww3d/jwst-data-analysis/pull/220) harden workflow docs and add consistency CI checks
 
-- **[#199](https://github.com/Snoww3d/jwst-data-analysis/pull/199)** chore(deps): Bump react-router-dom from 6.30.3 to 7.13.0 in /frontend/jwst-frontend
+### Maintenance (2)
 
-- **[#200](https://github.com/Snoww3d/jwst-data-analysis/pull/200)** chore(deps-dev): Bump @types/node from 25.1.0 to 25.2.1 in /frontend/jwst-frontend
+- [#224](https://github.com/Snoww3d/jwst-data-analysis/pull/224) enforce PR standards in CI
+- [#225](https://github.com/Snoww3d/jwst-data-analysis/pull/225) enforce tech debt handling in PR standards
 
-- **[#201](https://github.com/Snoww3d/jwst-data-analysis/pull/201)** Bump Microsoft.AspNetCore.Authentication.JwtBearer from 10.0.0 to 10.0.2
-
-- **[#202](https://github.com/Snoww3d/jwst-data-analysis/pull/202)** Bump Microsoft.CodeAnalysis.NetAnalyzers from 9.0.0 to 10.0.102
-
-- **[#203](https://github.com/Snoww3d/jwst-data-analysis/pull/203)** Bump Swashbuckle.AspNetCore from 10.1.0 to 10.1.2
-
-- **[#211](https://github.com/Snoww3d/jwst-data-analysis/pull/211)** feat: Make metadata sidebar panel collapsible
-
-    - Adds collapse/expand toggle to the metadata sidebar in the FITS ImageViewer
-    - Clicking the "Metadata" header toggles between full 320px sidebar and compact 42px icon-only state
-    - Follows the same collapsible panel pattern used by HistogramPanel, CurvesEditor, StretchControls, etc.
-    - Smooth CSS transition on the grid column resize
-    - Full keyboard accessibility (Enter/Space to toggle, aria-expande...
-
-- **[#212](https://github.com/Snoww3d/jwst-data-analysis/pull/212)** fix: Guard curves canvas against crash during level adjustments
-
-    - Adds guards to the curves LUT overlay canvas effect to prevent crash when adjusting levels while curves are active
-    - Checks `img.complete` and `naturalWidth/Height > 0` before attempting `drawImage`/`getImageData`
-    - Checks canvas dimensions are non-zero before `getImageData`
-    - Wraps entire canvas operation in `try/catch` with `console.error` logging
-    - Adds `console.warn` when guards trigger, so ...
-
-- **[#213](https://github.com/Snoww3d/jwst-data-analysis/pull/213)** fix: Curves overlay disappears when switching from Linear to preset
-
-    - Fixes the image disappearing when switching curves from Linear to Auto Contrast (or any preset)
-    - Root cause: the overlay canvas was conditionally mounted (`{curvesActive && ...}`), so the draw effect couldn't access the canvas ref in the same render cycle that `curvesActive` flipped to `true`
-    - Fix: always mount the canvas in the DOM, control visibility via `display: none/block`
-    - Split the sin...
-
-- **[#214](https://github.com/Snoww3d/jwst-data-analysis/pull/214)** fix: Add clock skew tolerance to JWT validation
-
-    - JWT validation was configured with `ClockSkew = TimeSpan.Zero`, causing any clock drift between Docker container and host to immediately reject valid tokens (401 Unauthorized)
-    - This manifested as sessions expiring after only a few minutes of active use in the image viewer
-    - Added configurable `ClockSkewSeconds` setting (default 30s) to `JwtSettings`, applied to both validation points (`Program....
-
-- **[#215](https://github.com/Snoww3d/jwst-data-analysis/pull/215)** fix: Separate collapse state for Stretched and Raw Data histogram panels
-
-    - Both the Stretched (Zoomed View) and Raw Data histogram panels shared a single `histogramCollapsed` state variable
-    - Clicking either panel's collapse toggle would open/close both panels simultaneously
-    - Split into two independent state variables: `stretchedHistogramCollapsed` and `rawHistogramCollapsed`
-
-- **[#216](https://github.com/Snoww3d/jwst-data-analysis/pull/216)** fix: Equal left/right margins on auth page form inputs
-
-    - Add `box-sizing: border-box` and `width: 100%` to auth page form inputs so padding/border don't cause the inputs to overflow past the container's right padding
-
-- **[#217](https://github.com/Snoww3d/jwst-data-analysis/pull/217)** feat: Add JWST background image to auth pages
-
-    - Add JWST hexagonal mirror mosaic deep-space image as full-page background on login and registration pages
-    - The existing frosted glass card (`rgba(255,255,255,0.95)` + `backdrop-filter: blur`) overlays nicely on top
-
-- **[#218](https://github.com/Snoww3d/jwst-data-analysis/pull/218)** feat: Show common filename prefix in MAST import file progress
-
-    - Extract the longest common prefix from all filenames in a MAST import observation
-    - Display the common prefix once in the file progress header (with tooltip for full text)
-    - Show only the unique suffix per file row (e.g., `_cal.fits`, `_i2d.fits`, `_uncal.fits`)
-    - Applied to both MastSearch and WhatsNewPanel file progress displays
-    - Adjusted CSS: header is now flexbox with label + monospace pref...
-
-- **[#219](https://github.com/Snoww3d/jwst-data-analysis/pull/219)** docs: add AGENTS guidance and align CLAUDE workflow
-
-    - Add `AGENTS.md` as the authoritative, model-agnostic workflow/process policy for all agents.
-    - Re-scope `CLAUDE.md` to Claude-specific guidance and explicitly defer shared process rules to `AGENTS.md`.
-    - Remove remaining direct-to-`main` and no-PR idea-capture instructions so docs align with branch + PR policy.
-
-- **[#220](https://github.com/Snoww3d/jwst-data-analysis/pull/220)** docs: harden workflow docs and add consistency CI checks
-
-    - Standardize shared documentation workflows to match `AGENTS.md` and remove assistant-specific command assumptions from shared docs.
-    - Remove non-portable doc references (machine-local paths) and align stale version/status facts.
-    - Add an automated docs consistency gate (`scripts/check-docs-consistency.sh`) and run it in CI.
-
-- **[#221](https://github.com/Snoww3d/jwst-data-analysis/pull/221)** feat: per-channel RGB params and composite access control
-
-    - Switch RGB wizard stretch state from data-id keyed params to per-channel params so duplicate image assignments stay independent.
-    - Keep preview/export payloads unchanged while mapping each channel's dataId plus its own stretch values.
-    - Allow anonymous composite generation for public data and enforce per-data access checks (public, owner, shared, admin) before resolving file paths.
-    - Return 403 ...
-
-- **[#222](https://github.com/Snoww3d/jwst-data-analysis/pull/222)** feat: add levels and curves controls to RGB composite wizard
-
-    - add per-channel tone curve support in the RGB Composite wizard and API payloads
-    - add overall levels and tone curve controls in composite preview/export and wire through backend + processing engine
-    - document the new composite controls in quick reference, backend/frontend standards, and desktop requirements
-
-- **[#223](https://github.com/Snoww3d/jwst-data-analysis/pull/223)** feat: improve mosaic wizard controls and export settings
-
-    - improve Mosaic Wizard request lifecycle handling with separate abort controllers and escape-to-close behavior
-    - add typed mosaic enums/options for stretch, combine method, and colormap to align UI and request contracts
-    - add step-1 selection quality-of-life actions (Select Filtered / Clear)
-    - add step-3 output dimension controls (Native/HD/2K/4K presets + custom width/height validation)
-    - apply ...
-
-- **[#224](https://github.com/Snoww3d/jwst-data-analysis/pull/224)** chore: enforce PR standards in CI
-
-    - add a new PR standards workflow that validates PR metadata and checklist completion on non-draft pull requests
-    - add a dedicated PR validation script to enforce title format, branch naming, required sections, and checklist expectations
-    - tighten the pull request template with required sections for rationale, risks, and quality gates
-    - update contributing guidelines to reflect CI-enforced PR stan...
-
-    *- low-detail PRs can pass CI without sufficient review context today - enforcing standards in CI makes expectations consistent and auditable before merge*
-
-- **[#225](https://github.com/Snoww3d/jwst-data-analysis/pull/225)** chore: enforce tech debt handling in PR standards
-
-    - add explicit tech debt impact classification to the PR template
-    - enforce tech debt handling in the PR validation script
-    - require documentation checkbox alignment when debt is introduced/reduced
-    - update contributing guidance to reflect the new requirement
-
-    *- before making the repo public, we need consistent visibility into whether changes add, reduce, or avoid tech debt - this keeps debt tracking intentional and ensures `docs/tech-debt.md` stays current*
-
-- **[#226](https://github.com/Snoww3d/jwst-data-analysis/pull/226)** feat: add target stage and instrument filters to mosaic selection
-
-    Adds quick dropdown filters to Mosaic Wizard Step 1 so users can narrow files by target, processing stage, and instrument before selecting files.
-
-    *The file list gets large quickly. Adding dedicated filters (with Stage defaulted to L3) makes it much faster to build a useful selection for mosaic generation.*
-
-- **[#227](https://github.com/Snoww3d/jwst-data-analysis/pull/227)** feat: add server-side FITS mosaic save flow
-
-    Add a server-side FITS mosaic save path so large mosaics can be generated and persisted without browser upload/download limits, and make FITS an explicit mosaic output format.
-
-    *Large WCS mosaics can exceed practical browser transfer size and fail the current download-then-upload workflow. Saving directly on the backend returns a reusable `dataId` for composer and keeps the flow reliable for big outputs.*
+**Dependencies** (18 updates: @types/node, @vitejs/plugin-react, Microsoft.AspNetCore.Authentication.JwtBearer, Microsoft.CodeAnalysis.NetAnalyzers, Swashbuckle.AspNetCore, actions/cache, actions/checkout, actions/setup-dotnet and 10 more)
 
 ---
-*36 commits across this session.*
+36 commits across 35 pull requests.
+*Next: February 9, 2026 — add public repository preflight audit script, expand AGENTS.md as model-independent agent guide, public preflight enhancements and repo readiness*

--- a/docs/blog/posts/2026-02-09.md
+++ b/docs/blog/posts/2026-02-09.md
@@ -19,75 +19,47 @@ authors:
 
 <!-- generated -->
 
-**2 fixes, 2 docs, 6 maintenance** — auth, ci, docs, e2e-tests, infrastructure
+A marathon session: 10 pull requests merged (2 fixes, 2 docs, 6 maintenance). Test reliability improvements.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#229](https://github.com/Snoww3d/jwst-data-analysis/pull/229)** chore: add public repository preflight audit script
+### [#238](https://github.com/Snoww3d/jwst-data-analysis/pull/238) resolve 10 e2e test failures with label accessibility and auth
 
-    Adds a reusable `scripts/public-preflight.sh` audit script to gate public-release decisions and documents its usage in the scripts README.
+- Fix all 10 failing e2e tests by addressing 3 root causes: register page accessible label mismatch, login error message mismatch, and unauthenticated smoke test
+- Add tech debt #95 (HIGH) for the 9 skipped export tests that need CI seed data
+- Replace Math.random() with crypto.randomUUID() to satis...
 
-    *Directly flipping this repository to public carries risk (agentic docs/history exposure, local path leaks, and portability issues). A repeatable preflight script creates a consistent go/no-go gate before any visibility change.*
+*The e2e test suite had 10 persistent failures caused by mismatches between what the app renders and what tests expect. All failures are real discrepancies — no tests were weakened or skipped.*
 
-- **[#230](https://github.com/Snoww3d/jwst-data-analysis/pull/230)** docs: expand AGENTS.md as model-independent agent guide
+### [#236](https://github.com/Snoww3d/jwst-data-analysis/pull/236) resolve e2e CI Docker stack permission and frontend issues
 
-    - **Expanded AGENTS.md** (61 → 389 lines) with all model-independent project knowledge: architecture, coding standards, testing standards, agent coordination, security notes, workflow rules, and documentation expectations.
-    - **Slimmed CLAUDE.md** (586 → 197 lines) to contain only Claude Code specific tips: skills, task system syntax, MCP policy, editor preference, cloud/phone sessions, and idea ca...
+Fix the e2e-test CI job so the Docker stack starts correctly and Playwright tests can run. Also refactor the Docker Compose setup so the frontend service is defined in the base file.
 
-    *AGENTS.md was a 61-line skeleton. Any non-Claude agent (e.g. Codex) reading it had almost no project context — all the real knowledge was locked inside CLAUDE.md. Now any coding agent gets the same foundational guidance from AGENTS.md.*
+*The e2e-test job added in PR #235 always fails because: (1) the processing engine container can't create `/app/data/mast` due to bind mount overriding Dockerfile permissions, and (2) the frontend serv...*
 
-- **[#231](https://github.com/Snoww3d/jwst-data-analysis/pull/231)** chore: public preflight enhancements and repo readiness
+## What Changed
 
-    - Enhanced `scripts/public-preflight.sh` with additional checks and fixes from the Codex base script
-    - Prepared the repository for public visibility by untracking internal files and fixing path leaks
+### Bug Fixes (2)
 
-- **[#232](https://github.com/Snoww3d/jwst-data-analysis/pull/232)** chore: enable CodeQL and branch protection
+- [#236](https://github.com/Snoww3d/jwst-data-analysis/pull/236) resolve e2e CI Docker stack permission and frontend issues
+- [#238](https://github.com/Snoww3d/jwst-data-analysis/pull/238) resolve 10 e2e test failures with label accessibility and auth
 
-    - Re-enabled CodeQL security scanning workflow (was disabled while repo was private)
-    - Configured branch protection rules on `main` via GitHub API
-    - Added tech debt #93 to track enabling PR reviews when contributors join
+### Documentation (2)
 
-    *The repository is now public. CodeQL (free for public repos) and branch protection are essential for security and code quality governance.*
+- [#230](https://github.com/Snoww3d/jwst-data-analysis/pull/230) expand AGENTS.md as model-independent agent guide
+- [#233](https://github.com/Snoww3d/jwst-data-analysis/pull/233) add challenge-first collaboration style
 
-- **[#233](https://github.com/Snoww3d/jwst-data-analysis/pull/233)** docs: add challenge-first collaboration style
+### Maintenance (6)
 
-    Adds a default collaboration policy to `AGENTS.md` requiring agents to constructively challenge proposals before endorsing them.
-
-    *Agent behavior can skew toward agreement-first responses. Making constructive pushback the explicit default improves decision quality across all agents.*
-
-- **[#234](https://github.com/Snoww3d/jwst-data-analysis/pull/234)** chore: remove stale CLAUDE.md references from public docs
-
-    Removes dead references to `CLAUDE.md` across public documentation now that the file is gitignored and untracked.
-
-    *`CLAUDE.md` was untracked in PR #231 as part of going public. Four references in public docs now point to a non-existent file, which would confuse visitors.*
-
-- **[#235](https://github.com/Snoww3d/jwst-data-analysis/pull/235)** chore: playwright-cli integration for browser automation
-
-    Add playwright-cli config, screenshot capture script, CI e2e job, and browser-debug Claude Code skill for agent-driven browser automation alongside the existing @playwright/test CI test runner.
-
-    *The project is now public and needs documentation screenshots for the README. playwright-cli provides agent-driven browser automation for screenshot capture and interactive debugging, complementing the existing @playwright/test setup used for CI test execution.*
-
-- **[#236](https://github.com/Snoww3d/jwst-data-analysis/pull/236)** fix: resolve e2e CI Docker stack permission and frontend issues
-
-    Fix the e2e-test CI job so the Docker stack starts correctly and Playwright tests can run. Also refactor the Docker Compose setup so the frontend service is defined in the base file.
-
-    *The e2e-test job added in PR #235 always fails because: (1) the processing engine container can't create `/app/data/mast` due to bind mount overriding Dockerfile permissions, and (2) the frontend service was only defined in `docker-compose.override.yml`, so CI (which used only the base file) never s...*
-
-- **[#237](https://github.com/Snoww3d/jwst-data-analysis/pull/237)** chore: use GHA cache for e2e Docker image builds
-
-    Speed up the e2e-test CI job by pulling Docker images from GHA cache instead of rebuilding from scratch.
-
-    *The e2e-test job takes ~15 min, with ~10 min spent rebuilding Docker images from source. The `docker-build` job already populates GHA cache for all three images — the e2e job should reuse those cached layers.*
-
-- **[#238](https://github.com/Snoww3d/jwst-data-analysis/pull/238)** fix: resolve 10 e2e test failures with label accessibility and auth
-
-    - Fix all 10 failing e2e tests by addressing 3 root causes: register page accessible label mismatch, login error message mismatch, and unauthenticated smoke test
-    - Add tech debt #95 (HIGH) for the 9 skipped export tests that need CI seed data
-    - Replace Math.random() with crypto.randomUUID() to satisfy CodeQL
-
-    *The e2e test suite had 10 persistent failures caused by mismatches between what the app renders and what tests expect. All failures are real discrepancies — no tests were weakened or skipped.*
+- [#229](https://github.com/Snoww3d/jwst-data-analysis/pull/229) add public repository preflight audit script
+- [#231](https://github.com/Snoww3d/jwst-data-analysis/pull/231) public preflight enhancements and repo readiness
+- [#232](https://github.com/Snoww3d/jwst-data-analysis/pull/232) enable CodeQL and branch protection
+- [#234](https://github.com/Snoww3d/jwst-data-analysis/pull/234) remove stale CLAUDE.md references from public docs
+- [#235](https://github.com/Snoww3d/jwst-data-analysis/pull/235) playwright-cli integration for browser automation
+- [#237](https://github.com/Snoww3d/jwst-data-analysis/pull/237) use GHA cache for e2e Docker image builds
 
 ---
-*25 commits across this session.*
+25 commits across 10 pull requests.
+*Next: February 10, 2026 — use CSS ::after for required field asterisks in re..., add noValidate to register form for custom email v...*

--- a/docs/blog/posts/2026-02-10.md
+++ b/docs/blog/posts/2026-02-10.md
@@ -13,23 +13,31 @@ authors:
 
 <!-- generated -->
 
-**2 fixes** — ui
+A focused session — 2 fixes.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#239](https://github.com/Snoww3d/jwst-data-analysis/pull/239)** fix: use CSS ::after for required field asterisks in register form
+### [#240](https://github.com/Snoww3d/jwst-data-analysis/pull/240) add noValidate to register form for custom email validation
 
-    - Replace DOM `<span>` asterisks with CSS `::after` pseudo-element for required field indicators on the register page
+- Add `noValidate` attribute to the register form so custom validation runs instead of browser native validation
 
-    *PR #238's `aria-hidden="true"` approach didn't work — Playwright's `getByLabel` still includes `aria-hidden` span text content in the computed label name. This caused 9 e2e tests to fail because `getByLabel('Password', { exact: true })` matched "Password *" instead of "Password".*
+*The last remaining e2e test failure: browser's native `type="email"` validation blocks form submission before React's `handleSubmit` fires, so the custom error "Please enter a valid email address" nev...*
 
-- **[#240](https://github.com/Snoww3d/jwst-data-analysis/pull/240)** fix: add noValidate to register form for custom email validation
+### [#239](https://github.com/Snoww3d/jwst-data-analysis/pull/239) use CSS ::after for required field asterisks in register form
 
-    - Add `noValidate` attribute to the register form so custom validation runs instead of browser native validation
+- Replace DOM `<span>` asterisks with CSS `::after` pseudo-element for required field indicators on the register page
 
-    *The last remaining e2e test failure: browser's native `type="email"` validation blocks form submission before React's `handleSubmit` fires, so the custom error "Please enter a valid email address" never appears.*
+*PR #238's `aria-hidden="true"` approach didn't work — Playwright's `getByLabel` still includes `aria-hidden` span text content in the computed label name. This caused 9 e2e tests to fail because `getB...*
+
+## What Changed
+
+### Bug Fixes (2)
+
+- [#239](https://github.com/Snoww3d/jwst-data-analysis/pull/239) use CSS ::after for required field asterisks in register form
+- [#240](https://github.com/Snoww3d/jwst-data-analysis/pull/240) add noValidate to register form for custom email validation
 
 ---
-*0 commits across this session.*
+0 commits across 2 pull requests.
+*Next: February 11, 2026 — improve UX hierarchy and add regression e2e covera..., cache playwright browsers in e2e workflow*

--- a/docs/blog/posts/2026-02-11.md
+++ b/docs/blog/posts/2026-02-11.md
@@ -14,25 +14,33 @@ authors:
 
 <!-- generated -->
 
-**2 fixes** — ci, e2e-tests
+A focused session — 2 fixes. Test reliability improvements.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#241](https://github.com/Snoww3d/jwst-data-analysis/pull/241)** fix: improve UX hierarchy and add regression e2e coverage
+### [#242](https://github.com/Snoww3d/jwst-data-analysis/pull/242) cache playwright browsers in e2e workflow
 
-    - add UX regression e2e coverage for dashboard control hierarchy and viewer compact-layout behavior
-    - validate destructive lineage actions remain text-labeled (`Delete`, `Archive`)
-    - keep this PR scoped to test coverage additions only
+Cache Playwright browser binaries in CI so the E2E workflow avoids re-installing Chromium on every run.
 
-    *This PR addresses the UX action-item requirement to include e2e coverage for the dashboard hierarchy and compact viewer behavior before approval.*
+*The E2E job currently runs `npx playwright install --with-deps chromium` on each execution, which adds several minutes to repeat runs.*
 
-- **[#242](https://github.com/Snoww3d/jwst-data-analysis/pull/242)** fix: cache playwright browsers in e2e workflow
+### [#241](https://github.com/Snoww3d/jwst-data-analysis/pull/241) improve UX hierarchy and add regression e2e coverage
 
-    Cache Playwright browser binaries in CI so the E2E workflow avoids re-installing Chromium on every run.
+- add UX regression e2e coverage for dashboard control hierarchy and viewer compact-layout behavior
+- validate destructive lineage actions remain text-labeled (`Delete`, `Archive`)
+- keep this PR scoped to test coverage additions only
 
-    *The E2E job currently runs `npx playwright install --with-deps chromium` on each execution, which adds several minutes to repeat runs.*
+*This PR addresses the UX action-item requirement to include e2e coverage for the dashboard hierarchy and compact viewer behavior before approval.*
+
+## What Changed
+
+### Bug Fixes (2)
+
+- [#241](https://github.com/Snoww3d/jwst-data-analysis/pull/241) improve UX hierarchy and add regression e2e coverage
+- [#242](https://github.com/Snoww3d/jwst-data-analysis/pull/242) cache playwright browsers in e2e workflow
 
 ---
-*7 commits across this session.*
+7 commits across 2 pull requests.
+*Next: February 12, 2026 — support multiple images per RGB composite channel, multi-image composite channels with fast preview d..., dark theme, CSS design tokens, and cascading dashb...*

--- a/docs/blog/posts/2026-02-12.md
+++ b/docs/blog/posts/2026-02-12.md
@@ -19,74 +19,44 @@ authors:
 
 <!-- generated -->
 
-**4 features, 5 fixes, 1 maintenance** — auth, imaging, infrastructure, security, ui
+A marathon session: 10 pull requests merged (4 features, 5 fixes, 1 maintenance). Security hardening across the stack.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#244](https://github.com/Snoww3d/jwst-data-analysis/pull/244)** feat: support multiple images per RGB composite channel
+### [#290](https://github.com/Snoww3d/jwst-data-analysis/pull/290) resolve 20 CodeQL security alerts (path traversal & sanitization)
 
-    Allow assigning multiple FITS files to each RGB channel in the composite wizard, with files mean-combined via the mosaic engine before RGB stacking.
+Resolve all 20 open CodeQL security alerts: 19 "Uncontrolled data used in path expression" (path traversal) and 1 "Incomplete multi-character sanitization."
 
-    *Users with many filters (e.g., 8 different NGC-3324 filters) need to group filters by wavelength range into R/G/B channels. The standard astronomical approach is to mean-combine multiple filters within each channel. Previously the wizard required exactly 3 images (1 per channel), which was too restr...*
+*CodeQL identified 20 open security alerts. Two are real vulnerabilities (obs_id path traversal in Python routes, observationBaseId path traversal in C# delete endpoints). The remaining 18 are defense-...*
 
-- **[#245](https://github.com/Snoww3d/jwst-data-analysis/pull/245)** feat: multi-image composite channels with fast preview downscaling
+### [#248](https://github.com/Snoww3d/jwst-data-analysis/pull/248) resolve analyzer warnings in MosaicService
 
-    Add support for assigning multiple FITS images per RGB channel in the composite wizard with mean-combination, and implement output-aware downscaling so preview requests process significantly less data than full exports.
+- Fixes 5 C# analyzer warnings in MosaicService that cause `--warnaserror` build failures
 
-    *With multi-image channels (5-8 FITS files), composite previews take minutes because the pipeline processes all requests identically — a 600x600 preview goes through the same 16M-pixel intermediate processing as a 4096x4096 export. Previews should feel faster while exports retain full quality.*
+*The compliance check (`dotnet build --warnaserror`) was failing with CA1859, CA1822, CA1848, and SA1204 warnings treated as errors. These were pre-existing issues in MosaicService that surfaced during...*
 
-- **[#247](https://github.com/Snoww3d/jwst-data-analysis/pull/247)** feat: dark theme, CSS design tokens, and cascading dashboard filters
+## What Changed
 
-    - Introduces a CSS custom property (design token) system as the theming foundation with ~30 tokens for surfaces, text, borders, accents, semantic colors, radius, shadows, transitions, and fonts
-    - Converts the entire dashboard UI to a cohesive dark theme — App shell, data dashboard, and user menu
-    - Replaces rainbow gradient toolbar buttons with a 3-tier button hierarchy (primary/secondary/ghost)
-    - ...
+### Features (4)
 
-    *The dashboard had inconsistent styling (rainbow gradient buttons, mixed light/dark elements, hardcoded colors), redundant filter dropdowns, and static filter options that showed irrelevant choices. This PR establishes a proper design token system, applies a cohesive dark theme, simplifies the filter...*
+- [#244](https://github.com/Snoww3d/jwst-data-analysis/pull/244) support multiple images per RGB composite channel
+- [#245](https://github.com/Snoww3d/jwst-data-analysis/pull/245) multi-image composite channels with fast preview downscaling
+- [#247](https://github.com/Snoww3d/jwst-data-analysis/pull/247) dark theme, CSS design tokens, and cascading dashboard filters
+- [#249](https://github.com/Snoww3d/jwst-data-analysis/pull/249) client-side caching for What's New panel
 
-- **[#248](https://github.com/Snoww3d/jwst-data-analysis/pull/248)** fix: resolve analyzer warnings in MosaicService
+### Bug Fixes (5)
 
-    - Fixes 5 C# analyzer warnings in MosaicService that cause `--warnaserror` build failures
+- [#248](https://github.com/Snoww3d/jwst-data-analysis/pull/248) resolve analyzer warnings in MosaicService
+- [#290](https://github.com/Snoww3d/jwst-data-analysis/pull/290) resolve 20 CodeQL security alerts (path traversal & sanitization)
+- [#291](https://github.com/Snoww3d/jwst-data-analysis/pull/291) resolve 16 CodeQL py/path-injection alerts with startswith sanitizer
+- [#292](https://github.com/Snoww3d/jwst-data-analysis/pull/292) resolve remaining 12 CodeQL py/path-injection alerts
+- [#293](https://github.com/Snoww3d/jwst-data-analysis/pull/293) remove default credentials from docker-compose.yml
 
-    *The compliance check (`dotnet build --warnaserror`) was failing with CA1859, CA1822, CA1848, and SA1204 warnings treated as errors. These were pre-existing issues in MosaicService that surfaced during a routine compliance run.*
+### Maintenance (1)
 
-- **[#249](https://github.com/Snoww3d/jwst-data-analysis/pull/249)** feat: client-side caching for What's New panel
-
-    Add localStorage-based caching (15-min TTL) with stale-while-revalidate to the What's New panel. Re-opening the panel now shows results instantly instead of a multi-second round-trip through .NET → Python → MAST.
-
-    *The What's New panel fetches from MAST on every open/toggle, taking several seconds each time. MAST releases change at most daily, so aggressive client-side caching is safe and eliminates redundant round-trips.*
-
-- **[#289](https://github.com/Snoww3d/jwst-data-analysis/pull/289)** chore: migrate tech debt & bug tracking to GitHub Issues
-
-    Migrates all 39 open tech debt items from `docs/tech-debt.md` to GitHub Issues with structured labels, and updates the PR workflow to reference GitHub Issues instead of the docs file.
-
-    *The repo is now public. GitHub Issues is the standard for open-source project tracking — discoverable, filterable, assignable, and visible to future contributors. The docs become historical record; GitHub Issues becomes the live backlog.*
-
-- **[#290](https://github.com/Snoww3d/jwst-data-analysis/pull/290)** fix: resolve 20 CodeQL security alerts (path traversal & sanitization)
-
-    Resolve all 20 open CodeQL security alerts: 19 "Uncontrolled data used in path expression" (path traversal) and 1 "Incomplete multi-character sanitization."
-
-    *CodeQL identified 20 open security alerts. Two are real vulnerabilities (obs_id path traversal in Python routes, observationBaseId path traversal in C# delete endpoints). The remaining 18 are defense-in-depth improvements where CodeQL doesn't recognize existing sanitizers like is_relative_to().*
-
-- **[#291](https://github.com/Snoww3d/jwst-data-analysis/pull/291)** fix: resolve 16 CodeQL py/path-injection alerts with startswith sanitizer
-
-    Resolves the remaining 16 `py/path-injection` CodeQL alerts by replacing `Path.is_relative_to()` checks with `str.startswith()` on normalized paths — a pattern CodeQL recognizes as a taint sanitizer.
-
-    *CodeQL's taint model clears taint when it sees `os.path.normpath()`/`os.path.abspath()` + `str.startswith()`. Our code used `Path.resolve()` + `Path.is_relative_to()` which is semantically identical but not in CodeQL's sanitizer model. These 16 alerts are false positives that create noise in securit...*
-
-- **[#292](https://github.com/Snoww3d/jwst-data-analysis/pull/292)** fix: resolve remaining 12 CodeQL py/path-injection alerts
-
-    Resolves the remaining 12 py/path-injection CodeQL alerts by refactoring path validation to use os.path string operations throughout.
-
-    *The previous fix (PR #291) used str(Path_object).startswith() but CodeQL could not connect the string check back to the Path object used in sinks (.exists(), .is_file(), .stat()). By using os.path.realpath() + os.path.exists() etc. with startswith on the same string variable, CodeQL can properly tra...*
-
-- **[#293](https://github.com/Snoww3d/jwst-data-analysis/pull/293)** fix: remove default credentials from docker-compose.yml
-
-    Remove hardcoded fallback credentials from docker-compose.yml so the app fails fast if .env isn't configured, preventing accidental deployment with weak defaults.
-
-    *The compose file used `:-changeme` fallbacks for MongoDB credentials, meaning `docker compose up` would succeed without a `.env` file — running MongoDB with `admin/changeme`. This is a security risk, especially for public release. Closes #280.*
+- [#289](https://github.com/Snoww3d/jwst-data-analysis/pull/289) migrate tech debt & bug tracking to GitHub Issues
 
 ## Issues
 
@@ -137,4 +107,5 @@ authors:
 - [#280](https://github.com/Snoww3d/jwst-data-analysis/issues/280) — Environment Variables with Credentials
 
 ---
-*14 commits across this session.*
+14 commits across 10 pull requests.
+*Next: February 13, 2026 — enable E2E export tests with seed data and auth fl..., add issue link prompt to PR template, add automatic FITS thumbnail generation for dashbo...*

--- a/docs/blog/posts/2026-02-13.md
+++ b/docs/blog/posts/2026-02-13.md
@@ -9,6 +9,7 @@ categories:
   - Refactoring
   - Testing
 tags:
+  - astronomy-data
   - auth
   - ci
   - docs
@@ -25,89 +26,56 @@ authors:
 
 <!-- generated -->
 
-**2 features, 2 fixes, 1 docs, 3 refactors, 1 test, 4 maintenance** — auth, ci, docs, e2e-tests, export, job-queue, testing, ui
+A marathon session: 13 pull requests merged (2 features, 2 fixes, 1 docs, 3 refactors, 1 test, 4 maintenance). Test reliability improvements.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#294](https://github.com/Snoww3d/jwst-data-analysis/pull/294)** fix: enable E2E export tests with seed data and auth flow
+### [#315](https://github.com/Snoww3d/jwst-data-analysis/pull/315) resolve analyzer warnings in thumbnail queue files
 
-    Enable all 9 E2E export tests that were previously skipping in CI by adding seed FITS data, MongoDB fixtures, and proper authentication flow.
+Fix 8 analyzer warnings (promoted to errors with `--warnaserror`) introduced in #314.
 
-    *Export E2E tests always skipped in CI because `openImageViewer()` navigated to `/` without auth (landing on `/login`) and CI had no FITS data. This meant zero E2E coverage for the export feature.*
+*The `dotnet build` in the Docker container doesn't use `--warnaserror`, so these passed CI but fail the local compliance check.*
 
-- **[#295](https://github.com/Snoww3d/jwst-data-analysis/pull/295)** chore: add issue link prompt to PR template
+### [#300](https://github.com/Snoww3d/jwst-data-analysis/pull/300) add lineage view thumbnails and fix thumbnail path bug
 
-    Add a comment at the top of the PR template prompting authors to link the related GitHub issue with `Closes #N`.
+Add inline 48x48 thumbnails to lineage file cards and fix a critical bug where thumbnail generation was failing with 403 Forbidden due to absolute file paths being sent to the processing engine.
 
-    *PR #294 had `Closes #286` in the initial body, but it was lost when the body was rewritten to match the template. Issue #286 stayed open after merge. A visible prompt in the template prevents this.*
+*Thumbnail generation was completely broken — all 2,020 queued records failed silently. The ThumbnailService sent absolute paths (`/app/data/mast/...`) but the processing engine expects relative paths ...*
 
-- **[#297](https://github.com/Snoww3d/jwst-data-analysis/pull/297)** feat: add automatic FITS thumbnail generation for dashboard cards
+## What Changed
 
-    Dashboard cards now show visual previews of FITS images. 256x256 PNG thumbnails are auto-generated after MAST import and displayed on cards with lazy loading.
+### Features (2)
 
-    *Dashboard cards only showed metadata (filename, type, badges) with no visual preview. Users had to click "View" to see what an image looked like. Thumbnail previews make the dashboard feel like a real data browser.*
+- [#297](https://github.com/Snoww3d/jwst-data-analysis/pull/297) add automatic FITS thumbnail generation for dashboard cards
+- [#300](https://github.com/Snoww3d/jwst-data-analysis/pull/300) add lineage view thumbnails and fix thumbnail path bug
 
-- **[#300](https://github.com/Snoww3d/jwst-data-analysis/pull/300)** feat: add lineage view thumbnails and fix thumbnail path bug
+### Bug Fixes (2)
 
-    Add inline 48x48 thumbnails to lineage file cards and fix a critical bug where thumbnail generation was failing with 403 Forbidden due to absolute file paths being sent to the processing engine.
+- [#294](https://github.com/Snoww3d/jwst-data-analysis/pull/294) enable E2E export tests with seed data and auth flow
+- [#315](https://github.com/Snoww3d/jwst-data-analysis/pull/315) resolve analyzer warnings in thumbnail queue files
 
-    *Thumbnail generation was completely broken — all 2,020 queued records failed silently. The ThumbnailService sent absolute paths (`/app/data/mast/...`) but the processing engine expects relative paths (`mast/...`). Additionally, lineage view file cards had no visual preview, making it harder to brows...*
+### Refactoring (3)
 
-- **[#308](https://github.com/Snoww3d/jwst-data-analysis/pull/308)** refactor: split JwstDataDashboard into focused view components
+- [#308](https://github.com/Snoww3d/jwst-data-analysis/pull/308) split JwstDataDashboard into focused view components
+- [#313](https://github.com/Snoww3d/jwst-data-analysis/pull/313) replace emoji indicators with SVG icons
+- [#314](https://github.com/Snoww3d/jwst-data-analysis/pull/314) replace fire-and-forget Task.Run with background task queue
 
-    Split the 1482-line `JwstDataDashboard.tsx` god component into 7 focused, single-responsibility components organized in a `dashboard/` subdirectory. The orchestrator is now 603 lines (59% reduction) — state, filters, and handlers stay in the parent; presentation is delegated to child components via props.
+### Testing (1)
 
-    *The monolithic dashboard was the most visible maintainability issue in the codebase — 20+ state variables, 15+ handlers, 7 useMemo chains, and ~1000 lines of JSX in a single file. This refactor makes each view independently readable, testable, and ready for future UI/UX improvements.*
+- [#309](https://github.com/Snoww3d/jwst-data-analysis/pull/309) add synthetic and fixture-based thumbnail tests
 
-- **[#309](https://github.com/Snoww3d/jwst-data-analysis/pull/309)** test: add synthetic and fixture-based thumbnail tests
+### Documentation (1)
 
-    Replace skip-prone thumbnail test (depended on real MAST data on disk) with a hybrid approach: synthetic FITS tests that always run plus a committed multi-extension JWST fixture for realistic integration testing.
+- [#316](https://github.com/Snoww3d/jwst-data-analysis/pull/316) update backend service documentation for thumbnail queue and missing services
 
-    *The thumbnail test was always skipping in CI because it required a real FITS file at a specific path. This meant the thumbnail generation code had zero test coverage in practice.*
+### Maintenance (4)
 
-- **[#310](https://github.com/Snoww3d/jwst-data-analysis/pull/310)** chore: block commits on main and allow branch deletion in hooks
-
-    Improve git hooks to prevent direct-to-main commits and fix branch cleanup workflow.
-
-    *During a session, a commit was accidentally made directly to main because nothing blocked it. Separately, `git push --delete` for branch cleanup was being blocked by the pre-push hook because it treated all pushes from main as disallowed.*
-
-- **[#311](https://github.com/Snoww3d/jwst-data-analysis/pull/311)** chore: add branch cleanup script for squash-merge workflows
-
-    Add a script to safely delete local branches after verifying their PRs were merged on GitHub, handling squash merges where `git branch -d` can't detect the merge.
-
-    *With squash merge enabled, `git branch -d` always fails for merged branches because commit SHAs differ. This forces `git branch -D` which skips safety checks. The script verifies merge status via GitHub API first, making `-D` safe.*
-
-- **[#312](https://github.com/Snoww3d/jwst-data-analysis/pull/312)** chore: optimize CodeQL CI with path filtering and caching
-
-    Optimizes the Security workflow (CodeQL) to skip unnecessary language analysis based on which files changed. Also documents the existing server-side branch protection in AGENTS.md (closes #278).
-
-    *CodeQL runs all 3 language analyses (C#, JS/TS, Python) on every PR regardless of which files changed. The C# analysis is the bottleneck at ~2 minutes due to `dotnet build` via Autobuild. Frontend-only or Python-only PRs shouldn't wait for C# CodeQL.*
-
-- **[#313](https://github.com/Snoww3d/jwst-data-analysis/pull/313)** refactor: replace emoji indicators with SVG icons
-
-    Replace emoji characters in dashboard components with consistent SVG icons from a new shared DashboardIcons module.
-
-    *Emoji rendering varies across OS/browser and looks inconsistent. The project already uses SVG icons in ImageViewer — this extends that pattern to the dashboard.*
-
-- **[#314](https://github.com/Snoww3d/jwst-data-analysis/pull/314)** refactor: replace fire-and-forget Task.Run with background task queue
-
-    Replace 4 fire-and-forget `Task.Run` thumbnail generation calls with a `BackgroundService` + `Channel<T>` queue that provides proper error logging, graceful shutdown, and sequential processing.
-
-    *The existing `_ = Task.Run(...)` pattern silently swallows exceptions, has no cancellation support, and loses in-flight work on app restart. This is a known tech debt item (#306).*
-
-- **[#315](https://github.com/Snoww3d/jwst-data-analysis/pull/315)** fix: resolve analyzer warnings in thumbnail queue files
-
-    Fix 8 analyzer warnings (promoted to errors with `--warnaserror`) introduced in #314.
-
-    *The `dotnet build` in the Docker container doesn't use `--warnaserror`, so these passed CI but fail the local compliance check.*
-
-- **[#316](https://github.com/Snoww3d/jwst-data-analysis/pull/316)** docs: update backend service documentation for thumbnail queue and missing services
-
-    Bring all backend documentation in sync with the current codebase. Multiple docs were stale, only listing the original 2-3 services from early phases.
-
-    *After the thumbnail background queue work (#314), a documentation review revealed that most backend services added since Phase 3 were missing from docs entirely — not just the new thumbnail queue.*
+- [#295](https://github.com/Snoww3d/jwst-data-analysis/pull/295) add issue link prompt to PR template
+- [#310](https://github.com/Snoww3d/jwst-data-analysis/pull/310) block commits on main and allow branch deletion in hooks
+- [#311](https://github.com/Snoww3d/jwst-data-analysis/pull/311) add branch cleanup script for squash-merge workflows
+- [#312](https://github.com/Snoww3d/jwst-data-analysis/pull/312) optimize CodeQL CI with path filtering and caching
 
 ## Issues
 
@@ -134,4 +102,5 @@ authors:
 - [#306](https://github.com/Snoww3d/jwst-data-analysis/issues/306) — refactor: replace fire-and-forget Task.Run with proper background task queue
 
 ---
-*17 commits across this session.*
+17 commits across 13 pull requests.
+*Next: February 14, 2026 — use memory-efficient loading for thumbnail generat..., fix markdown table alignment across project docs, add language specifiers to fenced code blocks*

--- a/docs/blog/posts/2026-02-14.md
+++ b/docs/blog/posts/2026-02-14.md
@@ -8,6 +8,7 @@ categories:
   - Feature
   - Bug Fix
 tags:
+  - astronomy-data
   - auth
   - ci
   - code-quality
@@ -17,6 +18,7 @@ tags:
   - imaging
   - infrastructure
   - mast-data
+  - performance
   - ui
   - viewer
 authors:
@@ -27,163 +29,60 @@ authors:
 
 <!-- generated -->
 
-**8 features, 10 fixes, 1 docs, 2 maintenance, 12 dep updates** — auth, ci, code-quality, dependencies, docs, guided-wizard, imaging, infrastructure, mast-data, ui, viewer
+A marathon session: 33 pull requests merged (8 features, 10 fixes, 1 docs, 2 maintenance, 12 dependency updates). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#318](https://github.com/Snoww3d/jwst-data-analysis/pull/318)** fix: use memory-efficient loading for thumbnail generation
+### [#361](https://github.com/Snoww3d/jwst-data-analysis/pull/361) add N-channel composite API endpoint with color mapping
 
-    Fix thumbnail generation failing with 413 for large FITS files (1.7–6 GB) by removing the file size check and using memory-efficient loading instead.
+Adds `POST /composite/generate-nchannel` endpoint (B3.2) that accepts N channels with hue or explicit RGB color assignments, enabling multi-filter JWST composites with 4-6+ filters.
 
-    *The `/thumbnail` endpoint only produces a 256x256 PNG regardless of input size. The 2GB file size limit was rejecting 7 valid FITS files even though memory usage is bounded by the slice dimensions, not the file size.*
+*The existing `/composite/generate` endpoint is hardcoded to 3 channels (R/G/B). NASA JWST composites typically use 4-6 filters. This endpoint uses the B3.1 color mapping engine to support arbitrary fi...*
 
-- **[#320](https://github.com/Snoww3d/jwst-data-analysis/pull/320)** chore: fix markdown table alignment across project docs
+### [#360](https://github.com/Snoww3d/jwst-data-analysis/pull/360) add N-channel color mapping engine for multi-filter composites
 
-    Fix markdownlint MD060 (table-column-style) violations across 13 project documentation files by aligning table pipe characters.
+Adds the core B3.1 N-channel color mapping engine — pure Python functions and Pydantic models that map N JWST filters to RGB via hue-based color assignment. This is the foundation that B3.2 (API) and B3.3 (UI) will build on.
 
-    *VS Code Problems tab showed MD060 warnings for misaligned table pipes throughout the project docs.*
+*The current composite pipeline is hardcoded to 3 channels (R/G/B). NASA JWST composites typically use 4-6 filters mapped to distinct colors. This engine enables that by providing hue→RGB conversion, w...*
 
-- **[#321](https://github.com/Snoww3d/jwst-data-analysis/pull/321)** chore: add language specifiers to fenced code blocks
+## What Changed
 
-    Add language tags to all untagged fenced code blocks across 14 documentation files to resolve markdownlint MD040 violations.
+### Features (8)
 
-    *VS Code Problems tab reported MD040 (fenced-code-language) for ~115 code blocks missing language specifiers, hurting syntax highlighting and accessibility.*
+- [#324](https://github.com/Snoww3d/jwst-data-analysis/pull/324) add server-side reprojection cache for composite previews
+- [#325](https://github.com/Snoww3d/jwst-data-analysis/pull/325) drag-and-drop channel assignment with thumbnails for composite wizard
+- [#328](https://github.com/Snoww3d/jwst-data-analysis/pull/328) mosaic wizard UI refresh with 2-step flow and thumbnail cards
+- [#329](https://github.com/Snoww3d/jwst-data-analysis/pull/329) normalize MAST target search variants
+- [#330](https://github.com/Snoww3d/jwst-data-analysis/pull/330) multi-agent Docker stack infrastructure
+- [#356](https://github.com/Snoww3d/jwst-data-analysis/pull/356) add background neutralization for RGB composite wizard
+- [#360](https://github.com/Snoww3d/jwst-data-analysis/pull/360) add N-channel color mapping engine for multi-filter composites
+- [#361](https://github.com/Snoww3d/jwst-data-analysis/pull/361) add N-channel composite API endpoint with color mapping
 
-- **[#322](https://github.com/Snoww3d/jwst-data-analysis/pull/322)** fix: show metadata for mosaic-generated FITS files in ImageViewer
+### Bug Fixes (10)
 
-    ImageViewer now displays metadata for mosaic-generated FITS files by falling back to `imageInfo` fields when `mast_*` metadata keys are absent.
+- [#318](https://github.com/Snoww3d/jwst-data-analysis/pull/318) use memory-efficient loading for thumbnail generation
+- [#322](https://github.com/Snoww3d/jwst-data-analysis/pull/322) show metadata for mosaic-generated FITS files in ImageViewer
+- [#346](https://github.com/Snoww3d/jwst-data-analysis/pull/346) agent-stack.sh bugs and review.sh improvements
+- [#349](https://github.com/Snoww3d/jwst-data-analysis/pull/349) add 127.0.0.1 to CORS allowed origins
+- [#350](https://github.com/Snoww3d/jwst-data-analysis/pull/350) improve mosaic wizard footer UX — primary action is now Generate Mosaic
+- [#351](https://github.com/Snoww3d/jwst-data-analysis/pull/351) collapsible footprint preview and mask sensor edge zeros in mosaic
+- [#352](https://github.com/Snoww3d/jwst-data-analysis/pull/352) replace instrument filter with wavelength filter, fix mosaic viewer and thumbnails
+- [#353](https://github.com/Snoww3d/jwst-data-analysis/pull/353) trim leading/trailing spaces from search input
+- [#354](https://github.com/Snoww3d/jwst-data-analysis/pull/354) include target name in dashboard search filtering
+- [#358](https://github.com/Snoww3d/jwst-data-analysis/pull/358) resolve SA1204 static member ordering warning
 
-    *Mosaic-generated files store their astronomical metadata in the structured `imageInfo` object (`ImageMetadata`) rather than `mast_*`-prefixed keys in the `metadata` dictionary. The ImageViewer only read `mast_*` keys, so mosaic files showed no metadata, "Unknown Target / JWST" in the header breadcru...*
+### Documentation (1)
 
-- **[#324](https://github.com/Snoww3d/jwst-data-analysis/pull/324)** feat: add server-side reprojection cache for composite previews
+- [#359](https://github.com/Snoww3d/jwst-data-analysis/pull/359) add B3 multi-channel composite epic to development plan
 
-    Adds an in-memory LRU cache for reprojected composite channel arrays so that stretch/levels slider changes skip the expensive load → downscale → mosaic → reproject pipeline and return much faster.
+### Maintenance (2)
 
-    *Composite preview generation re-runs the full pipeline on every request. When users adjust stretch/levels/gamma sliders (the most frequent interaction), the expensive steps re-run unnecessarily — those results only change when channel file assignments change. This cache makes slider adjustments retu...*
+- [#320](https://github.com/Snoww3d/jwst-data-analysis/pull/320) fix markdown table alignment across project docs
+- [#321](https://github.com/Snoww3d/jwst-data-analysis/pull/321) add language specifiers to fenced code blocks
 
-- **[#325](https://github.com/Snoww3d/jwst-data-analysis/pull/325)** feat: drag-and-drop channel assignment with thumbnails for composite wizard
-
-    Overhauls the RGB Composite Creator wizard from a 3-step flow into a streamlined 2-step flow with visual, drag-and-drop channel assignment, per-channel weight sliders, and consolidated controls.
-
-    *The previous wizard had three separate steps (Select Images → Assign Channels via dropdowns → Preview & Export) with no image thumbnails and clunky `<select>` controls. This consolidation provides a more visual, intuitive experience where users see their FITS thumbnails and drag images directly into...*
-
-- **[#328](https://github.com/Snoww3d/jwst-data-analysis/pull/328)** feat: mosaic wizard UI refresh with 2-step flow and thumbnail cards
-
-    Decompose the 1114-line monolithic MosaicWizard.tsx into a clean 2-step wizard matching the Composite Wizard patterns. Replace checkbox list with thumbnail card grid, add target grouping, inline footprint preview, and merge Configure + Generate into a single Preview & Export step.
-
-    *The mosaic wizard was a single monolithic component that didn't match the recently refreshed Composite Wizard patterns (PR #325). Decomposing it improves maintainability, consistency across wizards, and user experience with thumbnail cards instead of checkbox lists.*
-
-- **[#329](https://github.com/Snoww3d/jwst-data-analysis/pull/329)** feat: normalize MAST target search variants
-
-    Target search now normalizes common name-format variants so equivalent queries (space, hyphen, compact forms) resolve consistently.
-
-    *Users searching for the same object with different separators (for example `NGC 3132`, `NGC-3132`, `NGC3132`) can get inconsistent results. This update makes target lookup resilient to those formatting differences.*
-
-- **[#330](https://github.com/Snoww3d/jwst-data-analysis/pull/330)** feat: multi-agent Docker stack infrastructure
-
-    Add isolated Docker stacks per agent/team so Claude and Codex (or any agent swarm) can preview their changes simultaneously on separate ports — without changing your existing workflow at all.
-
-    *When multiple agents work in parallel on different features, only one could preview changes at a time because all stacks shared the same ports. Reviewing required manually switching branches and rebuilding. This infrastructure enables true parallel development with instant preview on separate URLs.*
-
-- **[#331](https://github.com/Snoww3d/jwst-data-analysis/pull/331)** chore(deps): bump actions/upload-artifact from 4 to 6
-
-- **[#332](https://github.com/Snoww3d/jwst-data-analysis/pull/332)** chore(deps): bump pillow from 10.1.0 to 12.1.1 in /processing-engine
-
-- **[#334](https://github.com/Snoww3d/jwst-data-analysis/pull/334)** chore(deps): bump aiohttp from 3.9.1 to 3.13.3 in /processing-engine
-
-- **[#335](https://github.com/Snoww3d/jwst-data-analysis/pull/335)** chore(deps-dev): bump @vitejs/plugin-react from 5.1.3 to 5.1.4 in /frontend/jwst-frontend
-
-- **[#336](https://github.com/Snoww3d/jwst-data-analysis/pull/336)** chore(deps): bump numpy from 2.0.2 to 2.2.6 in /processing-engine
-
-- **[#338](https://github.com/Snoww3d/jwst-data-analysis/pull/338)** chore(deps-dev): bump eslint-plugin-react-refresh from 0.4.26 to 0.5.0 in /frontend/jwst-frontend
-
-- **[#339](https://github.com/Snoww3d/jwst-data-analysis/pull/339)** chore(deps): bump scipy from 1.13.1 to 1.15.3 in /processing-engine
-
-- **[#341](https://github.com/Snoww3d/jwst-data-analysis/pull/341)** Bump Microsoft.AspNetCore.Authentication.JwtBearer from 10.0.2 to 10.0.3
-
-- **[#342](https://github.com/Snoww3d/jwst-data-analysis/pull/342)** chore(deps-dev): bump @typescript-eslint/eslint-plugin from 8.54.0 to 8.55.0 in /frontend/jwst-frontend
-
-- **[#343](https://github.com/Snoww3d/jwst-data-analysis/pull/343)** Bump Microsoft.AspNetCore.OpenApi from 10.0.2 to 10.0.3
-
-- **[#344](https://github.com/Snoww3d/jwst-data-analysis/pull/344)** Bump Microsoft.CodeAnalysis.NetAnalyzers from 10.0.102 to 10.0.103
-
-- **[#345](https://github.com/Snoww3d/jwst-data-analysis/pull/345)** Bump Swashbuckle.AspNetCore from 10.1.2 to 10.1.3
-
-- **[#346](https://github.com/Snoww3d/jwst-data-analysis/pull/346)** fix: agent-stack.sh bugs and review.sh improvements
-
-    Fixes bugs discovered during live testing of the multi-agent Docker stack infrastructure (PR #330) and adds the `--pr` flag and `review.sh` script.
-
-    *Three issues found during end-to-end testing after #330 merged: 1. `create_worktree()` stdout pollution corrupted `SOURCE_ROOT`, causing Docker Compose to fail with "invalid compose project" 2. Anonymous volumes (`/app/node_modules`) caused "undefined volume" errors in Docker Compose 3. `review.sh` ...*
-
-- **[#349](https://github.com/Snoww3d/jwst-data-analysis/pull/349)** fix: add 127.0.0.1 to CORS allowed origins
-
-    Add `http://127.0.0.1:3000` and `http://127.0.0.1:5173` to the default CORS allowed origins so login works when accessing the app via `127.0.0.1` instead of `localhost`.
-
-    *Browsers treat `localhost` and `127.0.0.1` as different origins. When accessing the app at `http://127.0.0.1:3000`, the backend rejects the CORS preflight because only `localhost` origins were allowed. This caused login to silently fail.*
-
-- **[#350](https://github.com/Snoww3d/jwst-data-analysis/pull/350)** fix: improve mosaic wizard footer UX — primary action is now Generate Mosaic
-
-    Moved "Generate Mosaic" to the wizard footer as the primary action button on step 2, replacing "Done" which caused users to accidentally close the wizard instead of generating. Export actions (Download + Save FITS) are now grouped together in the result area.
-
-    *The "Done" button occupied the primary action slot (bottom-right) on step 2 of the mosaic wizard. Users instinctively clicked it instead of "Generate Mosaic" which was buried in the sidebar — closing the wizard without generating. This is a UX hierarchy fix.*
-
-- **[#351](https://github.com/Snoww3d/jwst-data-analysis/pull/351)** fix: collapsible footprint preview and mask sensor edge zeros in mosaic
-
-    Three mosaic wizard fixes: collapsible footprint preview on step 1, sensor edge artifact elimination, and FITS save crash fix.
-
-    *1. Step 1 footprint preview consumed 280px fixed height, blocking file selection once it appeared. 2. Zero-value sensor edge/gap pixels were averaged into `mean` combine, creating dark bands — users had to use `max` as a workaround. 3. Saving FITS to library crashed the wizard back to dashboard beca...*
-
-- **[#352](https://github.com/Snoww3d/jwst-data-analysis/pull/352)** fix: replace instrument filter with wavelength filter, fix mosaic viewer and thumbnails
-
-    Replace Instrument dropdown with Filter (wavelength) dropdown in the mosaic wizard, implement cascading filter logic, fix mosaic FITS viewer 404 errors, and add automatic thumbnail generation for saved mosaics.
-
-    *- Users filter by wavelength (F1130W) far more often than by instrument when creating mosaics - Cascading filters reduce clutter — downstream dropdowns only show relevant options - Mosaic FITS files were unviewable due to relative path storage (`./data/mosaic/...` instead of `/app/data/mosaic/...`) ...*
-
-- **[#353](https://github.com/Snoww3d/jwst-data-analysis/pull/353)** fix: trim leading/trailing spaces from search input
-
-    Fixes search bars not handling leading/trailing whitespace — e.g. searching `" hubble "` returned no results instead of matching `"hubble"`.
-
-    *Users who accidentally type spaces before/after their search query get zero results. This is a common UX annoyance — trimming whitespace is standard practice for search inputs.*
-
-- **[#354](https://github.com/Snoww3d/jwst-data-analysis/pull/354)** fix: include target name in dashboard search filtering
-
-    Adds target name (`imageInfo.targetName`) to the dashboard search filter so users can search by astronomical target.
-
-    *The dashboard search only matched on filename, description, and tags — searching for a target name like "NGC 3132" returned no results even though images for that target existed.*
-
-- **[#356](https://github.com/Snoww3d/jwst-data-analysis/pull/356)** feat: add background neutralization for RGB composite wizard
-
-    - Add automatic background neutralization to the RGB composite wizard that subtracts per-channel sky background from raw (linear) data before stretching
-    - Eliminates the green/yellow color cast from MIRI thermal backgrounds that dominated RGB composites
-    - Changes default per-channel stretch from ZScale to Log and overall stretch from ZScale to Linear for better out-of-the-box results
-
-    *MIRI mid-infrared filters (especially F1130W at 11.30 μm) have significantly higher thermal backgrounds than shorter wavelength filters. When combining filters like F1800W + F1130W + F770W into an RGB composite, the green channel's background dominates, producing a green/yellow sky instead of black....*
-
-- **[#358](https://github.com/Snoww3d/jwst-data-analysis/pull/358)** fix: resolve SA1204 static member ordering warning
-
-    - Move `ToProcessingEngineRelativePath()` static method above non-static private methods in `JwstDataController.cs`
-
-    *StyleCop SA1204 requires static members to appear before non-static members. This was the only remaining warning in the backend build with `--warnaserror`, causing the compliance check to fail.*
-
-- **[#359](https://github.com/Snoww3d/jwst-data-analysis/pull/359)** docs: add B3 multi-channel composite epic to development plan
-
-    Adds B3: Multi-Channel Composite (4+ filters) as the next epic in the Color & Composite series, after the completed B1 (RGB Composite) and B2 (WCS Mosaic) epics.
-
-    *NASA's published JWST composites routinely use 4–6 filters mapped to distinct hues (e.g., Southern Ring Nebula MIRI uses 4 filters: F770W→Blue, F1130W→Cyan, F1280W→Green, F1800W→Red). The current wizard only supports 3 channels (R/G/B), which limits how closely users can recreate reference images. T...*
-
-- **[#360](https://github.com/Snoww3d/jwst-data-analysis/pull/360)** feat: add N-channel color mapping engine for multi-filter composites
-
-    Adds the core B3.1 N-channel color mapping engine — pure Python functions and Pydantic models that map N JWST filters to RGB via hue-based color assignment. This is the foundation that B3.2 (API) and B3.3 (UI) will build on.
-
-    *The current composite pipeline is hardcoded to 3 channels (R/G/B). NASA JWST composites typically use 4-6 filters mapped to distinct colors. This engine enables that by providing hue→RGB conversion, wavelength→hue mapping, and N-channel combination with per-component normalization.*
-
-- **[#361](https://github.com/Snoww3d/jwst-data-analysis/pull/361)** feat: add N-channel composite API endpoint with color mapping
-
-    Adds `POST /composite/generate-nchannel` endpoint (B3.2) that accepts N channels with hue or explicit RGB color assignments, enabling multi-filter JWST composites with 4-6+ filters.
-
-    *The existing `/composite/generate` endpoint is hardcoded to 3 channels (R/G/B). NASA JWST composites typically use 4-6 filters. This endpoint uses the B3.1 color mapping engine to support arbitrary filter-to-color assignments, which B3.3 (UI) will connect to.*
+**Dependencies** (12 updates: @typescript-eslint/eslint-plugin, @vitejs/plugin-react, Microsoft.AspNetCore.Authentication.JwtBearer, Microsoft.AspNetCore.OpenApi, Microsoft.CodeAnalysis.NetAnalyzers, Swashbuckle.AspNetCore, actions/upload-artifact, aiohttp and 4 more)
 
 ## Issues
 
@@ -204,4 +103,5 @@ authors:
 - [#326](https://github.com/Snoww3d/jwst-data-analysis/issues/326) — [Feature] Improve target search for name variants (Crab Nebula / NGC 3132 / NGC-3132)
 
 ---
-*30 commits across this session.*
+30 commits across 33 pull requests.
+*Next: February 15, 2026 — add F1 S3 direct access epic to development plan, increase default FITS file size limit from 2GB to ..., increase default FITS array element limit from 100...*

--- a/docs/blog/posts/2026-02-15.md
+++ b/docs/blog/posts/2026-02-15.md
@@ -8,10 +8,12 @@ categories:
   - Refactoring
   - Testing
 tags:
+  - astronomy-data
   - docs
   - e2e-tests
   - guided-wizard
   - imaging
+  - performance
   - testing
 authors:
   - shanon
@@ -21,83 +23,51 @@ authors:
 
 <!-- generated -->
 
-**2 features, 5 fixes, 2 docs, 1 refactor, 1 test** — docs, e2e-tests, guided-wizard, imaging, testing
+A marathon session: 11 pull requests merged (2 features, 5 fixes, 2 docs, 1 refactor, 1 test). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#362](https://github.com/Snoww3d/jwst-data-analysis/pull/362)** docs: add F1 S3 direct access epic to development plan
+### [#367](https://github.com/Snoww3d/jwst-data-analysis/pull/367) add N-channel composite wizard UI with dynamic channels and color pickers
 
-    - Adds new **Data Acquisition (F-series)** section to the Phase 4 development plan
-    - Introduces **F1: S3 Direct Access for FITS Downloads** — 5 tasks covering boto3 integration, S3 path resolution, multipart downloads, backend API, and frontend indicator
-    - Scheduled to start after B3 (Multi-Channel Composite) completes
+Extends the Composite Creator wizard from fixed 3 RGB channels to support arbitrary N channels with user-assignable colors, completing B3.3. Users can now add/remove channels, pick colors via a native color picker, and auto-assign filters by wavelength to get scientifically-meaningful hues.
 
-    *STScI mirrors the full JWST public archive on AWS S3 (`s3://stpubdata/jwst/public/`). S3 downloads are significantly faster than HTTP from MAST — no rate limiting, native AWS throughput, and multipart support. This is the same source professional pipelines use, and will dramatically improve the data...*
+*JWST programs routinely observe in 4-8 filters per target. The previous fixed R/G/B wizard forced users to either drop filters or awkwardly combine them into a single channel. N-channel support lets u...*
 
-- **[#363](https://github.com/Snoww3d/jwst-data-analysis/pull/363)** fix: increase default FITS file size limit from 2GB to 4GB
+### [#373](https://github.com/Snoww3d/jwst-data-analysis/pull/373) update stale pytest match patterns for ChannelColor validation
 
-    - Increases the default `MAX_FITS_FILE_SIZE_MB` from 2048 (2GB) to 4096 (4GB) in the processing engine
-    - Fixes 413 errors when viewing large JWST mosaic products
+Fixes 2 failing Python tests in `test_color_mapping.py` where `pytest.raises` match patterns were stale after the ChannelColor model's error messages were updated to include luminance support.
 
-    *Large JWST mosaic products like `jw05552-o008_t008_nircam_clear-f200w_i2d.fits` (3.5 GB) are blocked by the 2 GB default file size limit. All viewer endpoints (`/preview`, `/histogram`, `/pixeldata`, `/cubeinfo`) return 413 before even attempting to load the data. The actual memory safety is already...*
+*The ChannelColor validator messages changed from `"not both"` / `"either hue or rgb"` to `"Provide only one of: hue, rgb, or luminance=true"` / `"Provide one of: hue, rgb, or luminance=true"` when lum...*
 
-- **[#364](https://github.com/Snoww3d/jwst-data-analysis/pull/364)** fix: increase default FITS array element limit from 100M to 200M
+## What Changed
 
-    - Increases the default `MAX_FITS_ARRAY_ELEMENTS` from 100,000,000 to 200,000,000 in the processing engine
-    - Fixes 413 errors when viewing large JWST L3 mosaic products
+### Features (2)
 
-    *JWST Level 3 mosaic products like `jw05552-o008_t008_nircam_clear-f200w_i2d.fits` have dimensions of ~10,770 x 10,770 = 116M pixels, which exceeds the 100M pixel limit. The viewer downscales images to 1200px max before rendering, so actual memory usage is well within safe bounds. This was the second...*
+- [#367](https://github.com/Snoww3d/jwst-data-analysis/pull/367) add N-channel composite wizard UI with dynamic channels and color pickers
+- [#369](https://github.com/Snoww3d/jwst-data-analysis/pull/369) add luminance channel support for LRGB compositing (B3.4)
 
-- **[#365](https://github.com/Snoww3d/jwst-data-analysis/pull/365)** fix: optimize memory usage for large FITS file viewing
+### Bug Fixes (5)
 
-    - Fixes OOM crashes when viewing large JWST L3 mosaic products (e.g. 3.5 GB NIRCam mosaics)
-    - Reduces peak memory usage by ~5x through early downscaling, subsampling, and float32
+- [#363](https://github.com/Snoww3d/jwst-data-analysis/pull/363) increase default FITS file size limit from 2GB to 4GB
+- [#364](https://github.com/Snoww3d/jwst-data-analysis/pull/364) increase default FITS array element limit from 100M to 200M
+- [#365](https://github.com/Snoww3d/jwst-data-analysis/pull/365) optimize memory usage for large FITS file viewing
+- [#370](https://github.com/Snoww3d/jwst-data-analysis/pull/370) session persistence across backend restarts
+- [#373](https://github.com/Snoww3d/jwst-data-analysis/pull/373) update stale pytest match patterns for ChannelColor validation
 
-    *Large JWST L3 mosaics like `jw05552-o008_t008_nircam_clear-f200w_i2d.fits` (10090x11499 pixels, 3.5 GB) caused the processing engine container to crash with OOM when viewing. The code was loading the full array as float64 (~880 MB), then creating multiple copies during NaN handling and stretch opera...*
+### Refactoring (1)
 
-- **[#366](https://github.com/Snoww3d/jwst-data-analysis/pull/366)** docs: mark B3.1 and B3.2 as complete in development plan
+- [#368](https://github.com/Snoww3d/jwst-data-analysis/pull/368) remove deprecated 3-channel RGB composite endpoint (B3.6)
 
-    - Marks B3.1 (N-channel color mapping engine) and B3.2 (backend API) as complete in the development plan
-    - These were completed in PRs #360 and #361 but checkboxes were missed
+### Testing (1)
 
-    *The dev plan task checkboxes fell out of sync with actual progress. B3.1 and B3.2 were merged but still showed `[ ]`. Added a process rule to update checkboxes in the same PR going forward.*
+- [#371](https://github.com/Snoww3d/jwst-data-analysis/pull/371) add comprehensive E2E test suite with 53 new tests
 
-- **[#367](https://github.com/Snoww3d/jwst-data-analysis/pull/367)** feat: add N-channel composite wizard UI with dynamic channels and color pickers
+### Documentation (2)
 
-    Extends the Composite Creator wizard from fixed 3 RGB channels to support arbitrary N channels with user-assignable colors, completing B3.3. Users can now add/remove channels, pick colors via a native color picker, and auto-assign filters by wavelength to get scientifically-meaningful hues.
-
-    *JWST programs routinely observe in 4-8 filters per target. The previous fixed R/G/B wizard forced users to either drop filters or awkwardly combine them into a single channel. N-channel support lets users map every filter to its own color, matching professional tools like PixInsight and SAOImageDS9.*
-
-- **[#368](https://github.com/Snoww3d/jwst-data-analysis/pull/368)** refactor: remove deprecated 3-channel RGB composite endpoint (B3.6)
-
-    Remove the deprecated `POST /api/composite/generate` endpoint and all supporting code across backend, processing engine, and frontend. The N-channel composite system (B3.3) fully supersedes this endpoint.
-
-    *The old 3-channel RGB composite endpoint was deprecated when B3.3 introduced the N-channel system. Keeping dead code creates confusion and maintenance burden. This cleanup was planned as B3.6 in the development plan.*
-
-- **[#369](https://github.com/Snoww3d/jwst-data-analysis/pull/369)** feat: add luminance channel support for LRGB compositing (B3.4)
-
-    Add luminance (L) channel support to the N-channel composite system, enabling standard LRGB astrophotography compositing. A luminance channel contributes structural detail (lightness) rather than color, blended into the combined color channels via HSL color space conversion.
-
-    *LRGB is one of the most common techniques in astrophotography — broadband luminance provides high-resolution structural detail while narrowband color channels provide hue. Without this, users must do LRGB blending externally, breaking the end-to-end workflow.*
-
-- **[#370](https://github.com/Snoww3d/jwst-data-analysis/pull/370)** fix: session persistence across backend restarts
-
-    Fix session loss that occurs after backend restarts or when the user's access token expires while the tab is backgrounded (laptop sleep, tab switch).
-
-    *When `loadStoredAuth()` found an expired access token, it returned unauthenticated state **without attempting a refresh** — even though the refresh token (7-day TTL, persisted in MongoDB + localStorage) was still valid. This caused every backend restart and every >15-minute idle period to log the us...*
-
-- **[#371](https://github.com/Snoww3d/jwst-data-analysis/pull/371)** test: add comprehensive E2E test suite with 53 new tests
-
-    Adds 8 new Playwright spec files and a shared helpers module covering all core scientific features. Refactors existing 4 spec files to use API-based data seeding. Fixes a backend bug where uploaded files had null `UserId`. Total E2E coverage goes from 32 tests to 85 (1 skipped).
-
-    *The app had zero E2E coverage for its core scientific features — viewer, composite/mosaic/comparison wizards, region tools, annotations, WCS grid, curves editor, dashboard controls, MAST search, and session persistence. This made regressions invisible until manual testing.*
-
-- **[#373](https://github.com/Snoww3d/jwst-data-analysis/pull/373)** fix: update stale pytest match patterns for ChannelColor validation
-
-    Fixes 2 failing Python tests in `test_color_mapping.py` where `pytest.raises` match patterns were stale after the ChannelColor model's error messages were updated to include luminance support.
-
-    *The ChannelColor validator messages changed from `"not both"` / `"either hue or rgb"` to `"Provide only one of: hue, rgb, or luminance=true"` / `"Provide one of: hue, rgb, or luminance=true"` when luminance channel support was added in #369, but the test patterns weren't updated. This caused 2 persi...*
+- [#362](https://github.com/Snoww3d/jwst-data-analysis/pull/362) add F1 S3 direct access epic to development plan
+- [#366](https://github.com/Snoww3d/jwst-data-analysis/pull/366) mark B3.1 and B3.2 as complete in development plan
 
 ## Issues
 
@@ -106,4 +76,5 @@ authors:
 - [#372](https://github.com/Snoww3d/jwst-data-analysis/issues/372) — test: add WCS-enabled FITS fixture for E2E WCS grid toggle test
 
 ---
-*6 commits across this session.*
+6 commits across 11 pull requests.
+*Next: February 16, 2026 — add JWST filter presets dropdown for composite wiz..., add S3 direct access for JWST FITS downloads (F1), add storage abstraction layer for backend and proc...*

--- a/docs/blog/posts/2026-02-16.md
+++ b/docs/blog/posts/2026-02-16.md
@@ -6,6 +6,7 @@ categories:
   - Bug Fix
   - Testing
 tags:
+  - astronomy-data
   - auth
   - e2e-tests
   - guided-wizard
@@ -22,73 +23,46 @@ authors:
 
 <!-- generated -->
 
-**6 features, 3 fixes, 1 test** — auth, e2e-tests, guided-wizard, imaging, infrastructure, mast-data, security, testing
+A marathon session: 10 pull requests merged (6 features, 3 fixes, 1 test). Security hardening across the stack.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#374](https://github.com/Snoww3d/jwst-data-analysis/pull/374)** feat: add JWST filter presets dropdown for composite wizard (B3.5)
+### [#386](https://github.com/Snoww3d/jwst-data-analysis/pull/386) floating analysis bar, unified file selection & mosaic auto-filter
 
-    Add 7 curated JWST filter presets to the composite wizard's channel assignment step. Users can now recreate iconic NASA composites (Pillars of Creation, Deep Field, Southern Ring, Stephan's Quintet, etc.) with a single click instead of manually configuring 4-7 channels.
+- Adds a floating bottom bar that keeps analysis buttons accessible while scrolling the dashboard
+- Unifies file selection so the same checkbox feeds both Composite and Mosaic wizards
+- Auto-filters the Mosaic wizard's file list by wavelength when pre-selected files share a common filter
 
-    *Users trying to recreate NASA's published JWST composites currently need to manually set up channels with the correct filters and colors. This is tedious and error-prone, especially for 6-7 filter sets. Curated presets remove this friction and help users learn which filter combinations produce iconi...*
+*Users lose access to the Composite, Mosaic, and Compare buttons when scrolling through their files on the dashboard. Additionally, the Mosaic wizard had no way to accept pre-selected files from the da...*
 
-- **[#376](https://github.com/Snoww3d/jwst-data-analysis/pull/376)** feat: add S3 direct access for JWST FITS downloads (F1)
+### [#374](https://github.com/Snoww3d/jwst-data-analysis/pull/374) add JWST filter presets dropdown for composite wizard (B3.5)
 
-    Add anonymous S3 direct access to the public STScI bucket (`s3://stpubdata`) as an alternative download source for JWST FITS files. Users can select between S3, HTTP, or auto (S3 preferred with HTTP fallback) via a new dropdown in the MAST Search UI.
+Add 7 curated JWST filter presets to the composite wizard's channel assignment step. Users can now recreate iconic NASA composites (Pillars of Creation, Deep Field, Southern Ring, Stephan's Quintet, etc.) with a single click instead of manually configuring 4-7 channels.
 
-    *S3 downloads from the STScI public bucket offer significantly faster throughput than HTTP downloads from the MAST portal, especially for large FITS files. This implements development plan task F1 (F1.1-F1.5) to give users the choice of download source.*
+*Users trying to recreate NASA's published JWST composites currently need to manually set up channels with the correct filters and colors. This is tedious and error-prone, especially for 6-7 filter set...*
 
-- **[#378](https://github.com/Snoww3d/jwst-data-analysis/pull/378)** feat: add storage abstraction layer for backend and processing engine (F2)
+## What Changed
 
-    Introduces a storage abstraction layer in both the .NET backend and Python processing engine, allowing file storage to be swapped between local filesystem and future cloud providers (e.g. S3) via configuration. All .NET file I/O in controllers and services now goes through the abstraction instead of direct filesystem calls. Python abstraction layer created; integration into Python routes in follow...
+### Features (6)
 
-    *Currently, all file operations use hardcoded local filesystem paths, making it impossible to deploy with cloud storage without rewriting multiple services. This abstraction decouples business logic from the storage backend, enabling future S3 support and making the codebase more testable.*
+- [#374](https://github.com/Snoww3d/jwst-data-analysis/pull/374) add JWST filter presets dropdown for composite wizard (B3.5)
+- [#376](https://github.com/Snoww3d/jwst-data-analysis/pull/376) add S3 direct access for JWST FITS downloads (F1)
+- [#378](https://github.com/Snoww3d/jwst-data-analysis/pull/378) add storage abstraction layer for backend and processing engine (F2)
+- [#382](https://github.com/Snoww3d/jwst-data-analysis/pull/382) add processing engine health check and Docker healthcheck probes
+- [#385](https://github.com/Snoww3d/jwst-data-analysis/pull/385) auto-recovery startup scan, data visibility model & remove Sync MAST Files
+- [#386](https://github.com/Snoww3d/jwst-data-analysis/pull/386) floating analysis bar, unified file selection & mosaic auto-filter
 
-- **[#380](https://github.com/Snoww3d/jwst-data-analysis/pull/380)** test: add E2E tests for MAST download UI and source selection
+### Bug Fixes (3)
 
-    Adds 8 new E2E tests for the MAST download UI, covering the S3/HTTP/Auto source dropdown introduced in F1 (#376) and the import button behavior with mocked backend responses.
+- [#381](https://github.com/Snoww3d/jwst-data-analysis/pull/381) correct S3 downloader test assertion for path traversal sanitization
+- [#383](https://github.com/Snoww3d/jwst-data-analysis/pull/383) set IsPublic=true on MAST scan-imported data for dashboard visibility
+- [#384](https://github.com/Snoww3d/jwst-data-analysis/pull/384) make email comparison case-insensitive for login and registration
 
-    *The MAST E2E tests only covered the search panel UI (toggling, search types, form elements). There was zero coverage for the download initiation flow, source selection dropdown, or import button behavior. This was identified during the F1 S3 Direct Access review.*
+### Testing (1)
 
-- **[#381](https://github.com/Snoww3d/jwst-data-analysis/pull/381)** fix: correct S3 downloader test assertion for path traversal sanitization
-
-    Fixes a failing Python test (`test_skips_invalid_filenames`) in the S3 downloader test suite that was merged with an incorrect assertion in PR #376.
-
-    *The test asserted that path traversal filenames like `../../../etc/passwd` should be **skipped entirely**. But `_sanitize_filename()` correctly sanitizes them to safe basenames (`passwd`) within the download directory — the traversal is prevented without rejecting the file. The test assertion didn't...*
-
-- **[#382](https://github.com/Snoww3d/jwst-data-analysis/pull/382)** feat: add processing engine health check and Docker healthcheck probes
-
-    Add processing engine connectivity health check to the backend `/api/health` endpoint, Docker container healthcheck probes, and test coverage for the 503 error path that was completely untested.
-
-    *When the processing engine is down, users get a cryptic "Processing engine unavailable" error only after triggering a search. The `/api/health` endpoint was a bare "yes .NET is alive" check with zero visibility into inter-service connectivity. No tests existed for this failure path, and Docker had n...*
-
-- **[#383](https://github.com/Snoww3d/jwst-data-analysis/pull/383)** fix: set IsPublic=true on MAST scan-imported data for dashboard visibility
-
-    Fix scan-imported MAST data being invisible on the dashboard because `IsPublic` defaulted to `false`.
-
-    *When using "Sync MAST Files" (`DataManagementController.ScanAndImportFiles`), all imported `JwstDataModel` records were created without setting `IsPublic = true` or `UserId`. Since `GetAccessibleDataAsync` filters by `UserId == currentUser OR IsPublic == true OR SharedWith contains userId`, none of ...*
-
-- **[#384](https://github.com/Snoww3d/jwst-data-analysis/pull/384)** fix: make email comparison case-insensitive for login and registration
-
-    Fix duplicate accounts being created when the same email is used with different casing (e.g. `SClemmons@gmail.com` vs `sclemmons@gmail.com`).
-
-    *Email addresses are case-insensitive per RFC 5321, but our registration and login code performed exact case-sensitive comparisons. This allowed creating multiple accounts with the same email in different casing, and logging in with a different case than registered would fail to find the account.*
-
-- **[#385](https://github.com/Snoww3d/jwst-data-analysis/pull/385)** feat: auto-recovery startup scan, data visibility model & remove Sync MAST Files
-
-    Add automatic startup disk scan for database recovery, establish a clear data visibility model, and remove the manual "Sync MAST Files" button from the frontend.
-
-    *If MongoDB gets wiped, ~5800 FITS files on disk become invisible with no recovery path. The "Sync MAST Files" button was a development stopgap that shouldn't exist in production. Additionally, `IsPublic` defaults were inconsistent — MAST data is public NASA data but some paths created records with `...*
-
-- **[#386](https://github.com/Snoww3d/jwst-data-analysis/pull/386)** feat: floating analysis bar, unified file selection & mosaic auto-filter
-
-    - Adds a floating bottom bar that keeps analysis buttons accessible while scrolling the dashboard
-    - Unifies file selection so the same checkbox feeds both Composite and Mosaic wizards
-    - Auto-filters the Mosaic wizard's file list by wavelength when pre-selected files share a common filter
-
-    *Users lose access to the Composite, Mosaic, and Compare buttons when scrolling through their files on the dashboard. Additionally, the Mosaic wizard had no way to accept pre-selected files from the dashboard, forcing users to re-select files inside the wizard. This change improves workflow efficienc...*
+- [#380](https://github.com/Snoww3d/jwst-data-analysis/pull/380) add E2E tests for MAST download UI and source selection
 
 ## Issues
 
@@ -103,4 +77,5 @@ authors:
 - [#379](https://github.com/Snoww3d/jwst-data-analysis/issues/379) — test: add comprehensive MAST download E2E coverage
 
 ---
-*12 commits across this session.*
+12 commits across 10 pull requests.
+*Next: February 17, 2026 — mosaic wizard smart pre-selection with target prio..., dynamic file size warnings on mosaic selection car..., startup scan dedup compared absolute paths against...*

--- a/docs/blog/posts/2026-02-17.md
+++ b/docs/blog/posts/2026-02-17.md
@@ -8,8 +8,10 @@ categories:
   - Bug Fix
   - Refactoring
 tags:
+  - astronomy-data
   - auth
   - code-quality
+  - deployment
   - docs
   - guided-wizard
   - imaging
@@ -25,134 +27,65 @@ authors:
 
 <!-- generated -->
 
-**6 features, 9 fixes, 2 docs, 1 refactor, 1 maintenance** — auth, code-quality, docs, guided-wizard, imaging, infrastructure, mast-data, ui, viewer
+A marathon session: 19 pull requests merged (6 features, 9 fixes, 2 docs, 1 refactor, 1 maintenance). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#387](https://github.com/Snoww3d/jwst-data-analysis/pull/387)** feat: mosaic wizard smart pre-selection with target priority & warnings
+### [#388](https://github.com/Snoww3d/jwst-data-analysis/pull/388) dynamic file size warnings on mosaic selection cards
 
-    - All three filter dropdowns (Target, Stage, Filter) auto-populate from pre-selected files when values match
-    - Same-target files appear first with visual highlighting and "Other Targets" divider
-    - Contextual warnings for mixed selections: different targets, mixed stages, different filters
-    - Fix misleading "Processing engine unavailable" error when footprinting large FITS files
+- New `/api/mosaic/limits` endpoint returns per-wizard file size limits (mosaic=2GB, composite=4GB)
+- Red warning icon on mosaic selection thumbnails for files exceeding the generation limit
+- Summary banner when oversized files are selected explaining footprint works but generation will fail
+- Fixe...
 
-    *When pre-selecting files on the dashboard and opening the Mosaic wizard, the user shouldn't have to re-navigate dropdowns to find their files. Auto-populating dropdowns saves clicks, and surfacing warnings for unusual combinations (different targets, mixed calibration levels, mixed filters) prevents...*
+*JWST FITS files commonly exceed 2GB+. Users were hitting a cryptic "File too large for processing" error only after reaching the Generate step. Surfacing the limit on the selection cards lets users kn...*
 
-- **[#388](https://github.com/Snoww3d/jwst-data-analysis/pull/388)** feat: dynamic file size warnings on mosaic selection cards
+### [#387](https://github.com/Snoww3d/jwst-data-analysis/pull/387) mosaic wizard smart pre-selection with target priority & warnings
 
-    - New `/api/mosaic/limits` endpoint returns per-wizard file size limits (mosaic=2GB, composite=4GB)
-    - Red warning icon on mosaic selection thumbnails for files exceeding the generation limit
-    - Summary banner when oversized files are selected explaining footprint works but generation will fail
-    - Fixed memmap ValueError crash for FITS files with BZERO/BSCALE/BLANK headers (footprints + thumbnails)
-    -...
+- All three filter dropdowns (Target, Stage, Filter) auto-populate from pre-selected files when values match
+- Same-target files appear first with visual highlighting and "Other Targets" divider
+- Contextual warnings for mixed selections: different targets, mixed stages, different filters
+- Fix misl...
 
-    *JWST FITS files commonly exceed 2GB+. Users were hitting a cryptic "File too large for processing" error only after reaching the Generate step. Surfacing the limit on the selection cards lets users know immediately which files are problematic, and the per-wizard limits are designed for future user-r...*
+*When pre-selecting files on the dashboard and opening the Mosaic wizard, the user shouldn't have to re-navigate dropdowns to find their files. Auto-populating dropdowns saves clicks, and surfacing war...*
 
-- **[#389](https://github.com/Snoww3d/jwst-data-analysis/pull/389)** fix: startup scan dedup compared absolute paths against relative storage keys
+## What Changed
 
-    - Fixed path format mismatch in DataScanService startup scan that caused every FITS file to be re-imported on each container restart
-    - Cleaned 15,496 duplicate records from MongoDB (1,937 files × 9 restarts)
-    - Fixed mosaic wizard defaulting stage filter to 'L3' when opened without pre-selection, which hid files with null/unknown processing level and caused E2E test failures
+### Features (6)
 
-    ***Startup scan dedup:** The auto-recovery startup scan (PR #385) loaded existing `FilePath` values from MongoDB into a HashSet for deduplication. But the DB stores relative storage keys (`mast/obs/file.fits`) while `Directory.GetFiles()` returns absolute paths (`/app/data/mast/obs/file.fits`). The `...*
+- [#387](https://github.com/Snoww3d/jwst-data-analysis/pull/387) mosaic wizard smart pre-selection with target priority & warnings
+- [#388](https://github.com/Snoww3d/jwst-data-analysis/pull/388) dynamic file size warnings on mosaic selection cards
+- [#390](https://github.com/Snoww3d/jwst-data-analysis/pull/390) S3 storage providers, SeaweedFS infrastructure & config wiring
+- [#392](https://github.com/Snoww3d/jwst-data-analysis/pull/392) wire MAST downloads and user uploads through storage provider
+- [#393](https://github.com/Snoww3d/jwst-data-analysis/pull/393) presigned URL redirects, S3 bug fixes & lifecycle policy
+- [#405](https://github.com/Snoww3d/jwst-data-analysis/pull/405) extend access token to 60 minutes and add visibility-based refresh
 
-- **[#390](https://github.com/Snoww3d/jwst-data-analysis/pull/390)** feat: S3 storage providers, SeaweedFS infrastructure & config wiring
+### Bug Fixes (9)
 
-    Add S3-compatible object storage to both backend (.NET) and processing engine (Python), with SeaweedFS for local development and conditional DI wiring. This is PR 1 of 4 in the F3: S3 Storage for Application Data epic.
+- [#389](https://github.com/Snoww3d/jwst-data-analysis/pull/389) startup scan dedup compared absolute paths against relative storage keys
+- [#394](https://github.com/Snoww3d/jwst-data-analysis/pull/394) remove overly restrictive file size limit from viewer endpoints
+- [#395](https://github.com/Snoww3d/jwst-data-analysis/pull/395) propagate actual MAST errors instead of generic 503
+- [#396](https://github.com/Snoww3d/jwst-data-analysis/pull/396) use MAST cloud API for S3 key resolution
+- [#399](https://github.com/Snoww3d/jwst-data-analysis/pull/399) use fence_mermaid_format for Mermaid diagram rendering in MkDocs
+- [#400](https://github.com/Snoww3d/jwst-data-analysis/pull/400) close mermaid code fences in architecture.md and revert mkdocs.yml
+- [#401](https://github.com/Snoww3d/jwst-data-analysis/pull/401) use dark-theme-friendly colors for Data Lineage diagram
+- [#404](https://github.com/Snoww3d/jwst-data-analysis/pull/404) prevent auth token expiry during long-running operations
+- [#406](https://github.com/Snoww3d/jwst-data-analysis/pull/406) background refresh after data mutations + per-file archive in lineage view
 
-    *The app stores all files on a shared Docker volume at `/app/data`. This doesn't scale beyond a single host and costs ~$53/mo on EFS for 177GB vs ~$5/mo on S3 with Intelligent-Tiering. The storage abstraction layer (F2) exists but only has local implementations. This PR adds the S3 implementations an...*
+### Refactoring (1)
 
-- **[#391](https://github.com/Snoww3d/jwst-data-analysis/pull/391)** refactor: route processing engine FITS access through storage layer
+- [#391](https://github.com/Snoww3d/jwst-data-analysis/pull/391) route processing engine FITS access through storage layer
 
-    Refactors all processing engine route handlers to access FITS files through the storage abstraction layer instead of direct filesystem calls. This is the prerequisite for S3 storage to work end-to-end — without this, every endpoint calls `fits.open()` against hardcoded filesystem paths.
+### Documentation (2)
 
-    *The storage abstraction (PR #390) introduced `StorageProvider` with `read_to_temp()` for transparently accessing files from local or S3 storage. But every route handler still used its own `validate_file_path()` + `ALLOWED_DATA_DIR` pattern, bypassing the abstraction entirely. This PR eliminates that...*
+- [#397](https://github.com/Snoww3d/jwst-data-analysis/pull/397) update development roadmap to reflect current project state
+- [#398](https://github.com/Snoww3d/jwst-data-analysis/pull/398) fix stale documentation across 13 files
 
-- **[#392](https://github.com/Snoww3d/jwst-data-analysis/pull/392)** feat: wire MAST downloads and user uploads through storage provider
+### Maintenance (1)
 
-    Wire all MAST download flows and user file uploads through the storage abstraction layer so data reaches S3 when `STORAGE_PROVIDER=s3` is configured, while remaining a no-op for local storage.
-
-    *With the storage providers (PR #390) and route refactoring (PR #391) in place, the actual data flows still bypass the storage layer. MAST downloads write directly to the local filesystem and user uploads use a flat key structure. This PR completes the data flow wiring so that switching to S3 "just w...*
-
-- **[#393](https://github.com/Snoww3d/jwst-data-analysis/pull/393)** feat: presigned URL redirects, S3 bug fixes & lifecycle policy
-
-    File downloads redirect to presigned S3 URLs instead of proxying bytes through the backend, S3 lifecycle policy scripts enable Intelligent-Tiering for cost optimization, and critical S3 storage bugs across the PR stack are fixed.
-
-    *Proxying large FITS files (up to 4GB) through the .NET backend is wasteful when S3 can serve them directly. Presigned URLs eliminate this overhead and reduce backend memory pressure. Intelligent-Tiering on `mast/` and `mosaic/` prefixes automatically moves infrequently accessed data to cheaper stora...*
-
-- **[#394](https://github.com/Snoww3d/jwst-data-analysis/pull/394)** fix: remove overly restrictive file size limit from viewer endpoints
-
-    Remove the 4GB `validate_fits_file_size` check from preview, histogram, pixeldata, and cubeinfo endpoints, and improve frontend error messages to show actual error details instead of raw status codes.
-
-    *A 5.2GB NIRCam mosaic (`jw02731-o001_t017_nircam_clear-f187n_i2d.fits`) was completely unviewable — all viewer endpoints returned 413. The file size limit was a copy-paste from mosaic operations where entire arrays are loaded into memory. Viewer endpoints use memory-efficient patterns (memmap, subsa...*
-
-- **[#395](https://github.com/Snoww3d/jwst-data-analysis/pull/395)** fix: propagate actual MAST errors instead of generic 503
-
-    MAST search errors (e.g. "Could not resolve target name '3132'") were being swallowed by the backend and returned as generic 503 "Processing engine unavailable" messages. Now the backend distinguishes connectivity failures from response errors and forwards the actual error message to the frontend.
-
-    *Users searching for an invalid target name saw "The processing engine is currently unavailable" which is misleading — the engine is available, it just can't resolve the target. This fix gives users actionable error messages so they can correct their search query.*
-
-- **[#396](https://github.com/Snoww3d/jwst-data-analysis/pull/396)** fix: use MAST cloud API for S3 key resolution
-
-    S3 downloads from MAST were always failing with `HeadObject 404` because the S3 key resolver was constructing incorrect paths. Switched to using MAST's official `get_cloud_uris()` API and added proper auto-mode failover when S3 fails during transfer.
-
-    *The `s3_resolver.py` assumed a flat bucket structure (`jwst/public/{program_id}/{filename}`) but STScI's actual bucket uses a nested structure that varies by calibration level (e.g. `jwst/public/jw02733/L3/t/o001/{filename}` for Level 3 products). Every S3 download attempt resulted in a 404 error. W...*
-
-- **[#397](https://github.com/Snoww3d/jwst-data-analysis/pull/397)** docs: update development roadmap to reflect current project state
-
-    Update the development roadmap (`docs/development-plan.md`) to accurately reflect the current state of the project ahead of potential community release.
-
-    *The roadmap was stale — Phase 4 was marked "In Progress" despite being fully complete, Phase 7 understated testing/CI reality (listed 116 tests when we have 626), the Workflow-Fix section referenced work already shipped, and significant recent features weren't tracked.*
-
-- **[#398](https://github.com/Snoww3d/jwst-data-analysis/pull/398)** docs: fix stale documentation across 13 files
-
-    Comprehensive documentation audit identified 18 stale or incorrect items across the docs. This PR fixes all of them in a single pass across 13 files.
-
-    *Documentation had drifted from the codebase — missing S3 storage layer, outdated architecture diagrams, wrong resource limits, stale processing engine structure, and missing Docker services. Accurate docs are critical ahead of community release.*
-
-- **[#399](https://github.com/Snoww3d/jwst-data-analysis/pull/399)** fix: use fence_mermaid_format for Mermaid diagram rendering in MkDocs
-
-    Mermaid diagrams in MkDocs render as plain code blocks instead of interactive diagrams.
-
-    *The superfences config used `fence_code_format` which outputs `<code>` elements. Material 9.7+ requires `fence_mermaid_format` to activate its built-in Mermaid JS integration.*
-
-- **[#400](https://github.com/Snoww3d/jwst-data-analysis/pull/400)** fix: close mermaid code fences in architecture.md and revert mkdocs.yml
-
-    Mermaid diagrams in the docs site render as raw text instead of interactive diagrams.
-
-    *All 10 mermaid blocks in `architecture.md` were terminated with ` ```text `, ` ```tsx `, or ` ```mermaid ` instead of plain ` ``` `. This meant no mermaid block ever properly closed — each one bled into the next, and Material's Mermaid JS couldn't parse them.*
-
-- **[#401](https://github.com/Snoww3d/jwst-data-analysis/pull/401)** fix: use dark-theme-friendly colors for Data Lineage diagram
-
-    Data Lineage diagram in architecture docs is unreadable on the dark theme.
-
-    *The pastel fill colors (`#ffcccc`, `#ffeacc`, etc.) were designed for light backgrounds and wash out on Material's slate dark theme, making text and subgraph labels invisible.*
-
-- **[#402](https://github.com/Snoww3d/jwst-data-analysis/pull/402)** chore: update AWSSDK.S3 to 4.0.18.6
-
-    Updates AWSSDK.S3 from 4.0.1 to 4.0.18.6 to resolve a known vulnerability in the transitive AWSSDK.Core dependency.
-
-    *AWSSDK.Core 4.0.0.5 has a low-severity vulnerability ([GHSA-9cvc-h2w8-phrp](https://github.com/advisories/GHSA-9cvc-h2w8-phrp)) that causes `dotnet build --warnaserror` to fail with NU1901. Updating AWSSDK.S3 pulls in AWSSDK.Core 4.0.3.12 which resolves the advisory.*
-
-- **[#404](https://github.com/Snoww3d/jwst-data-analysis/pull/404)** fix: prevent auth token expiry during long-running operations
-
-    Fixes race condition where long-running operations (e.g., 93s composite generation) cause token expiry and user logout. Adds a 30-second refresh token grace window on the backend and fixes stale closure + refresh path duplication on the frontend.
-
-    *When a long-running operation is in flight, the access token expires. The proactive refresh fires, but after token rotation the old refresh token is immediately invalidated — so any concurrent or slightly-delayed refresh attempt fails with "Refresh token not found in database." After 3 retries, the ...*
-
-- **[#405](https://github.com/Snoww3d/jwst-data-analysis/pull/405)** feat: extend access token to 60 minutes and add visibility-based refresh
-
-    Extends access token lifetime from 15 minutes to 60 minutes and adds a `visibilitychange` listener that refreshes tokens when a backgrounded tab returns to focus.
-
-    *With a 15-minute access token, users needed to be constantly active to stay logged in. Background tabs had their `setTimeout` throttled by the browser, so the proactive refresh timer often missed its window. This meant stepping away for a few minutes or switching tabs could result in a logout.*
-
-- **[#406](https://github.com/Snoww3d/jwst-data-analysis/pull/406)** fix: background refresh after data mutations + per-file archive in lineage view
-
-    Two fixes: (1) prevents full-page loading spinner after archive/unarchive/delete/import operations, and (2) adds per-file Archive/Unarchive buttons to the lineage view's file cards.
-
-    *1. `onDataUpdate` called `fetchData`, which set `loading=true` — unmounting the entire dashboard to show the full-page spinner, losing scroll position and panel state. For a quick operation like archiving a file, this felt like a forced page reload. 2. The lineage view only had archive buttons at th...*
+- [#402](https://github.com/Snoww3d/jwst-data-analysis/pull/402) update AWSSDK.S3 to 4.0.18.6
 
 ## Issues
 
@@ -165,4 +98,5 @@ authors:
 - [#403](https://github.com/Snoww3d/jwst-data-analysis/issues/403) — Auth token expires during long-running operations, logging user out
 
 ---
-*19 commits across this session.*
+19 commits across 19 pull requests.
+*Next: February 18, 2026 — add archiving animation feedback to file cards, resolve CA1805 — remove redundant default value in..., enable SA1001 — commas should be spaced correctly*

--- a/docs/blog/posts/2026-02-18.md
+++ b/docs/blog/posts/2026-02-18.md
@@ -14,41 +14,36 @@ authors:
 
 <!-- generated -->
 
-**1 feature, 4 maintenance** — code-quality
+Productive session with 5 pull requests: 1 feature, 4 maintenance.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#407](https://github.com/Snoww3d/jwst-data-analysis/pull/407)** feat: add archiving animation feedback to file cards
+### [#407](https://github.com/Snoww3d/jwst-data-analysis/pull/407) add archiving animation feedback to file cards
 
-    Adds visual feedback when archiving/unarchiving files — the card dims with a pulsing "Archiving..." button so users know the operation is in progress.
+Adds visual feedback when archiving/unarchiving files — the card dims with a pulsing "Archiving..." button so users know the operation is in progress.
 
-    *Previously clicking Archive gave no visual feedback until the background data refresh completed, making it unclear whether the action registered. This is especially noticeable on slower connections.*
+*Previously clicking Archive gave no visual feedback until the background data refresh completed, making it unclear whether the action registered. This is especially noticeable on slower connections.*
 
-- **[#408](https://github.com/Snoww3d/jwst-data-analysis/pull/408)** chore: resolve CA1805 — remove redundant default value initializers
+### [#411](https://github.com/Snoww3d/jwst-data-analysis/pull/411) resolve SA1500, SA1117, SA1116, SA1113 — brace and parameter formatting
 
-    Remove explicit `= false` and `= 0` initializers on C# properties where the type default already matches, and enable CA1805 as a build warning to prevent recurrence.
+Fix parameter formatting violations and enable four StyleCop rules as build warnings. Batched since these rules are closely related (all govern multi-line formatting).
 
-    *CA1805 was suppressed in `.editorconfig` since the initial setup. These redundant initializers add visual noise without changing behavior — `bool` defaults to `false` and `int` defaults to `0` in C#. Enabling the rule as a warning ensures new code stays clean.*
+*These four rules enforce consistent multi-line formatting — parameters on their own lines, commas in the right place, braces on their own lines. All were suppressed in `.editorconfig`. Resolving them ...*
 
-- **[#409](https://github.com/Snoww3d/jwst-data-analysis/pull/409)** chore: enable SA1001 — commas should be spaced correctly
+## What Changed
 
-    Enable SA1001 (comma spacing) as a build warning. No code fixes needed — the codebase already complies.
+### Features (1)
 
-    *SA1001 was suppressed preemptively in `.editorconfig` but the codebase has no violations. Enabling it as a warning prevents future regressions.*
+- [#407](https://github.com/Snoww3d/jwst-data-analysis/pull/407) add archiving animation feedback to file cards
 
-- **[#410](https://github.com/Snoww3d/jwst-data-analysis/pull/410)** chore: resolve SA1316 — PascalCase tuple element names
+### Maintenance (4)
 
-    Rename tuple element names from camelCase to PascalCase per SA1316 and enable the rule as a build warning.
-
-    *SA1316 enforces PascalCase for tuple element names, consistent with C# naming conventions for public members. The rule was suppressed — this resolves the violations and enables enforcement.*
-
-- **[#411](https://github.com/Snoww3d/jwst-data-analysis/pull/411)** chore: resolve SA1500, SA1117, SA1116, SA1113 — brace and parameter formatting
-
-    Fix parameter formatting violations and enable four StyleCop rules as build warnings. Batched since these rules are closely related (all govern multi-line formatting).
-
-    *These four rules enforce consistent multi-line formatting — parameters on their own lines, commas in the right place, braces on their own lines. All were suppressed in `.editorconfig`. Resolving them and enabling enforcement prevents drift.*
+- [#408](https://github.com/Snoww3d/jwst-data-analysis/pull/408) resolve CA1805 — remove redundant default value initializers
+- [#409](https://github.com/Snoww3d/jwst-data-analysis/pull/409) enable SA1001 — commas should be spaced correctly
+- [#410](https://github.com/Snoww3d/jwst-data-analysis/pull/410) resolve SA1316 — PascalCase tuple element names
+- [#411](https://github.com/Snoww3d/jwst-data-analysis/pull/411) resolve SA1500, SA1117, SA1116, SA1113 — brace and parameter formatting
 
 ## Issues
 
@@ -63,4 +58,5 @@ authors:
 - [#271](https://github.com/Snoww3d/jwst-data-analysis/issues/271) — SA1001 — Commas Should Be Spaced Correctly
 
 ---
-*5 commits across this session.*
+5 commits across 5 pull requests.
+*Next: February 21, 2026 — bump Swashbuckle.AspNetCore from 10.1.3 to 10.1.4, add unit tests for ThumbnailService*

--- a/docs/blog/posts/2026-02-21.md
+++ b/docs/blog/posts/2026-02-21.md
@@ -3,7 +3,6 @@ date:
   created: 2026-02-21
 categories:
   - Maintenance
-  - Development
   - Testing
 tags:
   - code-quality
@@ -17,47 +16,21 @@ authors:
 
 <!-- generated -->
 
-**1 test, 1 maintenance, 4 dep updates** — code-quality, dependencies, testing
+Productive session with 6 pull requests: 1 test, 1 maintenance, 4 dependency updates.
 
 <!-- more -->
 
-## Pull Requests Merged
+## What Changed
 
-- **[#417](https://github.com/Snoww3d/jwst-data-analysis/pull/417)** chore(deps-dev): bump jsdom from 28.0.0 to 28.1.0 in /frontend/jwst-frontend
+### Testing (1)
 
-    Bump jsdom from 28.0.0 to 28.1.0 (minor).
+- [#424](https://github.com/Snoww3d/jwst-data-analysis/pull/424) add unit tests for ThumbnailService
 
-    *Keep test dependencies up to date with latest improvements.*
+### Maintenance (1)
 
-- **[#419](https://github.com/Snoww3d/jwst-data-analysis/pull/419)** chore(deps): bump ruff from 0.15.0 to 0.15.2 in /processing-engine
+- [#423](https://github.com/Snoww3d/jwst-data-analysis/pull/423) bump Swashbuckle.AspNetCore from 10.1.3 to 10.1.4
 
-    Bump ruff from 0.15.0 to 0.15.2 (patch).
-
-    *Keep Python linting tooling up to date with latest fixes.*
-
-- **[#420](https://github.com/Snoww3d/jwst-data-analysis/pull/420)** chore(deps-dev): bump @types/react from 19.2.10 to 19.2.14 in /frontend/jwst-frontend
-
-    Bump @types/react from 19.2.10 to 19.2.14 (patch).
-
-    *Keep type definitions up to date for better IDE support and type safety.*
-
-- **[#422](https://github.com/Snoww3d/jwst-data-analysis/pull/422)** chore(deps-dev): bump @typescript-eslint/eslint-plugin from 8.55.0 to 8.56.0 in /frontend/jwst-frontend
-
-    Bump @typescript-eslint/eslint-plugin from 8.55.0 to 8.56.0 (patch).
-
-    *Keep dev dependencies up to date with latest patch fixes.*
-
-- **[#423](https://github.com/Snoww3d/jwst-data-analysis/pull/423)** chore: bump Swashbuckle.AspNetCore from 10.1.3 to 10.1.4
-
-    Bump Swashbuckle.AspNetCore from 10.1.3 to 10.1.4 (patch).
-
-    *Keep dependencies up to date with latest patch fixes.*
-
-- **[#424](https://github.com/Snoww3d/jwst-data-analysis/pull/424)** test: add unit tests for ThumbnailService
-
-    Adds 16 unit tests for `ThumbnailService`, covering all code paths in both `GenerateThumbnailAsync` and `GenerateThumbnailsForIdsAsync`.
-
-    *`ThumbnailService` had zero test coverage despite containing path manipulation, HTTP calls, base64 decoding, and batch counting logic — all prone to subtle regressions.*
+**Dependencies** (4 updates: @types/react, @typescript-eslint/eslint-plugin, jsdom, ruff)
 
 ## Issues
 
@@ -71,4 +44,5 @@ authors:
 - [#377](https://github.com/Snoww3d/jwst-data-analysis/issues/377) — fix: validate-before-pr-create.sh hook matched body text and failed in worktrees
 
 ---
-*6 commits across this session.*
+6 commits across 6 pull requests.
+*Next: February 22, 2026 — bump httpx from 0.27.0 to 0.28.1, bump pytest from 7.4.3 to 9.0.2, bump eslint-plugin-react-hooks from 5.2.0 to 7.0.1*

--- a/docs/blog/posts/2026-02-22.md
+++ b/docs/blog/posts/2026-02-22.md
@@ -3,10 +3,10 @@ date:
   created: 2026-02-22
 categories:
   - Maintenance
-  - Development
   - Feature
   - Refactoring
 tags:
+  - astronomy-data
   - auth
   - ci
   - code-quality
@@ -20,87 +20,41 @@ authors:
 
 <!-- generated -->
 
-**1 feature, 2 refactors, 8 maintenance, 1 dep update** — auth, ci, code-quality, dependencies, mast-data
+A marathon session: 12 pull requests merged (1 feature, 2 refactors, 8 maintenance, 1 dependency update).
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#412](https://github.com/Snoww3d/jwst-data-analysis/pull/412)** chore: bump httpx from 0.27.0 to 0.28.1
+### [#429](https://github.com/Snoww3d/jwst-data-analysis/pull/429) hash refresh tokens with SHA-256 before storage
 
-    Bump httpx from 0.27.0 to 0.28.1.
+SHA-256 hash refresh tokens before storing in MongoDB to prevent token replay if the database is compromised. Raw tokens are only held in memory and returned to the client — the DB never sees them. Also cleans up stale issue references in the development roadmap.
 
-    *Keep HTTP client up to date. Deprecated `proxies` and `app` args were removed, but we don't use either. All tests pass.*
+*- Refresh tokens were stored as plaintext Base64 in MongoDB - If the database is compromised, an attacker could replay tokens to maintain persistent access - OWASP recommends SHA-256 (not BCrypt) for ...*
 
-- **[#413](https://github.com/Snoww3d/jwst-data-analysis/pull/413)** chore: bump pytest from 7.4.3 to 9.0.2
+## What Changed
 
-    Bump pytest from 7.4.3 to 9.0.2.
+### Features (1)
 
-    *Keep test framework up to date. Two major versions behind; all 359 Python tests pass on this version.*
+- [#429](https://github.com/Snoww3d/jwst-data-analysis/pull/429) hash refresh tokens with SHA-256 before storage
 
-- **[#414](https://github.com/Snoww3d/jwst-data-analysis/pull/414)** chore: bump eslint-plugin-react-hooks from 5.2.0 to 7.0.1
+### Refactoring (2)
 
-    Bump eslint-plugin-react-hooks from 5.2.0 to 7.0.1. This is a major version bump that includes breaking changes to config presets (flat config is now the default) and adds new rule violations for `use` in try/catch and `useEffectEvent` in closures.
+- [#426](https://github.com/Snoww3d/jwst-data-analysis/pull/426) replace eslint-plugin-react with @eslint-react
+- [#430](https://github.com/Snoww3d/jwst-data-analysis/pull/430) reduce redundant MAST model types (25 → 21)
 
-    *Keep linting dependencies current. The react-hooks plugin v7 works with our existing eslint 9 setup and flat config.*
+### Maintenance (8)
 
-- **[#415](https://github.com/Snoww3d/jwst-data-analysis/pull/415)** chore: bump uvicorn from 0.24.0 to 0.41.0
+- [#412](https://github.com/Snoww3d/jwst-data-analysis/pull/412) bump httpx from 0.27.0 to 0.28.1
+- [#413](https://github.com/Snoww3d/jwst-data-analysis/pull/413) bump pytest from 7.4.3 to 9.0.2
+- [#414](https://github.com/Snoww3d/jwst-data-analysis/pull/414) bump eslint-plugin-react-hooks from 5.2.0 to 7.0.1
+- [#415](https://github.com/Snoww3d/jwst-data-analysis/pull/415) bump uvicorn from 0.24.0 to 0.41.0
+- [#416](https://github.com/Snoww3d/jwst-data-analysis/pull/416) bump fastapi from 0.128.4 to 0.129.0
+- [#421](https://github.com/Snoww3d/jwst-data-analysis/pull/421) bump BCrypt.Net-Next from 4.0.3 to 4.1.0
+- [#428](https://github.com/Snoww3d/jwst-data-analysis/pull/428) upgrade ESLint from 9 to 10
+- [#431](https://github.com/Snoww3d/jwst-data-analysis/pull/431) remove dead DTO types from backend and frontend
 
-    Bump uvicorn from 0.24.0 to 0.41.0.
-
-    *Keep ASGI server up to date. Spans 17 minor releases with bug fixes and improvements. No breaking changes to our usage (we use uvicorn as a server runner only).*
-
-- **[#416](https://github.com/Snoww3d/jwst-data-analysis/pull/416)** chore: bump fastapi from 0.128.4 to 0.129.0
-
-    Bump fastapi from 0.128.4 to 0.129.0 (minor).
-
-    *Keep processing engine framework up to date with latest improvements.*
-
-- **[#421](https://github.com/Snoww3d/jwst-data-analysis/pull/421)** chore: bump BCrypt.Net-Next from 4.0.3 to 4.1.0
-
-    Bump BCrypt.Net-Next from 4.0.3 to 4.1.0 (minor).
-
-    *Keep auth dependency up to date. Release is internal-only changes (test deps, license metadata) — no API changes.*
-
-- **[#426](https://github.com/Snoww3d/jwst-data-analysis/pull/426)** refactor: replace eslint-plugin-react with @eslint-react
-
-    - Replace `eslint-plugin-react` (blocks ESLint 10 upgrade) with `@eslint-react/eslint-plugin` v2.13.0
-    - Bump `eslint` from ^9.17.0 to ^9.36.0
-    - Fix all 96 new lint warnings surfaced by @eslint-react's stricter rules — **0 errors, 0 warnings**
-
-    *`eslint-plugin-react` crashes on ESLint 10 because it uses the removed `context.getFilename()` API. Upstream fix (PR #3979) has no merge timeline. `@eslint-react/eslint-plugin` is a modern rewrite that already supports ESLint 10 and provides better React 19 rule coverage.*
-
-- **[#428](https://github.com/Snoww3d/jwst-data-analysis/pull/428)** chore: upgrade ESLint from 9 to 10
-
-    - Upgrade ESLint from v9 to v10 — the final step of the ESLint 10 migration (#347)
-    - Enable full `eslint-plugin-react-hooks` recommended preset (18 rules, up from 2)
-    - Fix all new lint violations
-
-    *ESLint 10 was blocked by `eslint-plugin-react` (#426 replaced it with `@eslint-react`). With that blocker removed, the upgrade is a dependency bump + adopting the new react-hooks rules.*
-
-- **[#429](https://github.com/Snoww3d/jwst-data-analysis/pull/429)** feat: hash refresh tokens with SHA-256 before storage
-
-    SHA-256 hash refresh tokens before storing in MongoDB to prevent token replay if the database is compromised. Raw tokens are only held in memory and returned to the client — the DB never sees them. Also cleans up stale issue references in the development roadmap.
-
-    *- Refresh tokens were stored as plaintext Base64 in MongoDB - If the database is compromised, an attacker could replay tokens to maintain persistent access - OWASP recommends SHA-256 (not BCrypt) for high-entropy tokens — immune to brute-force, no salt needed*
-
-- **[#430](https://github.com/Snoww3d/jwst-data-analysis/pull/430)** refactor: reduce redundant MAST model types (25 → 21)
-
-    Remove 4 redundant types from MastModels.cs by deleting dead code and merging near-identical DTOs. Reduces type count from 25 to 21 with no API contract changes.
-
-    *- `MastObservationResult` had zero references outside its own definition — dead code - Three separate job-start response types (`ImportJobStartResponse`, `DownloadJobStartResponse`, `ChunkedDownloadStartResponse`) had identical shapes (`JobId`, `ObsId`, `Message`) with only serialization attribute a...*
-
-- **[#431](https://github.com/Snoww3d/jwst-data-analysis/pull/431)** chore: remove dead DTO types from backend and frontend
-
-    Remove 9 unused DTO types identified during a comprehensive dead code audit across backend and frontend.
-
-    *Dead types add noise, increase cognitive load, and can mislead future developers into thinking they're part of the API contract. Removing them keeps the codebase honest and reduces maintenance surface.*
-
-- **[#432](https://github.com/Snoww3d/jwst-data-analysis/pull/432)** chore(deps): upgrade pytest-asyncio from 0.23.2 to 1.3.0
-
-    Upgrade pytest-asyncio to fix Python test suite that was completely broken due to version incompatibility.
-
-    *`pytest-asyncio==0.23.2` is incompatible with `pytest==9.0.2`, causing an `INTERNALERROR` (`'Package' object has no attribute 'obj'`) that prevents all 359 Python tests from running. The 1.x series supports `pytest>=8.2,<10`.*
+**Dependencies** (1 updates: upgrade pytest-asyncio)
 
 ## Issues
 
@@ -121,4 +75,5 @@ authors:
 - [#347](https://github.com/Snoww3d/jwst-data-analysis/issues/347) — chore: migrate eslint 9 → 10
 
 ---
-*13 commits across this session.*
+13 commits across 12 pull requests.
+*Next: February 23, 2026 — add Python CI coverage threshold at 50%, add Python tests for statistics, utils, and filter..., add enhancement and detection tests, bump coverage...*

--- a/docs/blog/posts/2026-02-23.md
+++ b/docs/blog/posts/2026-02-23.md
@@ -22,78 +22,49 @@ authors:
 
 <!-- generated -->
 
-**3 features, 1 fix, 5 tests, 2 maintenance** — auth, ci, code-quality, dependencies, job-queue, mast-data, testing
+A marathon session: 11 pull requests merged (3 features, 1 fix, 5 tests, 2 maintenance).
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#434](https://github.com/Snoww3d/jwst-data-analysis/pull/434)** feat: add Python CI coverage threshold at 50%
+### [#463](https://github.com/Snoww3d/jwst-data-analysis/pull/463) add smoothing controls and source detection overlay (C1 + D2)
 
-    Adds a 50% code coverage floor for the Python processing engine in CI, preventing silent coverage regression. Also enables the Python test step that was previously commented out.
+- **C1 (Smoothing/Noise Reduction)**: Adds `smoothMethod`, `smoothSigma`, `smoothSize` query params to existing preview and histogram endpoints. Server-side smoothing applied before stretch. Frontend panel with method selector, sigma slider, and kernel size slider.
+- **D2 (Source Detection Overlay)*...
 
-    *We have 359 Python tests but no coverage enforcement — coverage could silently regress to 0% and CI would still pass. The Python test job was also commented out entirely, meaning test failures wouldn't block PRs.*
+*Phase 5 Tier 2 features. Wires existing Python processing code (`filters.py`, `detection.py`, `background.py`) through the full stack — these modules were already implemented but had no HTTP routes, ....*
 
-- **[#435](https://github.com/Snoww3d/jwst-data-analysis/pull/435)** test: add Python tests for statistics, utils, and filters
+### [#462](https://github.com/Snoww3d/jwst-data-analysis/pull/462) admin-gate migration endpoints and prevent ownership spoofing on create
 
-    Adds 90 new unit tests covering three pure-computation Python modules, pushing coverage from 55% to 58%.
+Two critical security fixes: admin-gate migration endpoints and prevent ownership spoofing on the create endpoint.
 
-    *These modules had the lowest coverage (21-33%) despite being the easiest to test — pure numpy/scipy functions with no I/O dependencies. Covering them now builds toward raising the CI threshold from 50% to 60%.*
+*Security audit identified these as Critical (Bucket 1) access control gaps: - **#444**: Migration endpoints that rewrite all DB records were callable by any authenticated user - **#445**: Create endpo...*
 
-- **[#436](https://github.com/Snoww3d/jwst-data-analysis/pull/436)** test: add enhancement and detection tests, bump coverage to 55%
+## What Changed
 
-    Adds 71 new tests covering the enhancement and detection processing modules, and bumps the CI coverage threshold from 50% to 55%.
+### Features (3)
 
-    *These modules had the lowest coverage (enhancement 43%, detection 17%) despite being pure computation with no I/O dependencies. With these tests, overall Python coverage jumps from 58% to 62%, giving comfortable headroom above the new 55% threshold.*
+- [#434](https://github.com/Snoww3d/jwst-data-analysis/pull/434) add Python CI coverage threshold at 50%
+- [#438](https://github.com/Snoww3d/jwst-data-analysis/pull/438) add .NET backend CI coverage threshold at 15%
+- [#463](https://github.com/Snoww3d/jwst-data-analysis/pull/463) add smoothing controls and source detection overlay (C1 + D2)
 
-- **[#437](https://github.com/Snoww3d/jwst-data-analysis/pull/437)** chore: bump Python CI coverage threshold to 60%
+### Bug Fixes (1)
 
-    Raises the Python CI coverage floor from 55% to 60%.
+- [#462](https://github.com/Snoww3d/jwst-data-analysis/pull/462) admin-gate migration endpoints and prevent ownership spoofing on create
 
-    *Current coverage is 62% after adding 161 tests in PRs #435 and #436. The threshold should track closer to actual coverage to catch regressions early.*
+### Testing (5)
 
-- **[#438](https://github.com/Snoww3d/jwst-data-analysis/pull/438)** feat: add .NET backend CI coverage threshold at 15%
+- [#435](https://github.com/Snoww3d/jwst-data-analysis/pull/435) add Python tests for statistics, utils, and filters
+- [#436](https://github.com/Snoww3d/jwst-data-analysis/pull/436) add enhancement and detection tests, bump coverage to 55%
+- [#439](https://github.com/Snoww3d/jwst-data-analysis/pull/439) add unit tests for ImportJobTracker, FileContentValidator, LocalStorageProvider
+- [#441](https://github.com/Snoww3d/jwst-data-analysis/pull/441) add unit tests for AuthController, AnalysisController, and 3 services
+- [#464](https://github.com/Snoww3d/jwst-data-analysis/pull/464) fix SA1516, SA1202, CA2201 lint errors in test files
 
-    Adds code coverage enforcement for the .NET backend in CI, with auto-generated code excluded from measurement.
+### Maintenance (2)
 
-    *We have 294 backend tests but no coverage enforcement — coverage could silently regress. The Python engine already has a 60% threshold; the backend should have one too. Starting at 15% (current: 20%) to establish the floor without blocking existing work.*
-
-- **[#439](https://github.com/Snoww3d/jwst-data-analysis/pull/439)** test: add unit tests for ImportJobTracker, FileContentValidator, LocalStorageProvider
-
-    Adds 58 new unit tests covering three previously untested .NET backend services, raising line coverage from ~20% to ~24%.
-
-    *Continuing the coverage improvement effort started in #438. These three services (ImportJobTracker, FileContentValidator, LocalStorageProvider) were identified as easy wins with high test value and zero external dependencies.*
-
-- **[#440](https://github.com/Snoww3d/jwst-data-analysis/pull/440)** chore: bump .NET coverage threshold from 15% to 20%
-
-    Bumps the backend coverage threshold from 15% to 20% to lock in gains from PR #439.
-
-    *Actual coverage is ~24% after adding 58 new tests. This raises the floor to prevent regression.*
-
-- **[#441](https://github.com/Snoww3d/jwst-data-analysis/pull/441)** test: add unit tests for AuthController, AnalysisController, and 3 services
-
-    Adds 42 new unit tests covering 2 previously untested controllers and 3 services, raising backend line coverage from ~24% to ~27%.
-
-    *Continuing the .NET coverage improvement effort (PRs #438, #439, #440). Targets the remaining easy-win classes with no external HTTP/storage dependencies.*
-
-- **[#462](https://github.com/Snoww3d/jwst-data-analysis/pull/462)** fix: admin-gate migration endpoints and prevent ownership spoofing on create
-
-    Two critical security fixes: admin-gate migration endpoints and prevent ownership spoofing on the create endpoint.
-
-    *Security audit identified these as Critical (Bucket 1) access control gaps: - **#444**: Migration endpoints that rewrite all DB records were callable by any authenticated user - **#445**: Create endpoint trusted client-supplied UserId, enabling ownership spoofing*
-
-- **[#463](https://github.com/Snoww3d/jwst-data-analysis/pull/463)** feat: add smoothing controls and source detection overlay (C1 + D2)
-
-    - **C1 (Smoothing/Noise Reduction)**: Adds `smoothMethod`, `smoothSigma`, `smoothSize` query params to existing preview and histogram endpoints. Server-side smoothing applied before stretch. Frontend panel with method selector, sigma slider, and kernel size slider.
-    - **D2 (Source Detection Overlay)**: New `POST /api/analysis/detect-sources` endpoint returning JSON source list. Frontend renders cya...
-
-    *Phase 5 Tier 2 features. Wires existing Python processing code (`filters.py`, `detection.py`, `background.py`) through the full stack — these modules were already implemented but had no HTTP routes, .NET proxy, or UI.*
-
-- **[#464](https://github.com/Snoww3d/jwst-data-analysis/pull/464)** test: fix SA1516, SA1202, CA2201 lint errors in test files
-
-    Fix 8 pre-existing StyleCop and code analysis lint errors in backend test files that cause `dotnet build --warnaserror` to fail.
-
-    *These warnings were introduced in #441 and went unnoticed because CI runs `dotnet test` (which doesn't use `--warnaserror`). The local compliance check catches them, and they should be clean.*
+- [#437](https://github.com/Snoww3d/jwst-data-analysis/pull/437) bump Python CI coverage threshold to 60%
+- [#440](https://github.com/Snoww3d/jwst-data-analysis/pull/440) bump .NET coverage threshold from 15% to 20%
 
 ## Issues
 
@@ -143,4 +114,5 @@ authors:
 - [#445](https://github.com/Snoww3d/jwst-data-analysis/issues/445) — security: ownership spoofing via client-supplied UserId on create
 
 ---
-*12 commits across this session.*
+12 commits across 11 pull requests.
+*Next: February 24, 2026 — add FITS table viewer for non-image FITS products, add spectral data visualization with interactive P..., stabilize flaky E2E auth test with explicit naviga...*

--- a/docs/blog/posts/2026-02-24.md
+++ b/docs/blog/posts/2026-02-24.md
@@ -6,6 +6,7 @@ categories:
   - Bug Fix
   - Testing
 tags:
+  - astronomy-data
   - auth
   - ci
   - code-quality
@@ -22,73 +23,45 @@ authors:
 
 <!-- generated -->
 
-**2 features, 4 fixes, 4 tests** — auth, ci, code-quality, dependencies, e2e-tests, imaging, testing, viewer
+A marathon session: 10 pull requests merged (2 features, 4 fixes, 4 tests). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#465](https://github.com/Snoww3d/jwst-data-analysis/pull/465)** feat: add FITS table viewer for non-image FITS products
+### [#474](https://github.com/Snoww3d/jwst-data-analysis/pull/474) resolve all 41 backend test lint warnings (SA/CA rules)
 
-    - Adds a full-stack FITS table viewer enabling users to browse binary table data (`_cat`, `_x1d`, `_phot`, etc.) that was previously inaccessible behind a disabled "Table" button
-    - Two-endpoint design: `table-info` for HDU discovery, `table-data` for paginated row retrieval with sort/search
-    - Phase 5 Tier 1 feature (FITS table viewer for non-image FITS products)
+Resolves all 41 StyleCop/CA analyzer warnings across 7 backend test files so the build passes clean with `--warnaserror`.
 
-    *Table FITS products (catalogs, extracted spectra, photometry) represent a significant portion of JWST pipeline outputs. Users had no way to inspect this data — the dashboard showed a disabled button. This unlocks read access to all table-type files through the existing viewer pattern.*
+*Backend lint (`dotnet build --warnaserror`) was failing with 41 SA/CA warnings. These were masked by build caching in prior compliance checks.*
 
-- **[#466](https://github.com/Snoww3d/jwst-data-analysis/pull/466)** feat: add spectral data visualization with interactive Plotly.js chart
+### [#472](https://github.com/Snoww3d/jwst-data-analysis/pull/472) resolve all Python deprecation warnings and achieve 0-warning test suite
 
-    Add interactive spectral data visualization for JWST spectral products (`_x1d`, `_c1d`, `_x1dints`). These files now open in a SpectralViewer with a Plotly.js chart instead of the raw table viewer, showing wavelength vs flux with zoom, pan, hover tooltips, error bars, and y-axis column selection. Users can switch bidirectionally between spectral plot and table views.
+Eliminates all 75+ Python test warnings (was 8 visible + ~67 suppressed) by fixing deprecated APIs at the source and removing global warning suppression from pyproject.toml.
 
-    *Spectral products are currently viewable only as raw table data, making it difficult to analyze spectra visually. This is a Phase 5 Tier 1 feature that bridges the gap with tools like Jdaviz for basic spectral inspection.*
+*The test suite was hiding deprecation warnings behind `filterwarnings = ["ignore::DeprecationWarning"]` in pyproject.toml. With that removed, 75 warnings surfaced — all from deprecated `datetime.utcno...*
 
-- **[#467](https://github.com/Snoww3d/jwst-data-analysis/pull/467)** fix: stabilize flaky E2E auth test with explicit navigation waits
+## What Changed
 
-    Fixes intermittent E2E auth test failure (`should register, logout, and login successfully`) caused by race conditions between UI actions and navigation under CI load.
+### Features (2)
 
-    *This test has been failing sporadically in CI — it passes consistently locally but times out or fails when the CI runner is under load. The root cause is three spots where the test asserts on URL state without waiting for navigation to complete after form submissions.*
+- [#465](https://github.com/Snoww3d/jwst-data-analysis/pull/465) add FITS table viewer for non-image FITS products
+- [#466](https://github.com/Snoww3d/jwst-data-analysis/pull/466) add spectral data visualization with interactive Plotly.js chart
 
-- **[#468](https://github.com/Snoww3d/jwst-data-analysis/pull/468)** test: increase Python test coverage from 24% to 66%
+### Bug Fixes (4)
 
-    Increase Python test coverage from 24% to 66%, exceeding the 60% fail-under threshold so the coverage gate now passes.
+- [#467](https://github.com/Snoww3d/jwst-data-analysis/pull/467) stabilize flaky E2E auth test with explicit navigation waits
+- [#471](https://github.com/Snoww3d/jwst-data-analysis/pull/471) resolve all 72 frontend lint warnings with proper types
+- [#472](https://github.com/Snoww3d/jwst-data-analysis/pull/472) resolve all Python deprecation warnings and achieve 0-warning test suite
+- [#474](https://github.com/Snoww3d/jwst-data-analysis/pull/474) resolve all 41 backend test lint warnings (SA/CA rules)
 
-    *The `fail-under=60` coverage threshold in pyproject.toml was always failing at 24% coverage, making the gate useless. This brings coverage above the threshold so regressions are actually caught.*
+### Testing (4)
 
-- **[#469](https://github.com/Snoww3d/jwst-data-analysis/pull/469)** test: increase backend test coverage from 25% to 42%
-
-    Increase .NET backend test coverage from 25% to 42%, exceeding the 40% compliance threshold.
-
-    *Backend coverage was well below the 40% compliance check threshold. Generated compiler files (LoggerMessage.g.cs) were inflating the denominator by 3,400+ untestable lines.*
-
-- **[#470](https://github.com/Snoww3d/jwst-data-analysis/pull/470)** test: increase frontend test coverage from 4% to 49%
-
-    Adds 65 new test files with 810 tests to increase frontend statement coverage from 3.9% to 48.78%, well above the 40% compliance threshold.
-
-    *Frontend code coverage was at 3.9% — far below the 40% threshold established in the compliance check. This PR brings it to ~49%.*
-
-- **[#471](https://github.com/Snoww3d/jwst-data-analysis/pull/471)** fix: resolve all 72 frontend lint warnings with proper types
-
-    Fixes all 72 ESLint warnings across 13 files (12 test files + 1 production file) using proper types and null guards instead of suppression comments.
-
-    *Frontend lint had 72 warnings (56 `no-non-null-assertion`, 13 `no-explicit-any`, 2 stale eslint-disable directives, 1 `no-array-index-key`). Clean lint output makes real issues visible immediately.*
-
-- **[#472](https://github.com/Snoww3d/jwst-data-analysis/pull/472)** fix: resolve all Python deprecation warnings and achieve 0-warning test suite
-
-    Eliminates all 75+ Python test warnings (was 8 visible + ~67 suppressed) by fixing deprecated APIs at the source and removing global warning suppression from pyproject.toml.
-
-    *The test suite was hiding deprecation warnings behind `filterwarnings = ["ignore::DeprecationWarning"]` in pyproject.toml. With that removed, 75 warnings surfaced — all from deprecated `datetime.utcnow()`, `asyncio.get_event_loop()`, and FastAPI `on_event`. Fixing these now prevents breakage when Py...*
-
-- **[#473](https://github.com/Snoww3d/jwst-data-analysis/pull/473)** test: add CompositeService unit tests to bump backend coverage above 40%
-
-    Adds 15 unit tests for `CompositeService` to push backend code coverage from 38.5% to 40.2%, clearing the 40% compliance threshold.
-
-    *Backend coverage was 38.5%, below the 40% threshold flagged in compliance checks. `CompositeService` had 0% coverage despite ~150 lines of business logic.*
-
-- **[#474](https://github.com/Snoww3d/jwst-data-analysis/pull/474)** fix: resolve all 41 backend test lint warnings (SA/CA rules)
-
-    Resolves all 41 StyleCop/CA analyzer warnings across 7 backend test files so the build passes clean with `--warnaserror`.
-
-    *Backend lint (`dotnet build --warnaserror`) was failing with 41 SA/CA warnings. These were masked by build caching in prior compliance checks.*
+- [#468](https://github.com/Snoww3d/jwst-data-analysis/pull/468) increase Python test coverage from 24% to 66%
+- [#469](https://github.com/Snoww3d/jwst-data-analysis/pull/469) increase backend test coverage from 25% to 42%
+- [#470](https://github.com/Snoww3d/jwst-data-analysis/pull/470) increase frontend test coverage from 4% to 49%
+- [#473](https://github.com/Snoww3d/jwst-data-analysis/pull/473) add CompositeService unit tests to bump backend coverage above 40%
 
 ---
-*9 commits across this session.*
+9 commits across 10 pull requests.
+*Next: February 25, 2026 — add SignalR infrastructure for real-time job progr..., add unified job tracker with MongoDB persistence a..., migrate MAST import progress from HTTP polling to ...*

--- a/docs/blog/posts/2026-02-25.md
+++ b/docs/blog/posts/2026-02-25.md
@@ -6,6 +6,7 @@ categories:
   - Feature
   - Bug Fix
 tags:
+  - astronomy-data
   - docs
   - export
   - imaging
@@ -20,63 +21,45 @@ authors:
 
 <!-- generated -->
 
-**4 features, 3 fixes, 1 docs** — docs, export, imaging, infrastructure, job-queue, mast-data
+Productive session with 8 pull requests: 4 features, 3 fixes, 1 docs. Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#475](https://github.com/Snoww3d/jwst-data-analysis/pull/475)** feat: add SignalR infrastructure for real-time job progress (Phase 1)
+### [#482](https://github.com/Snoww3d/jwst-data-analysis/pull/482) add async composite export with job queue and SignalR progress (Phase 4)
 
-    - Add SignalR WebSocket infrastructure for real-time job progress push (Phase 1 of the [Job Queue + WebSocket Progress plan](docs/plans/job-queue-websocket-progress.md))
-    - Purely additive — no behavioral changes to existing functionality
+- Adds non-blocking composite image export via a bounded `Channel<T>` queue and `BackgroundService`, completing Phase 4 of the SignalR migration
+- Preview generation stays synchronous; only exports route through the async pipeline
+- New `POST /api/composite/export-nchannel` endpoint requires authent...
 
-    *All long-running operations (MAST imports, composite/mosaic generation) currently use 500ms HTTP polling for progress, which wastes bandwidth and adds latency. Composite and mosaic generation are fully synchronous — the HTTP request blocks for up to 10 minutes with no progress feedback. This PR lays...*
+*Large composite exports (4K, multi-channel) can take 30+ seconds. Synchronous exports block the HTTP request thread and risk timeouts. Routing through a job queue enables real-time progress feedback v...*
 
-- **[#477](https://github.com/Snoww3d/jwst-data-analysis/pull/477)** feat: add unified job tracker with MongoDB persistence and REST API (Phase 2)
+### [#481](https://github.com/Snoww3d/jwst-data-analysis/pull/481) use mast_obs_id for imported status matching in MAST search
 
-    Adds a unified job tracking system for all async operations (import, composite, mosaic). MongoDB-backed with in-memory `ConcurrentDictionary` cache, ownership enforcement, automatic SignalR push on every state change, and REST API for status/cancel/result retrieval.
+- Fix MAST search "Imported" badge never appearing after importing an observation
 
-    *The existing `ImportJobTracker` is import-specific and in-memory only. As we add async composite and mosaic generation (Phases 4-5), we need a single job tracker that persists across restarts, enforces ownership, and pushes real-time updates via the Phase 1 SignalR infrastructure.*
+*The `importedObsIds` set was built from `observationBaseId` (compact filename-derived format like `jw02733002002`) but compared against MAST search `obs_id` (MAST format like `jw02733-o002_t001_miri_f...*
 
-- **[#478](https://github.com/Snoww3d/jwst-data-analysis/pull/478)** feat: migrate MAST import progress from HTTP polling to SignalR WebSocket (Phase 3)
+## What Changed
 
-    Replace all HTTP polling loops for MAST import progress with SignalR WebSocket push notifications. Backend dual-write adapter bridges the sync ImportJobTracker (primary, in-memory) to the async IJobTracker (MongoDB + SignalR push). Frontend two-layer architecture handles both hook-based and imperative subscription patterns.
+### Features (4)
 
-    *MAST imports currently poll every 500ms (up to 1200 polls per job). With SignalR, progress is pushed instantly over a single WebSocket connection. This reduces HTTP request volume by ~99% during imports and enables real-time progress for future phases (composite/mosaic async operations).*
+- [#475](https://github.com/Snoww3d/jwst-data-analysis/pull/475) add SignalR infrastructure for real-time job progress (Phase 1)
+- [#477](https://github.com/Snoww3d/jwst-data-analysis/pull/477) add unified job tracker with MongoDB persistence and REST API (Phase 2)
+- [#478](https://github.com/Snoww3d/jwst-data-analysis/pull/478) migrate MAST import progress from HTTP polling to SignalR WebSocket (Phase 3)
+- [#482](https://github.com/Snoww3d/jwst-data-analysis/pull/482) add async composite export with job queue and SignalR progress (Phase 4)
 
-- **[#479](https://github.com/Snoww3d/jwst-data-analysis/pull/479)** fix: make MJD epoch timezone-aware to match datetime.now(UTC)
+### Bug Fixes (3)
 
-    Fix `can't subtract offset-naive and offset-aware datetimes` error that breaks the WhatsNewPanel "What's New on MAST" recent releases query.
+- [#479](https://github.com/Snoww3d/jwst-data-analysis/pull/479) make MJD epoch timezone-aware to match datetime.now(UTC)
+- [#480](https://github.com/Snoww3d/jwst-data-analysis/pull/480) convert MAST thumbnail URIs to HTTPS URLs
+- [#481](https://github.com/Snoww3d/jwst-data-analysis/pull/481) use mast_obs_id for imported status matching in MAST search
 
-    *`datetime.now(UTC)` returns a timezone-aware datetime, but `MJD_EPOCH = datetime(1858, 11, 17)` was naive. Subtracting them raises a `TypeError`, causing a 500 error on the `/mast/search/recent` endpoint.*
+### Documentation (1)
 
-- **[#480](https://github.com/Snoww3d/jwst-data-analysis/pull/480)** fix: convert MAST thumbnail URIs to HTTPS URLs
-
-    - Convert MAST `mast:` URI scheme fields to browser-loadable HTTPS URLs
-
-    *MAST API returns `jpegURL` and `dataURL` fields using the `mast:` URI scheme (e.g., `mast:JWST/product/filename.jpg`). Browsers don't recognize this scheme, causing `net::ERR_UNKNOWN_URL_SCHEME` errors and broken thumbnail images in the What's New panel and search results.*
-
-- **[#481](https://github.com/Snoww3d/jwst-data-analysis/pull/481)** fix: use mast_obs_id for imported status matching in MAST search
-
-    - Fix MAST search "Imported" badge never appearing after importing an observation
-
-    *The `importedObsIds` set was built from `observationBaseId` (compact filename-derived format like `jw02733002002`) but compared against MAST search `obs_id` (MAST format like `jw02733-o002_t001_miri_f1130w`). These formats never match, so imported observations were never marked as "Imported" in sear...*
-
-- **[#482](https://github.com/Snoww3d/jwst-data-analysis/pull/482)** feat: add async composite export with job queue and SignalR progress (Phase 4)
-
-    - Adds non-blocking composite image export via a bounded `Channel<T>` queue and `BackgroundService`, completing Phase 4 of the SignalR migration
-    - Preview generation stays synchronous; only exports route through the async pipeline
-    - New `POST /api/composite/export-nchannel` endpoint requires authentication and returns `202 Accepted` with a `jobId`
-    - Export button transforms into a filling progress...
-
-    *Large composite exports (4K, multi-channel) can take 30+ seconds. Synchronous exports block the HTTP request thread and risk timeouts. Routing through a job queue enables real-time progress feedback via SignalR, cancellation support, and result persistence via `IStorageProvider`.*
-
-- **[#483](https://github.com/Snoww3d/jwst-data-analysis/pull/483)** docs: correct job queue task status in development plan
-
-    - Unchecks the "Job queue + WebSocket progress" task — infrastructure is done but mosaic migration is still pending
-
-    *PR #482 incorrectly marked this task as fully complete. The infrastructure (SignalR hub, unified job tracker, queue pattern) and two migrations (MAST imports, composite exports) are done, but mosaic generation and mosaic save-as-FITS still use synchronous HTTP.*
+- [#483](https://github.com/Snoww3d/jwst-data-analysis/pull/483) correct job queue task status in development plan
 
 ---
-*10 commits across this session.*
+10 commits across 8 pull requests.
+*Next: February 26, 2026 — fix 9 roadmap discrepancies found during plan-vs-c..., add v1 plans — guided discovery, color mapping, jo..., add architecture assessment and risk analysis to d...*

--- a/docs/blog/posts/2026-02-26.md
+++ b/docs/blog/posts/2026-02-26.md
@@ -21,94 +21,50 @@ authors:
 
 <!-- generated -->
 
-**5 features, 4 fixes, 4 docs** — ci, docs, export, guided-wizard, imaging, job-queue, ui
+A marathon session: 13 pull requests merged (5 features, 4 fixes, 4 docs). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#484](https://github.com/Snoww3d/jwst-data-analysis/pull/484)** docs: fix 9 roadmap discrepancies found during plan-vs-code audit
+### [#495](https://github.com/Snoww3d/jwst-data-analysis/pull/495) add missing filterCount/compositePotential to featured targets
 
-    Deep audit of `development-plan.md` against the actual codebase found 9 discrepancies where the roadmap didn't match reality — items marked complete that aren't functional, stale test counts, and overstated capabilities.
+Fix blank/black screen on Discovery home page caused by frontend-backend data mismatch in featured targets.
 
-    *Accurate roadmap is critical for prioritization and knowing what's actually left to do. Several items were incorrectly checked off, which would lead to skipping work that's still needed (e.g., C1 smoothing).*
+*The frontend `TargetCard` component expected `filterCount`, `compositePotential`, and `thumbnail` fields that were never added to the backend `FeaturedTarget` model. When the API returned targets with...*
 
-- **[#485](https://github.com/Snoww3d/jwst-data-analysis/pull/485)** docs: add v1 plans — guided discovery, color mapping, job queue
+### [#488](https://github.com/Snoww3d/jwst-data-analysis/pull/488) cap mosaic preview resolution with structured timing logs
 
-    Track v1 planning documents in git and add them to the mkdocs documentation site under a new **Plans** section.
+- Cap synchronous mosaic preview resolution to 2048px (longest edge) to prevent timeout for large file counts
+- Add structured timing logs (file count, resolution, cap status, output size, duration) for evidence-based monitoring
+- Configurable via `Mosaic:MaxPreviewDimension` — async export/save pat...
 
-    *These plans were living as untracked files. Getting them into git means they're versioned, searchable, and visible on the docs site for reference during implementation.*
+*The synchronous `/api/mosaic/generate` endpoint times out for 49+ files because WCS reprojection reads all input pixels regardless of output size. Capping preview resolution reduces output generation ...*
 
-- **[#486](https://github.com/Snoww3d/jwst-data-analysis/pull/486)** docs: add architecture assessment and risk analysis to discovery plan
+## What Changed
 
-    Adds a "Current Architecture" section and expanded implementation details to the guided discovery experience plan.
+### Features (5)
 
-    *The plan described what to build but not what needs to change in the existing codebase. Without understanding the current modal-based architecture and the 685-line dashboard monolith, the phased implementation was just a task list without risk context.*
+- [#487](https://github.com/Snoww3d/jwst-data-analysis/pull/487) add async mosaic export and save with job queue and SignalR progress (Phase 5)
+- [#488](https://github.com/Snoww3d/jwst-data-analysis/pull/488) cap mosaic preview resolution with structured timing logs
+- [#490](https://github.com/Snoww3d/jwst-data-analysis/pull/490) add React Router routes and shared layout shell (Guided Discovery Phase A)
+- [#491](https://github.com/Snoww3d/jwst-data-analysis/pull/491) add chromatic ordering, recipe engine, and DiscoveryController (Phase B)
+- [#492](https://github.com/Snoww3d/jwst-data-analysis/pull/492) implement discovery pages and guided creation flow (Phase C)
 
-- **[#487](https://github.com/Snoww3d/jwst-data-analysis/pull/487)** feat: add async mosaic export and save with job queue and SignalR progress (Phase 5)
+### Bug Fixes (4)
 
-    - Migrate mosaic export and save-to-library from synchronous HTTP to the async job queue infrastructure (Phase 5)
-    - Both flows use bounded channel queue → BackgroundService → IJobTracker → SignalR progress push, matching the composite pattern from Phase 4 (#482)
-    - Frontend export and save buttons both show progress bar fills with simulated smooth interpolation — consistent UX across composite and ...
+- [#489](https://github.com/Snoww3d/jwst-data-analysis/pull/489) replace Task.Delay with TaskCompletionSource in flaky dual-write tests
+- [#494](https://github.com/Snoww3d/jwst-data-analysis/pull/494) address Phase B review findings
+- [#495](https://github.com/Snoww3d/jwst-data-analysis/pull/495) add missing filterCount/compositePotential to featured targets
+- [#496](https://github.com/Snoww3d/jwst-data-analysis/pull/496) align discovery frontend types with backend camelCase serialization
 
-    *Long-running mosaic operations (export large PNG/JPEG, save FITS to library) were blocking the HTTP request, causing timeouts and poor UX. This migrates them to the existing job queue + SignalR infrastructure.*
+### Documentation (4)
 
-- **[#488](https://github.com/Snoww3d/jwst-data-analysis/pull/488)** feat: cap mosaic preview resolution with structured timing logs
-
-    - Cap synchronous mosaic preview resolution to 2048px (longest edge) to prevent timeout for large file counts
-    - Add structured timing logs (file count, resolution, cap status, output size, duration) for evidence-based monitoring
-    - Configurable via `Mosaic:MaxPreviewDimension` — async export/save paths remain uncapped
-
-    *The synchronous `/api/mosaic/generate` endpoint times out for 49+ files because WCS reprojection reads all input pixels regardless of output size. Capping preview resolution reduces output generation time while the async export path (already implemented) handles full-resolution output. Structured lo...*
-
-- **[#489](https://github.com/Snoww3d/jwst-data-analysis/pull/489)** fix: replace Task.Delay with TaskCompletionSource in flaky dual-write tests
-
-    - Fix flaky `ImportJobTrackerTests.CompleteJob_DualWritesToUnifiedTracker` test that failed on CI
-    - Replace `Task.Delay(100)` with `TaskCompletionSource` + `WaitAsync(5s)` in all 5 dual-write tests
-
-    *The dual-write tests used `Task.Delay(100)` to wait for fire-and-forget async operations. On slow CI runners, 100ms isn't enough — the async callback hasn't completed when `Verify()` runs, causing spurious failures. `TaskCompletionSource` waits for the actual invocation instead of guessing timing.*
-
-- **[#490](https://github.com/Snoww3d/jwst-data-analysis/pull/490)** feat: add React Router routes and shared layout shell (Guided Discovery Phase A)
-
-    Restructure the frontend from single-page modal-only navigation to page-based routing with a persistent header/nav. This is **Phase A** of the Guided Discovery Experience — the foundational routing and layout changes needed before building the discovery pages.
-
-    *The app currently has no meaningful routing — every feature is a modal or toggled panel controlled by boolean state. Users can't bookmark views, browser back doesn't work within the app, and there's no way to add new pages. This PR adds the routing infrastructure that all subsequent Guided Discovery...*
-
-- **[#491](https://github.com/Snoww3d/jwst-data-analysis/pull/491)** feat: add chromatic ordering, recipe engine, and DiscoveryController (Phase B)
-
-    Add chromatic ordering color mapping, the suggestion/recipe engine, and the DiscoveryController — the full backend infrastructure for the Guided Discovery Experience.
-
-    *The guided discovery flow needs: (1) better default colors for composites (chromatic ordering), (2) a recipe engine that suggests composite configurations for any JWST target, and (3) API endpoints to serve featured targets and proxy recipe requests. This PR delivers all three, unblocking the fronte...*
-
-- **[#492](https://github.com/Snoww3d/jwst-data-analysis/pull/492)** feat: implement discovery pages and guided creation flow (Phase C)
-
-    Replaces Phase A placeholder pages with full implementations for the guided discovery experience. Adds the discovery home page with featured targets, target detail page with recipe suggestions, and the 3-step guided creation flow (download → process → result).
-
-    *Phase A created the routing shell with placeholder pages, and Phase B added the backend recipe engine and DiscoveryController. This PR brings those together with real frontend implementations that let users discover targets, see composite suggestions, and create composites through a guided flow — th...*
-
-- **[#493](https://github.com/Snoww3d/jwst-data-analysis/pull/493)** docs: update documentation for guided discovery Phases A–C
-
-    Updates project documentation to reflect all changes from the guided discovery experience (Phases A, B, and C).
-
-    *Three feature PRs (#490, #491, #492) added new controllers, services, components, pages, and endpoints that need to be reflected in the project documentation.*
-
-- **[#494](https://github.com/Snoww3d/jwst-data-analysis/pull/494)** fix: address Phase B review findings
-
-    Addresses the 2 should-fix items from the reviewer's PR #491 code review.
-
-    *The reviewer flagged two maintenance concerns: duplicate wavelength tables without cross-references, and `requires_mosaic` being described as functional when it's actually a placeholder.*
-
-- **[#495](https://github.com/Snoww3d/jwst-data-analysis/pull/495)** fix: add missing filterCount/compositePotential to featured targets
-
-    Fix blank/black screen on Discovery home page caused by frontend-backend data mismatch in featured targets.
-
-    *The frontend `TargetCard` component expected `filterCount`, `compositePotential`, and `thumbnail` fields that were never added to the backend `FeaturedTarget` model. When the API returned targets without these fields, `TargetCard` crashed accessing `undefined.label`, taking down the entire page with...*
-
-- **[#496](https://github.com/Snoww3d/jwst-data-analysis/pull/496)** fix: align discovery frontend types with backend camelCase serialization
-
-    Fix black screen on target detail page caused by frontend/backend JSON field naming mismatch.
-
-    *ASP.NET serializes response fields as camelCase (`colorMapping`, `requiresMosaic`, `estimatedTimeSeconds`) but the frontend `CompositeRecipe` type used snake_case (`color_mapping`, `requires_mosaic`, `estimated_time_seconds`). This caused `RecipeCard` to crash accessing undefined properties when ren...*
+- [#484](https://github.com/Snoww3d/jwst-data-analysis/pull/484) fix 9 roadmap discrepancies found during plan-vs-code audit
+- [#485](https://github.com/Snoww3d/jwst-data-analysis/pull/485) add v1 plans — guided discovery, color mapping, job queue
+- [#486](https://github.com/Snoww3d/jwst-data-analysis/pull/486) add architecture assessment and risk analysis to discovery plan
+- [#493](https://github.com/Snoww3d/jwst-data-analysis/pull/493) update documentation for guided discovery Phases A–C
 
 ---
-*13 commits across this session.*
+13 commits across 13 pull requests.
+*Next: February 27, 2026 — improve guided create flow — download feedback, pa..., resolve target aliases, download progress, auth er..., make discovery pages public, gate auth at download...*

--- a/docs/blog/posts/2026-02-27.md
+++ b/docs/blog/posts/2026-02-27.md
@@ -17,66 +17,42 @@ authors:
 
 <!-- generated -->
 
-**2 features, 7 fixes** — auth, e2e-tests, guided-wizard, imaging
+Productive session with 9 pull requests: 2 features, 7 fixes. Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#497](https://github.com/Snoww3d/jwst-data-analysis/pull/497)** fix: improve guided create flow — download feedback, parallel downloads, target resolution
+### [#505](https://github.com/Snoww3d/jwst-data-analysis/pull/505) make wizard page footers always visible without scrolling
 
-    Fixes multiple issues in the guided create flow discovered during end-to-end testing: zero-product error handling, parallel downloads, target name resolution, auth on discovery endpoints, JSON serialization, broken e2e tests, and CI reliability.
+Fixes layout issues after converting composite/mosaic wizard modals to dedicated route pages (PR #504). The wizard page footers (Next/Back/Done buttons) were pushed off-screen requiring scroll, and the layout needed tuning for full-page use.
 
-    *The guided create flow shipped from Phase C with several stacked bugs that made it unreliable — downloads failed silently, targets couldn't be resolved by MAST, discovery endpoints required auth unnecessarily, downloads ran serially, and the route change broke 318 existing e2e tests.*
+*After PR #504 converted the wizards from modals to pages, three issues emerged: 1. Footers were pushed below the viewport because `app-shell` used block flow instead of flex 2. The modal-era styling (...*
 
-- **[#498](https://github.com/Snoww3d/jwst-data-analysis/pull/498)** fix: resolve target aliases, download progress, auth errors, and skip re-downloads
+### [#504](https://github.com/Snoww3d/jwst-data-analysis/pull/504) convert wizard modals to pages and wire advanced editor link
 
-    Fixes multiple issues in the guided create flow: common name resolution for target search, broken download progress tracking, JWT expiration during long downloads, unclear download status icons, NaN recipe card durations, wasteful re-downloading of existing files, file progress status not reaching the frontend for fast-completing downloads, and flaky CI tests.
+- Convert Composite and Mosaic wizards from modal overlays to dedicated route pages (`/composite`, `/mosaic`)
+- Wire the "Open in Advanced Editor" link in the Guided Create result step to navigate to `/composite` with pre-populated channels
 
-    *These issues collectively degrade the guided create experience: common names like "Pillars of Creation" fail to resolve, download progress bars stall or show NaN, 401 errors kill long downloads, files that already exist on disk get re-downloaded, the file count shows "0 of N files" even when downloa...*
+*The guided create flow's "Open in Advanced Editor" link previously navigated to `/library` with no state — users lost their channel assignments. Converting the wizards to pages enables state passing v...*
 
-- **[#499](https://github.com/Snoww3d/jwst-data-analysis/pull/499)** feat: make discovery pages public, gate auth at download action
+## What Changed
 
-    Make Discovery, Target Detail, and Guided Create pages publicly accessible without login. Auth is only required when the user initiates a download — a sign-in gate intercepts at that point with redirect-back support.
+### Features (2)
 
-    *Previously all routes were wrapped in `ProtectedRoute`, forcing login just to browse targets. Users should be able to explore and view target details without creating an account. Auth is only needed when an action increases server storage (downloading files).*
+- [#499](https://github.com/Snoww3d/jwst-data-analysis/pull/499) make discovery pages public, gate auth at download action
+- [#504](https://github.com/Snoww3d/jwst-data-analysis/pull/504) convert wizard modals to pages and wire advanced editor link
 
-- **[#500](https://github.com/Snoww3d/jwst-data-analysis/pull/500)** fix: add file deduplication, unique index, and data integrity fixes
+### Bug Fixes (7)
 
-    Fix file deduplication and data integrity issues that arise from re-importing MAST observations. Adds a unique index on `FileName`, startup dedup cleanup, DuplicateKey race condition handling, userId/isPublic preservation through resume paths, and skip-redownload for existing files.
-
-    *During development/testing, the guided create flow was used to import MAST observations multiple times. The dedup check (`GetByFileNameAsync` before `CreateAsync`) is application-level only — no unique index on `FileName` in MongoDB. Race conditions, the `DataScanService` startup scan (which dedupli...*
-
-- **[#501](https://github.com/Snoww3d/jwst-data-analysis/pull/501)** fix: resolve E2E test failures from public discovery routes
-
-    Fixes all E2E test failures introduced by the public discovery routes PR (#499). Addresses four root causes: auth redirect tests, duplicate key upload errors, snake_case mock data, and logout navigation.
-
-    *PR #499 made discovery pages public, which broke 34 E2E tests across auth redirects, file uploads, mock data format, and logout behavior.*
-
-- **[#502](https://github.com/Snoww3d/jwst-data-analysis/pull/502)** fix: suppress CA1869 in test-only JsonSerializerOptions
-
-    Suppresses CA1869 analyzer warning in `DiscoveryServiceAliasTests` where `JsonSerializerOptions` is instantiated once during test setup to write a fixture JSON file.
-
-    *The `--warnaserror` local compliance build failed on this warning introduced by PR #498. CI doesn't use `--warnaserror` so it passed there, but local compliance checks caught it.*
-
-- **[#503](https://github.com/Snoww3d/jwst-data-analysis/pull/503)** fix: handle missing colorMapping in guided create composite flow
-
-    Fixes crash in guided composite creation when `recipe.colorMapping` is undefined. The error manifested as `Cannot read properties of undefined (reading 'F090W')` during the Process step.
-
-    *`buildChannelPayloads` accessed `recipe.colorMapping[filter]` without null-checking. While the API normally returns `colorMapping`, it can be undefined during transient backend issues (e.g., Docker rebuild mid-request) or serialization edge cases. The crash prevented retry from working.*
-
-- **[#504](https://github.com/Snoww3d/jwst-data-analysis/pull/504)** feat: convert wizard modals to pages and wire advanced editor link
-
-    - Convert Composite and Mosaic wizards from modal overlays to dedicated route pages (`/composite`, `/mosaic`)
-    - Wire the "Open in Advanced Editor" link in the Guided Create result step to navigate to `/composite` with pre-populated channels
-
-    *The guided create flow's "Open in Advanced Editor" link previously navigated to `/library` with no state — users lost their channel assignments. Converting the wizards to pages enables state passing via React Router, giving the Composite Creator a proper URL and allowing pre-population from both the...*
-
-- **[#505](https://github.com/Snoww3d/jwst-data-analysis/pull/505)** fix: make wizard page footers always visible without scrolling
-
-    Fixes layout issues after converting composite/mosaic wizard modals to dedicated route pages (PR #504). The wizard page footers (Next/Back/Done buttons) were pushed off-screen requiring scroll, and the layout needed tuning for full-page use.
-
-    *After PR #504 converted the wizards from modals to pages, three issues emerged: 1. Footers were pushed below the viewport because `app-shell` used block flow instead of flex 2. The modal-era styling (heavy borders, padding, box-shadow) wasted space in a full-page layout 3. The right padding was miss...*
+- [#497](https://github.com/Snoww3d/jwst-data-analysis/pull/497) improve guided create flow — download feedback, parallel downloads, target resolution
+- [#498](https://github.com/Snoww3d/jwst-data-analysis/pull/498) resolve target aliases, download progress, auth errors, and skip re-downloads
+- [#500](https://github.com/Snoww3d/jwst-data-analysis/pull/500) add file deduplication, unique index, and data integrity fixes
+- [#501](https://github.com/Snoww3d/jwst-data-analysis/pull/501) resolve E2E test failures from public discovery routes
+- [#502](https://github.com/Snoww3d/jwst-data-analysis/pull/502) suppress CA1869 in test-only JsonSerializerOptions
+- [#503](https://github.com/Snoww3d/jwst-data-analysis/pull/503) handle missing colorMapping in guided create composite flow
+- [#505](https://github.com/Snoww3d/jwst-data-analysis/pull/505) make wizard page footers always visible without scrolling
 
 ---
-*12 commits across this session.*
+12 commits across 9 pull requests.
+*Next: February 28, 2026 — use NASA/STScI discrete color palette for composit..., send job snapshot on SignalR subscribe to prevent ..., freshen AGENTS.md with current project state*

--- a/docs/blog/posts/2026-02-28.md
+++ b/docs/blog/posts/2026-02-28.md
@@ -8,10 +8,12 @@ categories:
   - Feature
   - Bug Fix
 tags:
+  - astronomy-data
   - auth
   - ci
   - code-quality
   - dependencies
+  - deployment
   - docs
   - e2e-tests
   - guided-wizard
@@ -19,6 +21,7 @@ tags:
   - infrastructure
   - job-queue
   - mast-data
+  - performance
 authors:
   - shanon
 ---
@@ -27,168 +30,61 @@ authors:
 
 <!-- generated -->
 
-**6 features, 12 fixes, 3 docs, 1 maintenance, 12 dep updates** — auth, ci, code-quality, dependencies, docs, e2e-tests, guided-wizard, imaging, infrastructure, job-queue, mast-data
+A marathon session: 34 pull requests merged (6 features, 12 fixes, 3 docs, 1 maintenance, 12 dependency updates). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#506](https://github.com/Snoww3d/jwst-data-analysis/pull/506)** feat: use NASA/STScI discrete color palette for composite presets
+### [#539](https://github.com/Snoww3d/jwst-data-analysis/pull/539) use synchronous composite endpoint for anonymous users
 
-    Replace the evenly-spaced hue interpolation for composite color assignments with NASA/STScI's discrete 7-color palette (Purple, Blue, Cyan, Green, Yellow, Orange, Red). This matches the color convention used in official NASA press releases for JWST imagery.
+Fixes 401 error when anonymous users attempt composite generation on the GuidedCreate page.
 
-    *Our previous approach distributed hues evenly across 0-240°, which produced arbitrary colors that didn't match NASA's published conventions. Users familiar with NASA imagery (Cranium Nebula, Pillars of Creation, etc.) expect the standard palette: Blue for shortest wavelength, Red for longest, with s...*
+*PR #538 enabled anonymous users to skip the download step when data already exists in the library, but the Process step still called the async export endpoint (`export-nchannel`) which requires authen...*
 
-- **[#507](https://github.com/Snoww3d/jwst-data-analysis/pull/507)** fix: send job snapshot on SignalR subscribe to prevent composite timeout
+### [#535](https://github.com/Snoww3d/jwst-data-analysis/pull/535) exclude spectral observations from composite pipeline
 
-    Fix SignalR race condition that caused "No progress updates received (SignalR timeout)" during composite generation for large multi-filter targets.
+Spectral observations (NIRSpec `_x1d.fits` files) have no 2D image data and crash the composite engine with `BadRequest - No image data found in FITS file`. This PR filters them out at three defensive layers.
 
-    *When a user starts composite processing (e.g., 8-filter PMR 1), the backend sends a 10% progress event immediately via SignalR. However, the frontend's SignalR subscription is established *after* the API call returns, so the 10% event is lost. With no events arriving, the 2-minute safety timeout fir...*
+*When a target has NIRSpec spectroscopic observations, the system tries to build composites from 1D spectral table files, crashing the composite engine. This affects any target with mixed imaging + spe...*
 
-- **[#508](https://github.com/Snoww3d/jwst-data-analysis/pull/508)** docs: freshen AGENTS.md with current project state
+## What Changed
 
-    Update AGENTS.md to reflect the current state of the project after months of development.
+### Features (6)
 
-    *Several sections were stale — referencing Phase 4 (now complete), modal wizards (now page routes), and markdown docs for bug tracking (now GitHub Issues).*
+- [#506](https://github.com/Snoww3d/jwst-data-analysis/pull/506) use NASA/STScI discrete color palette for composite presets
+- [#510](https://github.com/Snoww3d/jwst-data-analysis/pull/510) add per-channel color/weight controls with NASA preset swatches
+- [#523](https://github.com/Snoww3d/jwst-data-analysis/pull/523) add NASA/STScI thumbnail images to featured targets
+- [#526](https://github.com/Snoww3d/jwst-data-analysis/pull/526) add AWS EC2 staging deployment scripts
+- [#536](https://github.com/Snoww3d/jwst-data-analysis/pull/536) add auth badge to recipe cards and cache MAST target searches
+- [#538](https://github.com/Snoww3d/jwst-data-analysis/pull/538) allow anonymous access to read-only endpoints and skip download for existing data
 
-- **[#509](https://github.com/Snoww3d/jwst-data-analysis/pull/509)** fix: prevent OOM crash in 8-channel composite generation
+### Bug Fixes (12)
 
-    Fixes SIGKILL OOM crash when generating an 8-channel composite (e.g. Pillars of Creation from guided create). The processing engine was silently killed by the OS when `reproject_channels_to_common_wcs()` tried to reproject all 8 channels onto a ~4000x4000 grid simultaneously, exceeding available memory.
+- [#507](https://github.com/Snoww3d/jwst-data-analysis/pull/507) send job snapshot on SignalR subscribe to prevent composite timeout
+- [#509](https://github.com/Snoww3d/jwst-data-analysis/pull/509) prevent OOM crash in 8-channel composite generation
+- [#524](https://github.com/Snoww3d/jwst-data-analysis/pull/524) show active stage indicator during composite processing
+- [#525](https://github.com/Snoww3d/jwst-data-analysis/pull/525) cap download speed display and add GB formatting tier
+- [#527](https://github.com/Snoww3d/jwst-data-analysis/pull/527) set data directory ownership for container user in server-setup
+- [#528](https://github.com/Snoww3d/jwst-data-analysis/pull/528) add SignalR /hubs proxy to nginx staging and production configs
+- [#530](https://github.com/Snoww3d/jwst-data-analysis/pull/530) filter proprietary MAST data from searches and recipes
+- [#531](https://github.com/Snoww3d/jwst-data-analysis/pull/531) use Simbad-resolvable names for featured target searches
+- [#533](https://github.com/Snoww3d/jwst-data-analysis/pull/533) remove overflow hidden that prevents library dashboard scrolling
+- [#534](https://github.com/Snoww3d/jwst-data-analysis/pull/534) wait for wizard stepper in composite E2E tests
+- [#535](https://github.com/Snoww3d/jwst-data-analysis/pull/535) exclude spectral observations from composite pipeline
+- [#539](https://github.com/Snoww3d/jwst-data-analysis/pull/539) use synchronous composite endpoint for anonymous users
 
-    *With 8 channels (two NIRCam at ~16M pixels, six MIRI), peak memory during reprojection reached 4-5 GB — too much for the Docker container's ~8 GB share. The user saw "An error occurred while sending the request" with no traceback or useful error message, and the container restarted 6 times.*
+### Documentation (3)
 
-- **[#510](https://github.com/Snoww3d/jwst-data-analysis/pull/510)** feat: add per-channel color/weight controls with NASA preset swatches
+- [#508](https://github.com/Snoww3d/jwst-data-analysis/pull/508) freshen AGENTS.md with current project state
+- [#532](https://github.com/Snoww3d/jwst-data-analysis/pull/532) add tiered storage and email/account management roadmap
+- [#540](https://github.com/Snoww3d/jwst-data-analysis/pull/540) add OpenTelemetry observability roadmap (O-series)
 
-    Add per-channel color pickers and weight sliders to the guided create Result page, with a popover featuring NASA/STScI preset color swatches for one-click color selection.
+### Maintenance (1)
 
-    *The Result page only had global Brightness/Contrast/Saturation sliders — changing an individual channel's color required navigating to the full Advanced Editor. This adds inline controls with debounced auto-apply for a smoother workflow, plus quick-pick preset colors from the NASA/STScI palette so u...*
+- [#541](https://github.com/Snoww3d/jwst-data-analysis/pull/541) add staging server start/stop/deploy script
 
-- **[#511](https://github.com/Snoww3d/jwst-data-analysis/pull/511)** chore(deps): bump actions/upload-artifact from 6 to 7
-
-- **[#512](https://github.com/Snoww3d/jwst-data-analysis/pull/512)** chore(deps): bump fastapi from 0.129.2 to 0.134.0 in /processing-engine
-
-- **[#513](https://github.com/Snoww3d/jwst-data-analysis/pull/513)** chore(deps): bump pytest-cov from 6.2.1 to 7.0.0 in /processing-engine
-
-- **[#514](https://github.com/Snoww3d/jwst-data-analysis/pull/514)** chore(deps-dev): bump eslint-plugin-react-refresh from 0.5.0 to 0.5.2 in /frontend/jwst-frontend
-
-- **[#515](https://github.com/Snoww3d/jwst-data-analysis/pull/515)** chore(deps-dev): bump eslint from 10.0.1 to 10.0.2 in /frontend/jwst-frontend
-
-- **[#516](https://github.com/Snoww3d/jwst-data-analysis/pull/516)** chore(deps): bump ruff from 0.15.2 to 0.15.4 in /processing-engine
-
-- **[#517](https://github.com/Snoww3d/jwst-data-analysis/pull/517)** chore(deps): bump pandas from 2.2.3 to 2.3.3 in /processing-engine
-
-- **[#518](https://github.com/Snoww3d/jwst-data-analysis/pull/518)** chore(deps): bump python-multipart from 0.0.6 to 0.0.22 in /processing-engine
-
-- **[#519](https://github.com/Snoww3d/jwst-data-analysis/pull/519)** chore(deps-dev): bump @typescript-eslint/parser from 8.56.0 to 8.56.1 in /frontend/jwst-frontend
-
-- **[#520](https://github.com/Snoww3d/jwst-data-analysis/pull/520)** chore(deps): bump react-router-dom from 7.13.0 to 7.13.1 in /frontend/jwst-frontend
-
-- **[#521](https://github.com/Snoww3d/jwst-data-analysis/pull/521)** chore(deps-dev): bump @types/node from 25.2.2 to 25.3.2 in /frontend/jwst-frontend
-
-- **[#522](https://github.com/Snoww3d/jwst-data-analysis/pull/522)** Bump AWSSDK.S3 from 4.0.18.6 to 4.0.18.7
-
-- **[#523](https://github.com/Snoww3d/jwst-data-analysis/pull/523)** feat: add NASA/STScI thumbnail images to featured targets
-
-    Add official JWST thumbnail URLs to all 13 featured targets on the discovery home page.
-
-    *The featured target cards showed placeholder gradient backgrounds with a telescope icon instead of real images. The `FeaturedTarget` model already supports a `thumbnail` field and `TargetCard.tsx` renders it — the data just wasn't populated.*
-
-- **[#524](https://github.com/Snoww3d/jwst-data-analysis/pull/524)** fix: show active stage indicator during composite processing
-
-    Fix the process step (step 2) in guided create so it shows an active pulsing indicator on the current processing stage instead of leaving all stages as pending circles.
-
-    *After "Loading files" completed, "Applying color mapping" and "Final adjustments" both showed empty pending circles with no active indicator — making it look like processing had stalled. The root cause: the backend sends `stage="generating"` but the frontend expected exact stage names (`Loading`, `C...*
-
-- **[#525](https://github.com/Snoww3d/jwst-data-analysis/pull/525)** fix: cap download speed display and add GB formatting tier
-
-    Fixes absurd download speed display (e.g. "3173269.6 MB/s") caused by cached files completing near-instantly and `formatBytes()` lacking a GB tier.
-
-    *The `SpeedTracker` sliding window produces extreme byte/sec values when files complete from cache with near-zero elapsed time. Combined with `formatBytes()` only handling up to MB, users saw nonsensical multi-million MB/s speeds.*
-
-- **[#526](https://github.com/Snoww3d/jwst-data-analysis/pull/526)** feat: add AWS EC2 staging deployment scripts
-
-    Adds automated provisioning and deployment scripts for running the JWST app on an AWS EC2 instance. Enables testing in a real environment and sharing as a public demo.
-
-    *The app needs a publicly accessible staging server for real-environment testing and eventual portfolio/community sharing (Reddit). Starting with the simplest viable approach — single EC2 running Docker Compose — with a clear path to Terraform/CI/CD later.*
-
-- **[#527](https://github.com/Snoww3d/jwst-data-analysis/pull/527)** fix: set data directory ownership for container user in server-setup
-
-    Fix PermissionError on first EC2 deployment by setting data directory ownership to uid 1001.
-
-    *Containers run as non-root `appuser` (uid 1001). The data directory created by `mkdir` is owned by `ec2-user`, so the processing engine crashes with `PermissionError: [Errno 13] Permission denied: '/app/data/mast/.download_state'` on first boot.*
-
-- **[#528](https://github.com/Snoww3d/jwst-data-analysis/pull/528)** fix: add SignalR /hubs proxy to nginx staging and production configs
-
-    Add `/hubs` location block to nginx staging and production configs to proxy SignalR WebSocket connections to the backend.
-
-    *SignalR connects to `/hubs/job-progress` for real-time job progress updates. The nginx configs only proxied `/api`, so SignalR negotiate/connect requests hit the SPA fallback (`try_files → index.html`) instead of reaching the backend. This caused the guided create flow to appear stuck at "Loading fi...*
-
-- **[#530](https://github.com/Snoww3d/jwst-data-analysis/pull/530)** fix: filter proprietary MAST data from searches and recipes
-
-    Prevent users from encountering HTTP 401 download errors when JWST data is still under proprietary access periods. Implements dual-layer filtering: at MAST query time (Option A) and as a safety net in the recipe engine (Option B).
-
-    *Users hitting "Carina Nebula" on staging got 401 errors because program jw05408 data is still proprietary. MAST returns these observations in search results, but downloads fail because the data hasn't been publicly released yet. The `t_obs_release` MJD field indicates when data becomes public.*
-
-- **[#531](https://github.com/Snoww3d/jwst-data-analysis/pull/531)** fix: use Simbad-resolvable names for featured target searches
-
-    Fix featured target cards failing to resolve when clicked by using canonical astronomical names that Simbad/NED can look up.
-
-    *Several featured targets used abbreviated names in `mastSearchParams.target` that Simbad cannot resolve (e.g., "Cartwheel" instead of "Cartwheel Galaxy"). When users click these cards, the target detail page fails because `SkyCoord.from_name()` can't find coordinates for the abbreviated name. The va...*
-
-- **[#532](https://github.com/Snoww3d/jwst-data-analysis/pull/532)** docs: add tiered storage and email/account management roadmap
-
-    Add two roadmap items to the development plan and update deployment docs for the 100GB EBS volume.
-
-    *Planning session captured decisions on tiered storage architecture (F4) and email/account management (H-series) for Phase 6. Also documenting the EBS resize from 30→100GB that was done live on the staging server.*
-
-- **[#533](https://github.com/Snoww3d/jwst-data-analysis/pull/533)** fix: remove overflow hidden that prevents library dashboard scrolling
-
-    Removes `overflow: hidden` from `.my-library` container which was clipping all child content and preventing the library dashboard page from scrolling.
-
-    *The library dashboard stopped scrolling after PR #490 introduced `overflow: hidden` on the `.my-library` wrapper. The scroll chain is `.app-shell` (overflow: hidden) → `.app-main` (overflow-y: auto, scroll container) → `.my-library` (overflow: hidden — clips content so `.app-main` never sees overflo...*
-
-- **[#534](https://github.com/Snoww3d/jwst-data-analysis/pull/534)** fix: wait for wizard stepper in composite E2E tests
-
-    Fixes 3 failing E2E tests in `composite-wizard.spec.ts` by waiting for the wizard stepper to render instead of the loading state.
-
-    *The CompositePage shows a "Loading images..." state while fetching data asynchronously. The loading div shares the `.composite-page` class, so the tests' `await expect(page.locator('.composite-page')).toBeVisible()` was passing immediately during the loading state — before the wizard stepper existed...*
-
-- **[#535](https://github.com/Snoww3d/jwst-data-analysis/pull/535)** fix: exclude spectral observations from composite pipeline
-
-    Spectral observations (NIRSpec `_x1d.fits` files) have no 2D image data and crash the composite engine with `BadRequest - No image data found in FITS file`. This PR filters them out at three defensive layers.
-
-    *When a target has NIRSpec spectroscopic observations, the system tries to build composites from 1D spectral table files, crashing the composite engine. This affects any target with mixed imaging + spectroscopic data.*
-
-- **[#536](https://github.com/Snoww3d/jwst-data-analysis/pull/536)** feat: add auth badge to recipe cards and cache MAST target searches
-
-    - Recipe cards now show auth status badge ("Login required" / "Ready")
-    - MAST target searches are cached in-memory for 5 minutes on the backend
-
-    *Users need to know upfront whether they'll need to sign in before starting a composite. Additionally, repeated visits to the same target page trigger redundant MAST API calls, adding unnecessary latency.*
-
-- **[#538](https://github.com/Snoww3d/jwst-data-analysis/pull/538)** feat: allow anonymous access to read-only endpoints and skip download for existing data
-
-    Allow anonymous users to access read-only endpoints and skip MAST downloads when public data already exists in the library. This unblocks the GuidedCreate flow for anonymous users when all needed FITS data is already imported.
-
-    *Issue #537: GuidedCreate forces login even when all FITS data already exists as public data. The access-control logic (`FilterAccessibleData`, `IsDataAccessible`) already handles anonymous users correctly by restricting to public data — the only blocker was class-level `[Authorize]` attributes rejec...*
-
-- **[#539](https://github.com/Snoww3d/jwst-data-analysis/pull/539)** fix: use synchronous composite endpoint for anonymous users
-
-    Fixes 401 error when anonymous users attempt composite generation on the GuidedCreate page.
-
-    *PR #538 enabled anonymous users to skip the download step when data already exists in the library, but the Process step still called the async export endpoint (`export-nchannel`) which requires authentication for job queue tracking. Anonymous users hit a 401 at Step 2.*
-
-- **[#540](https://github.com/Snoww3d/jwst-data-analysis/pull/540)** docs: add OpenTelemetry observability roadmap (O-series)
-
-    Adds the O-series (Observability) task group to the Phase 6 roadmap.
-
-    *Logging/monitoring was scattered across vague checklist items. This consolidates into a concrete 13-task plan using OpenTelemetry with direct AWS export.*
-
-- **[#541](https://github.com/Snoww3d/jwst-data-analysis/pull/541)** chore: add staging server start/stop/deploy script
-
-    Adds `scripts/staging.sh` for managing the staging EC2 instance.
-
-    *Currently staging start/stop/deploy requires remembering SSH commands and AWS CLI invocations. This consolidates into one script and makes it easy to stop the instance when not testing (~$25/mo savings).*
+**Dependencies** (12 updates: @types/node, @typescript-eslint/parser, AWSSDK.S3, actions/upload-artifact, eslint, eslint-plugin-react-refresh, fastapi, pandas and 4 more)
 
 ## Issues
 
@@ -203,4 +99,5 @@ authors:
 - [#537](https://github.com/Snoww3d/jwst-data-analysis/issues/537) — Skip login gate in GuidedCreate when data already exists in library
 
 ---
-*36 commits across this session.*
+36 commits across 34 pull requests.
+*Next: March 1, 2026 — reorganize plans into design docs and exploration, comprehensive architecture diagram update, simplify anonymous composite code and fix review f...*

--- a/docs/blog/posts/2026-03-01.md
+++ b/docs/blog/posts/2026-03-01.md
@@ -7,12 +7,14 @@ categories:
   - Bug Fix
   - Refactoring
 tags:
+  - astronomy-data
   - auth
   - docs
   - guided-wizard
   - imaging
   - infrastructure
   - mast-data
+  - performance
   - ui
   - viewer
 authors:
@@ -23,111 +25,57 @@ authors:
 
 <!-- generated -->
 
-**4 features, 5 fixes, 5 docs, 2 refactors** — auth, docs, guided-wizard, imaging, infrastructure, mast-data, ui, viewer
+A marathon session: 16 pull requests merged (4 features, 5 fixes, 5 docs, 2 refactors). Major work on the composite imaging pipeline.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#542](https://github.com/Snoww3d/jwst-data-analysis/pull/542)** docs: reorganize plans into design docs and exploration
+### [#557](https://github.com/Snoww3d/jwst-data-analysis/pull/557) add rotation controls and auto-apply adjustments to guided wizard
 
-    Reorganizes the plans directory and adds the processing engine scaling brainstorm.
+Adds image rotation controls and replaces the manual "Apply Adjustments" button with debounced auto-apply in the guided create wizard's result step. Also adds comprehensive E2E test coverage for step 3 (result step) with a full SignalR long-polling mock.
 
-    *The plans/ directory mixed completed implementation plans with forward-looking exploration. Splitting into design/ and exploration/ makes intent clear.*
+*Users need basic rotation to orient composite images correctly. The "Apply Adjustments" button was an unnecessary extra click compared to the channel color/weight controls which already auto-apply on ...*
 
-- **[#543](https://github.com/Snoww3d/jwst-data-analysis/pull/543)** docs: comprehensive architecture diagram update
+### [#550](https://github.com/Snoww3d/jwst-data-analysis/pull/550) shared image filter toolbar for composite creator
 
-    Major update to architecture.md — updates 3 outdated diagrams and adds 5 new ones.
+- Extracts cascading image filter logic into a reusable `useImageFilters` hook and `<ImageFilterToolbar />` component
+- Wires the shared toolbar into the Composite Creator's Available Images pool
+- Enables search + Target/Stage/Filter dropdown filtering when browsing large image libraries
+- Fixes pr...
 
-    *The architecture doc was significantly behind the codebase. The frontend component hierarchy still showed the old single-page dashboard, the backend service layer was missing ~10 components, and there were no sequence diagrams for core user journeys (discovery, guided creation, auth, job queue).*
+*The Composite Creator's image pool shows a flat list of all unassigned images with no way to search or filter. When the library is large, finding specific images is tedious. The Mosaic Creator already...*
 
-- **[#544](https://github.com/Snoww3d/jwst-data-analysis/pull/544)** refactor: simplify anonymous composite code and fix review findings
+## What Changed
 
-    Code quality cleanup from `/simplify` review of PRs #538 and #539 (anonymous access feature). Extracts duplicated patterns, uses proper constants, and fixes a missing fetch abort.
+### Features (4)
 
-    *The anonymous composite feature introduced duplicated blob-to-preview-URL logic (4 copies), hard-coded composite dimensions in multiple places, string literals instead of existing constants, and a missing fetch abort that left HTTP requests in-flight after component unmount.*
+- [#547](https://github.com/Snoww3d/jwst-data-analysis/pull/547) polish guided discovery with retry, skeletons, and error states
+- [#550](https://github.com/Snoww3d/jwst-data-analysis/pull/550) shared image filter toolbar for composite creator
+- [#557](https://github.com/Snoww3d/jwst-data-analysis/pull/557) add rotation controls and auto-apply adjustments to guided wizard
+- [#558](https://github.com/Snoww3d/jwst-data-analysis/pull/558) sidebar split layout for guided create result step
 
-- **[#545](https://github.com/Snoww3d/jwst-data-analysis/pull/545)** docs: split architecture diagrams into individual pages
+### Bug Fixes (5)
 
-    Split the monolithic `docs/architecture.md` (1011 lines, ~18 Mermaid diagrams) into 15 individual pages under `docs/architecture/`, each with its own full-viewport rendering on the MkDocs site.
+- [#549](https://github.com/Snoww3d/jwst-data-analysis/pull/549) auth bug, base controller extraction, 501 stubs, and perf improvements
+- [#551](https://github.com/Snoww3d/jwst-data-analysis/pull/551) include calibration level 2 in default MAST searches
+- [#553](https://github.com/Snoww3d/jwst-data-analysis/pull/553) include calibration level 2 in .NET MAST search defaults
+- [#554](https://github.com/Snoww3d/jwst-data-analysis/pull/554) guided discovery pipeline fails for Carina Nebula and wide-field targets
+- [#556](https://github.com/Snoww3d/jwst-data-analysis/pull/556) add pre-request token freshness check to prevent session expiry
 
-    *Diagrams rendered too small to read on the MkDocs site because they were all crammed into one page. Individual pages give each Mermaid diagram full viewport width and let readers zoom/scroll independently.*
+### Refactoring (2)
 
-- **[#546](https://github.com/Snoww3d/jwst-data-analysis/pull/546)** docs: split dense architecture diagrams into readable sub-diagrams
+- [#544](https://github.com/Snoww3d/jwst-data-analysis/pull/544) simplify anonymous composite code and fix review findings
+- [#548](https://github.com/Snoww3d/jwst-data-analysis/pull/548) deduplicate frontend TS utilities and consolidate CSS keyframes
 
-    Split Backend Service Layer and Processing Engine diagrams into focused sub-diagrams so they're actually readable on the MkDocs site.
+### Documentation (5)
 
-    *Both pages had ~50 nodes in a single Mermaid flowchart. Mermaid compressed everything to fit the viewport, making labels impossible to read.*
-
-- **[#547](https://github.com/Snoww3d/jwst-data-analysis/pull/547)** feat: polish guided discovery with retry, skeletons, and error states
-
-    Phase D of the Guided Discovery Experience — adds retry behavior, loading skeletons, and proper error states across all guided discovery pages for a robust, professional UX.
-
-    *The guided discovery flow (Phases A-C) is functionally complete but lacked polish: error states showed fallback text instead of actionable retry buttons, skeletons didn't match actual content counts (causing layout reflow), the GuidedCreate page showed an empty download step during recipe resolution...*
-
-- **[#548](https://github.com/Snoww3d/jwst-data-analysis/pull/548)** refactor: deduplicate frontend TS utilities and consolidate CSS keyframes
-
-    Deduplicate shared TypeScript utilities and consolidate repeated CSS keyframes/classes into global stylesheets, removing ~200 lines of duplicated code across 24 files.
-
-    *Multiple CSS files independently defined identical `@keyframes spin`, `@keyframes shimmer`, `@keyframes progress-shimmer`, and `.skeleton-block` rules. Two pages (`CompositePage` and `MosaicPage`) had identical CSS files. Two components duplicated the `toObservationInputs` function, and `GuidedCreat...*
-
-- **[#549](https://github.com/Snoww3d/jwst-data-analysis/pull/549)** fix: auth bug, base controller extraction, 501 stubs, and perf improvements
-
-    Fix backend auth bug, eliminate controller code duplication, replace misleading fake endpoints with honest 501s, and improve MongoDB query performance across multiple services.
-
-    *- AnalysisController.IsDataAccessible was missing the "sub" claim fallback, which could cause authenticated users to get Forbid() on their own data - GetCurrentUserId/IsCurrentUserAdmin were duplicated across 7 controllers - ProcessData and ValidateData endpoints returned fake success responses, mis...*
-
-- **[#550](https://github.com/Snoww3d/jwst-data-analysis/pull/550)** feat: shared image filter toolbar for composite creator
-
-    - Extracts cascading image filter logic into a reusable `useImageFilters` hook and `<ImageFilterToolbar />` component
-    - Wires the shared toolbar into the Composite Creator's Available Images pool
-    - Enables search + Target/Stage/Filter dropdown filtering when browsing large image libraries
-    - Fixes pre-existing E2E test using wrong selector for discovery error state
-
-    *The Composite Creator's image pool shows a flat list of all unassigned images with no way to search or filter. When the library is large, finding specific images is tedious. The Mosaic Creator already has this filtering inline — this PR extracts a shared version for reuse.*
-
-- **[#551](https://github.com/Snoww3d/jwst-data-analysis/pull/551)** fix: include calibration level 2 in default MAST searches
-
-    - Broadens default MAST search calibration level from `[3]` to `[2, 3]`
-    - Fixes Carina Nebula (and other targets) showing "No observations found" on the target detail page
-
-    *MAST search defaulted to calibration level 3 (combined/mosaic) only. Targets like Carina Nebula that only have level 2 (calibrated) observations returned zero results, showing an empty page. This is the first featured target in the discovery flow — users clicking it see "No observations found."*
-
-- **[#553](https://github.com/Snoww3d/jwst-data-analysis/pull/553)** fix: include calibration level 2 in .NET MAST search defaults
-
-    Fixes the .NET backend MAST search DTOs to default `CalibLevel` to `[2, 3]` instead of `[3]`, matching the Python fix in PR #551.
-
-    *PR #551 changed the Python `calib_level` default from `[3]` to `[2, 3]` to include Level 2 (calibrated) data. However, the .NET DTOs (`MastModels.cs`) still defaulted to `[3]` and explicitly passed this to the Python engine, overriding the Python default. Targets like Carina Nebula that only have Le...*
-
-- **[#554](https://github.com/Snoww3d/jwst-data-analysis/pull/554)** fix: guided discovery pipeline fails for Carina Nebula and wide-field targets
-
-    Fixes the guided create flow failing for Carina Nebula and addresses several compounding issues in the discovery → guided create pipeline.
-
-    *Clicking "Create Composite" on the Carina Nebula target detail page fails because: (1) the MAST target was "Carina Nebula" (resolves to NGC 3372), but the famous JWST ERO data targets NGC 3324 — a specific star-forming region within the nebula, (2) spectroscopic observations polluted the recipe matc...*
-
-- **[#555](https://github.com/Snoww3d/jwst-data-analysis/pull/555)** docs: add cloud storage evaluation for JWST data analysis deployment
-
-    Adds a cloud storage evaluation document comparing S3, Azure Blob Storage, GCS, and MinIO for the JWST Data Analysis platform's cloud deployment needs. Includes a decision matrix, cost estimates, and a phased implementation strategy using fsspec for provider-agnostic file access.
-
-    *Cloud deployment planning requires a storage backend decision. The current local filesystem approach doesn't scale to cloud environments, and the JWST data lifecycle (write-once, read-many with tiered access patterns) has specific requirements that favor certain storage options.*
-
-- **[#556](https://github.com/Snoww3d/jwst-data-analysis/pull/556)** fix: add pre-request token freshness check to prevent session expiry
-
-    Adds a proactive token freshness check before every authenticated API request, preventing "Session expired" errors caused by Chrome throttling background tab timers.
-
-    *Chrome aggressively throttles `setTimeout` in background tabs — timers can be delayed by minutes or suspended entirely. The auth flow relies on a `setTimeout`-based proactive refresh (scheduled 60s before token expiry), which silently fails when the tab is backgrounded. The user then gets a "Session...*
-
-- **[#557](https://github.com/Snoww3d/jwst-data-analysis/pull/557)** feat: add rotation controls and auto-apply adjustments to guided wizard
-
-    Adds image rotation controls and replaces the manual "Apply Adjustments" button with debounced auto-apply in the guided create wizard's result step. Also adds comprehensive E2E test coverage for step 3 (result step) with a full SignalR long-polling mock.
-
-    *Users need basic rotation to orient composite images correctly. The "Apply Adjustments" button was an unnecessary extra click compared to the channel color/weight controls which already auto-apply on change — this inconsistency was confusing. Step 3 had zero E2E test coverage, making regressions inv...*
-
-- **[#558](https://github.com/Snoww3d/jwst-data-analysis/pull/558)** feat: sidebar split layout for guided create result step
-
-    Restructures the guided create wizard's result step (step 3) from a vertically stacked layout to a **sidebar split layout** — preview image on the left, all controls on the right. Everything is visible at once without scrolling.
-
-    *The stacked layout required scrolling past the preview image to reach controls. This made it hard to see the effect of adjustments (brightness, contrast, channel colors) while interacting with the sliders.*
+- [#542](https://github.com/Snoww3d/jwst-data-analysis/pull/542) reorganize plans into design docs and exploration
+- [#543](https://github.com/Snoww3d/jwst-data-analysis/pull/543) comprehensive architecture diagram update
+- [#545](https://github.com/Snoww3d/jwst-data-analysis/pull/545) split architecture diagrams into individual pages
+- [#546](https://github.com/Snoww3d/jwst-data-analysis/pull/546) split dense architecture diagrams into readable sub-diagrams
+- [#555](https://github.com/Snoww3d/jwst-data-analysis/pull/555) add cloud storage evaluation for JWST data analysis deployment
 
 ---
-*11 commits across this session.*
+11 commits across 16 pull requests.
+*Next: March 2, 2026 — auth race condition in guided create when all data..., exclude coverage directory from Vite file watcher, move exploration docs into docs/plans/exploration/*

--- a/docs/blog/posts/2026-03-02.md
+++ b/docs/blog/posts/2026-03-02.md
@@ -19,53 +19,38 @@ authors:
 
 <!-- generated -->
 
-**5 fixes, 2 maintenance** — auth, e2e-tests, export, guided-wizard, security, viewer
+Productive session with 7 pull requests: 5 fixes, 2 maintenance. Security hardening across the stack.
 
 <!-- more -->
 
-## Pull Requests Merged
+## Highlights
 
-- **[#559](https://github.com/Snoww3d/jwst-data-analysis/pull/559)** fix: auth race condition in guided create when all data cached
+### [#559](https://github.com/Snoww3d/jwst-data-analysis/pull/559) auth race condition in guided create when all data cached
 
-    Fixes auth race condition in the guided create wizard that caused E2E test failures and would affect real users when all FITS data is already cached.
+Fixes auth race condition in the guided create wizard that caused E2E test failures and would affect real users when all FITS data is already cached.
 
-    *When all FITS data for a recipe is already cached (no downloads needed), `startProcessing()` was called immediately during `resolveRecipe` — before `useAuth()` had loaded `isAuthenticated` from localStorage. This caused the code to take the anonymous/sync path (`/api/composite/nchannel`) instead of ...*
+*When all FITS data for a recipe is already cached (no downloads needed), `startProcessing()` was called immediately during `resolveRecipe` — before `useAuth()` had loaded `isAuthenticated` from localS...*
 
-- **[#560](https://github.com/Snoww3d/jwst-data-analysis/pull/560)** fix: exclude coverage directory from Vite file watcher
+### [#573](https://github.com/Snoww3d/jwst-data-analysis/pull/573) add missing authorization checks for issues #565-#570
 
-    Prevents Vite's HMR file watcher from picking up vitest coverage output files, which caused continuous page reloads in Docker.
+Adds missing authorization checks across 6 endpoints in MastController and DataManagementController, closing all remaining authorization gap issues from the security model review.
 
-    *Running `npx vitest run --coverage` generates HTML files in the `coverage/` directory. Since this directory is volume-mounted into the Docker frontend container, Vite detects the new files as changes and triggers page reloads. Each reload aborts in-flight API fetches, so the app never finishes loadi...*
+*The security model audit (PR #564) identified 7 authorization gaps where authenticated users could access or modify other users' data. Issue #572 was fixed in that PR; this PR resolves the remaining 6...*
 
-- **[#561](https://github.com/Snoww3d/jwst-data-analysis/pull/561)** chore: move exploration docs into docs/plans/exploration/
+## What Changed
 
-    Reorganizes exploration/evaluation documents into the existing `docs/plans/exploration/` folder.
+### Bug Fixes (5)
 
-    *`cloud-storage-evaluation.md` and `desktop-requirements.md` are exploratory/speculative documents (no decisions made, future-facing) that belong alongside `processing-engine-scaling.md` in the exploration folder, not in the docs root.*
+- [#559](https://github.com/Snoww3d/jwst-data-analysis/pull/559) auth race condition in guided create when all data cached
+- [#560](https://github.com/Snoww3d/jwst-data-analysis/pull/560) exclude coverage directory from Vite file watcher
+- [#563](https://github.com/Snoww3d/jwst-data-analysis/pull/563) resolve E2E test failures in viewer, export, and auth refresh
+- [#564](https://github.com/Snoww3d/jwst-data-analysis/pull/564) add missing authorization checks across backend and processing engine
+- [#573](https://github.com/Snoww3d/jwst-data-analysis/pull/573) add missing authorization checks for issues #565-#570
 
-- **[#562](https://github.com/Snoww3d/jwst-data-analysis/pull/562)** chore: March 2026 git history audit and audit folder structure
+### Maintenance (2)
 
-    Monthly git history security audit and reorganization of audit reports into a dedicated folder.
-
-    *Establishing a monthly git history audit cadence. The old audit lived as a standalone file in docs root with personal email addresses exposed. This moves to a dated, organized structure with PII redacted.*
-
-- **[#563](https://github.com/Snoww3d/jwst-data-analysis/pull/563)** fix: resolve E2E test failures in viewer, export, and auth refresh
-
-    Fixes 10 pre-existing E2E test failures across 3 spec files (export, fits-viewer, session-persistence).
-
-    *E2E tests have been failing consistently due to three compounding issues: stale test data contamination, missing wait conditions for async preview generation, and a deadlock in the token refresh flow.*
-
-- **[#564](https://github.com/Snoww3d/jwst-data-analysis/pull/564)** fix: add missing authorization checks across backend and processing engine
-
-    Add authorization checks to 10+ endpoints that were missing ownership/access verification, allowing any authenticated user to modify, delete, or access another user's data (IDOR/BFLA vulnerabilities). Also fix path traversal vulnerabilities in the Python processing engine's non-chunked download paths. Additionally, open mosaic generate/footprint endpoints to anonymous users for the guided discover...
-
-    *Security audit identified critical authorization gaps: any authenticated user could share/archive/delete other users' data, access private thumbnails anonymously, view other users' import jobs, generate mosaics from private data, and potentially write files to arbitrary locations via crafted observa...*
-
-- **[#573](https://github.com/Snoww3d/jwst-data-analysis/pull/573)** fix: add missing authorization checks for issues #565-#570
-
-    Adds missing authorization checks across 6 endpoints in MastController and DataManagementController, closing all remaining authorization gap issues from the security model review.
-
-    *The security model audit (PR #564) identified 7 authorization gaps where authenticated users could access or modify other users' data. Issue #572 was fixed in that PR; this PR resolves the remaining 6 (#565-#570).*
+- [#561](https://github.com/Snoww3d/jwst-data-analysis/pull/561) move exploration docs into docs/plans/exploration/
+- [#562](https://github.com/Snoww3d/jwst-data-analysis/pull/562) March 2026 git history audit and audit folder structure
 
 ## Issues
 
@@ -99,4 +84,5 @@ authors:
 - [#572](https://github.com/Snoww3d/jwst-data-analysis/issues/572) — feat: allow anonymous mosaic generation for public data (guided wizard)
 
 ---
-*8 commits across this session.*
+9 commits across 7 pull requests.
+*Latest session.*

--- a/scripts/generate-session-blog.sh
+++ b/scripts/generate-session-blog.sh
@@ -97,6 +97,9 @@ format_date() {
   date -d "$date" "+%B %-d, %Y" 2>/dev/null || echo "$date"
 }
 
+# Store all filtered dates globally for next-session lookup
+ALL_FILTERED_DATES=""
+
 # --- Category Detection ---
 
 pr_prefix_to_category() {
@@ -118,7 +121,7 @@ get_categories() {
   local prefixes
   prefixes=$(jq -r --arg d "$date" '
     [.[] | select(.mergedAt | startswith($d))]
-    | [.[].title | split(":")[0] | gsub("^ +| +$";"")]
+    | [.[].title | split(":")[0] | gsub("\\(.*";"") | gsub("^ +| +$";"")]
     | unique | .[]
   ' "$CACHE_DIR/prs.json" 2>/dev/null || true)
 
@@ -167,11 +170,13 @@ get_tags() {
       (if ($t | any(test("ci|workflow|github.action"))) then ["ci"] else [] end) +
       (if ($t | any(test("sidebar|panel|collaps|margin|layout|css|background"))) then ["ui"] else [] end) +
       (if ($t | any(test("^test"))) then ["testing"] else [] end) +
-      (if ($t | any(test("^docs|readme|standard|contributing"))) then ["docs"] else [] end) |
+      (if ($t | any(test("^docs|readme|standard|contributing"))) then ["docs"] else [] end) +
+      (if ($t | any(test("oom|crash|memory|perf"))) then ["performance"] else [] end) +
+      (if ($t | any(test("ec2|staging|nginx|aws"))) then ["deployment"] else [] end) +
+      (if ($t | any(test("mast|fits|wcs|simbad"))) then ["astronomy-data"] else [] end) |
       unique | .[]
     ' "$CACHE_DIR/prs.json" 2>/dev/null || true
   else
-    # Pre-PR: extract tags from commit messages
     local commit_msgs
     commit_msgs=$(grep "|${date}|" "$CACHE_DIR/git-log.txt" | cut -d'|' -f3 | tr '[:upper:]' '[:lower:]' || true)
     [[ -z "$commit_msgs" ]] && return
@@ -190,80 +195,126 @@ get_tags() {
   fi
 }
 
-# --- Headline Generation ---
+# --- Narrative Generation ---
 
-get_headline() {
+generate_narrative() {
   local date="$1"
   local pr_count="$2"
   local commit_count="$3"
 
-  if [[ "$pr_count" -gt 0 ]]; then
-    jq -r --arg d "$date" '
-      [.[] | select(.mergedAt | startswith($d))] |
-      (map(select(.title | test("^feat"))) | length) as $feat |
-      (map(select(.title | test("^fix"))) | length) as $fix |
-      (map(select(.title | test("^docs"))) | length) as $docs |
-      (map(select(.title | test("^refactor"))) | length) as $refactor |
-      (map(select(.title | test("^test"))) | length) as $tst |
-      (map(select(.title | (test("deps") or test("^Bump")))) | length) as $deps |
-      (map(select(.title | (test("^chore") and (test("deps") | not)))) | length) as $chore |
-      (
-        (if $feat > 0 then ["\($feat) feature" + (if $feat > 1 then "s" else "" end)] else [] end) +
-        (if $fix > 0 then ["\($fix) fix" + (if $fix > 1 then "es" else "" end)] else [] end) +
-        (if $docs > 0 then ["\($docs) docs"] else [] end) +
-        (if $refactor > 0 then ["\($refactor) refactor" + (if $refactor > 1 then "s" else "" end)] else [] end) +
-        (if $tst > 0 then ["\($tst) test" + (if $tst > 1 then "s" else "" end)] else [] end) +
-        (if $chore > 0 then ["\($chore) maintenance"] else [] end) +
-        (if $deps > 0 then ["\($deps) dep update" + (if $deps > 1 then "s" else "" end)] else [] end)
-      ) | join(", ")
-    ' "$CACHE_DIR/prs.json" 2>/dev/null || true
-  elif [[ "$commit_count" -gt 0 ]]; then
-    # Pre-PR: summarize from commit messages
-    grep "|${date}|" "$CACHE_DIR/git-log.txt" | cut -d'|' -f3 | sed 's/^[[:space:]]*//' | head -3 | tr '\n' '|' | sed 's/|$//' | sed 's/|/; /g'
-  fi
-}
-
-# --- Post Generation ---
-
-generate_post() {
-  local date="$1"
-  local post_file="$POSTS_DIR/$date.md"
-
-  # Skip enriched posts
-  if [[ -f "$post_file" ]] && grep -q '<!-- enriched -->' "$post_file"; then
-    echo "  Skipping $date (enriched — manually edited)"
+  # Special case: project inception
+  if [[ "$date" == "2025-06-28" ]]; then
+    echo "Project inception day. Initial repository setup, Docker configuration, and frontend submodule integration."
     return
   fi
 
-  local display_date
-  display_date=$(format_date "$date")
-
-  # --- Compute metrics ---
-
-  local commit_count
-  commit_count=$(grep -c "|${date}|" "$CACHE_DIR/git-log.txt" || true)
-
-  local pr_count
-  pr_count=$(jq --arg d "$date" '[.[] | select(.mergedAt | startswith($d))] | length' "$CACHE_DIR/prs.json" 2>/dev/null || echo 0)
-
-  # --- Generate headline and tags ---
-
-  local headline
-  headline=$(get_headline "$date" "$pr_count" "$commit_count")
-
-  local tags_list
-  tags_list=$(get_tags "$date" "$pr_count")
-
-  local tag_inline=""
-  if [[ -n "$tags_list" ]]; then
-    tag_inline=$(echo "$tags_list" | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
+  # First PR date
+  local first_pr_date
+  first_pr_date=$(jq -r '[.[] | .mergedAt] | sort | first | split("T")[0]' "$CACHE_DIR/prs.json" 2>/dev/null || true)
+  if [[ "$date" == "$first_pr_date" ]]; then
+    echo "The project restarts with a proper PR workflow. First pull requests merged, CI pipeline established."
+    return
   fi
 
-  # --- Gather content ---
+  # Pre-PR era (no PRs)
+  if [[ "$pr_count" -eq 0 ]]; then
+    echo "Early development — ${commit_count} commits before the PR workflow was established."
+    return
+  fi
 
-  # PRs (rich format with body excerpts)
-  local pr_content
-  pr_content=$(jq -r --arg d "$date" '
+  # Get PR type counts for the narrative
+  local counts
+  counts=$(jq -r --arg d "$date" '
+    [.[] | select(.mergedAt | startswith($d))] |
+    {
+      feat: (map(select(.title | test("^feat"))) | length),
+      fix: (map(select(.title | test("^fix"))) | length),
+      docs: (map(select(.title | test("^docs"))) | length),
+      refactor: (map(select(.title | test("^refactor"))) | length),
+      test: (map(select(.title | test("^test"))) | length),
+      deps: (map(select(.title | (test("deps") or test("^Bump")))) | length),
+      chore: (map(select(.title | (test("^chore") and (test("deps") | not)))) | length)
+    } | "\(.feat)|\(.fix)|\(.docs)|\(.refactor)|\(.test)|\(.deps)|\(.chore)"
+  ' "$CACHE_DIR/prs.json" 2>/dev/null || true)
+
+  local feat fix docs refactor tst deps chore
+  IFS='|' read -r feat fix docs refactor tst deps chore <<< "$counts"
+
+  # Build a breakdown suffix
+  local parts=()
+  [[ "$feat" -gt 0 ]] && parts+=("${feat} feature$([ "$feat" -gt 1 ] && echo 's')")
+  [[ "$fix" -gt 0 ]] && parts+=("${fix} fix$([ "$fix" -gt 1 ] && echo 'es')")
+  [[ "$docs" -gt 0 ]] && parts+=("${docs} docs")
+  [[ "$refactor" -gt 0 ]] && parts+=("${refactor} refactor$([ "$refactor" -gt 1 ] && echo 's')")
+  [[ "$tst" -gt 0 ]] && parts+=("${tst} test$([ "$tst" -gt 1 ] && echo 's')")
+  [[ "$chore" -gt 0 ]] && parts+=("${chore} maintenance")
+  [[ "$deps" -gt 0 ]] && parts+=("${deps} dependency update$([ "$deps" -gt 1 ] && echo 's')")
+
+  local breakdown=""
+  if [[ ${#parts[@]} -gt 0 ]]; then
+    local first=true
+    for p in "${parts[@]}"; do
+      if [[ "$first" == true ]]; then
+        breakdown="$p"
+        first=false
+      else
+        breakdown="$breakdown, $p"
+      fi
+    done
+  fi
+
+  # Detect theme keywords from PR titles
+  local theme_suffix=""
+  local titles_lower
+  titles_lower=$(jq -r --arg d "$date" '
+    [.[] | select(.mergedAt | startswith($d))] | [.[].title | ascii_downcase] | join(" ")
+  ' "$CACHE_DIR/prs.json" 2>/dev/null || true)
+
+  if echo "$titles_lower" | grep -qi "security\|authorization\|auth.*check\|idor\|traversal"; then
+    theme_suffix=" Security hardening across the stack."
+  elif echo "$titles_lower" | grep -qi "composite\|mosaic\|color.*palette\|nchannel"; then
+    theme_suffix=" Major work on the composite imaging pipeline."
+  elif echo "$titles_lower" | grep -qi "deploy\|staging\|ec2\|nginx"; then
+    theme_suffix=" Deployment and infrastructure focus."
+  elif echo "$titles_lower" | grep -qi "guided\|wizard\|discovery"; then
+    theme_suffix=" Guided wizard workflow improvements."
+  elif echo "$titles_lower" | grep -qi "oom\|crash\|memory"; then
+    theme_suffix=" Tackling stability and memory issues."
+  elif echo "$titles_lower" | grep -qi "e2e\|playwright\|test.*fail"; then
+    theme_suffix=" Test reliability improvements."
+  fi
+
+  # Build narrative by PR count
+  local non_dep_count=$((pr_count - deps))
+  if [[ "$pr_count" -eq 1 ]]; then
+    echo "A focused session with a single pull request.${theme_suffix}"
+  elif [[ "$pr_count" -eq 2 ]]; then
+    echo "A focused session — ${breakdown}.${theme_suffix}"
+  elif [[ "$pr_count" -le 9 ]]; then
+    echo "Productive session with ${pr_count} pull requests: ${breakdown}.${theme_suffix}"
+  else
+    echo "A marathon session: ${pr_count} pull requests merged (${breakdown}).${theme_suffix}"
+  fi
+}
+
+# --- Highlights Generation ---
+
+generate_highlights() {
+  local date="$1"
+  local pr_count="$2"
+
+  [[ "$pr_count" -eq 0 ]] && return
+
+  # Score PRs and pick top 1-2 with score >= 5
+  local highlights
+  highlights=$(jq -r --arg d "$date" '
+    def score_pr:
+      (if (.title | test("^feat|^fix")) then 3 else 0 end) +
+      (if ((.body // "") | length > 500) then 2 else 0 end) +
+      (if (.title | ascii_downcase | test("crash|oom|race|security|deploy|wizard|composite|mosaic|staging")) then 2 else 0 end) +
+      (if ((.body // "") | test("## Summary")) and ((.body // "") | test("## Why")) then 1 else 0 end) +
+      (if (.title | ascii_downcase | (test("deps") or test("^bump"))) then -5 else 0 end);
+
     def extract_section(header):
       (.body // "") | gsub("\r"; "") |
       if test(header) then
@@ -278,43 +329,166 @@ generate_post() {
     def trunc(n):
       if length > n then .[0:n] + "..." else . end;
 
-    [.[] | select(.mergedAt | startswith($d))] | sort_by(.number) |
-    [.[] |
-      (extract_section("## Summary\n") | first_para | trunc(400)) as $summary |
-      (extract_section("## Why\n") | first_para | trunc(300) | gsub("\n+"; " ") | gsub("^ +| +$"; "")) as $why |
-      "- **[#\(.number)](\(.url))** \(.title)"
-      + (if $summary != "" then "\n\n    " + ($summary | gsub("\n"; "\n    ")) else "" end)
-      + (if $why != "" then "\n\n    *" + $why + "*" else "" end)
-    ] | join("\n\n")
+    [.[] | select(.mergedAt | startswith($d))]
+    | [.[] | . + {score: score_pr}]
+    | sort_by(-.score)
+    | [.[] | select(.score >= 5)]
+    | .[0:2]
+    | if length == 0 then ""
+      else
+        [.[] |
+          (extract_section("## Summary\n") | first_para | trunc(300)) as $summary |
+          (extract_section("## Why\n") | first_para | trunc(200) | gsub("\n+"; " ") | gsub("^ +| +$"; "")) as $why |
+          (if (.title | test(": ")) then (.title | split(": ") | .[1:] | join(": ")) else .title end) as $short |
+          "### [#\(.number)](\(.url)) \($short)\n\n"
+          + (if $summary != "" then $summary + "\n\n" else "" end)
+          + (if $why != "" then "*" + $why + "*\n" else "" end)
+        ] | join("\n")
+      end
   ' "$CACHE_DIR/prs.json" 2>/dev/null || true)
 
-  # Issues opened (with titles)
-  local issues_opened
-  issues_opened=$(jq -r --arg d "$date" '
-    [.[] | select(.createdAt | startswith($d))]
-    | sort_by(.number)
-    | if length > 0 then
-        [.[] | "- [#\(.number)](\(.url)) — \(.title)"] | join("\n")
-      else "" end
-  ' "$CACHE_DIR/issues.json" 2>/dev/null || true)
-
-  # Issues closed (with titles)
-  local issues_closed
-  issues_closed=$(jq -r --arg d "$date" '
-    [.[] | select(.closedAt != null and (.closedAt | startswith($d)))]
-    | sort_by(.number)
-    | if length > 0 then
-        [.[] | "- [#\(.number)](\(.url)) — \(.title)"] | join("\n")
-      else "" end
-  ' "$CACHE_DIR/issues.json" 2>/dev/null || true)
-
-  # Commit messages (for pre-PR days)
-  local commit_messages=""
-  if [[ "$pr_count" -eq 0 && "$commit_count" -gt 0 ]]; then
-    commit_messages=$(grep "|${date}|" "$CACHE_DIR/git-log.txt" | cut -d'|' -f3 | sed 's/^[[:space:]]*//' | while IFS= read -r msg; do
-      echo "- ${msg}"
-    done)
+  if [[ -n "$highlights" ]]; then
+    echo "$highlights"
   fi
+}
+
+# --- Grouped PR Generation ---
+
+generate_grouped_prs() {
+  local date="$1"
+  local pr_count="$2"
+
+  [[ "$pr_count" -eq 0 ]] && return
+
+  # Generate grouped output with jq
+  jq -r --arg d "$date" '
+    def classify:
+      if (.title | test("^feat")) then "Features"
+      elif (.title | test("^fix")) then "Bug Fixes"
+      elif (.title | test("^refactor")) then "Refactoring"
+      elif (.title | test("^test")) then "Testing"
+      elif (.title | test("^docs")) then "Documentation"
+      elif (.title | (test("deps") or test("^Bump"))) then "Dependencies"
+      elif (.title | test("^chore")) then "Maintenance"
+      else "Other" end;
+
+    def group_order:
+      if . == "Features" then 0
+      elif . == "Bug Fixes" then 1
+      elif . == "Refactoring" then 2
+      elif . == "Testing" then 3
+      elif . == "Documentation" then 4
+      elif . == "Maintenance" then 5
+      elif . == "Dependencies" then 6
+      else 7 end;
+
+    def short_title:
+      if (.title | test(": ")) then (.title | split(": ") | .[1:] | join(": "))
+      else .title end;
+
+    def extract_pkg:
+      .title | gsub("^[^:]+:\\s*";"") | gsub("^[Bb]ump\\s+";"") | split(" from ")[0] | split(" in ")[0] | gsub("^ +| +$";"");
+
+    [.[] | select(.mergedAt | startswith($d))]
+    | sort_by(.number)
+    | group_by(classify)
+    | [.[] | {group: (.[0] | classify), items: ., order: (.[0] | classify | group_order)}]
+    | sort_by(.order)
+    | [.[] |
+        if .group == "Dependencies" then
+          (.items | length) as $n |
+          ([.items[] | extract_pkg] | unique | .[0:8]) as $pkgs |
+          (if $n > ($pkgs | length) then
+            "**Dependencies** (" + ($n | tostring) + " updates: " + ($pkgs | join(", ")) + " and " + (($n - ($pkgs | length)) | tostring) + " more)"
+          else
+            "**Dependencies** (" + ($n | tostring) + " updates: " + ($pkgs | join(", ")) + ")"
+          end) + "\n"
+        else
+          "### " + .group + " (" + (.items | length | tostring) + ")\n\n"
+          + ([.items[] | "- [#\(.number)](\(.url)) \(short_title)"] | join("\n"))
+          + "\n"
+        end
+      ] | join("\n")
+  ' "$CACHE_DIR/prs.json" 2>/dev/null || true
+}
+
+# --- Footer Generation ---
+
+generate_footer() {
+  local date="$1"
+  local commit_count="$2"
+  local pr_count="$3"
+
+  # Main stat line
+  if [[ "$pr_count" -gt 0 ]]; then
+    printf '%s commits across %s pull request%s.' "$commit_count" "$pr_count" "$([ "$pr_count" -gt 1 ] && echo 's')"
+  else
+    printf '%s commits.' "$commit_count"
+  fi
+  echo ""
+
+  # Next session teaser
+  local next_date=""
+  local found_current=false
+  while IFS= read -r d; do
+    [[ -z "$d" ]] && continue
+    if [[ "$found_current" == true ]]; then
+      next_date="$d"
+      break
+    fi
+    [[ "$d" == "$date" ]] && found_current=true
+  done <<< "$ALL_FILTERED_DATES"
+
+  if [[ -z "$next_date" ]]; then
+    echo "*Latest session.*"
+  else
+    # Get a teaser from next session's PR titles (first 3 non-dep titles)
+    local teaser
+    teaser=$(jq -r --arg d "$next_date" '
+      [.[] | select(.mergedAt | startswith($d)) | select(.title | (test("deps") or test("^Bump")) | not)]
+      | sort_by(.number)
+      | .[0:3]
+      | [.[].title | (if test(": ") then split(": ") | .[1:] | join(": ") else . end) | .[0:50] + (if length > 50 then "..." else "" end)]
+      | join(", ")
+    ' "$CACHE_DIR/prs.json" 2>/dev/null || true)
+
+    local next_display
+    next_display=$(format_date "$next_date")
+    if [[ -n "$teaser" ]]; then
+      echo "*Next: ${next_display} — ${teaser}*"
+    else
+      echo "*Next: ${next_display}*"
+    fi
+  fi
+}
+
+# --- Post Generation ---
+
+generate_post() {
+  local date="$1"
+  local post_file="$POSTS_DIR/$date.md"
+
+  # Skip enriched posts
+  if [[ -f "$post_file" ]] && grep -q '<!-- enriched -->' "$post_file"; then
+    echo "  Skipping $date (enriched)"
+    return
+  fi
+
+  local display_date
+  display_date=$(format_date "$date")
+
+  # --- Compute metrics ---
+
+  local commit_count
+  commit_count=$(grep -c "|${date}|" "$CACHE_DIR/git-log.txt" || true)
+
+  local pr_count
+  pr_count=$(jq --arg d "$date" '[.[] | select(.mergedAt | startswith($d))] | length' "$CACHE_DIR/prs.json" 2>/dev/null || echo 0)
+
+  # --- Generate tags ---
+
+  local tags_list
+  tags_list=$(get_tags "$date" "$pr_count")
 
   # --- Build frontmatter ---
 
@@ -332,13 +506,46 @@ generate_post() {
     done <<< "$tags_list"
   fi
 
-  # Build headline line
-  local headline_line=""
-  if [[ -n "$headline" && -n "$tag_inline" ]]; then
-    headline_line="**${headline}** — ${tag_inline}"
-  elif [[ -n "$headline" ]]; then
-    headline_line="**${headline}**"
+  # --- Generate content sections ---
+
+  local narrative
+  narrative=$(generate_narrative "$date" "$pr_count" "$commit_count")
+
+  local highlights
+  highlights=$(generate_highlights "$date" "$pr_count")
+
+  local grouped_prs
+  grouped_prs=$(generate_grouped_prs "$date" "$pr_count")
+
+  # Commit messages (for pre-PR days)
+  local commit_messages=""
+  if [[ "$pr_count" -eq 0 && "$commit_count" -gt 0 ]]; then
+    commit_messages=$(grep "|${date}|" "$CACHE_DIR/git-log.txt" | while IFS='|' read -r hash _ msg; do
+      echo "- \`${hash:0:7}\` ${msg}"
+    done)
   fi
+
+  # Issues (with titles)
+  local issues_opened
+  issues_opened=$(jq -r --arg d "$date" '
+    [.[] | select(.createdAt | startswith($d))]
+    | sort_by(.number)
+    | if length > 0 then
+        [.[] | "- [#\(.number)](\(.url)) — \(.title)"] | join("\n")
+      else "" end
+  ' "$CACHE_DIR/issues.json" 2>/dev/null || true)
+
+  local issues_closed
+  issues_closed=$(jq -r --arg d "$date" '
+    [.[] | select(.closedAt != null and (.closedAt | startswith($d)))]
+    | sort_by(.number)
+    | if length > 0 then
+        [.[] | "- [#\(.number)](\(.url)) — \(.title)"] | join("\n")
+      else "" end
+  ' "$CACHE_DIR/issues.json" 2>/dev/null || true)
+
+  local footer
+  footer=$(generate_footer "$date" "$commit_count" "$pr_count")
 
   # --- Write post ---
 
@@ -360,23 +567,28 @@ generate_post() {
     echo ""
     echo "<!-- generated -->"
     echo ""
-    if [[ -n "$headline_line" ]]; then
-      echo "${headline_line}"
-      echo ""
-    fi
+    echo "${narrative}"
+    echo ""
     echo "<!-- more -->"
     echo ""
   } > "$post_file"
 
-  # PRs section
-  if [[ -n "$pr_content" ]]; then
-    echo "## Pull Requests Merged" >> "$post_file"
+  # Highlights section (optional)
+  if [[ -n "$highlights" ]]; then
+    echo "## Highlights" >> "$post_file"
     echo "" >> "$post_file"
-    echo "$pr_content" >> "$post_file"
+    echo "$highlights" >> "$post_file"
     echo "" >> "$post_file"
   fi
 
-  # Commit messages (pre-PR days)
+  # What Changed (grouped PRs) or Commits (pre-PR)
+  if [[ -n "$grouped_prs" ]]; then
+    echo "## What Changed" >> "$post_file"
+    echo "" >> "$post_file"
+    echo "$grouped_prs" >> "$post_file"
+    echo "" >> "$post_file"
+  fi
+
   if [[ -n "$commit_messages" ]]; then
     echo "## Commits" >> "$post_file"
     echo "" >> "$post_file"
@@ -402,9 +614,9 @@ generate_post() {
     fi
   fi
 
-  # Stats footer
+  # Footer
   echo "---" >> "$post_file"
-  echo "*${commit_count} commits across this session.*" >> "$post_file"
+  echo "$footer" >> "$post_file"
 
   echo "  Generated: $date ($commit_count commits, $pr_count PRs)"
 }
@@ -472,6 +684,7 @@ fetch_data
 
 all_dates=$(get_active_dates)
 filtered_dates=$(filter_dates "$all_dates")
+ALL_FILTERED_DATES="$filtered_dates"
 date_count=$(echo "$filtered_dates" | grep -c . || echo "0")
 
 echo ""


### PR DESCRIPTION
## Summary

Transforms the 43 session blog posts from flat PR lists into structured, narrative dev journal entries. Adds `/enrich-blog` command for future Slack journal enrichment.

## Why

The blog posts read like changelogs — no narrative, no visual hierarchy, no personality. This overhaul adds structure that makes the posts worth reading as a dev journal while keeping everything deterministic and re-runnable.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

### Layer 1: Script Overhaul (`scripts/generate-session-blog.sh`)
- **Narrative openings** — template-based from PR counts + keyword themes (inception, first-PR, focused, productive, marathon)
- **Highlights section** — scored top 1-2 PRs by heuristic (feat/fix prefix, body length, keyword importance, Summary+Why presence)
- **Grouped "What Changed"** — PRs grouped by type (Features, Bug Fixes, Refactoring, etc.) with counts
- **Collapsed dependencies** — "Dependencies (12 updates: pkg1, pkg2, ... and N more)" instead of listing each
- **Footer with next-session teaser** — "{N} commits across {M} pull requests. *Next: March 1 — sidebar split layout, rotation controls...*"
- **Pre-PR era** — commit hashes (`abc1234 message`) instead of just "Commits: 6"
- **Special inception template** — 2025-06-28 gets "Project inception day" narrative
- **Title handling** — safely handles both `type: description` and plain titles (e.g., "Feature/archive files")
- **Additional tags** — performance, deployment, astronomy-data

### Layer 2: Slack Enrichment Command (`.claude/commands/enrich-blog.md`)
- `/enrich-blog` reads Slack channels via MCP tools for a date range
- Generates "Developer Journal" sections from Shanon's messages
- Privacy rules: never quote friends directly, no names/usernames, paraphrase in narrative voice
- Updates marker from `<!-- generated -->` to `<!-- enriched -->` to prevent overwrites
- Caches Slack data to avoid re-fetching

## Test Plan

- [x] `./scripts/generate-session-blog.sh --date 2025-06-28` — inception narrative, commit hashes, no PRs
- [x] `./scripts/generate-session-blog.sh --date 2026-01-12` — first PR narrative, "Other" group for non-prefixed PR
- [x] `./scripts/generate-session-blog.sh --date 2026-02-28` — marathon narrative (34 PRs), highlights, collapsed deps (12 updates), grouped sections
- [x] `./scripts/generate-session-blog.sh --date 2026-03-02` — security theme detection, "Latest session" footer
- [x] Full backfill — all 43 posts generated clean
- [x] Enriched post skip — `<!-- enriched -->` marker causes Layer 1 to skip
- [x] All posts validated: frontmatter, generated marker, more marker present
- [x] Next-session teasers work across full date range
- [ ] Blog renders at localhost:8001/blog/ (Docker docs container has corrupted overlay — needs `docker system prune` then rebuild)

## Documentation Checklist

- [x] No new controllers/services/endpoints added
- [x] No API parameter changes

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — blog posts are generated artifacts, script is idempotent, enriched posts are protected.

Rollback: Revert commit and re-run `./scripts/generate-session-blog.sh` to regenerate from previous version.

## Quality Checklist

- [x] Code follows project conventions
- [x] Tests pass locally (script tested on 4 key dates + full backfill)
- [x] Security implications reviewed (no user input, no auth changes)
- [x] No unnecessary changes beyond scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)