### PR TITLE
feat: add radius-xs and radius-full tokens (P15)

### DIFF
--- a/frontend/jwst-frontend/src/index.css
+++ b/frontend/jwst-frontend/src/index.css
@@ -44,9 +44,11 @@
   --border-aqua: rgba(76, 201, 240, 0.3);
 
   /* Border radius */
+  --radius-xs: 2px;
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
+  --radius-full: 50%;
 
   /* Shadows (dark theme — heavier) */
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
## Summary
Adds `--radius-xs: 2px` and `--radius-full: 50%` tokens for the upcoming spacing/radius/typography migration.

## Why
The existing radius scale (sm=4px, md=8px, lg=12px) lacks coverage for micro-radius elements (2-3px scrollbar thumbs, small badges) and circular elements (50% avatars, spinners). These are needed before the radius migration can proceed.

## Type of Change
- [x] Refactoring / tech debt

## Changes Made
- Added `--radius-xs: 2px` for micro-radius elements
- Added `--radius-full: 50%` for circular elements

## Test Plan
- [x] Token definitions only — no visual changes until consumed
- [x] All existing styles unchanged

## Documentation Checklist
- [x] No doc updates needed

## Tech Debt Impact
- [x] Reduces tech debt — enables radius migration

## Risk & Rollback
Risk: None — additive token definitions.
Rollback: Revert single commit.

## Quality Checklist
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)