### PR TITLE
feat: extend design token palette with canvas, panel, and aqua tokens

### DIFF
--- a/frontend/jwst-frontend/src/index.css
+++ b/frontend/jwst-frontend/src/index.css
@@ -78,6 +78,24 @@
   --bg-toolbar-hover: #3a3a6a;
   --border-toolbar: #444;
 
+  /* Canvas & inset — pure-black and near-black backgrounds */
+  --bg-canvas: #000000;
+  --bg-inset: #0a0a0c;
+
+  /* Glass panels — semi-transparent dark overlays */
+  --bg-panel: rgba(15, 15, 20, 0.85);
+  --bg-panel-heavy: rgba(15, 15, 20, 0.95);
+
+  /* Additional text opacities */
+  --text-soft: rgba(255, 255, 255, 0.8);
+
+  /* Additional border opacities */
+  --border-bright: rgba(255, 255, 255, 0.3);
+
+  /* Aqua accent — comparison & analysis UIs */
+  --accent-aqua: #4cc9f0;
+  --accent-aqua-subtle: rgba(76, 201, 240, 0.15);
+
   /* Transitions */
   --transition-fast: 0.15s ease-out;
   --transition-base: 0.2s ease-out;


### PR DESCRIPTION
## Summary
Extends the CSS design token palette with new tokens needed for the remaining tokenization sweep (P11–P13).

## Why
The existing token palette lacks coverage for pure-black canvas backgrounds, semi-transparent panel overlays, soft text opacity, bright borders, and the aqua accent family used in comparison/analysis UIs. These are needed before the remaining ~820 hardcoded color values can be replaced.

## Type of Change
- [x] Refactoring / tech debt

## Changes Made
- Added `--bg-canvas` (#000) and `--bg-inset` (#0a0a0c) for pure/near-black backgrounds
- Added `--bg-panel` and `--bg-panel-heavy` for semi-transparent dark panel overlays
- Added `--text-soft` for rgba(255,255,255,0.8) text
- Added `--border-bright` for higher-contrast rgba(255,255,255,0.3) borders
- Added `--accent-aqua` and `--accent-aqua-subtle` for comparison/analysis UI cyan (#4cc9f0)

## Test Plan
- [x] Token definitions only — no visual changes until consumed by subsequent PRs
- [x] All existing styles unchanged

## Documentation Checklist
- [x] No doc updates needed (token definitions only)

## Tech Debt Impact
- [x] Reduces tech debt — enables full CSS tokenization

## Risk & Rollback
Risk: None — additive token definitions with no consumers yet.
Rollback: Revert the single commit.

## Quality Checklist
- [x] Self-reviewed
- [x] No hardcoded values introduced
- [x] Follows existing token naming conventions

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)