### PR TITLE
refactor: add semantic border tokens for error, warning, and aqua (P14)

### DIFF
--- a/frontend/jwst-frontend/src/components/ComparisonImagePicker.css
+++ b/frontend/jwst-frontend/src/components/ComparisonImagePicker.css
@@ -147,7 +147,7 @@
 
 .comparison-picker-item.selected {
   background: var(--accent-aqua-subtle);
-  border-color: rgba(76, 201, 240, 0.3);
+  border-color: var(--border-aqua);
 }
 
 .comparison-picker-item.disabled {

--- a/frontend/jwst-frontend/src/components/ImageComparisonViewer.css
+++ b/frontend/jwst-frontend/src/components/ImageComparisonViewer.css
@@ -123,7 +123,7 @@
 .comparison-mode-btn.active {
   background: var(--accent-aqua-subtle);
   color: var(--accent-aqua);
-  border-color: rgba(76, 201, 240, 0.3);
+  border-color: var(--border-aqua);
 }
 
 .comparison-mode-btn:hover:not(.active) {
@@ -361,7 +361,7 @@
 
 .blink-toggle-btn {
   background: var(--accent-aqua-subtle);
-  border: 1px solid rgba(76, 201, 240, 0.3);
+  border: 1px solid var(--border-aqua);
   color: var(--accent-aqua);
   padding: 4px 12px;
   border-radius: 4px;
@@ -387,7 +387,7 @@
 
 .blink-auto-btn.active {
   background: var(--accent-aqua-subtle);
-  border-color: rgba(76, 201, 240, 0.3);
+  border-color: var(--border-aqua);
   color: var(--accent-aqua);
 }
 

--- a/frontend/jwst-frontend/src/components/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/MastSearch.css
@@ -238,7 +238,7 @@
   color: var(--color-error);
   padding: 12px 16px;
   background: var(--color-error-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: 8px;
   margin-bottom: 20px;
 }
@@ -629,7 +629,7 @@
 .import-progress-error {
   color: var(--color-error);
   background: var(--color-error-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: 6px;
   padding: 12px;
   margin-top: 16px;
@@ -1146,7 +1146,7 @@
   margin-top: 20px;
   margin-bottom: 20px;
   background: var(--color-warning-subtle);
-  border: 1px solid rgba(245, 158, 11, 0.3);
+  border: 1px solid var(--border-warning);
   border-radius: 10px;
   padding: 16px;
 }

--- a/frontend/jwst-frontend/src/components/WhatsNewPanel.css
+++ b/frontend/jwst-frontend/src/components/WhatsNewPanel.css
@@ -114,7 +114,7 @@
   color: var(--color-error);
   padding: 12px 16px;
   background: var(--color-error-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: 8px;
   margin-bottom: 20px;
 }
@@ -387,7 +387,7 @@
 .whats-new-panel .import-progress-error {
   color: var(--color-error);
   background: var(--color-error-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: 6px;
   padding: 12px;
   margin-top: 16px;

--- a/frontend/jwst-frontend/src/components/dashboard/DeleteConfirmationModal.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DeleteConfirmationModal.css
@@ -113,7 +113,7 @@
   font-weight: 500;
   padding: 12px;
   background-color: var(--color-error-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: var(--radius-md);
   margin-top: 16px;
 }

--- a/frontend/jwst-frontend/src/components/dashboard/LineageView.css
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageView.css
@@ -138,7 +138,7 @@
   align-items: center;
   gap: 6px;
   background: var(--color-error-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   color: var(--color-error);
   padding: 5px 10px;
   border-radius: var(--radius-md);
@@ -265,7 +265,7 @@
 .level-action-btn.archive-btn {
   color: var(--color-warning);
   background: var(--color-warning-subtle);
-  border-color: rgba(245, 158, 11, 0.3);
+  border-color: var(--border-warning);
 }
 
 .level-action-btn.archive-btn:hover {
@@ -275,7 +275,7 @@
 .level-action-btn.delete-btn {
   color: var(--color-error);
   background: var(--color-error-subtle);
-  border-color: rgba(239, 68, 68, 0.3);
+  border-color: var(--border-error);
 }
 
 .level-action-btn.delete-btn:hover {

--- a/frontend/jwst-frontend/src/components/guided/DownloadStep.css
+++ b/frontend/jwst-frontend/src/components/guided/DownloadStep.css
@@ -163,7 +163,7 @@
 .download-step-error {
   padding: 20px;
   background: var(--color-error-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: var(--radius-md);
   text-align: center;
   color: var(--color-error, #ef4444);

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.css
@@ -81,7 +81,7 @@
 .process-step-error {
   padding: 20px;
   background: var(--color-error-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: var(--radius-md);
   text-align: center;
   color: var(--color-error, #ef4444);

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -122,7 +122,7 @@
   margin: 0;
   padding: 10px 16px;
   background: var(--color-error-subtle);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: var(--radius-md);
   color: var(--color-error, #ef4444);
   font-size: 0.8rem;

--- a/frontend/jwst-frontend/src/index.css
+++ b/frontend/jwst-frontend/src/index.css
@@ -39,6 +39,9 @@
   --color-error: #ef4444;
   --color-error-subtle: rgba(239, 68, 68, 0.12);
   --color-info: #3b82f6;
+  --border-error: rgba(239, 68, 68, 0.3);
+  --border-warning: rgba(245, 158, 11, 0.3);
+  --border-aqua: rgba(76, 201, 240, 0.3);
 
   /* Border radius */
   --radius-sm: 4px;

--- a/frontend/jwst-frontend/src/pages/AuthPages.css
+++ b/frontend/jwst-frontend/src/pages/AuthPages.css
@@ -50,7 +50,7 @@
 
 .auth-error {
   background: var(--auth-error-bg);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: 8px;
   color: var(--auth-error-text);
   font-size: 0.9rem;

--- a/frontend/jwst-frontend/src/pages/DiscoveryHome.css
+++ b/frontend/jwst-frontend/src/pages/DiscoveryHome.css
@@ -65,7 +65,7 @@
 .discovery-error {
   padding: 32px 20px;
   background: var(--bg-surface);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: var(--radius-lg);
   text-align: center;
   color: var(--color-error, #ef4444);

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.css
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.css
@@ -28,7 +28,7 @@
 .guided-create-error {
   padding: 32px 20px;
   background: var(--bg-surface);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: var(--radius-lg);
   text-align: center;
   color: var(--color-error, #ef4444);

--- a/frontend/jwst-frontend/src/pages/TargetDetail.css
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.css
@@ -51,7 +51,7 @@
 .target-detail-error {
   padding: 32px 20px;
   background: var(--bg-surface);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--border-error);
   border-radius: var(--radius-lg);
   text-align: center;
   color: var(--color-error, #ef4444);


### PR DESCRIPTION
## Summary
Adds `--border-error`, `--border-warning`, and `--border-aqua` semantic border tokens and replaces 19 hardcoded rgba values across 13 CSS files.

## Why
These three rgba patterns (`rgba(239,68,68,0.3)`, `rgba(245,158,11,0.3)`, `rgba(76,201,240,0.3)`) were the most repeated untokenized values remaining after the P10–P13 sweep.

## Type of Change
- [x] Refactoring / tech debt

## Changes Made
- Added 3 new semantic border tokens to `:root` in index.css
- Replaced `rgba(239, 68, 68, 0.3)` → `var(--border-error)` in 11 files
- Replaced `rgba(245, 158, 11, 0.3)` → `var(--border-warning)` in 2 files
- Replaced `rgba(76, 201, 240, 0.3)` → `var(--border-aqua)` in 2 files

## Test Plan
- [x] CSS-only changes — no behavioral impact
- [x] All 859 unit tests pass locally
- [x] Error/warning/aqua borders render identically (same color values)

## Documentation Checklist
- [x] No doc updates needed (CSS refactoring only)

## Tech Debt Impact
- [x] Reduces tech debt — eliminates 19 more hardcoded color values

## Risk & Rollback
Risk: None — identical color values, just moved to tokens.
Rollback: Revert the single commit.

## Quality Checklist
- [x] Self-reviewed
- [x] No new hardcoded values introduced
- [x] All var() references point to existing tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)