### PR TITLE
feat: add localStorage caching for searchByTarget and suggestRecipes

### DIFF
--- a/frontend/jwst-frontend/src/pages/TargetDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.tsx
@@ -42,10 +42,22 @@ export function TargetDetail() {
       setErrorMessage(null);
 
       try {
-        // Step 1: Search MAST for observations
+        // Step 1: Search MAST for observations (with stale-while-revalidate)
+        let showedStale = false;
         const searchResult = await searchByTarget(
           { targetName: displayName, radius },
-          controller.signal
+          controller.signal,
+          {
+            onStaleData: (staleResult) => {
+              if (controller.signal.aborted) return;
+              const staleObs = staleResult.results || [];
+              if (staleObs.length > 0) {
+                setObservations(staleObs);
+                setLoadState('ready');
+                showedStale = true;
+              }
+            },
+          }
         );
 
         if (controller.signal.aborted) return;
@@ -67,7 +79,16 @@ export function TargetDetail() {
 
         const recipeResponse = await suggestRecipes(
           { targetName: displayName, observations: inputs },
-          controller.signal
+          controller.signal,
+          {
+            onStaleData: (staleRecipes) => {
+              if (controller.signal.aborted) return;
+              setRecipes(staleRecipes.recipes);
+              if (!showedStale) {
+                setLoadState('ready');
+              }
+            },
+          }
         );
 
         if (controller.signal.aborted) return;

--- a/frontend/jwst-frontend/src/services/discoveryService.test.ts
+++ b/frontend/jwst-frontend/src/services/discoveryService.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for discoveryService
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./apiClient', () => ({
+  apiClient: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('../utils/cacheUtils', () => ({
+  getCached: vi.fn().mockReturnValue(null),
+  getStale: vi.fn().mockReturnValue(null),
+  setCache: vi.fn(),
+}));
+
+import { apiClient } from './apiClient';
+import { getCached, getStale, setCache } from '../utils/cacheUtils';
+import { getFeaturedTargets, suggestRecipes } from './discoveryService';
+
+describe('discoveryService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getCached).mockReturnValue(null);
+    vi.mocked(getStale).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getFeaturedTargets', () => {
+    it('should GET /api/discovery/featured', async () => {
+      const mockResponse = { targets: [] };
+      vi.mocked(apiClient.get).mockResolvedValue(mockResponse);
+
+      const result = await getFeaturedTargets();
+
+      expect(apiClient.get).toHaveBeenCalledWith('/api/discovery/featured', { signal: undefined });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('suggestRecipes', () => {
+    const mockRequest = {
+      targetName: 'M51',
+      observations: [
+        { filter: 'F200W', instrument: 'NIRCam', observationId: 'obs-1' },
+        { filter: 'F150W', instrument: 'NIRCam', observationId: 'obs-2' },
+      ],
+    };
+
+    it('should POST to /api/discovery/suggest-recipes', async () => {
+      const mockResponse = { recipes: [{ name: 'RGB' }] };
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse);
+
+      const result = await suggestRecipes(mockRequest);
+
+      expect(apiClient.post).toHaveBeenCalledWith('/api/discovery/suggest-recipes', mockRequest, {
+        signal: undefined,
+      });
+      expect(result).toEqual(mockResponse);
+      expect(setCache).toHaveBeenCalled();
+    });
+
+    it('should return cached data when available', async () => {
+      const cachedData = { recipes: [{ name: 'cached-recipe' }] };
+      vi.mocked(getCached).mockReturnValue(cachedData);
+
+      const result = await suggestRecipes(mockRequest);
+
+      expect(result).toEqual(cachedData);
+      expect(apiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should call onStaleData callback with stale data', async () => {
+      const staleData = { recipes: [{ name: 'stale-recipe' }] };
+      const freshData = { recipes: [{ name: 'fresh-recipe' }] };
+      vi.mocked(getCached).mockReturnValue(null);
+      vi.mocked(getStale).mockReturnValue(staleData);
+      vi.mocked(apiClient.post).mockResolvedValue(freshData);
+
+      const onStaleData = vi.fn();
+      const result = await suggestRecipes(mockRequest, undefined, { onStaleData });
+
+      expect(onStaleData).toHaveBeenCalledWith(staleData);
+      expect(result).toEqual(freshData);
+    });
+
+    it('should skip cache when skipCache is true', async () => {
+      const cachedData = { recipes: [{ name: 'cached-recipe' }] };
+      const freshData = { recipes: [{ name: 'fresh-recipe' }] };
+      vi.mocked(getCached).mockReturnValue(cachedData);
+      vi.mocked(apiClient.post).mockResolvedValue(freshData);
+
+      const result = await suggestRecipes(mockRequest, undefined, { skipCache: true });
+
+      expect(getCached).not.toHaveBeenCalled();
+      expect(getStale).not.toHaveBeenCalled();
+      expect(result).toEqual(freshData);
+    });
+
+    it('should use sorted observation IDs in cache key', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ recipes: [] });
+
+      // obs-2 comes before obs-1 in array, but cache key should sort them
+      await suggestRecipes({
+        targetName: 'M51',
+        observations: [
+          { filter: 'F200W', instrument: 'NIRCam', observationId: 'obs-2' },
+          { filter: 'F150W', instrument: 'NIRCam', observationId: 'obs-1' },
+        ],
+      });
+
+      expect(getCached).toHaveBeenCalledWith('recipes:m51:obs-1,obs-2', expect.any(Number));
+    });
+
+    it('should handle observations without observationId in cache key', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ recipes: [] });
+
+      await suggestRecipes({
+        targetName: 'M51',
+        observations: [
+          { filter: 'F200W', instrument: 'NIRCam' },
+          { filter: 'F150W', instrument: 'MIRI' },
+        ],
+      });
+
+      expect(getCached).toHaveBeenCalledWith(
+        'recipes:m51:MIRI:F150W,NIRCam:F200W',
+        expect.any(Number)
+      );
+    });
+  });
+});

--- a/frontend/jwst-frontend/src/services/discoveryService.ts
+++ b/frontend/jwst-frontend/src/services/discoveryService.ts
@@ -5,11 +5,19 @@
  */
 
 import { apiClient } from './apiClient';
+import { getCached, getStale, setCache } from '../utils/cacheUtils';
 import type {
   FeaturedTargetsResponse,
   SuggestRecipesRequest,
   SuggestRecipesResponse,
 } from '../types/DiscoveryTypes';
+
+const RECIPE_CACHE_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
+
+export interface RecipeCacheOptions {
+  skipCache?: boolean;
+  onStaleData?: (data: SuggestRecipesResponse) => void;
+}
 
 /**
  * Fetch featured targets for the discovery home page.
@@ -23,12 +31,35 @@ export async function getFeaturedTargets(signal?: AbortSignal): Promise<Featured
  * Get composite recipe suggestions for a set of observations.
  * @param request - Target name and observations to generate recipes from
  * @param signal - Optional AbortSignal for cancellation
+ * @param options - Cache options (skipCache, onStaleData callback)
  */
 export async function suggestRecipes(
   request: SuggestRecipesRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  options?: RecipeCacheOptions
 ): Promise<SuggestRecipesResponse> {
-  return apiClient.post<SuggestRecipesResponse>('/api/discovery/suggest-recipes', request, {
-    signal,
-  });
+  const sortedObsIds = (request.observations || [])
+    .map((o) => o.observationId ?? `${o.instrument}:${o.filter}`)
+    .sort()
+    .join(',');
+  const cacheKey = `recipes:${(request.targetName ?? '').toLowerCase()}:${sortedObsIds}`;
+
+  if (!options?.skipCache) {
+    const fresh = getCached<SuggestRecipesResponse>(cacheKey, RECIPE_CACHE_TTL_MS);
+    if (fresh) return fresh;
+
+    const stale = getStale<SuggestRecipesResponse>(cacheKey);
+    if (stale) {
+      options?.onStaleData?.(stale);
+    }
+  }
+
+  const data = await apiClient.post<SuggestRecipesResponse>(
+    '/api/discovery/suggest-recipes',
+    request,
+    { signal }
+  );
+
+  setCache(cacheKey, data);
+  return data;
 }

--- a/frontend/jwst-frontend/src/services/mastService.test.ts
+++ b/frontend/jwst-frontend/src/services/mastService.test.ts
@@ -87,6 +87,52 @@ describe('mastService', () => {
         signal: controller.signal,
       });
     });
+
+    it('should return cached data when available', async () => {
+      const cachedData = { results: [{ id: 'cached' }], totalCount: 1 };
+      vi.mocked(getCached).mockReturnValue(cachedData);
+
+      const result = await searchByTarget({ targetName: 'M51' });
+
+      expect(result).toEqual(cachedData);
+      expect(apiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should call onStaleData callback with stale data', async () => {
+      const staleData = { results: [{ id: 'stale' }], totalCount: 1 };
+      const freshData = { results: [{ id: 'fresh' }], totalCount: 2 };
+      vi.mocked(getCached).mockReturnValue(null);
+      vi.mocked(getStale).mockReturnValue(staleData);
+      vi.mocked(apiClient.post).mockResolvedValue(freshData);
+
+      const onStaleData = vi.fn();
+      const result = await searchByTarget({ targetName: 'M51' }, undefined, { onStaleData });
+
+      expect(onStaleData).toHaveBeenCalledWith(staleData);
+      expect(result).toEqual(freshData);
+      expect(setCache).toHaveBeenCalledWith('mast_search:m51:default:all', freshData);
+    });
+
+    it('should skip cache when skipCache is true', async () => {
+      const cachedData = { results: [{ id: 'cached' }], totalCount: 1 };
+      const freshData = { results: [{ id: 'fresh' }], totalCount: 2 };
+      vi.mocked(getCached).mockReturnValue(cachedData);
+      vi.mocked(apiClient.post).mockResolvedValue(freshData);
+
+      const result = await searchByTarget({ targetName: 'M51' }, undefined, { skipCache: true });
+
+      expect(getCached).not.toHaveBeenCalled();
+      expect(getStale).not.toHaveBeenCalled();
+      expect(result).toEqual(freshData);
+    });
+
+    it('should use correct cache key with all params', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ results: [] });
+
+      await searchByTarget({ targetName: 'NGC 1234', radius: 0.5, calibLevel: [2, 3] });
+
+      expect(getCached).toHaveBeenCalledWith('mast_search:ngc 1234:0.5:2,3', expect.any(Number));
+    });
   });
 
   describe('searchByCoordinates', () => {

--- a/frontend/jwst-frontend/src/services/mastService.ts
+++ b/frontend/jwst-frontend/src/services/mastService.ts
@@ -20,8 +20,14 @@ import { MetadataRefreshAllResponse } from '../types/JwstDataTypes';
 import { getCached, getStale, setCache } from '../utils/cacheUtils';
 
 const WHATS_NEW_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const SEARCH_CACHE_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
 
 export interface RecentReleasesOptions {
+  skipCache?: boolean;
+  onStaleData?: (data: MastSearchResponse) => void;
+}
+
+export interface SearchCacheOptions {
   skipCache?: boolean;
   onStaleData?: (data: MastSearchResponse) => void;
 }
@@ -63,16 +69,33 @@ export interface StartImportParams {
  * Search MAST by target name
  * @param params - Target name, optional search radius, and calibration level filter
  * @param signal - Optional AbortSignal for cancellation
+ * @param options - Cache options (skipCache, onStaleData callback)
  */
 export async function searchByTarget(
   params: SearchByTargetParams,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  options?: SearchCacheOptions
 ): Promise<MastSearchResponse> {
-  return apiClient.post<MastSearchResponse>(
+  const cacheKey = `mast_search:${params.targetName.toLowerCase()}:${params.radius ?? 'default'}:${params.calibLevel?.join(',') ?? 'all'}`;
+
+  if (!options?.skipCache) {
+    const fresh = getCached<MastSearchResponse>(cacheKey, SEARCH_CACHE_TTL_MS);
+    if (fresh) return fresh;
+
+    const stale = getStale<MastSearchResponse>(cacheKey);
+    if (stale) {
+      options?.onStaleData?.(stale);
+    }
+  }
+
+  const data = await apiClient.post<MastSearchResponse>(
     '/api/mast/search/target',
     { targetName: params.targetName, radius: params.radius, calibLevel: params.calibLevel },
     { signal }
   );
+
+  setCache(cacheKey, data);
+  return data;
 }
 
 /**


### PR DESCRIPTION
## Summary
Add localStorage caching with stale-while-revalidate to `searchByTarget` and `suggestRecipes`, eliminating redundant API calls on back-navigation, page refresh, and multi-recipe browsing.

## Why
After PR #616 (router state passthrough), the TargetDetail → GuidedCreate transition is fast. But back-navigation from wizard to target detail, page refreshes, and browsing multiple recipes still re-fetch from scratch. These two endpoints return data that changes on the order of weeks/months, making them ideal for aggressive client caching.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- **`mastService.ts`**: Added 48h localStorage cache to `searchByTarget` with `SearchCacheOptions` param (`skipCache`, `onStaleData`), following the proven `getRecentReleases` pattern
- **`discoveryService.ts`**: Added 48h localStorage cache to `suggestRecipes` with `RecipeCacheOptions` param, using sorted observation IDs in cache key for consistency
- **`TargetDetail.tsx`**: Passes `onStaleData` callbacks so cached data renders instantly while fresh data loads in background (no skeleton flash on revisit)
- **`mastService.test.ts`**: Added 4 cache tests for `searchByTarget` (cache hit, stale-while-revalidate, skipCache, cache key format)
- **`discoveryService.test.ts`**: New test file with 7 tests covering `getFeaturedTargets` and `suggestRecipes` caching (hit, stale, skipCache, sorted keys, fallback keys)

## Test Plan
- [x] All 870 unit tests pass (`npx vitest run`)
- [x] ESLint clean on all modified files
- [ ] Manual: Navigate to target detail → navigate away → back → should show cached data instantly (no skeleton)
- [ ] Manual: Refresh target detail page → cached data shown immediately, silently updated in background
- [ ] Manual: Browse multiple recipes for same target → instant load after first visit

## Documentation Checklist
- [x] No new controllers, services, or endpoints added
- [x] No documentation updates needed (internal caching only)

## Tech Debt Impact
- [x] No tech debt impact — follows existing proven pattern from `getRecentReleases`

## Risk & Rollback
Risk: Low — additive caching layer, all existing behavior preserved. Cache misses fall through to normal API calls.
Rollback: Revert this PR. Cached data in localStorage will be ignored after code revert (dead entries auto-expire).

## Quality Checklist
- [x] Code follows existing patterns (mirrors `getRecentReleases` caching exactly)
- [x] Tests cover cache hit, miss, stale-while-revalidate, and skipCache paths
- [x] No breaking changes to existing function signatures (new params are optional)

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)