### PR TITLE
fix: show partial download failures as warnings instead of blocking errors

### DIFF
--- a/frontend/jwst-frontend/src/components/guided/DownloadStep.css
+++ b/frontend/jwst-frontend/src/components/guided/DownloadStep.css
@@ -211,6 +211,26 @@
   font-style: italic;
 }
 
+/* Partial-failure warnings (amber/yellow) */
+.download-step-warnings {
+  margin-top: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: color-mix(in srgb, #f59e0b 10%, transparent);
+  border: 1px solid color-mix(in srgb, #f59e0b 40%, transparent);
+  border-radius: var(--radius-md);
+}
+
+.download-step-warning {
+  margin: 0;
+  padding: var(--space-1) 0;
+  font-size: var(--text-sm);
+  color: #f59e0b;
+}
+
+.download-step-warning::before {
+  content: '\26A0\FE0F ';
+}
+
 /* Waiting state */
 .download-step-waiting {
   margin: var(--space-4) 0 0;

--- a/frontend/jwst-frontend/src/components/guided/DownloadStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/DownloadStep.tsx
@@ -6,8 +6,10 @@ interface DownloadStepProps {
   targetName: string;
   /** Current job progress (null before job starts) */
   progress: ImportJobStatus | null;
-  /** Error message if download failed */
+  /** Error message if download failed (blocking — all failed or non-NO_PRODUCTS error) */
   error: string | null;
+  /** Per-observation warnings (e.g. NO_PRODUCTS for individual filters) */
+  warnings?: string[];
   /** Whether the download step is complete */
   isComplete: boolean;
   /** Retry callback */
@@ -80,6 +82,7 @@ export function DownloadStep({
   targetName,
   progress,
   error,
+  warnings = [],
   isComplete,
   onRetry,
 }: DownloadStepProps) {
@@ -100,7 +103,11 @@ export function DownloadStep({
   return (
     <div className="download-step" role="status" aria-live="polite">
       <h3 className="download-step-title">
-        {isComplete ? `${targetName} data ready` : `Downloading ${targetName} data...`}
+        {isComplete
+          ? warnings.length > 0
+            ? `${targetName} data ready (with warnings)`
+            : `${targetName} data ready`
+          : `Downloading ${targetName} data...`}
       </h3>
 
       {error && (
@@ -121,43 +128,48 @@ export function DownloadStep({
         </div>
       )}
 
-      {!error && (
-        <>
-          <div className="download-overall-bar-wrap">
-            <div
-              className={`download-overall-bar ${isComplete ? 'bar-complete' : ''}`}
-              style={{ width: `${overallPercent}%` }}
-            />
-          </div>
+      {/* Always show progress section — not gated on !error for partial failures */}
+      <div className="download-overall-bar-wrap">
+        <div
+          className={`download-overall-bar ${isComplete ? 'bar-complete' : ''}`}
+          style={{ width: `${overallPercent}%` }}
+        />
+      </div>
 
-          <p className="download-step-meta">
-            {totalFiles > 0 && (
-              <span>
-                {completedFiles} of {totalFiles} file{totalFiles !== 1 ? 's' : ''}
-              </span>
-            )}
-            {progress?.stage && <span className="download-step-stage">{progress.stage}</span>}
-            {progress?.speedBytesPerSec != null &&
-              progress.speedBytesPerSec > 0 &&
-              progress.speedBytesPerSec < 10 * 1024 * 1024 * 1024 && (
-                <span className="download-step-speed">
-                  {formatBytes(progress.speedBytesPerSec)}/s
-                </span>
-              )}
-          </p>
-
-          {fileProgress.length > 0 && (
-            <div className="download-file-list" ref={containerRef}>
-              {fileProgress.map((file) => (
-                <FileRow key={file.filename} file={file} />
-              ))}
-            </div>
+      <p className="download-step-meta">
+        {totalFiles > 0 && (
+          <span>
+            {completedFiles} of {totalFiles} file{totalFiles !== 1 ? 's' : ''}
+          </span>
+        )}
+        {progress?.stage && <span className="download-step-stage">{progress.stage}</span>}
+        {progress?.speedBytesPerSec != null &&
+          progress.speedBytesPerSec > 0 &&
+          progress.speedBytesPerSec < 10 * 1024 * 1024 * 1024 && (
+            <span className="download-step-speed">{formatBytes(progress.speedBytesPerSec)}/s</span>
           )}
+      </p>
 
-          {!progress && !isComplete && (
-            <p className="download-step-waiting">Starting download...</p>
-          )}
-        </>
+      {fileProgress.length > 0 && (
+        <div className="download-file-list" ref={containerRef}>
+          {fileProgress.map((file) => (
+            <FileRow key={file.filename} file={file} />
+          ))}
+        </div>
+      )}
+
+      {!progress && !isComplete && !error && (
+        <p className="download-step-waiting">Starting download...</p>
+      )}
+
+      {warnings.length > 0 && (
+        <div className="download-step-warnings">
+          {warnings.map((warning) => (
+            <p key={warning} className="download-step-warning">
+              {warning}
+            </p>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -115,6 +115,7 @@ export function GuidedCreate() {
   // Download state
   const [downloadProgress, setDownloadProgress] = useState<ImportJobStatus | null>(null);
   const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [downloadWarnings, setDownloadWarnings] = useState<string[]>([]);
   const [downloadComplete, setDownloadComplete] = useState(false);
 
   // Process state
@@ -354,7 +355,10 @@ export function GuidedCreate() {
           setDownloadComplete(true);
           startProcessing(matchedRecipe);
         } else {
-          // All failed — keep error state (already set)
+          // All failed — ensure a meaningful error is shown
+          setDownloadError(
+            (prev) => prev ?? 'All observations failed to download — no FITS products found'
+          );
         }
       }
     }
@@ -393,10 +397,21 @@ export function GuidedCreate() {
               failedCount++;
               jobProgressMap.set(jobResponse.jobId, status);
 
-              // Only set error if this is the first failure
-              setDownloadError(
-                (prev) => prev ?? status.error ?? `Download failed for ${obs.filters ?? obsId}`
-              );
+              const isNoProducts = status.error?.startsWith('NO_PRODUCTS:');
+              const filterLabel = obs.filters ?? obsId;
+
+              if (isNoProducts) {
+                // Partial failure — add warning, don't block progress
+                setDownloadWarnings((prev) => [
+                  ...prev,
+                  `${filterLabel}: no FITS products available at this calibration level`,
+                ]);
+              } else {
+                // Real error — block
+                setDownloadError(
+                  (prev) => prev ?? status.error ?? `Download failed for ${filterLabel}`
+                );
+              }
               setDownloadProgress((prev) => prev ?? status);
 
               mergeProgress();
@@ -696,9 +711,11 @@ export function GuidedCreate() {
             targetName={target}
             progress={downloadProgress}
             error={downloadError}
+            warnings={downloadWarnings}
             isComplete={downloadComplete}
             onRetry={() => {
               setDownloadError(null);
+              setDownloadWarnings([]);
               setDownloadProgress(null);
               setDownloadComplete(false);
               setRetryCount((c) => c + 1);


### PR DESCRIPTION
## Summary
- Partial NO_PRODUCTS download failures now appear as amber inline warnings instead of blocking red errors
- Download progress bar and file list remain visible throughout, even when some observations fail
- Wizard proceeds to processing when at least one download succeeds

## Why
When creating a composite from multiple observations (e.g., 5 filters for a target), if one observation has no FITS products at calibration level 3, the download step showed a blocking red error that hid all progress. The backend correctly handles partial failures, and `checkAllDone()` already proceeds if `completedCount > 0`, but the UI made it look broken because:
1. `DownloadStep` rendered `{error && <error-block>}` which hid the `{!error && <progress-block>}`
2. Only the first error was captured — user didn't know which filter failed
3. No indication that other downloads were still running

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Changes Made
- **GuidedCreate.tsx**: Added `downloadWarnings` state (`string[]`). In `onFailed`, NO_PRODUCTS errors push to warnings instead of setting `downloadError`. Real errors still block. `checkAllDone()` now sets a meaningful error when all observations fail.
- **DownloadStep.tsx**: Added `warnings?: string[]` prop. Progress bar and file list always render (no longer gated on `!error`). Warnings display as amber notices below progress. Title shows "with warnings" when complete with warnings.
- **DownloadStep.css**: Added `.download-step-warnings` and `.download-step-warning` styles with amber/yellow border and text color.

## Test Plan
- [x] Frontend lint passes (0 errors)
- [x] Frontend unit tests pass (859/859)
- [ ] Navigate to a target with mixed observations (some with products, some without)
- [ ] Create composite — verify download progress stays visible throughout
- [ ] Failed filters show as amber warnings, not red errors
- [ ] Wizard proceeds to step 2 when successful downloads complete
- [ ] If ALL observations fail, red error shown with no proceed

## Documentation Checklist
- [x] No new controllers, services, or endpoints
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No tech debt added
- [ ] Tech debt added (explain below)
- [ ] Tech debt reduced

## Risk & Rollback
Risk: Low — frontend-only change, no backend or API modifications. Existing error handling preserved for non-NO_PRODUCTS failures.
Rollback: Revert this commit.

## Quality Checklist
- [x] Code follows project conventions
- [x] No new lint warnings
- [x] E2E selectors checked — all existing selectors preserved
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)