### PR TITLE
feat: add LRU eviction and cache stats to localStorage cache

### DIFF
--- a/frontend/jwst-frontend/src/utils/cacheUtils.test.ts
+++ b/frontend/jwst-frontend/src/utils/cacheUtils.test.ts
@@ -1,12 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getCached, getStale, setCache, clearCacheByPrefix } from './cacheUtils';
+import { getCached, getStale, setCache, clearCacheByPrefix, getCacheStats } from './cacheUtils';
 
-// Mock localStorage
+// Mock localStorage with optional quota simulation
 const mockStorage = new Map<string, string>();
+let quotaLimit: number | null = null; // null = no limit
 
 vi.stubGlobal('localStorage', {
   getItem: (key: string) => mockStorage.get(key) ?? null,
-  setItem: (key: string, val: string) => mockStorage.set(key, val),
+  setItem: (key: string, val: string) => {
+    if (quotaLimit !== null) {
+      // Estimate total size after this write
+      const currentSize = [...mockStorage.entries()].reduce(
+        (sum, [k, v]) => sum + k.length + v.length,
+        0
+      );
+      const existingSize = mockStorage.has(key)
+        ? key.length + (mockStorage.get(key)?.length ?? 0)
+        : 0;
+      const newTotal = currentSize - existingSize + key.length + val.length;
+      if (newTotal > quotaLimit) {
+        throw new Error('QuotaExceededError');
+      }
+    }
+    mockStorage.set(key, val);
+  },
   removeItem: (key: string) => mockStorage.delete(key),
   get length() {
     return mockStorage.size;
@@ -17,6 +34,7 @@ vi.stubGlobal('localStorage', {
 
 beforeEach(() => {
   mockStorage.clear();
+  quotaLimit = null;
 });
 
 describe('setCache + getCached', () => {
@@ -183,5 +201,171 @@ describe('clearCacheByPrefix', () => {
     expect(getCached('a', 60_000)).toBeNull();
     expect(getCached('b', 60_000)).toBeNull();
     expect(getCached('c', 60_000)).toBeNull();
+  });
+});
+
+describe('LRU eviction', () => {
+  it('evicts oldest entry when quota is exceeded', () => {
+    // Write two small entries with known timestamps
+    const oldEntry = JSON.stringify({ data: 'old', timestamp: 1000, version: 1 });
+    const newEntry = JSON.stringify({ data: 'new', timestamp: 2000, version: 1 });
+    mockStorage.set('jwst_cache_old-key', oldEntry);
+    mockStorage.set('jwst_cache_new-key', newEntry);
+
+    // Calculate current total size
+    const currentSize = [...mockStorage.entries()].reduce(
+      (sum, [k, v]) => sum + k.length + v.length,
+      0
+    );
+
+    // Build what setCache will try to write, so we can size the quota
+    const newCacheEntry = JSON.stringify({ data: 'data', timestamp: Date.now(), version: 1 });
+    const newKeySize = 'jwst_cache_another'.length + newCacheEntry.length;
+
+    // Set quota so all 3 don't fit, but 2 (new-key + another) do
+    const oldKeySize = 'jwst_cache_old-key'.length + oldEntry.length;
+    quotaLimit = currentSize - oldKeySize + newKeySize + 1;
+
+    setCache('another', 'data');
+
+    // old-key should have been evicted
+    expect(mockStorage.has('jwst_cache_old-key')).toBe(false);
+    // new-key should survive
+    expect(mockStorage.has('jwst_cache_new-key')).toBe(true);
+    // new entry should be stored
+    expect(mockStorage.has('jwst_cache_another')).toBe(true);
+  });
+
+  it('evicts multiple entries if needed', () => {
+    // Insert 3 entries with ascending timestamps
+    for (let i = 0; i < 3; i++) {
+      mockStorage.set(
+        `jwst_cache_entry-${i}`,
+        JSON.stringify({ data: 'x'.repeat(50), timestamp: 1000 + i, version: 1 })
+      );
+    }
+
+    // Set a very tight quota — only room for the new entry
+    quotaLimit = 300;
+
+    setCache('big', 'y'.repeat(50));
+
+    expect(mockStorage.has('jwst_cache_big')).toBe(true);
+    // At least some old entries should have been evicted
+    const remaining = [...mockStorage.keys()].filter((k) => k.startsWith('jwst_cache_entry-'));
+    expect(remaining.length).toBeLessThan(3);
+  });
+
+  it('silently no-ops when entry is too large even after evicting everything', () => {
+    // Set very small quota
+    quotaLimit = 10;
+
+    // Should not throw
+    expect(() => setCache('huge', 'x'.repeat(1000))).not.toThrow();
+    // Entry should not be stored
+    expect(mockStorage.has('jwst_cache_huge')).toBe(false);
+  });
+
+  it('does not evict non-cache keys', () => {
+    mockStorage.set('other_app_key', 'important data');
+    mockStorage.set('jwst_cache_old', JSON.stringify({ data: 'x', timestamp: 1000, version: 1 }));
+
+    // Tight quota
+    quotaLimit = 200;
+
+    setCache('new-entry', 'data');
+
+    // Non-cache key must survive
+    expect(mockStorage.has('other_app_key')).toBe(true);
+  });
+});
+
+describe('getCached touch-on-read', () => {
+  it('updates timestamp on cache hit', () => {
+    const oldTimestamp = Date.now() - 60_000;
+    mockStorage.set(
+      'jwst_cache_touch-test',
+      JSON.stringify({ data: 'value', timestamp: oldTimestamp, version: 1 })
+    );
+
+    const result = getCached<string>('touch-test', 120_000);
+    expect(result).toBe('value');
+
+    // Verify timestamp was updated
+    const raw = mockStorage.get('jwst_cache_touch-test') ?? '';
+    const entry = JSON.parse(raw);
+    expect(entry.timestamp).toBeGreaterThan(oldTimestamp);
+    expect(entry.timestamp).toBeCloseTo(Date.now(), -2); // Within ~100ms
+  });
+
+  it('does not touch timestamp for expired entries', () => {
+    const oldTimestamp = Date.now() - 120_000;
+    const json = JSON.stringify({ data: 'expired', timestamp: oldTimestamp, version: 1 });
+    mockStorage.set('jwst_cache_expired-touch', json);
+
+    const result = getCached<string>('expired-touch', 60_000);
+    expect(result).toBeNull();
+
+    // Timestamp should not have changed
+    expect(mockStorage.get('jwst_cache_expired-touch')).toBe(json);
+  });
+
+  it('still returns data if touch write fails due to quota', () => {
+    setCache('quota-touch', 'value');
+
+    // Now set quota to prevent writes but allow reads
+    quotaLimit = 1;
+
+    const result = getCached<string>('quota-touch', 60_000);
+    expect(result).toBe('value');
+  });
+});
+
+describe('getCacheStats', () => {
+  it('returns empty stats for empty cache', () => {
+    const stats = getCacheStats();
+    expect(stats.totalBytes).toBe(0);
+    expect(stats.entryCount).toBe(0);
+    expect(stats.entries).toEqual([]);
+  });
+
+  it('counts only jwst_cache_ entries', () => {
+    setCache('a', 'data-a');
+    setCache('b', 'data-b');
+    mockStorage.set('other_key', 'not counted');
+
+    const stats = getCacheStats();
+    expect(stats.entryCount).toBe(2);
+  });
+
+  it('reports bytes and age for each entry', () => {
+    setCache('stats-test', { value: 42 });
+
+    const stats = getCacheStats();
+    expect(stats.entryCount).toBe(1);
+    expect(stats.entries[0].key).toBe('stats-test');
+    expect(stats.entries[0].bytes).toBeGreaterThan(0);
+    expect(stats.entries[0].ageMs).toBeGreaterThanOrEqual(0);
+    expect(stats.entries[0].ageMs).toBeLessThan(1000); // Just written
+  });
+
+  it('sorts entries by size descending', () => {
+    setCache('small', 'x');
+    setCache('large', 'x'.repeat(500));
+    setCache('medium', 'x'.repeat(100));
+
+    const stats = getCacheStats();
+    expect(stats.entries[0].key).toBe('large');
+    expect(stats.entries[1].key).toBe('medium');
+    expect(stats.entries[2].key).toBe('small');
+  });
+
+  it('totalBytes is sum of all entry bytes', () => {
+    setCache('one', 'data1');
+    setCache('two', 'data2');
+
+    const stats = getCacheStats();
+    const summedBytes = stats.entries.reduce((sum, e) => sum + e.bytes, 0);
+    expect(stats.totalBytes).toBe(summedBytes);
   });
 });

--- a/frontend/jwst-frontend/src/utils/cacheUtils.ts
+++ b/frontend/jwst-frontend/src/utils/cacheUtils.ts
@@ -7,13 +7,29 @@ interface CacheEntry<T> {
   version: number;
 }
 
+export interface CacheStats {
+  totalBytes: number;
+  entryCount: number;
+  entries: { key: string; bytes: number; ageMs: number }[];
+}
+
 export function getCached<T>(key: string, ttlMs: number): T | null {
   try {
-    const raw = localStorage.getItem(CACHE_PREFIX + key);
+    const fullKey = CACHE_PREFIX + key;
+    const raw = localStorage.getItem(fullKey);
     if (!raw) return null;
     const entry: CacheEntry<T> = JSON.parse(raw);
     if (entry.version !== CACHE_VERSION) return null;
     if (Date.now() - entry.timestamp > ttlMs) return null;
+
+    // Touch timestamp on read for LRU accuracy
+    try {
+      entry.timestamp = Date.now();
+      localStorage.setItem(fullKey, JSON.stringify(entry));
+    } catch {
+      // Quota error on touch is fine — data is still valid
+    }
+
     return entry.data;
   } catch {
     return null;
@@ -32,17 +48,92 @@ export function getStale<T>(key: string): T | null {
   }
 }
 
-export function setCache<T>(key: string, data: T): void {
-  try {
-    const entry: CacheEntry<T> = {
-      data,
-      timestamp: Date.now(),
-      version: CACHE_VERSION,
-    };
-    localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(entry));
-  } catch {
-    // localStorage full or disabled — silent no-op
+/**
+ * Evicts the oldest jwst_cache_* entry from localStorage.
+ * Returns true if an entry was evicted, false if none remain.
+ */
+function evictOldest(): boolean {
+  let oldestKey: string | null = null;
+  let oldestTime = Infinity;
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key || !key.startsWith(CACHE_PREFIX)) continue;
+
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      const entry: CacheEntry<unknown> = JSON.parse(raw);
+      if (typeof entry.timestamp === 'number' && entry.timestamp < oldestTime) {
+        oldestTime = entry.timestamp;
+        oldestKey = key;
+      }
+    } catch {
+      // Unparseable entry — evict it first as it's likely corrupt
+      localStorage.removeItem(key);
+      return true;
+    }
   }
+
+  if (oldestKey) {
+    localStorage.removeItem(oldestKey);
+    return true;
+  }
+  return false;
+}
+
+export function setCache<T>(key: string, data: T): void {
+  const entry: CacheEntry<T> = {
+    data,
+    timestamp: Date.now(),
+    version: CACHE_VERSION,
+  };
+  const json = JSON.stringify(entry);
+  const fullKey = CACHE_PREFIX + key;
+
+  for (;;) {
+    try {
+      localStorage.setItem(fullKey, json);
+      return;
+    } catch {
+      // Quota exceeded — evict oldest entry and retry
+      if (!evictOldest()) {
+        // Nothing left to evict — silent no-op
+        return;
+      }
+    }
+  }
+}
+
+export function getCacheStats(): CacheStats {
+  const now = Date.now();
+  const entries: CacheStats['entries'] = [];
+  let totalBytes = 0;
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key || !key.startsWith(CACHE_PREFIX)) continue;
+
+    const raw = localStorage.getItem(key);
+    if (!raw) continue;
+
+    const bytes = key.length + raw.length; // Characters ≈ bytes for localStorage (UTF-16, but close enough for reporting)
+    totalBytes += bytes;
+
+    let ageMs: number;
+    try {
+      const entry: CacheEntry<unknown> = JSON.parse(raw);
+      ageMs = now - entry.timestamp;
+    } catch {
+      ageMs = -1; // Corrupt entry
+    }
+
+    entries.push({ key: key.slice(CACHE_PREFIX.length), bytes, ageMs });
+  }
+
+  entries.sort((a, b) => b.bytes - a.bytes); // Largest first
+
+  return { totalBytes, entryCount: entries.length, entries };
 }
 
 export function clearCacheByPrefix(prefix: string): void {


### PR DESCRIPTION
## Summary
Adds LRU eviction to `setCache` so writes no longer silently fail when localStorage hits quota. Adds `getCacheStats()` for runtime cache debugging.

## Why
PR #618 adds localStorage caching that uses ~3.2 MB (65% of the 5 MB limit) for featured targets alone. Users browsing non-featured targets will exceed quota, causing silent write failures with no reclamation. LRU eviction ensures old entries get purged automatically.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test update
- [ ] Configuration change

## Changes Made
- Added `evictOldest()` helper that scans `jwst_cache_*` keys, finds the one with the smallest timestamp, and removes it (corrupt entries evicted first)
- Modified `setCache` to catch quota errors and evict-then-retry in a loop until the write succeeds or no cache entries remain
- Modified `getCached` to touch (update) the entry timestamp on cache hit for true LRU behavior (not just least-recently-written)
- Added exported `getCacheStats()` returning `{ totalBytes, entryCount, entries[] }` sorted by size — callable from browser console for debugging
- Added 12 new tests covering eviction, touch-on-read, and cache stats

## Test Plan
- [x] `npx vitest run src/utils/cacheUtils.test.ts` — all 32 tests pass (20 existing + 12 new)
- [ ] Eviction: verify oldest `jwst_cache_*` entry is evicted when quota exceeded
- [ ] Eviction: verify non-cache keys (`other_app_key`) are never evicted
- [ ] Eviction: verify silent no-op when entry is too large even after evicting everything
- [ ] Touch-on-read: verify `getCached` updates timestamp so frequently-read entries survive eviction
- [ ] Stats: call `getCacheStats()` in browser console after browsing targets — see entry sizes and ages

## Documentation Checklist
- [x] No new controllers, services, or endpoints
- [x] No API parameter changes
- [x] No new frontend components
- [x] No workflow/step changes

## Tech Debt Impact
- [x] Reduces tech debt (silent quota failures → graceful eviction)
- [ ] No impact on tech debt
- [ ] Adds tech debt (explain below)

## Risk & Rollback
Risk: Low — changes are isolated to `cacheUtils.ts`, no API or component changes. Eviction only triggers on quota errors.
Rollback: Revert this commit. Cache entries remain valid, writes just silently fail again on quota.

## Quality Checklist
- [x] Code follows project conventions
- [x] No unnecessary complexity added
- [x] Error handling is appropriate
- [x] No security concerns introduced
- [x] Tests cover the changes adequately

🤖 Generated with [Claude Code](https://claude.com/claude-code)