### PR TITLE
feat: pass recipe via Router state to skip redundant API calls

### DIFF
--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
@@ -135,7 +135,7 @@ export function RecipeCard({
         )}
       </div>
 
-      <Link to={createUrl} className="recipe-card-cta">
+      <Link to={createUrl} state={{ recipe, observations }} className="recipe-card-cta">
         Create This Composite
       </Link>
     </div>

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -22,6 +22,12 @@ import { chromaticOrderHues, hueToHex, hexToRgb, rgbToHue } from '../utils/wavel
 import { toObservationInputs } from '../utils/observationUtils';
 import './GuidedCreate.css';
 
+/** Router state passed from RecipeCard to skip redundant MAST + recipe API calls */
+interface GuidedCreateLocationState {
+  recipe?: CompositeRecipe;
+  observations?: MastObservationResult[];
+}
+
 type FlowStep = 1 | 2 | 3;
 
 const WIZARD_STEPS = [
@@ -180,37 +186,54 @@ export function GuidedCreate() {
       setResolving(true);
 
       try {
-        // Search MAST for observations
-        const searchResult = await searchByTarget(
-          { targetName: target, radius },
-          controller.signal
-        );
-        if (controller.signal.aborted) return;
+        // Try to use pre-resolved recipe + observations from Router state
+        // (passed by RecipeCard to skip redundant MAST search + suggestRecipes calls)
+        const routerState = location.state as GuidedCreateLocationState | null;
+        const preResolvedRecipe = routerState?.recipe;
+        const preResolvedObs = routerState?.observations;
+        const preResolved =
+          preResolvedRecipe?.name === recipeName &&
+          preResolvedObs != null &&
+          preResolvedObs.length > 0;
 
-        // Filter to imaging observations — spectroscopic data has no downloadable image FITS
-        const observations = (searchResult.results ?? []).filter(
-          (obs) => obs.dataproduct_type === 'image'
-        );
-        if (observations.length === 0) {
-          setInitError('No observations found for this target.');
-          setResolving(false);
-          return;
-        }
+        let matched: CompositeRecipe;
+        let observations: MastObservationResult[];
 
-        // Get recipe suggestions
-        const inputs = toObservationInputs(observations);
-        const recipeResponse = await suggestRecipes(
-          { targetName: target, observations: inputs },
-          controller.signal
-        );
-        if (controller.signal.aborted) return;
+        if (preResolved) {
+          // Fast path — recipe and observations already resolved by TargetDetail
+          matched = preResolvedRecipe;
+          observations = preResolvedObs.filter((obs) => obs.dataproduct_type === 'image');
+        } else {
+          // Slow path — direct URL navigation (bookmark, shared link, retry)
+          const searchResult = await searchByTarget(
+            { targetName: target, radius },
+            controller.signal
+          );
+          if (controller.signal.aborted) return;
 
-        // Find the matching recipe by name
-        const matched = recipeResponse.recipes.find((r) => r.name === recipeName);
-        if (!matched) {
-          setInitError(`Recipe "${recipeName}" not found for this target.`);
-          setResolving(false);
-          return;
+          observations = (searchResult.results ?? []).filter(
+            (obs) => obs.dataproduct_type === 'image'
+          );
+          if (observations.length === 0) {
+            setInitError('No observations found for this target.');
+            setResolving(false);
+            return;
+          }
+
+          const inputs = toObservationInputs(observations);
+          const recipeResponse = await suggestRecipes(
+            { targetName: target, observations: inputs },
+            controller.signal
+          );
+          if (controller.signal.aborted) return;
+
+          const found = recipeResponse.recipes.find((r) => r.name === recipeName);
+          if (!found) {
+            setInitError(`Recipe "${recipeName}" not found for this target.`);
+            setResolving(false);
+            return;
+          }
+          matched = found;
         }
 
         setRecipe(matched);


### PR DESCRIPTION
## Summary
- RecipeCard now passes the resolved recipe and observations through React Router state when linking to the guided create page
- GuidedCreate uses pre-resolved data to skip the MAST search and suggestRecipes API calls on the happy path
- Direct URL navigation (bookmarks, shared links, retries) falls back to the existing full-resolve path

## Why
When navigating from TargetDetail → GuidedCreate, the wizard was re-fetching MAST observations and re-calling suggestRecipes — the exact same data TargetDetail already had. This added 1-3 seconds of unnecessary loading (two HTTP round-trips through .NET → Python → .NET → browser). The recipe computation itself is microseconds; all the cost was in the network hops.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Changes Made
- **RecipeCard.tsx**: Added `state={{ recipe, observations }}` to the `<Link>` component, passing the already-resolved recipe and MAST observations through React Router state
- **GuidedCreate.tsx**: Added `GuidedCreateLocationState` interface. In `resolveRecipe()`, checks `location.state` first — if recipe name matches and observations are present, uses them directly (fast path) and skips `searchByTarget` + `suggestRecipes`. Falls back to the existing full-resolve path when state is missing (slow path for direct URL navigation)

## Test Plan
- [x] Frontend lint passes (0 errors, 0 warnings)
- [x] Frontend unit tests pass (859/859)
- [x] E2E selectors checked — all existing selectors preserved (E2E tests use direct URL nav, testing the fallback path)
- [ ] Navigate to a target detail page, click "Create This Composite" — verify wizard loads faster (no skeleton/loading for MAST+recipe)
- [ ] Open a `/create?target=...&recipe=...` URL directly in browser — verify wizard still resolves correctly via the slow path
- [ ] Click browser back from wizard to target detail, then forward — verify wizard still works
- [ ] Retry button on wizard error — verify it re-fetches (retryCount change clears state dependency)

## Documentation Checklist
- [x] No new controllers, services, or endpoints
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No tech debt added
- [ ] Tech debt added (explain below)
- [ ] Tech debt reduced

## Risk & Rollback
Risk: Low — frontend-only optimization. The slow path (existing behavior) is always available as fallback. No backend changes.
Rollback: Revert this commit; GuidedCreate will resume fetching everything from scratch.

## Quality Checklist
- [x] Code follows project conventions
- [x] No new lint warnings
- [x] E2E selectors checked
- [x] Self-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)