### PR TITLE
fix: redirect to discovery page after sign out

### DIFF
--- a/frontend/jwst-frontend/e2e/auth.spec.ts
+++ b/frontend/jwst-frontend/e2e/auth.spec.ts
@@ -179,10 +179,11 @@ test.describe('Authentication', () => {
       await expect(page.getByText('Sign Out')).toBeVisible();
       await page.getByText('Sign Out').click();
 
-      // Should redirect to login
-      await expect(page).toHaveURL('/login');
+      // Should redirect to discovery page (home)
+      await expect(page).toHaveURL('/');
 
       // Step 3: Login with the registered credentials
+      await page.goto('/login');
       await page.getByLabel('Username').fill(username);
       await page.getByLabel('Password').fill(password);
       await page.getByRole('button', { name: 'Sign In' }).click();

--- a/frontend/jwst-frontend/src/components/UserMenu.tsx
+++ b/frontend/jwst-frontend/src/components/UserMenu.tsx
@@ -64,7 +64,7 @@ export function UserMenu() {
   const handleLogout = async () => {
     setIsOpen(false);
     await logout();
-    navigate('/login');
+    navigate('/');
   };
 
   return (


### PR DESCRIPTION
## Summary

Sign out now redirects to `/` (discovery page) instead of `/login`.

## Why

The discovery page is the public landing page — users should land there after signing out, not on the login form.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Updated `UserMenu.tsx` `handleLogout` to `navigate('/')` instead of `navigate('/login')`
- Updated E2E auth test to expect `/` redirect and navigate to `/login` explicitly for the re-login step

## Test Plan

- [x] Sign in, click user menu → Sign Out → lands on discovery page (`/`)
- [x] E2E auth test updated to match new behavior

## Documentation Checklist

- [x] No documentation updates needed (behavioral fix, no new endpoints)

## Tech Debt Impact

- [x] No tech debt impact

## Risk & Rollback

Risk: None — single-line navigation change.
Rollback: Revert commit.

## Quality Checklist

- [x] Code compiles without warnings
- [x] All 884 frontend unit tests pass
- [x] E2E test updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)