### PR TITLE
fix: remove Jupiter from featured targets

### DIFF
--- a/backend/JwstDataAnalysis.API/Configuration/featured-targets.json
+++ b/backend/JwstDataAnalysis.API/Configuration/featured-targets.json
@@ -105,21 +105,6 @@
     }
   },
   {
-    "name": "Jupiter",
-    "catalogId": "Jupiter",
-    "category": "planetary",
-    "description": "Our solar system's largest planet. JWST captured auroras, hazes, and faint rings in infrared.",
-    "instruments": ["NIRCam"],
-    "filterCount": 3,
-    "compositePotential": "limited",
-    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/10/STScI-01HCX1B69H5ZEF6S18S0F6PM1V.png?w=600",
-    "mastSearchParams": {
-      "target": "Jupiter",
-      "instrument": "NIRCAM",
-      "productLevel": "2b"
-    }
-  },
-  {
     "name": "Cassiopeia A",
     "catalogId": "Cas A",
     "category": "nebula",

--- a/docs/plans/exploration/processing-engine-scaling.md
+++ b/docs/plans/exploration/processing-engine-scaling.md
@@ -25,7 +25,7 @@ Before scaling compute, eliminate redundant compute. Most users visiting a popul
 
 100 users looking at M16 = 1 composite generation + 99 cache hits.
 
-**Pre-generation for featured targets**: the 13 featured targets have curated recipes. Generate default composites on deploy or nightly. Users see instant results for the most common paths.
+**Pre-generation for featured targets**: the 12 featured targets have curated recipes. Generate default composites on deploy or nightly. Users see instant results for the most common paths.
 
 Ties into the "permalinkable viewer state" roadmap item — a cached composite with a stable hash is naturally shareable.
 

--- a/docs/standards/backend-development.md
+++ b/docs/standards/backend-development.md
@@ -141,7 +141,7 @@
 
 ### DiscoveryController (`/api/discovery`)
 
-- GET /api/discovery/featured - Get curated featured targets list (13 targets with metadata, instruments, composite potential)
+- GET /api/discovery/featured - Get curated featured targets list (12 targets with metadata, instruments, composite potential)
 - POST /api/discovery/suggest-recipes - Generate ranked composite recipe suggestions for a set of observations (proxies to Python recipe engine)
 
 ### AnalysisController (`/api/analysis`)


### PR DESCRIPTION
## Summary
Removes Jupiter from `featured-targets.json` because `SkyCoord.from_name("Jupiter")` fails — Simbad/NED don't catalog solar system (moving) targets.

## Why
Discovered during prefetch dry-run (#626). Jupiter is the only featured target that fails MAST resolution. It was also NIRCam-only with `compositePotential: "limited"`.

## Type of Change
- [x] Bug fix

## Changes Made
- Removed Jupiter entry from `featured-targets.json` (13 → 12 targets)
- Updated `docs/plans/exploration/processing-engine-scaling.md` — 13 → 12
- Updated `docs/standards/backend-development.md` — 13 → 12

## Test Plan
- [x] Backend tests pass (797/797)
- [x] JSON validated (12 entries, valid structure)
- [x] `./scripts/prefetch-discovery.sh --dry-run` succeeds for all 12 remaining targets

## Documentation Checklist
- [x] `docs/standards/backend-development.md` — updated target count
- [x] `docs/plans/exploration/processing-engine-scaling.md` — updated target count
- [ ] `docs/tech-debt.md` — N/A

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — removes one entry from a config file. No code changes.
Rollback: Re-add Jupiter entry to `featured-targets.json`.

## Quality Checklist
- [x] Config file validated
- [x] All doc references updated
- [x] Issue #627 tracks re-adding Jupiter with proper solar system resolution

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)