### PR TITLE
refactor: align UI consistency outliers across buttons, badges, shadows, and toolbars

### DIFF
--- a/frontend/jwst-frontend/src/components/ComparisonImagePicker.css
+++ b/frontend/jwst-frontend/src/components/ComparisonImagePicker.css
@@ -22,7 +22,7 @@
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg);
 }
 
 .comparison-picker-header {
@@ -35,7 +35,7 @@
 
 .comparison-picker-header h2 {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: var(--text-xl);
   color: var(--text-primary);
   font-weight: 600;
 }
@@ -44,7 +44,7 @@
   background: none;
   border: none;
   color: var(--text-secondary);
-  font-size: 1.5rem;
+  font-size: var(--text-2xl);
   cursor: pointer;
   padding: var(--space-1) var(--space-2);
   line-height: 1;
@@ -81,13 +81,13 @@
 
 .comparison-picker-column-header h3 {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   color: var(--accent-aqua);
   font-weight: 600;
 }
 
 .comparison-picker-selected-label {
-  font-size: 0.75rem;
+  font-size: var(--text-sm);
   color: var(--color-success);
   font-weight: 500;
 }
@@ -99,7 +99,7 @@
   border: 1px solid var(--bg-surface);
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 0.85rem;
+  font-size: var(--text-base);
   margin-bottom: var(--space-2);
   outline: none;
   transition: border-color var(--transition-base);
@@ -133,11 +133,11 @@
 .comparison-picker-item {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  border-radius: 6px;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--transition-fast);
   border: 1px solid transparent;
 }
 
@@ -158,7 +158,7 @@
 .comparison-picker-item-thumb {
   width: 48px;
   height: 48px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   object-fit: cover;
   background: var(--bg-inset);
   flex-shrink: 0;
@@ -170,7 +170,7 @@
 }
 
 .comparison-picker-item-name {
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -178,15 +178,15 @@
 }
 
 .comparison-picker-item-meta {
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
-  margin-top: 2px;
+  margin-top: var(--space-1);
 }
 
 .comparison-picker-divider {
   width: 1px;
   background: var(--bg-surface);
-  margin: 0 4px;
+  margin: 0 var(--space-1);
   flex-shrink: 0;
 }
 
@@ -194,19 +194,19 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 12px;
-  padding: 16px 24px;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-6);
   border-top: 1px solid var(--bg-surface);
 }
 
 .comparison-picker-btn {
-  padding: 8px 20px;
+  padding: var(--space-2) var(--space-5);
   border: none;
-  border-radius: 6px;
-  font-size: 0.85rem;
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--transition-base);
 }
 
 .comparison-picker-btn.primary {

--- a/frontend/jwst-frontend/src/components/WhatsNewPanel.css
+++ b/frontend/jwst-frontend/src/components/WhatsNewPanel.css
@@ -3,7 +3,7 @@
   border-radius: var(--radius-lg);
   padding: var(--space-6);
   margin-bottom: var(--space-6);
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
 }
 
 .whats-new-header {
@@ -44,7 +44,7 @@
 .whats-new-description {
   color: var(--text-secondary);
   margin: 0 0 var(--space-5) 0;
-  font-size: 0.9rem;
+  font-size: var(--text-base);
 }
 
 .whats-new-filters {
@@ -78,7 +78,7 @@
   background: var(--border-subtle);
   color: var(--text-secondary);
   border: 1px solid var(--bg-surface);
-  border-radius: 20px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   font-size: var(--text-base);
   transition: all var(--transition-base);
@@ -121,7 +121,7 @@
 
 .results-count {
   color: var(--text-secondary);
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   margin-bottom: var(--space-4);
 }
 
@@ -145,7 +145,7 @@
 .observation-card:hover {
   transform: translateY(-2px);
   border-color: var(--border-interactive-hover);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
 }
 
 .card-thumbnail {
@@ -159,7 +159,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transition: transform 0.3s ease;
+  transition: transform var(--transition-base);
 }
 
 .observation-card:hover .card-thumbnail img {
@@ -187,7 +187,7 @@
 
 .card-target {
   color: var(--text-primary);
-  font-size: 0.95rem;
+  font-size: var(--text-lg);
   font-weight: 600;
   margin: 0 0 var(--space-2) 0;
   overflow: hidden;
@@ -204,7 +204,7 @@
 
 .detail-item {
   font-size: var(--text-sm);
-  padding: 2px var(--space-2);
+  padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-sm);
   background: var(--border-default);
   color: var(--text-secondary);
@@ -302,7 +302,7 @@
   padding: var(--space-8);
   min-width: 400px;
   max-width: 500px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg);
   border: 1px solid var(--border-interactive-hover);
 }
 
@@ -315,14 +315,14 @@
 
 .whats-new-panel .import-progress-title {
   color: var(--text-primary);
-  font-size: 1.1rem;
+  font-size: var(--text-xl);
   font-weight: 600;
   margin: 0;
 }
 
 .whats-new-panel .import-progress-percent {
   color: var(--accent-interactive);
-  font-size: 1.1rem;
+  font-size: var(--text-xl);
   font-weight: 600;
 }
 
@@ -344,7 +344,7 @@
   );
   background-size: 200% 100%;
   border-radius: var(--radius-md);
-  transition: width 0.3s ease;
+  transition: width var(--transition-base);
   animation: progress-shimmer 2s infinite linear;
 }
 
@@ -360,7 +360,7 @@
 
 .whats-new-panel .import-progress-stage {
   color: var(--text-secondary);
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   margin: 0 0 var(--space-4) 0;
   display: flex;
   justify-content: center;
@@ -379,7 +379,7 @@
 
 .whats-new-panel .import-progress-obs-id {
   color: var(--text-muted);
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   margin-top: var(--space-3);
   font-family: monospace;
 }
@@ -391,18 +391,18 @@
   border-radius: var(--radius-md);
   padding: var(--space-3);
   margin-top: var(--space-4);
-  font-size: 0.9rem;
+  font-size: var(--text-base);
 }
 
 .whats-new-panel .import-progress-success {
   color: var(--color-success);
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   margin-top: var(--space-2);
 }
 
 .whats-new-panel .import-progress-resumable {
   color: var(--color-warning);
-  font-size: 0.85rem;
+  font-size: var(--text-base);
   margin-top: var(--space-2);
 }
 
@@ -414,7 +414,7 @@
   background: rgba(0, 0, 0, 0.2);
   border-radius: var(--radius-md);
   margin-bottom: var(--space-3);
-  font-size: 0.85rem;
+  font-size: var(--text-base);
   flex-wrap: wrap;
   gap: var(--space-2);
 }
@@ -478,13 +478,13 @@
   flex: 1;
   height: 6px;
   background: var(--border-default);
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   overflow: hidden;
 }
 
 .whats-new-panel .file-progress-fill {
   height: 100%;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   transition: width var(--transition-base);
 }
 
@@ -610,12 +610,12 @@
 
 .whats-new-panel .file-progress-list::-webkit-scrollbar-track {
   background: var(--border-subtle);
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
 
 .whats-new-panel .file-progress-list::-webkit-scrollbar-thumb {
   background: var(--border-bright);
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
 
 .whats-new-panel .file-progress-list::-webkit-scrollbar-thumb:hover {

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.css
@@ -88,7 +88,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  padding: 2px var(--space-2);
+  padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);
   font-weight: 500;
@@ -116,7 +116,7 @@
 .filter-badge {
   display: inline-flex;
   align-items: center;
-  padding: 2px var(--space-2);
+  padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);
   font-weight: 600;
@@ -171,7 +171,7 @@
 .tag {
   background-color: var(--bg-elevated);
   color: var(--text-secondary);
-  padding: 2px var(--space-2);
+  padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
   border: 1px solid var(--border-default);
@@ -229,7 +229,7 @@
 .data-card.archiving {
   opacity: 0.6;
   pointer-events: none;
-  transition: opacity 0.3s ease;
+  transition: opacity var(--transition-base);
 }
 
 .card-actions .archive-btn:disabled {
@@ -254,7 +254,7 @@
   background-color: var(--accent-primary);
   color: white;
   border: none;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: var(--text-sm);
   transition: all var(--transition-fast);

--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.css
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.css
@@ -30,7 +30,7 @@
 
 .recipe-card-name {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -50,8 +50,8 @@
   padding: 0 var(--space-3);
   background: var(--bg-elevated);
   border: 1px solid var(--border-subtle);
-  border-radius: 14px;
-  font-size: 0.8rem;
+  border-radius: var(--radius-lg);
+  font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-secondary);
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
@@ -68,7 +68,7 @@
 .recipe-card-color-bar {
   display: flex;
   height: 6px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   overflow: hidden;
   margin-top: var(--space-4);
 }
@@ -83,7 +83,7 @@
   align-items: center;
   gap: var(--space-2);
   margin-top: var(--space-4);
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
 }
 
@@ -112,7 +112,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 40px;
+  padding: var(--space-3) var(--space-5);
   margin-top: var(--space-5);
   background: var(--accent-primary);
   color: var(--text-primary);

--- a/frontend/jwst-frontend/src/components/wizard/ImageFilterToolbar.css
+++ b/frontend/jwst-frontend/src/components/wizard/ImageFilterToolbar.css
@@ -2,7 +2,7 @@
 
 .image-filter-toolbar {
   flex-shrink: 0;
-  padding: var(--space-3) var(--space-1);
+  padding: var(--space-3) var(--space-3);
 }
 
 /* --- Search row --- */
@@ -87,29 +87,29 @@
 }
 
 .image-filter-toolbar.wide .ift-search-input {
-  padding: 0.6rem 1rem;
-  font-size: 0.9rem;
-  border-radius: 8px;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-base);
+  border-radius: var(--radius-md);
 }
 
 .image-filter-toolbar.wide .ift-search-row {
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-3);
 }
 
 .image-filter-toolbar.wide .ift-filter-row {
-  gap: 0.75rem;
+  gap: var(--space-3);
 }
 
 .image-filter-toolbar.wide .ift-filter-control label {
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
 }
 
 .image-filter-toolbar.wide .ift-filter-control select {
-  padding: 0.55rem 0.6rem;
-  font-size: 0.83rem;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-base);
 }
 
 /* --- Compact variant adjustments (default, used in pool sidebar) --- */
 .image-filter-toolbar.compact .ift-filter-count {
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
 }

--- a/frontend/jwst-frontend/src/components/wizard/MosaicSelectStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/MosaicSelectStep.css
@@ -86,7 +86,7 @@
 .mosaic-filter-control {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: var(--space-1);
 }
 
 .mosaic-filter-control label {
@@ -155,7 +155,7 @@
 .mosaic-mixed-warnings {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: var(--space-1);
   margin: 0 var(--space-6);
 }
 
@@ -237,7 +237,7 @@
   align-items: center;
   gap: var(--space-3);
   margin-bottom: var(--space-3);
-  padding-bottom: 0.375rem;
+  padding-bottom: var(--space-1);
   border-bottom: 1px solid var(--accent-interactive-subtle);
 }
 
@@ -257,13 +257,13 @@
   background: var(--accent-interactive-subtle);
   border: 1px solid var(--border-interactive);
   border-radius: var(--radius-sm);
-  padding: 0.1rem 0.35rem;
+  padding: var(--space-1) var(--space-2);
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }
 
 .mosaic-target-count {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
@@ -274,7 +274,7 @@
   gap: var(--space-3);
   margin: var(--space-3) 0;
   color: var(--text-muted);
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -407,14 +407,14 @@
 .mosaic-card-info {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--space-1);
   padding: var(--space-2) var(--space-3);
   min-width: 0;
 }
 
 .mosaic-card-filter {
   flex: 1;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
@@ -423,7 +423,7 @@
 
 .mosaic-card-level {
   flex-shrink: 0;
-  padding: 0.1rem 0.35rem;
+  padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-xs);
   color: white;
   font-size: var(--text-xs);

--- a/frontend/jwst-frontend/src/pages/AuthPages.css
+++ b/frontend/jwst-frontend/src/pages/AuthPages.css
@@ -16,9 +16,9 @@
 
 .auth-container {
   background: var(--auth-bg-card);
-  border-radius: 16px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  padding: 40px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-8);
   width: 100%;
   max-width: 420px;
   backdrop-filter: blur(10px);
@@ -31,7 +31,7 @@
 
 .auth-header h1 {
   color: var(--bg-wizard);
-  font-size: 1.8rem;
+  font-size: var(--text-2xl);
   font-weight: 700;
   margin: 0 0 var(--space-2) 0;
 }
@@ -53,7 +53,7 @@
   border: 1px solid var(--border-error);
   border-radius: var(--radius-md);
   color: var(--auth-error-text);
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   padding: var(--space-3) var(--space-4);
   text-align: center;
 }
@@ -66,7 +66,7 @@
 
 .form-group label {
   color: var(--auth-text);
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   font-weight: 500;
 }
 
@@ -112,7 +112,7 @@
   cursor: pointer;
   font-size: var(--text-lg);
   font-weight: 600;
-  padding: var(--space-4) var(--space-6);
+  padding: var(--space-3) var(--space-5);
   margin-top: var(--space-2);
   transition:
     transform var(--transition-base),
@@ -140,7 +140,7 @@
 
 .auth-footer p {
   color: var(--text-muted);
-  font-size: 0.9rem;
+  font-size: var(--text-base);
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
Standardizes similar UI elements that were using inconsistent values. Replaces hardcoded shadows, border-radius, font-sizes, padding, and transitions with design tokens across 7 CSS files.

## Why
After the P16 full token sweep migrated all values to tokens, an audit revealed that similar UI elements (buttons, badges, shadows, toolbars) were using different token values despite serving the same visual role. This PR aligns those outliers for cross-component consistency.

## Type of Change
- [x] Refactoring (no functional changes)

## Changes Made
- **WhatsNewPanel.css**: Replace 3 hardcoded `box-shadow` values with `--shadow-md`/`--shadow-lg`, tokenize pill `border-radius: 20px` → `radius-lg`, fix badge `padding: 2px` → `space-1`, tokenize 8 hardcoded font-sizes and 2 transitions
- **DataCard.css**: Align badge padding `2px` → `var(--space-1)` for `.fits-type-badge`, `.filter-badge`, and `.tag`; fix `.view-file-btn` radius-sm → radius-md to match peer buttons; tokenize archiving transition
- **ComparisonImagePicker.css**: Tokenize all hardcoded values in `.comparison-picker-item` (gap, padding, border-radius, transition), footer (gap, padding), buttons (padding, border-radius, font-size, transition), thumbnail radius, meta margin, modal shadow, and font-sizes
- **AuthPages.css**: Replace hardcoded `border-radius: 16px` → `radius-lg`, `box-shadow: 0 20px 60px` → `shadow-lg`, `padding: 40px` → `space-8`, align submit button padding from `space-4 space-6` → `space-3 space-5` (standard primary tier), tokenize `font-size: 1.8rem` and three `0.9rem` values
- **ImageFilterToolbar.css**: Fix too-tight default horizontal padding `space-1` → `space-3`, tokenize entire `.wide` variant (6 hardcoded rem values → tokens), tokenize `.compact` font-size
- **RecipeCard.css**: Tokenize `font-size: 1.1rem` → `text-xl`, pill `border-radius: 14px` → `radius-lg`, `font-size: 0.8rem` → `text-sm`, `border-radius: 3px` → `radius-xs`, replace fixed `height: 40px` CTA with `padding: space-3 space-5`
- **MosaicSelectStep.css**: Tokenize 5 hardcoded fine-grained values (`0.35rem`, `0.375rem`, `0.72rem`, `0.1rem 0.35rem`)

## Test Plan
- [x] Docker build succeeds
- [x] All 859 unit tests pass
- [x] No cross-contamination (spacing tokens never in font-size, text tokens never in padding)
- [x] Zero class name changes — E2E tests unaffected
- [ ] Visual spot-check: Auth login/register pages, WhatsNewPanel cards, DataCard badges, ComparisonImagePicker modal, RecipeCard on target detail, MosaicSelectStep filters

## Documentation Checklist
- [x] No new controllers, services, or endpoints
- [x] No API parameter changes
- [x] No new frontend components
- [x] No workflow/step changes

## Tech Debt Impact
- [x] Reduces tech debt (eliminates ~40 hardcoded CSS values, improves cross-component consistency)

## Risk & Rollback
Risk: Low — CSS-only changes, no logic or markup modifications
Rollback: Revert the single commit

## Quality Checklist
- [x] CSS-only refactor — no functional changes
- [x] All tokens map to existing `:root` definitions
- [x] No new tokens introduced
- [x] Intentional non-token values preserved (48px icon size, 2rem placeholder icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)