### PR TITLE
feat: bicolor compositing with synthetic green for 2-filter cases

### DIFF
--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -37,14 +37,23 @@ const COMPOSITE_OUTPUT = {
   height: 2000,
 };
 
+/** Bicolor RGB weights for 2-filter composites (synthetic green) */
+const BICOLOR_WEIGHTS: [number, number, number][] = [
+  [0, 0.5, 1.0], // short wavelength → blue + half green
+  [1.0, 0.5, 0], // long wavelength → red + half green
+];
+
 /**
  * Build NChannelConfigPayload array from recipe + imported data mappings.
  * Falls back to chromatic-ordered colors if colorMapping is missing.
+ * For 2-filter recipes, uses bicolor RGB weights (synthetic green).
  */
 function buildChannelPayloads(
   recipe: CompositeRecipe,
   filterDataMap: Map<string, string[]>
 ): NChannelConfigPayload[] {
+  const isBicolor = recipe.filters.length === 2;
+
   // Build fallback color mapping if the API response didn't include one
   const colorMapping =
     recipe.colorMapping ??
@@ -53,13 +62,18 @@ function buildChannelPayloads(
     );
 
   const payloads: NChannelConfigPayload[] = [];
-  for (const filter of recipe.filters) {
+  for (let i = 0; i < recipe.filters.length; i++) {
+    const filter = recipe.filters[i];
     const dataIds = filterDataMap.get(filter.toUpperCase()) ?? [];
     if (dataIds.length === 0) continue;
-    const hexColor = colorMapping[filter] ?? '#ffffff';
+
+    const color = isBicolor
+      ? { rgb: BICOLOR_WEIGHTS[i] as [number, number, number] }
+      : { hue: rgbToHue(...hexToRgb(colorMapping[filter] ?? '#ffffff')) };
+
     payloads.push({
       dataIds,
-      color: { hue: rgbToHue(...hexToRgb(hexColor)) },
+      color,
       label: filter,
       stretch: DEFAULT_CHANNEL_PARAMS.stretch,
       blackPoint: DEFAULT_CHANNEL_PARAMS.blackPoint,

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -178,6 +178,19 @@ export function hueToColorName(hue: number): string {
 }
 
 /**
+ * Create an N-channel with explicit RGB weights (e.g. for bicolor compositing)
+ */
+export function createNChannelWithRgb(rgb: [number, number, number]): NChannelState {
+  channelIdCounter += 1;
+  return {
+    id: `ch-${Date.now()}-${channelIdCounter}`,
+    dataIds: [],
+    color: { rgb },
+    params: { ...DEFAULT_CHANNEL_PARAMS },
+  };
+}
+
+/**
  * Create a default N-channel with the given hue
  */
 export function createDefaultNChannel(hue: number): NChannelState {

--- a/frontend/jwst-frontend/src/utils/wavelengthUtils.test.ts
+++ b/frontend/jwst-frontend/src/utils/wavelengthUtils.test.ts
@@ -503,6 +503,28 @@ describe('autoAssignNChannels', () => {
     expect(channels[0].color.hue).toBe(0);
   });
 
+  it('assigns bicolor RGB weights for exactly 2 known-wavelength filters', () => {
+    const images = [mockImage('1', 'F150W'), mockImage('2', 'F444W')];
+    const channels = autoAssignNChannels(images);
+    expect(channels).toHaveLength(2);
+    // Short wavelength → blue + half green
+    expect(channels[0].color.rgb).toEqual([0, 0.5, 1.0]);
+    expect(channels[0].color.hue).toBeUndefined();
+    expect(channels[0].label).toBe('F150W (Bicolor)');
+    // Long wavelength → red + half green
+    expect(channels[1].color.rgb).toEqual([1.0, 0.5, 0]);
+    expect(channels[1].color.hue).toBeUndefined();
+    expect(channels[1].label).toBe('F444W (Bicolor)');
+  });
+
+  it('falls back to hue-based for 2 filters when one has unknown wavelength', () => {
+    const images = [mockImage('1', 'UNKNOWN'), mockImage('2', 'F444W')];
+    const channels = autoAssignNChannels(images);
+    // Should NOT use bicolor — one filter has unknown wavelength
+    expect(channels[0].color.hue).toBeDefined();
+    expect(channels[0].color.rgb).toBeUndefined();
+  });
+
   it('assigns chromatic ordering hues for multiple filters', () => {
     const images = [mockImage('1', 'F090W'), mockImage('2', 'F200W'), mockImage('3', 'F444W')];
     const channels = autoAssignNChannels(images);

--- a/frontend/jwst-frontend/src/utils/wavelengthUtils.ts
+++ b/frontend/jwst-frontend/src/utils/wavelengthUtils.ts
@@ -6,6 +6,7 @@ import { JwstDataModel } from '../types/JwstDataTypes';
 import {
   NChannelState,
   createDefaultNChannel,
+  createNChannelWithRgb,
   DEFAULT_CHANNEL_PARAMS,
 } from '../types/CompositeTypes';
 
@@ -456,6 +457,27 @@ export function autoAssignNChannels(images: JwstDataModel[]): NChannelState[] {
   // Separate known and unknown wavelength groups
   const known = sorted.filter(([, g]) => g.wavelength !== null);
   const unknown = sorted.filter(([, g]) => g.wavelength === null);
+
+  // Bicolor with synthetic green: when exactly 2 known-wavelength filters,
+  // use explicit RGB weights so Green = 0.5*(short + long) — standard
+  // astronomical technique for 2-filter composites (HOO palette, NASA).
+  if (known.length === 2 && unknown.length === 0) {
+    const bicolorWeights: [number, number, number][] = [
+      [0, 0.5, 1.0], // short wavelength → blue + half green
+      [1.0, 0.5, 0], // long wavelength → red + half green
+    ];
+
+    const channels: NChannelState[] = known.map(([filterName, group], idx) => {
+      const channel = createNChannelWithRgb(bicolorWeights[idx]);
+      channel.dataIds = group.dataIds;
+      channel.label = `${filterName} (Bicolor)`;
+      channel.wavelengthUm = group.wavelength ?? undefined;
+      channel.params = { ...DEFAULT_CHANNEL_PARAMS };
+      return channel;
+    });
+
+    return channels;
+  }
 
   // Chromatic ordering: evenly-spaced hues for known-wavelength filters
   const knownHues = chromaticOrderHues(known.length > 0 ? known.length : 1);

--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -93,7 +93,18 @@ def hue_to_hex(hue: float) -> str:
 
 
 def build_color_mapping(filters_sorted: list[str]) -> dict[str, str]:
-    """Build chromatic-ordered color mapping for a sorted filter list."""
+    """Build chromatic-ordered color mapping for a sorted filter list.
+
+    For exactly 2 filters, uses bicolor hex values that represent synthetic
+    green weights: short → #0080ff (rgb [0, 0.5, 1.0]),
+    long → #ff8000 (rgb [1.0, 0.5, 0]). This produces Green = 0.5*(short+long),
+    the standard astronomical technique for 2-filter composites.
+    """
+    if len(filters_sorted) == 2:
+        return {
+            filters_sorted[0]: "#0080ff",  # short: blue + half green
+            filters_sorted[1]: "#ff8000",  # long: red + half green
+        }
     hues = chromatic_order_hues(len(filters_sorted))
     return {f: hue_to_hex(h) for f, h in zip(filters_sorted, hues, strict=True)}
 

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -74,14 +74,14 @@ class TestHueToHex:
 class TestBuildColorMapping:
     """Tests for chromatic-ordered color mapping."""
 
-    def test_two_filters(self):
+    def test_two_filters_bicolor(self):
         mapping = build_color_mapping(["F090W", "F444W"])
         assert len(mapping) == 2
         assert "F090W" in mapping
         assert "F444W" in mapping
-        # First filter should be blue-ish, last should be red
-        assert mapping["F090W"] == "#0000ff"
-        assert mapping["F444W"] == "#ff0000"
+        # 2-filter bicolor: short → cyan-blue, long → orange-red (synthetic green)
+        assert mapping["F090W"] == "#0080ff"
+        assert mapping["F444W"] == "#ff8000"
 
     def test_three_filters(self):
         mapping = build_color_mapping(["F090W", "F200W", "F444W"])


### PR DESCRIPTION
## Summary

- Implements bicolor compositing with synthetic green for 2-filter JWST composites, replacing flat magenta output with color-rich images using the standard astronomical technique `G = 0.5*(short + long)`

## Why

When a user has only 2 filters, the current system assigns pure Blue (hue 240) and pure Red (hue 0), producing an image with **zero green channel** — flat, magenta-tinted output. The bicolor synthetic green technique is the community-standard approach used in HOO palettes and NASA image processing.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Added `createNChannelWithRgb` factory function in `CompositeTypes.ts` for creating channels with explicit RGB weights (parallels `createDefaultNChannel`)
- Updated `autoAssignNChannels` in `wavelengthUtils.ts` to detect 2 known-wavelength filters and apply bicolor RGB weights: short → `[0, 0.5, 1.0]`, long → `[1.0, 0.5, 0]`
- Updated `buildChannelPayloads` in `GuidedCreate.tsx` to send `rgb` weights (not hue) for 2-filter guided recipes, preserving synthetic green through to backend
- Updated `build_color_mapping` in `recipe_engine.py` to return bicolor hex values (`#0080ff`, `#ff8000`) for 2-filter discovery cards
- Added frontend tests for bicolor auto-assign (2 known wavelengths) and fallback (unknown wavelength)
- Updated Python test for 2-filter color mapping to expect bicolor hex values

## Test Plan

- [x] `npx vitest run src/utils/wavelengthUtils.test.ts` — 90 tests pass including new bicolor tests
- [x] `docker exec jwst-processing python -m pytest tests/test_recipe_engine.py` — 36 tests pass including updated bicolor test
- [x] Full frontend test suite (861 tests) passes
- [ ] Manual: Select 2 images with different filters → Composite → channels show bicolor colors (cyan-blue + orange-red), not pure blue + red
- [ ] Manual: Discovery flow → pick a 2-filter recipe → guided create → composite preview has visible green tones
- [ ] Manual: Select 3+ images → Composite → unchanged chromatic behavior

## Documentation Checklist

- [x] No new controllers, services, or endpoints added
- [x] No new API parameters added
- [x] No new frontend components added
- [x] No workflow/step changes

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Reduces existing tech debt
- [ ] Adds tech debt (explain below)

## Risk & Rollback

Risk: Low — only affects color assignment for exactly 2-filter composites. 3+ filter behavior unchanged. Backend already supports `rgb` weights.
Rollback: Revert this PR. No data model or API contract changes.

## Quality Checklist

- [x] Code follows project style guidelines
- [x] Changes are covered by tests
- [x] No security concerns introduced
- [x] Error handling is appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)