### PR TITLE
refactor: tokenize remaining wizard CSS colors (P11)

### DIFF
--- a/frontend/jwst-frontend/src/components/CompositeWizard.css
+++ b/frontend/jwst-frontend/src/components/CompositeWizard.css
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.75);
+  background: var(--bg-overlay);
   backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
@@ -23,10 +23,10 @@
   max-height: 900px;
   background: linear-gradient(135deg, var(--bg-wizard) 0%, var(--bg-wizard-alt) 100%);
   border-radius: 16px;
-  border: 1px solid rgba(74, 144, 217, 0.3);
+  border: 1px solid var(--border-interactive);
   box-shadow:
-    0 25px 50px -12px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(255, 255, 255, 0.05);
+    var(--shadow-lg),
+    0 0 0 1px var(--border-subtle);
   overflow: hidden;
   min-height: 0;
   margin: auto;
@@ -37,7 +37,7 @@
   display: flex;
   align-items: center;
   padding: 0.75rem 1.25rem;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-bottom: 1px solid var(--border-interactive);
   gap: 1rem;
 }
@@ -49,7 +49,7 @@
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #e5e7eb;
+  color: var(--text-primary);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -77,7 +77,7 @@
 
 .btn-close:hover {
   background: var(--border-default);
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 /* Content */
@@ -98,7 +98,7 @@
   display: flex;
   align-items: center;
   padding: 1rem 1.5rem;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-top: 1px solid var(--border-interactive);
 }
 
@@ -130,42 +130,42 @@
 }
 
 .btn-wizard.btn-primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, #5a9fe8, #4089cc);
+  background: linear-gradient(135deg, var(--accent-interactive), var(--accent-interactive-hover));
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(74, 144, 217, 0.3);
+  box-shadow: 0 4px 12px var(--accent-interactive-subtle);
 }
 
 .btn-wizard.btn-secondary {
-  background: rgba(107, 114, 128, 0.2);
-  border: 1px solid rgba(107, 114, 128, 0.3);
+  background: var(--border-subtle);
+  border: 1px solid var(--border-default);
   color: var(--text-secondary);
 }
 
 .btn-wizard.btn-secondary:hover:not(:disabled) {
-  background: rgba(107, 114, 128, 0.3);
-  color: #e5e7eb;
+  background: var(--border-default);
+  color: var(--text-primary);
 }
 
 .btn-wizard.btn-success {
-  background: linear-gradient(135deg, var(--accent-teal), #3ba99c);
+  background: linear-gradient(135deg, var(--accent-teal), var(--accent-teal));
   color: white;
 }
 
 .btn-wizard.btn-success:hover:not(:disabled) {
-  background: linear-gradient(135deg, #5edcd3, #4ab8ab);
+  background: linear-gradient(135deg, var(--accent-teal), var(--accent-teal));
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(78, 205, 196, 0.3);
+  box-shadow: 0 4px 12px var(--accent-teal-subtle);
 }
 
 .btn-wizard.btn-generate {
-  background: linear-gradient(135deg, #8844ff, #6633cc);
+  background: linear-gradient(135deg, var(--accent-secondary), var(--accent-secondary-hover));
   color: white;
 }
 
 .btn-wizard.btn-generate:hover:not(:disabled) {
-  background: linear-gradient(135deg, #9955ff, #7744dd);
+  background: linear-gradient(135deg, var(--accent-secondary), var(--accent-secondary-hover));
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(136, 68, 255, 0.3);
+  box-shadow: 0 4px 12px var(--accent-secondary-subtle);
 }
 
 .btn-wizard-close {

--- a/frontend/jwst-frontend/src/components/MosaicWizard.css
+++ b/frontend/jwst-frontend/src/components/MosaicWizard.css
@@ -6,7 +6,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.75);
+  background: var(--bg-overlay);
   backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
@@ -25,10 +25,10 @@
   max-height: 900px;
   background: linear-gradient(135deg, var(--bg-wizard) 0%, var(--bg-wizard-alt) 100%);
   border-radius: 16px;
-  border: 1px solid rgba(74, 144, 217, 0.3);
+  border: 1px solid var(--border-interactive);
   box-shadow:
-    0 25px 50px -12px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(255, 255, 255, 0.05);
+    var(--shadow-lg),
+    0 0 0 1px var(--border-subtle);
   overflow: hidden;
   min-height: 0;
   margin: auto;
@@ -62,14 +62,14 @@
 .mosaic-footprint-error {
   text-align: center;
   padding: 2rem;
-  color: #f87171;
+  color: var(--color-error);
 }
 
 .mosaic-btn-retry {
   margin-top: 0.75rem;
   padding: 0.4rem 1rem;
   background: var(--border-interactive);
-  border: 1px solid rgba(74, 144, 217, 0.3);
+  border: 1px solid var(--border-interactive);
   border-radius: 6px;
   color: var(--accent-interactive);
   font-size: 0.85rem;
@@ -77,7 +77,7 @@
 }
 
 .mosaic-btn-retry:hover {
-  background: rgba(74, 144, 217, 0.3);
+  background: var(--border-interactive);
 }
 
 .mosaic-footprint-empty {
@@ -99,7 +99,7 @@
   flex: 1;
   min-height: 200px;
   border-radius: 8px;
-  border: 1px solid rgba(74, 144, 217, 0.15);
+  border: 1px solid var(--accent-interactive-subtle);
 }
 
 .mosaic-footprint-legend {
@@ -113,7 +113,7 @@
   align-items: center;
   gap: 0.4rem;
   padding: 0.25rem 0.5rem;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-radius: 4px;
 }
 

--- a/frontend/jwst-frontend/src/components/wizard/ChannelAssignStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/ChannelAssignStep.css
@@ -18,7 +18,7 @@
 .channel-assign-step .step-instructions h3 {
   margin: 0 0 0.375rem 0;
   font-size: 1.15rem;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .channel-assign-step .step-instructions p {
@@ -38,7 +38,7 @@
 .preset-buttons {
   display: flex;
   gap: 0.25rem;
-  background: rgba(15, 23, 42, 0.5);
+  background: var(--bg-panel);
   border-radius: 6px;
   padding: 0.2rem;
   margin-right: 0.25rem;
@@ -58,14 +58,14 @@
 }
 
 .btn-preset:hover {
-  color: #e5e7eb;
-  background: rgba(74, 144, 217, 0.1);
+  color: var(--text-primary);
+  background: var(--accent-interactive-subtle);
 }
 
 .btn-preset.active {
   background: var(--border-interactive);
   border-color: var(--border-interactive-hover);
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 /* JWST Presets dropdown */
@@ -80,7 +80,7 @@
 }
 
 .btn-preset-dropdown.active {
-  background: rgba(74, 144, 217, 0.15);
+  background: var(--accent-interactive-subtle);
   border-color: var(--border-interactive-hover);
 }
 
@@ -98,9 +98,9 @@
   max-height: 420px;
   overflow-y: auto;
   background: var(--bg-wizard);
-  border: 1px solid rgba(74, 144, 217, 0.3);
+  border: 1px solid var(--border-interactive);
   border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg);
   padding: 0.375rem;
 }
 
@@ -109,12 +109,12 @@
 }
 
 .preset-dropdown-menu::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-radius: 3px;
 }
 
 .preset-dropdown-menu::-webkit-scrollbar-thumb {
-  background: rgba(74, 144, 217, 0.3);
+  background: var(--border-interactive);
   border-radius: 3px;
 }
 
@@ -123,7 +123,7 @@
 }
 
 .preset-group + .preset-group {
-  border-top: 1px solid rgba(74, 144, 217, 0.15);
+  border-top: 1px solid var(--accent-interactive-subtle);
   margin-top: 0.25rem;
   padding-top: 0.5rem;
 }
@@ -149,12 +149,12 @@
   border-radius: 6px;
   cursor: pointer;
   text-align: left;
-  color: #e5e7eb;
+  color: var(--text-primary);
   transition: all 0.12s ease;
 }
 
 .preset-menu-item:hover {
-  background: rgba(74, 144, 217, 0.1);
+  background: var(--accent-interactive-subtle);
   border-color: var(--border-interactive);
 }
 
@@ -186,15 +186,15 @@
   font-weight: 700;
   padding: 0.15rem 0.4rem;
   border-radius: 10px;
-  background: rgba(74, 144, 217, 0.15);
-  color: #60a5fa;
-  border: 1px solid rgba(74, 144, 217, 0.3);
+  background: var(--accent-interactive-subtle);
+  color: var(--accent-primary);
+  border: 1px solid var(--border-interactive);
 }
 
 .preset-match-badge.full-match {
-  background: rgba(34, 197, 94, 0.15);
-  color: #4ade80;
-  border-color: rgba(34, 197, 94, 0.3);
+  background: var(--color-success-subtle);
+  color: var(--color-success);
+  border-color: var(--color-success);
 }
 
 /* Main body: channels on top (scrolls), pool on bottom (scrolls) */
@@ -221,12 +221,12 @@
 }
 
 .channel-lanes::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-radius: 3px;
 }
 
 .channel-lanes::-webkit-scrollbar-thumb {
-  background: rgba(74, 144, 217, 0.3);
+  background: var(--border-interactive);
   border-radius: 3px;
 }
 
@@ -312,9 +312,9 @@
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: rgba(204, 204, 204, 0.2);
-  border: 1.5px solid #cccccc;
-  color: #cccccc;
+  background: var(--border-subtle);
+  border: 1.5px solid var(--text-secondary);
+  color: var(--text-secondary);
   font-size: 0.65rem;
   font-weight: 700;
   display: flex;
@@ -330,7 +330,7 @@
   height: 18px;
   border-radius: 4px;
   background: transparent;
-  border: 1px solid rgba(107, 114, 128, 0.4);
+  border: 1px solid var(--text-faint);
   color: var(--text-muted);
   font-size: 0.6rem;
   font-weight: 700;
@@ -345,16 +345,16 @@
 }
 
 .lane-lum-toggle:hover {
-  border-color: #cccccc;
-  color: #cccccc;
-  background: rgba(204, 204, 204, 0.1);
+  border-color: var(--text-secondary);
+  color: var(--text-secondary);
+  background: var(--border-subtle);
 }
 
 .lane-lum-toggle.active {
-  background: rgba(204, 204, 204, 0.2);
-  border-color: #cccccc;
-  color: #cccccc;
-  box-shadow: 0 0 6px rgba(204, 204, 204, 0.3);
+  background: var(--border-default);
+  border-color: var(--text-secondary);
+  color: var(--text-secondary);
+  box-shadow: 0 0 6px var(--border-bright);
 }
 
 /* Editable channel label */
@@ -362,7 +362,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: 4px;
-  color: #e5e7eb;
+  color: var(--text-primary);
   font-size: 0.85rem;
   font-weight: 600;
   padding: 0.125rem 0.375rem;
@@ -372,13 +372,13 @@
 }
 
 .lane-label-input:hover {
-  border-color: rgba(74, 144, 217, 0.3);
+  border-color: var(--border-interactive);
 }
 
 .lane-label-input:focus {
   outline: none;
-  border-color: rgba(74, 144, 217, 0.6);
-  background: rgba(15, 23, 42, 0.5);
+  border-color: var(--border-interactive-hover);
+  background: var(--bg-panel);
 }
 
 .lane-label-input::placeholder {
@@ -408,7 +408,7 @@
 
 .lane-remove-btn:hover {
   color: var(--color-error);
-  background: rgba(239, 68, 68, 0.15);
+  background: var(--color-error-subtle);
 }
 
 .lane-cards {
@@ -437,8 +437,8 @@
   justify-content: center;
   gap: 0.375rem;
   padding: 0.5rem;
-  background: rgba(22, 33, 62, 0.4);
-  border: 2px dashed rgba(74, 144, 217, 0.25);
+  background: var(--bg-wizard-inner);
+  border: 2px dashed var(--border-interactive);
   border-radius: 10px;
   color: var(--text-secondary);
   font-size: 0.8rem;
@@ -448,18 +448,18 @@
 }
 
 .add-channel-btn:hover {
-  border-color: rgba(74, 144, 217, 0.5);
-  background: rgba(74, 144, 217, 0.08);
-  color: #e5e7eb;
+  border-color: var(--border-interactive-hover);
+  background: var(--accent-interactive-subtle);
+  color: var(--text-primary);
 }
 
 /* Available Images Pool — fills remaining space, scrolls internally */
 .image-pool {
   flex: 1;
   min-height: 0;
-  background: rgba(22, 33, 62, 0.5);
+  background: var(--bg-wizard-inner);
   border-radius: 10px;
-  border: 2px dashed rgba(74, 144, 217, 0.25);
+  border: 2px dashed var(--border-interactive);
   padding: 0.75rem;
   transition: all 0.2s ease;
   display: flex;
@@ -468,8 +468,8 @@
 }
 
 .image-pool.drag-over {
-  border-color: rgba(74, 144, 217, 0.6);
-  background: rgba(74, 144, 217, 0.08);
+  border-color: var(--border-interactive-hover);
+  background: var(--accent-interactive-subtle);
 }
 
 .pool-header {
@@ -484,7 +484,7 @@
 .pool-label {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .pool-count {
@@ -506,12 +506,12 @@
 }
 
 .pool-cards::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-radius: 3px;
 }
 
 .pool-cards::-webkit-scrollbar-thumb {
-  background: rgba(74, 144, 217, 0.3);
+  background: var(--border-interactive);
   border-radius: 3px;
 }
 
@@ -529,7 +529,7 @@
   align-items: center;
   gap: 0.625rem;
   padding: 0.5rem;
-  background: rgba(26, 26, 46, 0.8);
+  background: var(--bg-wizard-inner);
   border: 1px solid var(--border-interactive);
   border-radius: 8px;
   cursor: grab;
@@ -539,7 +539,7 @@
 
 .dnd-image-card:hover {
   border-color: var(--border-interactive-hover);
-  background: rgba(26, 26, 46, 0.95);
+  background: var(--bg-panel-heavy);
 }
 
 .dnd-image-card:active {
@@ -551,12 +551,12 @@
 /* Non-matching target — dimmed but still draggable */
 .dnd-image-card.dimmed {
   opacity: 0.4;
-  border-color: rgba(107, 114, 128, 0.15);
+  border-color: var(--border-subtle);
 }
 
 .dnd-image-card.dimmed:hover {
   opacity: 0.6;
-  border-color: rgba(107, 114, 128, 0.3);
+  border-color: var(--border-default);
 }
 
 /* Card thumbnail */
@@ -566,7 +566,7 @@
   border-radius: 6px;
   overflow: hidden;
   background: var(--bg-deep);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-subtle);
   flex-shrink: 0;
   position: relative;
 }
@@ -598,7 +598,7 @@
 .dnd-card-target {
   font-size: 0.75rem;
   font-weight: 500;
-  color: #e5e7eb;
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/jwst-frontend/src/components/wizard/ChannelCard.css
+++ b/frontend/jwst-frontend/src/components/wizard/ChannelCard.css
@@ -1,5 +1,5 @@
 .channel-card {
-  background: rgba(22, 33, 62, 0.8);
+  background: var(--bg-wizard-inner);
   border-radius: 12px;
   border: 2px solid var(--channel-color, #666);
   overflow: hidden;
@@ -7,7 +7,7 @@
 }
 
 .channel-card:hover {
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
 }
 
 .channel-header {
@@ -35,7 +35,7 @@
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .channel-content {
@@ -67,7 +67,7 @@
   grid-template-columns: auto 1fr;
   gap: 0.25rem 0.75rem;
   padding: 0.75rem;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-radius: 8px;
   font-size: 0.8rem;
 }
@@ -77,7 +77,7 @@
 }
 
 .info-value {
-  color: #e5e7eb;
+  color: var(--text-primary);
   font-weight: 500;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -90,7 +90,7 @@
 }
 
 .channel-stretch .stretch-controls {
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-radius: 8px;
   padding: 0.5rem;
 }

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.css
@@ -50,8 +50,8 @@
 
 .btn-retry {
   padding: 0.5rem 1rem;
-  background: rgba(239, 68, 68, 0.2);
-  border: 1px solid rgba(239, 68, 68, 0.4);
+  background: var(--color-error-subtle);
+  border: 1px solid var(--color-error);
   border-radius: 6px;
   color: var(--color-error);
   font-size: 0.85rem;
@@ -60,7 +60,7 @@
 }
 
 .btn-retry:hover {
-  background: rgba(239, 68, 68, 0.3);
+  background: var(--color-error-subtle);
 }
 
 /* Channel summary */
@@ -131,9 +131,9 @@
   width: 15px;
   height: 15px;
   border-radius: 3px;
-  background: rgba(204, 204, 204, 0.2);
-  border: 1px solid rgba(204, 204, 204, 0.5);
-  color: #cccccc;
+  background: var(--border-subtle);
+  border: 1px solid var(--text-muted);
+  color: var(--text-secondary);
   font-size: 0.6rem;
   font-weight: 700;
   line-height: 1;
@@ -142,7 +142,7 @@
 
 .channel-value {
   font-size: 0.85rem;
-  color: #e5e7eb;
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -154,7 +154,7 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1.5rem;
-  background: rgba(22, 33, 62, 0.8);
+  background: var(--bg-wizard-inner);
   border-left: 1px solid var(--border-interactive);
   overflow-y: auto;
   min-height: 0;
@@ -166,7 +166,7 @@
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .option-group {
@@ -177,9 +177,9 @@
 
 .overall-adjustments-group {
   padding: 0.9rem;
-  border: 1px solid rgba(74, 144, 217, 0.25);
+  border: 1px solid var(--border-interactive);
   border-radius: 10px;
-  background: rgba(26, 26, 46, 0.75);
+  background: var(--bg-wizard-inner);
 }
 
 .overall-header {
@@ -189,9 +189,9 @@
 }
 
 .btn-overall-reset {
-  border: 1px solid rgba(74, 144, 217, 0.35);
-  background: rgba(74, 144, 217, 0.15);
-  color: #9dc9f0;
+  border: 1px solid var(--border-interactive-hover);
+  background: var(--accent-interactive-subtle);
+  color: var(--text-secondary);
   border-radius: 6px;
   padding: 0.3rem 0.55rem;
   font-size: 0.75rem;
@@ -200,17 +200,17 @@
 }
 
 .btn-overall-reset:hover {
-  background: rgba(74, 144, 217, 0.28);
-  color: #d4e9fb;
+  background: var(--border-interactive);
+  color: var(--text-primary);
 }
 
 .overall-select {
   width: 100%;
   padding: 0.55rem 0.65rem;
   border-radius: 7px;
-  background: rgba(15, 23, 42, 0.8);
-  border: 1px solid rgba(74, 144, 217, 0.35);
-  color: #e5e7eb;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-interactive-hover);
+  color: var(--text-primary);
   font-size: 0.85rem;
 }
 
@@ -221,7 +221,7 @@
 
 .overall-hint {
   font-size: 0.75rem;
-  color: #8fb8dc;
+  color: var(--text-secondary);
 }
 
 .option-label {
@@ -245,9 +245,9 @@
 /* Channel Balance weight sliders */
 .channel-balance-group {
   padding: 0.75rem 0.9rem;
-  border: 1px solid rgba(74, 144, 217, 0.25);
+  border: 1px solid var(--border-interactive);
   border-radius: 10px;
-  background: rgba(26, 26, 46, 0.75);
+  background: var(--bg-wizard-inner);
 }
 
 .weight-sliders {
@@ -275,7 +275,7 @@
   flex: 1;
   height: 6px;
   border-radius: 3px;
-  background: rgba(74, 144, 217, 0.15);
+  background: var(--accent-interactive-subtle);
   appearance: none;
   cursor: pointer;
 }
@@ -287,7 +287,7 @@
   border-radius: 50%;
   background: var(--weight-color);
   cursor: pointer;
-  border: 2px solid rgba(255, 255, 255, 0.8);
+  border: 2px solid var(--text-soft);
   transition: transform 0.15s ease;
 }
 
@@ -301,7 +301,7 @@
   border-radius: 50%;
   background: var(--weight-color);
   cursor: pointer;
-  border: 2px solid rgba(255, 255, 255, 0.8);
+  border: 2px solid var(--text-soft);
 }
 
 .weight-slider:focus {
@@ -311,7 +311,7 @@
 .weight-value {
   font-size: 0.8rem;
   font-weight: 600;
-  color: #e5e7eb;
+  color: var(--text-primary);
   min-width: 38px;
   text-align: right;
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
@@ -320,9 +320,9 @@
 /* Background neutralization */
 .background-neutralization-group {
   padding: 0.6rem 0.9rem;
-  border: 1px solid rgba(74, 144, 217, 0.25);
+  border: 1px solid var(--border-interactive);
   border-radius: 10px;
-  background: rgba(26, 26, 46, 0.75);
+  background: var(--bg-wizard-inner);
 }
 
 .background-neutralization-label {
@@ -334,7 +334,7 @@
 
 .background-neutralization-hint {
   font-size: 0.72rem;
-  color: #8fb8dc;
+  color: var(--text-secondary);
   margin-top: 0.15rem;
 }
 
@@ -368,7 +368,7 @@
 
 .toggle-switch.active .toggle-thumb {
   left: 18px;
-  background: #fff;
+  background: var(--text-primary);
 }
 
 /* Per-channel adjustments */
@@ -382,8 +382,8 @@
   justify-content: space-between;
   width: 100%;
   padding: 0.65rem 0.9rem;
-  background: rgba(26, 26, 46, 0.75);
-  border: 1px solid rgba(74, 144, 217, 0.25);
+  background: var(--bg-wizard-inner);
+  border: 1px solid var(--border-interactive);
   border-radius: 8px;
   color: var(--text-secondary);
   font-size: 0.85rem;
@@ -393,15 +393,15 @@
 }
 
 .per-channel-toggle:hover {
-  background: rgba(26, 26, 46, 0.95);
+  background: var(--bg-panel-heavy);
   border-color: var(--border-interactive-hover);
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .per-channel-toggle.expanded {
   border-radius: 8px 8px 0 0;
   border-bottom-color: transparent;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .per-channel-chevron {
@@ -417,8 +417,8 @@
   flex-direction: column;
   gap: 0.625rem;
   padding: 0.75rem;
-  background: rgba(26, 26, 46, 0.5);
-  border: 1px solid rgba(74, 144, 217, 0.25);
+  background: var(--bg-wizard-inner);
+  border: 1px solid var(--border-interactive);
   border-top: none;
   border-radius: 0 0 8px 8px;
 }
@@ -435,7 +435,7 @@
   gap: 0.375rem;
   font-size: 0.8rem;
   font-weight: 500;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .per-channel-dot {
@@ -488,7 +488,7 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.75rem;
-  background: rgba(26, 26, 46, 0.8);
+  background: var(--bg-wizard-inner);
   border: 2px solid var(--border-interactive);
   border-radius: 8px;
   color: var(--text-secondary);
@@ -498,12 +498,12 @@
 
 .format-btn:hover {
   border-color: var(--border-interactive-hover);
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .format-btn.active {
   border-color: var(--accent-interactive);
-  background: rgba(74, 144, 217, 0.15);
+  background: var(--accent-interactive-subtle);
   color: var(--accent-interactive);
 }
 
@@ -552,7 +552,7 @@
 
 .preset-btn {
   padding: 0.5rem 0.75rem;
-  background: rgba(26, 26, 46, 0.8);
+  background: var(--bg-wizard-inner);
   border: 1px solid var(--border-interactive);
   border-radius: 6px;
   color: var(--text-secondary);
@@ -563,12 +563,12 @@
 
 .preset-btn:hover {
   border-color: var(--border-interactive-hover);
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .preset-btn.active {
   border-color: var(--accent-interactive);
-  background: rgba(74, 144, 217, 0.15);
+  background: var(--accent-interactive-subtle);
   color: var(--accent-interactive);
 }
 
@@ -593,10 +593,10 @@
 .dimension-field input {
   width: 100px;
   padding: 0.5rem;
-  background: rgba(26, 26, 46, 0.8);
-  border: 1px solid rgba(74, 144, 217, 0.3);
+  background: var(--bg-wizard-inner);
+  border: 1px solid var(--border-interactive);
   border-radius: 6px;
-  color: #e5e7eb;
+  color: var(--text-primary);
   font-size: 0.85rem;
 }
 
@@ -648,8 +648,8 @@
 
 /* Exporting state: button becomes a progress bar */
 .btn-export.exporting {
-  background: rgba(74, 144, 217, 0.15);
-  border: 1px solid rgba(74, 144, 217, 0.3);
+  background: var(--accent-interactive-subtle);
+  border: 1px solid var(--border-interactive);
   cursor: default;
   opacity: 1;
 }
@@ -712,10 +712,10 @@
 
 .export-error {
   padding: 0.75rem;
-  background: rgba(248, 81, 73, 0.1);
-  border: 1px solid rgba(248, 81, 73, 0.3);
+  background: var(--color-error-subtle);
+  border: 1px solid var(--color-error);
   border-radius: 8px;
-  color: #f85149;
+  color: var(--color-error);
   font-size: 0.85rem;
   margin-top: 0.5rem;
 }

--- a/frontend/jwst-frontend/src/components/wizard/ImageFilterToolbar.css
+++ b/frontend/jwst-frontend/src/components/wizard/ImageFilterToolbar.css
@@ -16,17 +16,17 @@
 .ift-search-input {
   flex: 1;
   padding: 0.45rem 0.75rem;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-overlay);
   border: 1px solid var(--border-interactive);
   border-radius: 6px;
-  color: #e5e7eb;
+  color: var(--text-primary);
   font-size: 0.8rem;
   outline: none;
   transition: border-color 0.2s;
 }
 
 .ift-search-input:focus {
-  border-color: rgba(74, 144, 217, 0.5);
+  border-color: var(--border-interactive-hover);
 }
 
 .ift-search-input::placeholder {
@@ -63,27 +63,27 @@
 .ift-filter-control select {
   width: 100%;
   padding: 0.4rem 0.5rem;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-overlay);
   border: 1px solid var(--border-interactive);
   border-radius: 6px;
-  color: #e5e7eb;
+  color: var(--text-primary);
   font-size: 0.78rem;
   outline: none;
 }
 
 .ift-filter-control select:focus {
-  border-color: rgba(74, 144, 217, 0.5);
+  border-color: var(--border-interactive-hover);
 }
 
 .ift-filter-control select option {
   background: var(--bg-wizard);
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 /* --- Wide variant (for mosaic-style full-width toolbar) --- */
 .image-filter-toolbar.wide {
   padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid rgba(74, 144, 217, 0.15);
+  border-bottom: 1px solid var(--accent-interactive-subtle);
 }
 
 .image-filter-toolbar.wide .ift-search-input {

--- a/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.css
@@ -14,7 +14,7 @@
 .step-instructions h3 {
   margin: 0 0 0.5rem 0;
   font-size: 1.25rem;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .step-instructions p {
@@ -43,7 +43,7 @@
 }
 
 .btn-action:hover:not(:disabled) {
-  background: rgba(74, 144, 217, 0.3);
+  background: var(--border-interactive);
   border-color: var(--accent-interactive);
 }
 
@@ -53,13 +53,13 @@
 }
 
 .btn-action.btn-secondary {
-  background: rgba(107, 114, 128, 0.2);
-  border-color: rgba(107, 114, 128, 0.4);
+  background: var(--border-subtle);
+  border-color: var(--text-faint);
   color: var(--text-secondary);
 }
 
 .btn-action.btn-secondary:hover:not(:disabled) {
-  background: rgba(107, 114, 128, 0.3);
+  background: var(--border-default);
   border-color: var(--text-secondary);
 }
 
@@ -85,17 +85,17 @@
 }
 
 .image-grid::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-radius: 4px;
 }
 
 .image-grid::-webkit-scrollbar-thumb {
-  background: rgba(74, 144, 217, 0.3);
+  background: var(--border-interactive);
   border-radius: 4px;
 }
 
 .image-grid::-webkit-scrollbar-thumb:hover {
-  background: rgba(74, 144, 217, 0.5);
+  background: var(--border-interactive-hover);
 }
 
 /* Image card */
@@ -112,15 +112,15 @@
 }
 
 .image-card:hover:not(:disabled) {
-  background: rgba(22, 33, 62, 0.8);
+  background: var(--bg-wizard-inner);
   border-color: var(--border-interactive-hover);
   transform: translateY(-2px);
 }
 
 .image-card.selected {
-  background: rgba(78, 205, 196, 0.1);
+  background: var(--accent-teal-subtle);
   border-color: var(--accent-teal);
-  box-shadow: 0 0 20px rgba(78, 205, 196, 0.2);
+  box-shadow: 0 0 20px var(--accent-teal-subtle);
 }
 
 .image-card.disabled {
@@ -141,13 +141,13 @@
   justify-content: center;
   width: 48px;
   height: 48px;
-  background: rgba(74, 144, 217, 0.15);
+  background: var(--accent-interactive-subtle);
   border-radius: 8px;
   color: var(--accent-interactive);
 }
 
 .image-card.selected .image-icon {
-  background: rgba(78, 205, 196, 0.15);
+  background: var(--accent-teal-subtle);
   color: var(--accent-teal);
 }
 
@@ -162,7 +162,7 @@
 .image-name {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #e5e7eb;
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/jwst-frontend/src/components/wizard/MosaicPreviewStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/MosaicPreviewStep.css
@@ -34,9 +34,9 @@
 }
 
 .mosaic-preview-error {
-  color: #f87171;
-  background: rgba(13, 17, 23, 0.92);
-  border: 1px solid rgba(248, 113, 113, 0.3);
+  color: var(--color-error);
+  background: var(--bg-overlay);
+  border: 1px solid var(--color-error);
   border-radius: 10px;
   padding: 1.25rem 1.75rem;
   max-width: 480px;
@@ -53,8 +53,8 @@
   align-items: center;
   justify-content: center;
   gap: 0.75rem;
-  background: rgba(13, 17, 23, 0.85);
-  color: #e5e7eb;
+  background: var(--bg-panel);
+  color: var(--text-primary);
   font-size: 0.95rem;
   z-index: 1;
 }
@@ -74,8 +74,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(74, 144, 217, 0.15);
+  background: var(--bg-overlay);
+  border: 1px solid var(--accent-interactive-subtle);
   border-radius: 8px;
   overflow: hidden;
   min-height: 0;
@@ -112,7 +112,7 @@
   flex-direction: column;
   gap: 0.875rem;
   padding: 1.5rem;
-  background: rgba(22, 33, 62, 0.8);
+  background: var(--bg-wizard-inner);
   border-left: 1px solid var(--border-interactive);
   overflow-y: auto;
   min-height: 0;
@@ -124,12 +124,12 @@
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .mosaic-sidebar-divider {
   height: 1px;
-  background: rgba(74, 144, 217, 0.15);
+  background: var(--accent-interactive-subtle);
   margin: 0.25rem 0;
 }
 
@@ -151,21 +151,21 @@
 .mosaic-setting-group input[type='number'] {
   width: 100%;
   padding: 0.5rem;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-overlay);
   border: 1px solid var(--border-interactive);
   border-radius: 6px;
-  color: #e5e7eb;
+  color: var(--text-primary);
   font-size: 0.85rem;
   outline: none;
 }
 
 .mosaic-setting-group select:focus {
-  border-color: rgba(74, 144, 217, 0.5);
+  border-color: var(--border-interactive-hover);
 }
 
 .mosaic-setting-group select option {
   background: var(--bg-wizard);
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 /* Resolution presets */
@@ -179,8 +179,8 @@
 .mosaic-resolution-preset {
   padding: 0.45rem 0.7rem;
   border-radius: 6px;
-  border: 1px solid rgba(74, 144, 217, 0.25);
-  background: rgba(26, 26, 46, 0.8);
+  border: 1px solid var(--border-interactive);
+  background: var(--bg-wizard-inner);
   color: var(--text-secondary);
   font-size: 0.75rem;
   cursor: pointer;
@@ -188,14 +188,14 @@
 }
 
 .mosaic-resolution-preset:hover {
-  border-color: rgba(74, 144, 217, 0.45);
-  color: #e5e7eb;
+  border-color: var(--border-interactive-hover);
+  color: var(--text-primary);
 }
 
 .mosaic-resolution-preset.active {
   border-color: var(--accent-interactive);
-  background: rgba(74, 144, 217, 0.18);
-  color: #d4e9fb;
+  background: var(--accent-interactive-subtle);
+  color: var(--text-primary);
 }
 
 /* Dimension inputs */
@@ -215,7 +215,7 @@
 .mosaic-dimension-field label {
   margin-bottom: 0;
   font-size: 0.72rem;
-  color: #7f8ea3;
+  color: var(--text-muted);
 }
 
 .mosaic-dimension-separator {
@@ -227,13 +227,13 @@
 
 .mosaic-dimension-hint {
   margin: 0.35rem 0 0;
-  color: #7f8ea3;
+  color: var(--text-muted);
   font-size: 0.72rem;
 }
 
 .mosaic-dimension-error {
   margin: 0.3rem 0 0;
-  color: #f87171;
+  color: var(--color-error);
   font-size: 0.75rem;
 }
 
@@ -244,7 +244,7 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, #8844ff, #6633cc);
+  background: linear-gradient(135deg, var(--accent-secondary), var(--accent-secondary-hover));
   border: none;
   border-radius: 8px;
   color: white;
@@ -255,9 +255,9 @@
 }
 
 .mosaic-btn-generate:hover:not(:disabled) {
-  background: linear-gradient(135deg, #9955ff, #7744dd);
+  background: linear-gradient(135deg, var(--accent-secondary), var(--accent-secondary-hover));
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(136, 68, 255, 0.3);
+  box-shadow: 0 4px 12px var(--accent-secondary-subtle);
 }
 
 .mosaic-btn-generate:disabled {
@@ -273,8 +273,8 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 0.6rem 1.25rem;
-  background: rgba(78, 205, 196, 0.15);
-  border: 1px solid rgba(78, 205, 196, 0.3);
+  background: var(--accent-teal-subtle);
+  border: 1px solid var(--accent-teal);
   border-radius: 8px;
   color: var(--accent-teal);
   font-size: 0.9rem;
@@ -284,10 +284,10 @@
 }
 
 .mosaic-btn-save-fits:hover:not(:disabled):not(.saving) {
-  background: rgba(78, 205, 196, 0.25);
-  border-color: rgba(78, 205, 196, 0.5);
+  background: var(--accent-teal-subtle);
+  border-color: var(--accent-teal);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(78, 205, 196, 0.15);
+  box-shadow: 0 4px 12px var(--accent-teal-subtle);
 }
 
 .mosaic-btn-save-fits:disabled:not(.saving) {
@@ -297,8 +297,8 @@
 
 /* Saving state: button becomes a progress bar */
 .mosaic-btn-save-fits.saving {
-  background: rgba(78, 205, 196, 0.1);
-  border: 1px solid rgba(78, 205, 196, 0.3);
+  background: var(--accent-teal-subtle);
+  border: 1px solid var(--accent-teal);
   cursor: default;
   opacity: 1;
 }
@@ -363,7 +363,7 @@
 
 .btn-export:hover:not(:disabled):not(.exporting) {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(74, 144, 217, 0.3);
+  box-shadow: 0 4px 12px var(--accent-interactive-subtle);
 }
 
 .btn-export:disabled:not(.exporting) {
@@ -373,8 +373,8 @@
 
 /* Exporting state: button becomes a progress bar */
 .btn-export.exporting {
-  background: rgba(74, 144, 217, 0.15);
-  border: 1px solid rgba(74, 144, 217, 0.3);
+  background: var(--accent-interactive-subtle);
+  border: 1px solid var(--border-interactive);
   cursor: default;
   opacity: 1;
 }
@@ -421,10 +421,10 @@
 /* Error / info messages */
 .mosaic-error-msg {
   padding: 0.6rem 0.75rem;
-  background: rgba(248, 113, 113, 0.1);
-  border: 1px solid rgba(248, 113, 113, 0.3);
+  background: var(--color-error-subtle);
+  border: 1px solid var(--color-error);
   border-radius: 8px;
-  color: #f87171;
+  color: var(--color-error);
   font-size: 0.8rem;
 }
 
@@ -434,8 +434,8 @@
 
 .mosaic-saved-info {
   padding: 0.6rem 0.75rem;
-  background: rgba(78, 205, 196, 0.1);
-  border: 1px solid rgba(78, 205, 196, 0.3);
+  background: var(--accent-teal-subtle);
+  border: 1px solid var(--accent-teal);
   border-radius: 8px;
   color: var(--accent-teal);
   font-size: 0.8rem;

--- a/frontend/jwst-frontend/src/components/wizard/MosaicSelectStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/MosaicSelectStep.css
@@ -12,7 +12,7 @@
 .mosaic-select-toolbar {
   flex-shrink: 0;
   padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid rgba(74, 144, 217, 0.15);
+  border-bottom: 1px solid var(--accent-interactive-subtle);
 }
 
 .mosaic-search-bar {
@@ -25,17 +25,17 @@
 .mosaic-search-input {
   flex: 1;
   padding: 0.6rem 1rem;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-overlay);
   border: 1px solid var(--border-interactive);
   border-radius: 8px;
-  color: #e5e7eb;
+  color: var(--text-primary);
   font-size: 0.9rem;
   outline: none;
   transition: border-color 0.2s;
 }
 
 .mosaic-search-input:focus {
-  border-color: rgba(74, 144, 217, 0.5);
+  border-color: var(--border-interactive-hover);
 }
 
 .mosaic-search-input::placeholder {
@@ -58,9 +58,9 @@
 .mosaic-selection-btn {
   padding: 0.4rem 0.65rem;
   border-radius: 6px;
-  border: 1px solid rgba(74, 144, 217, 0.3);
-  background: rgba(74, 144, 217, 0.15);
-  color: #9dc9f0;
+  border: 1px solid var(--border-interactive);
+  background: var(--accent-interactive-subtle);
+  color: var(--text-secondary);
   font-size: 0.75rem;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -68,8 +68,8 @@
 }
 
 .mosaic-selection-btn:hover:not(:disabled) {
-  background: rgba(74, 144, 217, 0.3);
-  color: #d4e9fb;
+  background: var(--border-interactive);
+  color: var(--text-primary);
 }
 
 .mosaic-selection-btn:disabled {
@@ -98,21 +98,21 @@
 .mosaic-filter-control select {
   width: 100%;
   padding: 0.55rem 0.6rem;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--bg-overlay);
   border: 1px solid var(--border-interactive);
   border-radius: 6px;
-  color: #e5e7eb;
+  color: var(--text-primary);
   font-size: 0.83rem;
   outline: none;
 }
 
 .mosaic-filter-control select:focus {
-  border-color: rgba(74, 144, 217, 0.5);
+  border-color: var(--border-interactive-hover);
 }
 
 .mosaic-filter-control select option {
   background: var(--bg-wizard);
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 /* Auto-filter notice (matching filter from pre-selected files) */
@@ -124,22 +124,22 @@
   margin: 0 1.5rem;
   padding: 0.5rem 0.75rem;
   background: var(--accent-interactive-subtle);
-  border: 1px solid rgba(74, 144, 217, 0.25);
+  border: 1px solid var(--border-interactive);
   border-radius: 6px;
   font-size: 0.82rem;
-  color: #9dc9f0;
+  color: var(--text-secondary);
 }
 
 .mosaic-auto-filter-notice strong {
-  color: #d4e9fb;
+  color: var(--text-primary);
 }
 
 .mosaic-auto-filter-clear {
   padding: 0.25rem 0.5rem;
   background: var(--border-interactive);
-  border: 1px solid rgba(74, 144, 217, 0.3);
+  border: 1px solid var(--border-interactive);
   border-radius: 4px;
-  color: #9dc9f0;
+  color: var(--text-secondary);
   font-size: 0.75rem;
   cursor: pointer;
   white-space: nowrap;
@@ -147,8 +147,8 @@
 }
 
 .mosaic-auto-filter-clear:hover {
-  background: rgba(74, 144, 217, 0.35);
-  color: #d4e9fb;
+  background: var(--border-interactive-hover);
+  color: var(--text-primary);
 }
 
 /* Mixed selection warnings */
@@ -171,21 +171,21 @@
 }
 
 .mosaic-mixed-warning-target {
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.25);
-  color: #f87171;
+  background: var(--color-error-subtle);
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
 }
 
 .mosaic-mixed-warning-stage {
-  background: rgba(234, 179, 8, 0.1);
-  border: 1px solid rgba(234, 179, 8, 0.25);
-  color: #eab308;
+  background: var(--color-warning-subtle);
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
 }
 
 .mosaic-mixed-warning-filter {
-  background: rgba(234, 179, 8, 0.1);
-  border: 1px solid rgba(234, 179, 8, 0.25);
-  color: #eab308;
+  background: var(--color-warning-subtle);
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
 }
 
 /* Scrollable card grid area */
@@ -201,12 +201,12 @@
 }
 
 .mosaic-card-grid-scroll::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--border-subtle);
   border-radius: 3px;
 }
 
 .mosaic-card-grid-scroll::-webkit-scrollbar-thumb {
-  background: rgba(74, 144, 217, 0.3);
+  background: var(--border-interactive);
   border-radius: 3px;
 }
 
@@ -226,8 +226,8 @@
 }
 
 .mosaic-target-group.matching-target {
-  background: rgba(74, 144, 217, 0.06);
-  border: 1px solid rgba(74, 144, 217, 0.15);
+  background: var(--accent-interactive-subtle);
+  border: 1px solid var(--accent-interactive-subtle);
   border-radius: 8px;
   padding: 0.75rem;
 }
@@ -247,15 +247,15 @@
   gap: 0.5rem;
   font-size: 0.85rem;
   font-weight: 600;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .mosaic-target-match-badge {
   font-size: 0.65rem;
   font-weight: 500;
   color: var(--accent-interactive);
-  background: rgba(74, 144, 217, 0.15);
-  border: 1px solid rgba(74, 144, 217, 0.25);
+  background: var(--accent-interactive-subtle);
+  border: 1px solid var(--border-interactive);
   border-radius: 4px;
   padding: 0.1rem 0.35rem;
   text-transform: uppercase;
@@ -285,7 +285,7 @@
   content: '';
   flex: 1;
   height: 1px;
-  background: rgba(107, 114, 128, 0.3);
+  background: var(--border-default);
 }
 
 /* Card grid */
@@ -299,8 +299,8 @@
 .mosaic-image-card {
   display: flex;
   flex-direction: column;
-  background: rgba(26, 26, 46, 0.8);
-  border: 2px solid rgba(74, 144, 217, 0.15);
+  background: var(--bg-wizard-inner);
+  border: 2px solid var(--accent-interactive-subtle);
   border-radius: 10px;
   overflow: hidden;
   cursor: pointer;
@@ -310,14 +310,14 @@
 
 .mosaic-image-card:hover {
   border-color: var(--border-interactive-hover);
-  background: rgba(26, 26, 46, 0.95);
+  background: var(--bg-panel-heavy);
   transform: translateY(-1px);
 }
 
 .mosaic-image-card.selected {
   border-color: var(--accent-interactive);
   background: var(--accent-interactive-subtle);
-  box-shadow: 0 0 0 1px rgba(74, 144, 217, 0.3);
+  box-shadow: 0 0 0 1px var(--border-interactive);
 }
 
 .mosaic-image-card:focus-visible {
@@ -362,7 +362,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Oversized file warning overlay */
@@ -373,34 +373,34 @@
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background: rgba(239, 68, 68, 0.9);
+  background: var(--color-error);
   color: white;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-sm);
   cursor: help;
 }
 
 /* Oversized card border */
 .mosaic-image-card.oversized {
-  border-color: rgba(239, 68, 68, 0.35);
+  border-color: var(--color-error-subtle);
 }
 
 .mosaic-image-card.oversized:hover {
-  border-color: rgba(239, 68, 68, 0.55);
+  border-color: var(--color-error);
 }
 
 .mosaic-image-card.oversized.selected {
   border-color: var(--color-error);
-  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.3);
+  box-shadow: 0 0 0 1px var(--color-error-subtle);
 }
 
 /* Size limit warning banner */
 .mosaic-mixed-warning-size {
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.25);
-  color: #f87171;
+  background: var(--color-error-subtle);
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
 }
 
 /* Card info row */
@@ -434,7 +434,7 @@
 /* Collapsible footprint preview */
 .mosaic-inline-footprint {
   flex-shrink: 0;
-  border-top: 1px solid rgba(74, 144, 217, 0.15);
+  border-top: 1px solid var(--accent-interactive-subtle);
 }
 
 .mosaic-inline-footprint-toggle {
@@ -453,7 +453,7 @@
 }
 
 .mosaic-inline-footprint-toggle:hover {
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .mosaic-footprint-chevron {

--- a/frontend/jwst-frontend/src/components/wizard/WizardStepper.css
+++ b/frontend/jwst-frontend/src/components/wizard/WizardStepper.css
@@ -40,7 +40,7 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: rgba(107, 114, 128, 0.2);
+  background: var(--border-subtle);
   border: 2px solid currentColor;
   font-weight: 600;
   font-size: 0.75rem;
@@ -53,7 +53,7 @@
 }
 
 .wizard-step.completed .step-number {
-  background: rgba(78, 205, 196, 0.2);
+  background: var(--accent-teal-subtle);
   border-color: var(--accent-teal);
 }
 
@@ -65,7 +65,7 @@
 .step-connector {
   width: 40px;
   height: 2px;
-  background: rgba(107, 114, 128, 0.3);
+  background: var(--border-default);
   margin: 0 0.25rem;
   transition: background 0.2s ease;
 }


### PR DESCRIPTION
## Summary
Replaces all remaining hardcoded color values in wizard CSS files with design token var() references.

## Why
Continuation of the CSS tokenization effort. Eliminates ~270 hardcoded colors across 10 wizard component CSS files, enabling consistent theming.

## Type of Change
- [x] Refactoring / tech debt

## Changes Made
- Tokenized CompositePreviewStep.css (~57 hardcoded values replaced)
- Tokenized ChannelAssignStep.css (~55 hardcoded values replaced)
- Tokenized MosaicSelectStep.css (~52 hardcoded values replaced)
- Tokenized MosaicPreviewStep.css (~49 hardcoded values replaced)
- Tokenized CompositeWizard.css (~19 hardcoded values replaced)
- Tokenized ImageSelectionStep.css (~14 hardcoded values replaced)
- Tokenized MosaicWizard.css (~9 hardcoded values replaced)
- Tokenized ImageFilterToolbar.css (~8 hardcoded values replaced)
- Tokenized ChannelCard.css (~6 hardcoded values replaced)
- Tokenized WizardStepper.css (~3 hardcoded values replaced)
- Consolidated similar color shades to canonical design tokens
- Kept complex gradient/glow rgba values inline in progress bar pseudo-elements

## Test Plan
- [x] CSS-only changes — no behavioral impact
- [x] All 859 unit tests pass
- [x] ESLint passes (0 errors)
- [x] Prettier auto-format applied
- [x] Verify wizard pages render correctly (composite wizard, mosaic wizard)
- [x] Token references match existing :root definitions

## Documentation Checklist
- [x] No doc updates needed (CSS refactoring only)

## Tech Debt Impact
- [x] Reduces tech debt — eliminates hardcoded colors in wizard CSS

## Risk & Rollback
Risk: Low — CSS-only visual changes consolidating similar color shades.
Rollback: Revert the single commit.

## Quality Checklist
- [x] Self-reviewed
- [x] No new hardcoded color values introduced
- [x] All var() references point to existing tokens

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)