### PR TITLE
fix: add missing blank line between properties (SA1516)

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/DataManagementController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/DataManagementController.cs
@@ -548,6 +548,7 @@ namespace JwstDataAnalysis.API.Controllers
         private sealed class ExportMetadata
         {
             public string UserId { get; set; } = string.Empty;
+
             public DateTime CreatedAt { get; set; }
         }
     }


### PR DESCRIPTION
## Summary
Adds a missing blank line between properties in `ExportMetadata` class to fix SA1516 StyleCop violation.

## Why
Backend lint (`dotnet build --warnaserror`) was failing on `main` due to this missing blank line.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Added blank line between `UserId` and `CreatedAt` properties in `DataManagementController.ExportMetadata`

## Test Plan
- [x] Backend build passes with `--warnaserror` (0 warnings, 0 errors)
- [x] All 797 backend tests pass

## Documentation Checklist
- [x] No documentation updates needed (single blank line fix)

## Tech Debt Impact
- [x] This change has no tech debt implications

## Risk & Rollback
Risk: None — single blank line addition.
Rollback: Revert the commit.

## Quality Checklist
- [x] Code follows the project's style guidelines
- [x] No new warnings introduced