### PR TITLE
feat: wire blog screenshots into posts (Feb 1-9)

### DIFF
--- a/docs/blog/posts/2026-02-01.md
+++ b/docs/blog/posts/2026-02-01.md
@@ -32,7 +32,17 @@ Went for a 2.5-mile walk and came back with clarity — skills, workflows, and t
 
 Asked friends to review the workflow documentation but acknowledged "it's Sunday and I'm not your infant child." Shared the agent-project-templates repo. Asked Gemini to grade the project as an agentic coding effort — scored an A-, shared proudly.
 
+![Claude CLI output showing PR #85 merged and eagerly asking to proceed with Tech Debt #17](../images/2026-02-01/image.png)
+
 "I'm never going to write code again" — said with a mix of unease and acceptance. The conductor role fits, but there's a nagging fear that conductors themselves get replaced by mid-2026. "I am not one of those 10x RTS vibe coders" — this is feature branches, an n-tiered application, and deliberate process. Meanwhile, Claude was reviewing a PR and kept trying to eagerly start tech debt #17 — had to rein it in.
+
+![Implementation plan for Task #17 Zoomed Range View showing current vs proposed histogram UX](../images/2026-02-01/image-2.png)
+
+![Claude thinking through a CI lint failure on ImageViewer.tsx during the DI refactor PR](../images/2026-02-01/image-3.png)
+
+![Claude identifying an extra blank line causing a Prettier CI failure](../images/2026-02-01/image-4.png)
+
+![Session summary table showing PRs #101-#104 merged with workflow rules added](../images/2026-02-01/image-5.png)
 
 ## Highlights
 

--- a/docs/blog/posts/2026-02-02.md
+++ b/docs/blog/posts/2026-02-02.md
@@ -35,6 +35,10 @@ Claude tried to simplify tests by removing interfaces rather than adding them â€
 
 Spotted Codex for the first time â€” the cloud environments could solve the feature branching problem on a single machine. Looks like a much cleaner version of the Claude Code TUI with slightly less workflow automation but seemingly easy to add.
 
+![PR body showing workflow compliance checklist with all steps passing](../images/2026-02-02/image.png)
+
+![Claude CLI output showing PR ready for review with all CI checks passing and 23 new security tests](../images/2026-02-02/image-2.png)
+
 ## Highlights
 
 ### [#101](https://github.com/Snoww3d/jwst-data-analysis/pull/101) add PNG export to FITS viewer

--- a/docs/blog/posts/2026-02-03.md
+++ b/docs/blog/posts/2026-02-03.md
@@ -32,9 +32,25 @@ A marathon session: 17 pull requests merged (4 features, 4 fixes, 8 docs, 1 main
 
 The compositing pipeline is starting to take shape — shared screenshots of three FITS files at different wavelengths combined into a single image (B1.1 through B1.7). Meanwhile, Claude tried to resolve merge conflicts by writing new code rather than just taking one side — and it actually worked. "If someone thinks you can 'claude --dangerously-skip-permissions' an app today you are WRONG!"
 
+![GitHub diff showing +1,168 -2 lines changed for the composite generation backend PR](../images/2026-02-03/image.png)
+
+![Workflow file diff showing session resume note and compliance table display instructions](../images/2026-02-03/image-2.png)
+
+![RGB composite output combining three JWST FITS files at different wavelengths into a single color image](../images/2026-02-03/image-3.png)
+
 Claude churned for 17.5 minutes and produced a PR with 5 endpoints, several UI components, full integration and E2E testing, and a well-documented workflow. "This is not that special or unique, it's a very solved problem, but less than a year ago I was on a web app where a team of 5 devs took a sprint to do this — and Claude is about to do it while I watch YouTube." The human is the bottleneck now, slow at reviewing huge PRs.
 
+![Claude CLI showing both PRs #121 and #122 merged successfully with branches cleaned up](../images/2026-02-03/image-4.png)
+
 An unfinished feature from the previous day broke the dashboard on load — the smoke test existed but didn't catch it. "This is the DEFINITION of a smoke test." The guardrails are mostly working though: rm -rf of build directories deleted a .sln file but git recovered it. "I'm gonna have to ~science~ DevOps the shit out of this." Also had Claude write a full desktop application requirements doc — it was an excellent novel-length spec that was exactly right, the only problem being it had to be read. Encouraged friends to try Codex while it's free through March 2nd.
+
+![Application UI showing user menu dropdown with avatar, email, and sign out option](../images/2026-02-03/image-5.png)
+
+![Claude CLI summary of frontend authentication UI implementation with 21 unit tests and key files list](../images/2026-02-03/image-6.png)
+
+![FITS viewer showing a JWST observation in Rainbow colormap with zoom controls](../images/2026-02-03/image-7.png)
+
+![Codex welcome screen showing free access through March 2nd](../images/2026-02-03/image-8.png)
 
 ## Highlights
 

--- a/docs/blog/posts/2026-02-06.md
+++ b/docs/blog/posts/2026-02-06.md
@@ -23,9 +23,33 @@ A focused session — 1 fix, 1 docs.
 
 First mosaic creation — three raw FITS images aligned in the sky, stitched together. Then six rateints, then fifty images. Level 3 images look much better than raw. The output quality was lowered because there's no offline processing pipeline yet, and the mosaic tool outputs images rather than new FITS files (a future feature). Shared multiple screenshots showing the progression. "NASA just used more than 3" — the current 3-channel composite limitation is becoming the obvious next target.
 
+![JWST mosaic of two overlapping fields showing deep-sky galaxies in infrared](../images/2026-02-06/image-5.png)
+
+![JWST mosaic combining approximately fifty images of a nebula region with visible tiling seams](../images/2026-02-06/image-6.png)
+
+![Crab Nebula reference image showing the multi-filter NASA-quality target for compositing](../images/2026-02-06/image-7.png)
+
+![Three raw FITS images stitched together as the first mosaic attempt in the application](../images/2026-02-06/image-8.png)
+
+![JWST mosaic of the Crab Nebula showing filament structure in infrared colormap](../images/2026-02-06/image-9.png)
+
+![JWST mosaic of Carina Nebula region stitched from multiple FITS observations](../images/2026-02-06/image-3.png)
+
+![First mosaic output exported as a standalone image from the mosaic tool](../images/2026-02-06/jwst-mosaic-2026-02-06T12-31-52.png)
+
 Gave a friend a detailed walkthrough of the development process and guardrails: how Claude writes a plan, turns it into CLI commands and source edits, and how none of that code gets near the main branch without passing linting, unit tests, E2E tests, and a human-reviewed PR with a test plan. The tech lead experience of managing offshore teams that could break things overnight translated directly into managing an AI developer.
 
+![Claude CLI showing the git push-to-main hook blocking a direct commit and forcing a branch-based workflow](../images/2026-02-06/image.png)
+
+![Mosaic feature known limitations and TODO list showing completed items and remaining work](../images/2026-02-06/image-4.png)
+
 Tried the Claude `/insights` feature — "getting graded by the AI, and it hurts." A friend found it interesting that their earlier concerns were called out as areas for improvement. Also tried the agent teams feature for the first time — hit the usage limit right at the end of the session. Connected the Claude mobile app to a cloud environment and claimed $50 of overage credit. "I got ahead of my skis."
+
+![Claude mobile app writing a feature-ideas.md file to the repo from a phone](../images/2026-02-06/File.png)
+
+![Claude CLI usage panel showing 100% session usage and 21% weekly usage](../images/2026-02-06/image-10.png)
+
+![Claude web app usage settings showing 100% session limit hit with $50 extra usage balance](../images/2026-02-06/image-11.png)
 
 ## Highlights
 

--- a/docs/blog/posts/2026-02-07.md
+++ b/docs/blog/posts/2026-02-07.md
@@ -32,7 +32,15 @@ A marathon session: 20 pull requests merged (7 features, 6 fixes, 7 docs). Major
 
 Saturday session — Phase 4 finished the day before, now making small changes and finding bugs. 210 PRs closed to date. The Claude CLI updated at least twice during the session (2.1.34 → 2.1.36 → 2.1.37), with version 35 presumably landing overnight. Hard to keep track of features across the CLI, desktop app, and phone app when all three are getting daily updates.
 
+![Feature comparison table across Claude CLI, Desktop Code Tab, Cowork Tab, Chat Tab, and iOS App](../images/2026-02-07/image.png)
+
 Connected the GitHub project to the Claude mobile app's cloud environment — the idea being to capture feature ideas and quick thoughts from the phone using Sonnet. Found a good 3-image set to composite that produced an ok result; swapping the channel order improved it. Mosaic and composite both work individually, but the composite is still limited to 3 channels (R/G/B) — not enough for the multi-filter NASA-quality images.
+
+![GitHub PR list showing 210 closed PRs including recent bug fixes and the collapsible sidebar feature](../images/2026-02-07/image-2.png)
+
+![JWST 3-channel RGB composite of a nebula region showing green-tinted gas and dust structures](../images/2026-02-07/image-3.png)
+
+![Same JWST composite with swapped channel order showing warmer orange-brown tones](../images/2026-02-07/image-4.png)
 
 ## Highlights
 

--- a/docs/blog/posts/2026-02-08.md
+++ b/docs/blog/posts/2026-02-08.md
@@ -38,7 +38,23 @@ A marathon session: 35 pull requests merged (8 features, 5 fixes, 2 docs, 2 main
 
 Five minutes into Codex and the verdict was immediate: "so much better user experience." The uncommitted changes shown in a side panel instead of inline, collapsed file explorations you can expand — the review flow is dramatically clearer. On February 8th, the call was that Codex is the way to do agentic engineering. The two models are extremely close in capability, but the internet's claim that Codex is cheaper is "just OpenAI throwing money at the problem because Claude led this for two months."
 
+![Codex desktop app showing a code review with diff panel and file exploration sidebar](../images/2026-02-08/image.png)
+
+![Codex thread showing file reads and documentation edits with line change counts](../images/2026-02-08/image-2.png)
+
 The compositer is working noticeably better now. Shared screenshots showing improvements — selection filtering is easier, and using max for overlapping pixels helps remove hardware artifacts captured in the images. Also discovered that the app works much better on a wider monitor. Started making documentation model-agnostic since both tools are in active use.
+
+![Chat prompt requesting mosaic wizard improvements based on PRs #121 and #122](../images/2026-02-08/image-6.png)
+
+![Claude planning four concrete upgrades to the MosaicWizard component](../images/2026-02-08/image-7.png)
+
+![JWST RGB composite showing a blue-tinted galaxy or star-forming region](../images/2026-02-08/jwst-composite-2026-02-08T18-16-11.png)
+
+![Same JWST field with swapped channel order showing orange-red emission features](../images/2026-02-08/jwst-composite-2026-02-08T18-18-38.png)
+
+![JWST mosaic of the Crab Nebula in infrared showing detailed filament structure](../images/2026-02-08/jwst-mosaic-2026-02-08T19-27-36.png)
+
+![Ultrawide monitor workstation setup showing the application and code review side by side](../images/2026-02-08/IMG_0158.jpeg)
 
 ## Highlights
 

--- a/docs/blog/posts/2026-02-09.md
+++ b/docs/blog/posts/2026-02-09.md
@@ -27,9 +27,31 @@ A marathon session: 10 pull requests merged (2 fixes, 2 docs, 6 maintenance). Te
 
 The repo needs to go public — hit a GitHub limit that forces the conversion. The fear: documentation or git history might contain passwords or secrets. A friend immediately suggested rotating everything and checking for API keys, which became the day's action item. Checked many times, 98% confident it's clean, but the alarm bells still go off.
 
+![Claude pushing back on making the repo public directly, recommending a curated mirror instead](../images/2026-02-09/image-3.png)
+
+![Public preflight audit results showing 4 blocking issues and 2 warnings before repo can go public](../images/2026-02-09/image-4.png)
+
+![GitHub Actions CI checks all failing due to billing/spending limit error on the account](../images/2026-02-09/image.png)
+
+![GitHub Actions annotations showing all 5 jobs failed due to account payment issues](../images/2026-02-09/image-2.png)
+
 Spent most of the day wrestling with Playwright E2E tests. The MCP-based browser automation eats tokens and runs painfully slow. 20 of 29 tests pass and they're part of the pipeline, but can't enforce them as required yet — some tests were written before the login page existed and need updating. Shared screenshots of test results and the review process. "Reviewing every line of code before the PR is such a normal software experience" — said with the weariness of someone who didn't write the code but owns every line of it.
 
+![CI results showing Frontend Tests passing but E2E Tests failing in 3 minutes](../images/2026-02-09/image-6.png)
+
+![Claude reporting Docker stack started successfully with 10 passed, 10 failed, 9 skipped E2E tests](../images/2026-02-09/image-7.png)
+
+![Claude CLI pollinating status showing 28 minutes and 35 seconds of processing time](../images/2026-02-09/image-8.png)
+
+![Claude CLI running lint and unit tests in the agent-1 worktree with all 24 tests passing](../images/2026-02-09/image-9.png)
+
+![Git commit message showing the three root causes fixed for 10 E2E test failures](../images/2026-02-09/image-10.png)
+
+![Tech debt tracking showing 38 remaining items after session with net +2 new items added](../images/2026-02-09/image-11.png)
+
 A friend had mixed feelings about Playwright after watching a demo video — felt strongly that tests need to be hardcoded and deterministic. Fair point, but the immediate problem isn't philosophy, it's getting the Docker MCP to stop failing randomly.
+
+![GitHub PR showing all 11 checks passing including E2E tests, CodeQL, and PR Standards](../images/2026-02-09/image-12.png)
 
 ## Highlights
 


### PR DESCRIPTION
## Summary
- Embed 50 screenshot images across 7 blog posts (Feb 1-9) with descriptive alt text
- Images placed inline next to the narrative paragraphs that reference them
- Covers mosaic outputs, RGB composites, CLI sessions, CI results, Codex impressions, and workstation photos

## Why
Blog posts reference screenshots shared in Slack but the images were never wired into the markdown. This connects the visual evidence to the narrative for each session.

## Type of Change
- [x] Documentation (docs, comments, etc.)

## Changes Made
- `docs/blog/posts/2026-02-01.md` — 5 images: Claude CLI eager task start, zoomed range view plan, CI lint debugging, Prettier fix, session summary
- `docs/blog/posts/2026-02-02.md` — 2 images: workflow compliance checklist, PR ready with CI checks
- `docs/blog/posts/2026-02-03.md` — 8 images: composite backend diff, workflow file, RGB composite output, merged PRs, auth UI, auth summary, FITS viewer rainbow colormap, Codex welcome
- `docs/blog/posts/2026-02-06.md` — 12 images: mosaic progression (galaxies, nebula, Crab Nebula, Carina), push-to-main hook, feature TODO list, mobile app, usage limits
- `docs/blog/posts/2026-02-07.md` — 4 images: feature comparison table, 210 PRs milestone, two composite channel-order comparisons
- `docs/blog/posts/2026-02-08.md` — 8 images: Codex UI, mosaic wizard planning, two RGB composites, Crab Nebula mosaic, ultrawide workstation photo
- `docs/blog/posts/2026-02-09.md` — 11 images: CI billing failures, public preflight audit, E2E test results, Claude processing, lint/test runs, commit details, tech debt tracking, all-checks-passing

## Test Plan
- [x] Verify each blog post renders correctly in MkDocs with images visible
- [x] Confirm all 50 image paths resolve to existing files in docs/blog/images/
- [x] Check alt text accurately describes each image

## Documentation Checklist
- [x] Blog posts updated (this PR)
- [x] No new controllers/services/endpoints added
- [x] docs/tech-debt.md not modified

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: None — docs-only change adding image embeds to blog posts.
Rollback: Revert the single commit.

## Quality Checklist
- [x] Changes follow project conventions
- [x] Alt text is descriptive and accurate
- [x] Image paths use correct relative format