### PR TITLE
feat: add GitHub Pages deployment for docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install mkdocs-material
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to deploy the mkdocs documentation site to GitHub Pages automatically on push to main.

## Why

The project has a full mkdocs site with architecture docs, dev journal with 130+ screenshots, standards, and plans — but it's only viewable locally. GitHub Pages makes it accessible at https://snoww3d.github.io/jwst-data-analysis/ with zero infrastructure cost.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `.github/workflows/docs.yml` — builds mkdocs-material and deploys to GitHub Pages
- Triggered on push to main when `docs/`, `mkdocs.yml`, or the workflow itself changes
- Also supports manual trigger via `workflow_dispatch`
- Uses strict build mode to catch broken links
- Enabled GitHub Pages in repo settings (source: GitHub Actions)

## Test Plan

- [x] GitHub Pages enabled via API (build_type: workflow)
- [ ] Merge PR and verify workflow runs on push to main
- [ ] Verify site loads at https://snoww3d.github.io/jwst-data-analysis/
- [ ] Verify blog posts render with images at /blog/

## Documentation Checklist

- [x] No new controllers, services, or endpoints — N/A

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — adds a new workflow, no code changes. If the build fails it doesn't affect CI or the app.
Rollback: Delete the workflow file and disable Pages in repo settings.

## Quality Checklist

- [x] Workflow uses pinned action versions (v4/v5)
- [x] Concurrency group prevents parallel deploys
- [x] Path filters avoid unnecessary builds