### PR TITLE
fix: handle NIRCam compound filter names in prefetch discovery

### DIFF
--- a/processing-engine/scripts/prefetch_discovery.py
+++ b/processing-engine/scripts/prefetch_discovery.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import sys
 import time
@@ -124,16 +125,21 @@ def find_combined_mosaics(
         if any(det in fname_lower for det in DETECTOR_FRAGMENTS):
             continue
 
-        # Extract filter from filename (e.g., jw..._miri_f770w_i2d.fits)
-        parts = fname_lower.replace("_i2d.fits", "").split("_")
-        filt = None
-        for part in parts:
-            if part.upper() in FILTER_WAVELENGTHS:
-                filt = part.upper()
-                break
+        # Extract filter from filename.
+        # MIRI: jw..._miri_f770w_i2d.fits → split by _ gives "f770w"
+        # NIRCam: jw..._nircam_clear-f090w_i2d.fits → split by _ gives "clear-f090w"
+        # NIRCam dual: jw..._nircam_f405n-f444w_i2d.fits → split by _ gives "f405n-f444w"
+        # Strategy: split by both _ and -, check each token against FILTER_WAVELENGTHS.
+        # For dual-filter names, pick the shorter wavelength as the primary filter.
+        stem = fname_lower.replace("_i2d.fits", "")
+        tokens = re.split(r"[_\-]", stem)
+        found_filters = [t.upper() for t in tokens if t.upper() in FILTER_WAVELENGTHS]
 
-        if filt is None:
+        if not found_filters:
             continue
+
+        # Pick the primary filter (shortest wavelength for consistency)
+        filt = min(found_filters, key=lambda f: FILTER_WAVELENGTHS.get(f, 999))
 
         # Determine instrument from filter wavelength
         wl = FILTER_WAVELENGTHS.get(filt, 0)


### PR DESCRIPTION
## Summary
Fix NIRCam filter extraction in the prefetch discovery script to handle compound filter names.

## Why
NIRCam L3 mosaics use compound filter names like `clear-f090w` and `f405n-f444w`. The previous filter extraction only split on `_`, so tokens like `clear-f090w` didn't match any known filter. This caused the dry-run to miss all NIRCam mosaics.

## Type of Change
- [x] Bug fix

## Changes Made
- Split mosaic filenames on both `_` and `-` using `re.split(r"[_\-]", stem)` instead of just `split("_")`
- When multiple filter tokens match (compound names), pick the shortest-wavelength filter as the canonical name
- Added `import re` for the regex split

## Test Plan
- [x] Verified MIRI filters still extract correctly (Southern Ring dry-run)
- [x] Verified NIRCam compound filters extract correctly (`clear-f090w` → `F090W`, `f405n-f444w` → `F405N`)
- [x] Full `--all-instruments` dry-run across all 12 targets completed successfully

## Documentation Checklist
- [x] No documentation changes needed — script-only fix

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — only affects the prefetch script, no production code changes.
Rollback: Revert the commit.

## Quality Checklist
- [x] Code follows project conventions
- [x] No security concerns

🤖 Generated with [Claude Code](https://claude.com/claude-code)