### PR TITLE
refactor: tokenize FITS viewer and tool panel CSS colors

### DIFF
--- a/frontend/jwst-frontend/src/components/AnnotationOverlay.css
+++ b/frontend/jwst-frontend/src/components/AnnotationOverlay.css
@@ -34,7 +34,7 @@
   background: rgba(0, 0, 0, 0.75);
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 4px;
-  color: #fff;
+  color: var(--text-primary);
   font-family: 'Inter', sans-serif;
   font-size: 14px;
   padding: 4px 8px;
@@ -44,7 +44,7 @@
 }
 
 .annotation-text-input:focus {
-  border-color: #4db8ff;
+  border-color: var(--accent-cyan);
   box-shadow: 0 0 6px rgba(77, 184, 255, 0.3);
 }
 

--- a/frontend/jwst-frontend/src/components/CubeNavigator.css
+++ b/frontend/jwst-frontend/src/components/CubeNavigator.css
@@ -1,6 +1,6 @@
 .cube-navigator {
   background: rgba(20, 20, 30, 0.95);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-default);
   border-radius: 8px;
   overflow: hidden;
   min-width: 220px;
@@ -54,7 +54,7 @@
 .cube-slice-badge {
   font-size: 10px;
   color: rgba(255, 255, 255, 0.6);
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-default);
   padding: 2px 6px;
   border-radius: 4px;
 }
@@ -111,10 +111,10 @@
   border-radius: 3px;
   background: linear-gradient(
     to right,
-    #4db8ff 0%,
-    #4db8ff var(--slider-fill, 0%),
-    rgba(255, 255, 255, 0.1) var(--slider-fill, 0%),
-    rgba(255, 255, 255, 0.1) 100%
+    var(--accent-cyan) 0%,
+    var(--accent-cyan) var(--slider-fill, 0%),
+    var(--border-default) var(--slider-fill, 0%),
+    var(--border-default) 100%
   );
   appearance: none;
   cursor: pointer;
@@ -126,7 +126,7 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background: #4db8ff;
+  background: var(--accent-cyan);
   cursor: pointer;
   border: 2px solid rgba(255, 255, 255, 0.9);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
@@ -142,7 +142,7 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background: #4db8ff;
+  background: var(--accent-cyan);
   cursor: pointer;
   border: 2px solid rgba(255, 255, 255, 0.9);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
@@ -179,8 +179,8 @@
 }
 
 .cube-btn {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: var(--border-default);
+  border: 1px solid var(--border-strong);
   color: rgba(255, 255, 255, 0.8);
   cursor: pointer;
   padding: 6px 8px;
@@ -192,7 +192,7 @@
 }
 
 .cube-btn:hover {
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--border-strong);
   color: rgba(255, 255, 255, 1);
   border-color: rgba(255, 255, 255, 0.25);
 }
@@ -208,7 +208,7 @@
 .cube-btn-play {
   background: rgba(77, 184, 255, 0.2);
   border-color: rgba(77, 184, 255, 0.4);
-  color: #4db8ff;
+  color: var(--accent-cyan);
 }
 
 .cube-btn-play:hover {
@@ -242,9 +242,9 @@
 
 .speed-select {
   background: rgba(30, 30, 45, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 4px;
-  color: #fff;
+  color: var(--text-primary);
   padding: 4px 8px;
   font-size: 11px;
   cursor: pointer;
@@ -257,12 +257,12 @@
 
 .speed-select:focus {
   outline: none;
-  border-color: #4db8ff;
+  border-color: var(--accent-cyan);
 }
 
 .speed-select option {
-  background: #1a1a2e;
-  color: #fff;
+  background: var(--bg-wizard);
+  color: var(--text-primary);
 }
 
 /* Keyboard hints */

--- a/frontend/jwst-frontend/src/components/CurvesEditor.css
+++ b/frontend/jwst-frontend/src/components/CurvesEditor.css
@@ -1,6 +1,6 @@
 .curves-editor {
   background: rgba(20, 20, 30, 0.95);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-default);
   border-radius: 8px;
   overflow: hidden;
   min-width: 220px;
@@ -82,7 +82,7 @@
 
 .curves-preset-btn {
   background: rgba(30, 30, 45, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 4px;
   color: rgba(255, 255, 255, 0.7);
   padding: 4px 8px;
@@ -95,13 +95,13 @@
 
 .curves-preset-btn:hover {
   border-color: rgba(255, 255, 255, 0.3);
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .curves-preset-btn.active {
   background: rgba(77, 184, 255, 0.2);
-  border-color: #4db8ff;
-  color: #4db8ff;
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
 }
 
 .curves-hint {

--- a/frontend/jwst-frontend/src/components/ExportOptionsPanel.css
+++ b/frontend/jwst-frontend/src/components/ExportOptionsPanel.css
@@ -1,6 +1,6 @@
 .export-options-panel {
   background: rgba(20, 20, 30, 0.95);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-default);
   border-radius: 8px;
   overflow: hidden;
   min-width: 240px;
@@ -51,7 +51,7 @@
 
 .export-close-btn:hover {
   color: rgba(255, 255, 255, 0.9);
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-default);
 }
 
 .export-options-body {
@@ -99,7 +99,7 @@
   flex: 1;
   padding: 8px 12px;
   background: rgba(30, 30, 45, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 6px;
   color: rgba(255, 255, 255, 0.7);
   font-size: 13px;
@@ -110,13 +110,13 @@
 
 .export-format-btn:hover {
   border-color: rgba(255, 255, 255, 0.3);
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .export-format-btn.active {
   background: rgba(77, 184, 255, 0.2);
-  border-color: #4db8ff;
-  color: #4db8ff;
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
 }
 
 .export-format-hint {
@@ -130,7 +130,7 @@
   width: 100%;
   height: 4px;
   border-radius: 2px;
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-default);
   appearance: none;
   cursor: pointer;
 }
@@ -140,7 +140,7 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #4db8ff;
+  background: var(--accent-cyan);
   cursor: pointer;
   border: 2px solid rgba(255, 255, 255, 0.9);
   transition: all 0.15s;
@@ -155,7 +155,7 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #4db8ff;
+  background: var(--accent-cyan);
   cursor: pointer;
   border: 2px solid rgba(255, 255, 255, 0.9);
   transition: all 0.15s;
@@ -178,7 +178,7 @@
 .export-slider::-moz-range-track {
   height: 4px;
   border-radius: 2px;
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-default);
 }
 
 .export-slider-labels {
@@ -193,9 +193,9 @@
 .export-select {
   width: 100%;
   background: rgba(30, 30, 45, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 6px;
-  color: #fff;
+  color: var(--text-primary);
   padding: 8px 10px;
   font-size: 13px;
   cursor: pointer;
@@ -208,13 +208,13 @@
 
 .export-select:focus {
   outline: none;
-  border-color: #4db8ff;
+  border-color: var(--accent-cyan);
   box-shadow: 0 0 0 2px rgba(77, 184, 255, 0.2);
 }
 
 .export-select option {
-  background: #1a1a2e;
-  color: #fff;
+  background: var(--bg-wizard);
+  color: var(--text-primary);
 }
 
 /* Custom Resolution */
@@ -244,9 +244,9 @@
 .export-dimension-input {
   width: 70px;
   background: rgba(30, 30, 45, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 4px;
-  color: #fff;
+  color: var(--text-primary);
   padding: 6px 8px;
   font-size: 12px;
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
@@ -255,7 +255,7 @@
 
 .export-dimension-input:focus {
   outline: none;
-  border-color: #4db8ff;
+  border-color: var(--accent-cyan);
 }
 
 .export-dimension-input::-webkit-outer-spin-button,
@@ -308,7 +308,7 @@
   position: relative;
   width: 32px;
   height: 18px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--border-strong);
   border-radius: 9px;
   transition: background 0.2s;
   flex-shrink: 0;
@@ -332,7 +332,7 @@
 
 .export-toggle-checkbox:checked + .export-toggle-switch::after {
   left: 16px;
-  background: #4db8ff;
+  background: var(--accent-cyan);
 }
 
 .export-toggle-text {
@@ -353,10 +353,10 @@
   justify-content: center;
   gap: 8px;
   padding: 10px 16px;
-  background: linear-gradient(135deg, #4db8ff 0%, #3d8bff 100%);
+  background: linear-gradient(135deg, var(--accent-cyan) 0%, #3d8bff 100%);
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--text-primary);
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
@@ -381,7 +381,7 @@
   width: 14px;
   height: 14px;
   border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: #fff;
+  border-top-color: var(--text-primary);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }

--- a/frontend/jwst-frontend/src/components/FitsViewer.css
+++ b/frontend/jwst-frontend/src/components/FitsViewer.css
@@ -85,7 +85,7 @@
   background: rgba(20, 20, 25, 0.7);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-subtle);
   /* Minimal Border */
   border-radius: 12px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
@@ -118,7 +118,7 @@
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -141,7 +141,7 @@
 }
 
 .breadcrumb-item.active {
-  color: #fff;
+  color: var(--text-primary);
   font-weight: 500;
 }
 
@@ -166,7 +166,7 @@
   /* Sleek Pill */
   background: rgba(15, 15, 20, 0.85);
   backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-default);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
   border-radius: 100px;
 }
@@ -180,7 +180,7 @@
 .toolbar-divider {
   width: 1px;
   height: 20px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--border-strong);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -189,7 +189,7 @@
 .viewer-sidebar {
   background: #0a0a0c;
   /* Slight contrast from canvas bg */
-  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 1px solid var(--border-subtle);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -319,7 +319,7 @@
 }
 
 .sidebar-content::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-default);
   border-radius: 3px;
 }
 
@@ -347,8 +347,8 @@
 }
 
 .btn-icon:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: #fff;
+  background: var(--border-default);
+  color: var(--text-primary);
 }
 
 .viewer-floating-toolbar .btn-icon.active {
@@ -364,7 +364,7 @@
 
 .btn-text {
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-default);
   color: rgba(255, 255, 255, 0.8);
   padding: 4px 10px;
   border-radius: 4px;
@@ -377,7 +377,7 @@
 
 .btn-text:hover {
   border-color: rgba(255, 255, 255, 0.4);
-  color: #fff;
+  color: var(--text-primary);
 }
 
 /* Select */
@@ -391,7 +391,7 @@
 .fits-select {
   background: transparent;
   border: none;
-  color: #fff;
+  color: var(--text-primary);
   font-size: 0.85rem;
   padding: 8px 12px;
   cursor: pointer;
@@ -402,13 +402,13 @@
 
 .fits-select option {
   background: #15151a;
-  color: #fff;
+  color: var(--text-primary);
 }
 
 /* States */
 .viewer-loading-state {
   position: absolute;
-  color: #4db8ff;
+  color: var(--accent-cyan);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -420,7 +420,7 @@
   width: 48px;
   height: 48px;
   border: 3px solid rgba(77, 184, 255, 0.2);
-  border-top-color: #4db8ff;
+  border-top-color: var(--accent-cyan);
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
@@ -467,7 +467,7 @@
 }
 
 .viewer-floating-panels::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-default);
   border-radius: 2px;
 }
 
@@ -489,7 +489,7 @@
 
   /* Solid dark background - sits below viewport */
   background: rgba(10, 10, 12, 0.95);
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--border-subtle);
 
   /* Monospace font for values */
   font-family: 'JetBrains Mono', 'SF Mono', Monaco, Consolas, monospace;
@@ -519,7 +519,7 @@
 .status-bar-divider {
   width: 1px;
   height: 20px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--border-strong);
 }
 
 .status-bar-placeholder {
@@ -544,7 +544,7 @@
   width: 12px;
   height: 12px;
   border: 2px solid rgba(77, 184, 255, 0.2);
-  border-top-color: #4db8ff;
+  border-top-color: var(--accent-cyan);
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
@@ -571,7 +571,7 @@
 
 .annotation-tools .btn-icon.active {
   background: rgba(77, 184, 255, 0.2);
-  color: #4db8ff;
+  color: var(--accent-cyan);
 }
 
 .annotation-color-picker {
@@ -580,7 +580,7 @@
   gap: 4px;
   margin-left: 4px;
   padding-left: 8px;
-  border-left: 1px solid rgba(255, 255, 255, 0.15);
+  border-left: 1px solid var(--border-strong);
 }
 
 .annotation-color-swatch {
@@ -598,7 +598,7 @@
 }
 
 .annotation-color-swatch.active {
-  border-color: #fff;
+  border-color: var(--text-primary);
   box-shadow: 0 0 6px rgba(255, 255, 255, 0.4);
 }
 

--- a/frontend/jwst-frontend/src/components/HistogramPanel.css
+++ b/frontend/jwst-frontend/src/components/HistogramPanel.css
@@ -4,7 +4,7 @@
   border-radius: 8px;
   overflow: hidden;
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-default);
 }
 
 .histogram-panel.collapsed {
@@ -23,7 +23,7 @@
 }
 
 .histogram-header:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--border-subtle);
 }
 
 .histogram-header-left {

--- a/frontend/jwst-frontend/src/components/StretchControls.css
+++ b/frontend/jwst-frontend/src/components/StretchControls.css
@@ -1,6 +1,6 @@
 .stretch-controls {
   background: rgba(20, 20, 30, 0.95);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-default);
   border-radius: 8px;
   overflow: hidden;
   min-width: 220px;
@@ -61,7 +61,7 @@
 
 .btn-reset:hover {
   color: rgba(255, 255, 255, 0.9);
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-default);
 }
 
 .collapse-icon {
@@ -108,9 +108,9 @@
 .stretch-select {
   width: 100%;
   background: rgba(30, 30, 45, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 6px;
-  color: #fff;
+  color: var(--text-primary);
   padding: 8px 10px;
   font-size: 13px;
   cursor: pointer;
@@ -123,13 +123,13 @@
 
 .stretch-select:focus {
   outline: none;
-  border-color: #4db8ff;
+  border-color: var(--accent-cyan);
   box-shadow: 0 0 0 2px rgba(77, 184, 255, 0.2);
 }
 
 .stretch-select option {
-  background: #1a1a2e;
-  color: #fff;
+  background: var(--bg-wizard);
+  color: var(--text-primary);
 }
 
 .control-hint {
@@ -142,7 +142,7 @@
   width: 100%;
   height: 4px;
   border-radius: 2px;
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-default);
   appearance: none;
   cursor: pointer;
 }
@@ -152,7 +152,7 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #4db8ff;
+  background: var(--accent-cyan);
   cursor: pointer;
   border: 2px solid rgba(255, 255, 255, 0.9);
   transition: all 0.15s;
@@ -167,7 +167,7 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #4db8ff;
+  background: var(--accent-cyan);
   cursor: pointer;
   border: 2px solid rgba(255, 255, 255, 0.9);
   transition: all 0.15s;
@@ -190,7 +190,7 @@
 .stretch-slider::-moz-range-track {
   height: 4px;
   border-radius: 2px;
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-default);
 }
 
 .slider-labels {


### PR DESCRIPTION
## Summary

Replace hardcoded CSS color values with design token custom properties in FitsViewer.css, StretchControls.css, HistogramPanel.css, ExportOptionsPanel.css, CubeNavigator.css, CurvesEditor.css, and AnnotationOverlay.css (P6 of the design token migration).

## Why

Final phase of the design token migration for viewer/tool components. These files use a glass-morphism aesthetic with many unique rgba opacities; only values with exact token matches were replaced to maintain the visual design.

## Type of Change

- [x] Refactoring (no functional changes)

## Changes Made

- Replace `rgba(255,255,255,0.08)` with `var(--border-subtle)` for thin borders across all files
- Replace `rgba(255,255,255,0.1)` with `var(--border-default)` for standard borders and backgrounds
- Replace `rgba(255,255,255,0.15)` with `var(--border-strong)` for toolbar dividers and emphasized borders
- Replace `#fff` in color-property contexts with `var(--text-primary)` across all files
- Replace `#4db8ff` with `var(--accent-cyan)` for focus states, active states, and slider fills
- Replace `#1a1a2e` with `var(--bg-wizard)` for select option backgrounds
- Preserve all component-specific rgba values (0.03, 0.05, 0.2, 0.3, 0.35, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95) that have no matching tokens
- Preserve unique colors (#e0e0e0, #050505, #0a0a0c, #15151a, #4cc9f0, #66c4ff, #ff6b6b, #ff4d4d, #00e5cc, #ffa500, #3d8bff)

## Test Plan

- [x] No visual changes — all tokens resolve to identical values as hardcoded originals
- [ ] Verify FITS viewer renders correctly (canvas, header, toolbar, sidebar, status bar)
- [ ] Verify stretch controls panel functions (slider, select, collapse)
- [ ] Verify histogram panel displays correctly
- [ ] Verify export options panel functions (format buttons, sliders, toggles)
- [ ] Verify cube navigator slider and controls work
- [ ] Verify curves editor presets and canvas
- [ ] Verify annotation overlay text input and focus states
- [ ] Run frontend unit tests: `npm test` passes

## Documentation Checklist

- [x] No documentation updates needed (CSS-only refactor, no new components or endpoints)

## Tech Debt Impact

- [x] Decreases tech debt (migrates hardcoded colors to design tokens)
- [ ] No impact on tech debt
- [ ] Increases tech debt (explain why)

## Risk & Rollback

Risk: Low — mechanical color value replacement with no functional changes. All token values match original hardcoded values exactly. Conservative approach: only replaced values with exact token matches.

Rollback: Revert the single commit.

## Quality Checklist

- [x] Changes are minimal and focused on the task
- [x] No unnecessary refactoring beyond token migration
- [x] CSS-only changes, no logic affected