### PR TITLE
fix: resolve SA1202 member ordering in JwstDataControllerTests

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
@@ -1128,36 +1128,6 @@ public class JwstDataControllerTests
         lineageResponse.TotalFiles.Should().Be(2);
     }
 
-    /// <summary>
-    /// Sets up a mock HttpContext with the specified user claims.
-    /// </summary>
-    private void SetupAuthenticatedUser(string userId, bool isAdmin = false)
-    {
-        var claims = new List<Claim>
-        {
-            new(ClaimTypes.NameIdentifier, userId),
-            new("sub", userId),
-        };
-
-        if (isAdmin)
-        {
-            claims.Add(new Claim(ClaimTypes.Role, "Admin"));
-        }
-
-        var identity = new ClaimsIdentity(claims, "TestAuth");
-        var principal = new ClaimsPrincipal(identity);
-
-        var httpContext = new DefaultHttpContext
-        {
-            User = principal,
-        };
-
-        sut.ControllerContext = new ControllerContext
-        {
-            HttpContext = httpContext,
-        };
-    }
-
     [Fact]
     public async Task ShareData_ReturnsForbid_WhenNotOwner()
     {
@@ -1289,6 +1259,36 @@ public class JwstDataControllerTests
 
         // Assert
         result.Should().BeOfType<FileContentResult>();
+    }
+
+    /// <summary>
+    /// Sets up a mock HttpContext with the specified user claims.
+    /// </summary>
+    private void SetupAuthenticatedUser(string userId, bool isAdmin = false)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId),
+            new("sub", userId),
+        };
+
+        if (isAdmin)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, "Admin"));
+        }
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = principal,
+        };
+
+        sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext,
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes StyleCop SA1202 violation: public test methods must appear before private helper methods.

## Why

`dotnet build --warnaserror` fails due to `SetupAuthenticatedUser` (private) being placed before public test methods `ShareData_ReturnsForbid_WhenNotOwner` et al.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Moved `SetupAuthenticatedUser` private helper from mid-file (line 1134) to end of class, next to the existing `SetupAnonymousUser` private helper

## Test Plan

- [x] `dotnet build --warnaserror` — 0 warnings, 0 errors
- [x] `dotnet test` — 797 passed, 0 skipped

## Documentation Checklist

- [x] No documentation changes needed (test file only)

## Tech Debt Impact

- [x] Reduces tech debt — eliminates SA1202 lint violation

## Risk & Rollback

Risk: None — test file reordering only, no behavioral changes.

Rollback: Revert commit.

## Quality Checklist

- [x] No functional changes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)