### PR TITLE
feat: group instrument filter by JWST instrument with mode sub-options

### DIFF
--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -188,17 +188,27 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     );
   }, [afterTypeFilter, selectedProcessingLevel]);
 
+  // Extract instrument prefix from full instrument_name (e.g. "NIRCAM/IMAGE" → "NIRCAM")
+  const getInstrumentGroup = (inst: string | undefined) => {
+    if (!inst) return null;
+    const slash = inst.indexOf('/');
+    return slash > 0 ? inst.substring(0, slash) : inst;
+  };
+
   const availableInstruments = useMemo(() => {
-    const counts = new Map<string, number>();
+    const groupCounts = new Map<string, number>();
+    const modeCounts = new Map<string, number>();
     afterLevelFilter.forEach((item) => {
       const inst = item.imageInfo?.instrument || item.sensorInfo?.instrument;
       if (inst) {
-        counts.set(inst, (counts.get(inst) || 0) + 1);
+        modeCounts.set(inst, (modeCounts.get(inst) || 0) + 1);
+        const group = getInstrumentGroup(inst)!;
+        groupCounts.set(group, (groupCounts.get(group) || 0) + 1);
       } else {
-        counts.set('Unknown', (counts.get('Unknown') || 0) + 1);
+        groupCounts.set('Unknown', (groupCounts.get('Unknown') || 0) + 1);
       }
     });
-    return counts;
+    return { groupCounts, modeCounts };
   }, [afterLevelFilter]);
 
   const afterInstrumentFilter = useMemo(() => {
@@ -206,6 +216,12 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     return afterLevelFilter.filter((item) => {
       const inst = item.imageInfo?.instrument || item.sensorInfo?.instrument;
       if (selectedInstrument === 'Unknown') return !inst;
+      // Group-level filter (e.g. "__MIRI" matches all MIRI/* modes)
+      if (selectedInstrument.startsWith('__')) {
+        const group = selectedInstrument.substring(2);
+        return getInstrumentGroup(inst) === group;
+      }
+      // Exact mode filter (e.g. "MIRI/IMAGE")
       return inst === selectedInstrument;
     });
   }, [afterLevelFilter, selectedInstrument]);
@@ -228,14 +244,21 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     return Array.from(tagsByKey.entries())
       .map(([value, { label, count }]) => ({ value, label, count }))
       .sort((a, b) => a.label.localeCompare(b.label));
-  }, [afterLevelFilter]);
+  }, [afterInstrumentFilter]);
 
   // Auto-reset downstream filters when upstream changes make current selection invalid
   // (adjust state during render)
   if (selectedProcessingLevel !== 'all' && !availableLevels.has(selectedProcessingLevel)) {
     setSelectedProcessingLevel('all');
   }
-  if (selectedInstrument !== 'all' && !availableInstruments.has(selectedInstrument)) {
+  if (
+    selectedInstrument !== 'all' &&
+    !(selectedInstrument.startsWith('__')
+      ? availableInstruments.groupCounts.has(selectedInstrument.substring(2))
+      : selectedInstrument === 'Unknown'
+        ? availableInstruments.groupCounts.has('Unknown')
+        : availableInstruments.modeCounts.has(selectedInstrument))
+  ) {
     setSelectedInstrument('all');
   }
   if (selectedTag !== 'all' && !availableTags.some((t) => t.value === selectedTag)) {

--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.test.tsx
@@ -26,7 +26,10 @@ describe('DashboardToolbar', () => {
       tableCount: 2,
     },
     availableLevels: new Map<string, number>(),
-    availableInstruments: new Map<string, number>(),
+    availableInstruments: {
+      groupCounts: new Map<string, number>(),
+      modeCounts: new Map<string, number>(),
+    },
     availableTags: [],
     viewMode: 'lineage' as const,
     onViewModeChange: vi.fn(),

--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
@@ -26,7 +26,10 @@ interface DashboardToolbarProps {
     tableCount: number;
   };
   availableLevels: Map<string, number>;
-  availableInstruments: Map<string, number>;
+  availableInstruments: {
+    groupCounts: Map<string, number>;
+    modeCounts: Map<string, number>;
+  };
   availableTags: Array<{ value: string; label: string; count: number }>;
 
   viewMode: 'lineage' | 'target';
@@ -190,27 +193,41 @@ const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
               onChange={(e) => onInstrumentChange(e.target.value)}
             >
               <option value="all">All Instruments ({afterLevelFilterCount})</option>
-              {['NIRCam', 'MIRI', 'NIRISS', 'NIRSpec'].map((inst) => {
-                const count = availableInstruments.get(inst) || 0;
-                return count > 0 ? (
-                  <option key={inst} value={inst}>
-                    {inst} ({count})
-                  </option>
-                ) : null;
+              {['MIRI', 'NIRCAM', 'NIRISS', 'NIRSPEC'].map((group) => {
+                const groupCount = availableInstruments.groupCounts.get(group) || 0;
+                if (groupCount === 0) return null;
+                // Find modes for this group
+                const modes = Array.from(availableInstruments.modeCounts.entries())
+                  .filter(([mode]) => mode.startsWith(group + '/'))
+                  .sort(([a], [b]) => a.localeCompare(b));
+                // Single mode — no need for optgroup, just show the mode directly
+                if (modes.length <= 1) {
+                  return (
+                    <option key={group} value={modes.length === 1 ? modes[0][0] : `__${group}`}>
+                      {group} ({groupCount})
+                    </option>
+                  );
+                }
+                return (
+                  <optgroup key={group} label={`${group} (${groupCount})`}>
+                    <option value={`__${group}`}>
+                      All {group} ({groupCount})
+                    </option>
+                    {modes.map(([mode, count]) => {
+                      const modeSuffix = mode.substring(group.length + 1);
+                      return (
+                        <option key={mode} value={mode}>
+                          {modeSuffix} ({count})
+                        </option>
+                      );
+                    })}
+                  </optgroup>
+                );
               })}
-              {/* Show any other instruments not in the standard list */}
-              {Array.from(availableInstruments.entries())
-                .filter(
-                  ([inst]) => !['NIRCam', 'MIRI', 'NIRISS', 'NIRSpec', 'Unknown'].includes(inst)
-                )
-                .sort(([a], [b]) => a.localeCompare(b))
-                .map(([inst, count]) => (
-                  <option key={inst} value={inst}>
-                    {inst} ({count})
-                  </option>
-                ))}
-              {(availableInstruments.get('Unknown') || 0) > 0 && (
-                <option value="Unknown">Unknown ({availableInstruments.get('Unknown')})</option>
+              {(availableInstruments.groupCounts.get('Unknown') || 0) > 0 && (
+                <option value="Unknown">
+                  Unknown ({availableInstruments.groupCounts.get('Unknown')})
+                </option>
               )}
             </select>
           </div>

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -70,14 +70,19 @@ const DataCard: React.FC<DataCardProps> = ({
           <span className={`fits-type-badge ${fitsInfo.type}`} title={fitsInfo.description}>
             {fitsInfo.viewable ? <ImageIcon /> : <TableIcon />} {fitsInfo.label}
           </span>
-          {(item.imageInfo?.instrument || item.sensorInfo?.instrument) && (
-            <span
-              className={`instrument-badge ${(item.imageInfo?.instrument || item.sensorInfo?.instrument || '').toLowerCase()}`}
-              title={`Instrument: ${item.imageInfo?.instrument || item.sensorInfo?.instrument}`}
-            >
-              {item.imageInfo?.instrument || item.sensorInfo?.instrument}
-            </span>
-          )}
+          {(item.imageInfo?.instrument || item.sensorInfo?.instrument) &&
+            (() => {
+              const inst = item.imageInfo?.instrument || item.sensorInfo?.instrument || '';
+              const group = inst.includes('/') ? inst.substring(0, inst.indexOf('/')) : inst;
+              return (
+                <span
+                  className={`instrument-badge ${group.toLowerCase()}`}
+                  title={`Instrument: ${inst}`}
+                >
+                  {inst}
+                </span>
+              );
+            })()}
           {item.imageInfo?.filter && (
             <span className="filter-badge" title={`Filter: ${item.imageInfo.filter}`}>
               {item.imageInfo.filter}

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
@@ -69,14 +69,19 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
             <span className={`fits-type-badge small ${fitsInfo.type}`} title={fitsInfo.description}>
               {fitsInfo.viewable ? <ImageIcon /> : <TableIcon />}
             </span>
-            {(item.imageInfo?.instrument || item.sensorInfo?.instrument) && (
-              <span
-                className={`instrument-badge small ${(item.imageInfo?.instrument || item.sensorInfo?.instrument || '').toLowerCase()}`}
-                title={`Instrument: ${item.imageInfo?.instrument || item.sensorInfo?.instrument}`}
-              >
-                {item.imageInfo?.instrument || item.sensorInfo?.instrument}
-              </span>
-            )}
+            {(item.imageInfo?.instrument || item.sensorInfo?.instrument) &&
+              (() => {
+                const inst = item.imageInfo?.instrument || item.sensorInfo?.instrument || '';
+                const group = inst.includes('/') ? inst.substring(0, inst.indexOf('/')) : inst;
+                return (
+                  <span
+                    className={`instrument-badge small ${group.toLowerCase()}`}
+                    title={`Instrument: ${inst}`}
+                  >
+                    {inst}
+                  </span>
+                );
+              })()}
             {item.imageInfo?.filter && (
               <span className="filter-badge small" title={`Filter: ${item.imageInfo.filter}`}>
                 {item.imageInfo.filter}


### PR DESCRIPTION
## Summary
- Restructures the instrument filter dropdown to group by the 4 JWST instruments (MIRI, NIRCam, NIRISS, NIRSpec)
- Each instrument with multiple modes gets an `<optgroup>` with "All [instrument]" and individual mode options (IMAGE, IFU, CORON, WFSS)
- Fixes badge CSS colors to use instrument prefix (e.g. `MIRI/IMAGE` → `.miri` class)

## Why
The raw MAST `instrument_name` values (e.g. `MIRI/IFU`, `NIRCAM/IMAGE`) weren't matching the hardcoded filter options. Users need to filter by instrument (all MIRI regardless of mode) and optionally drill down to a specific observation mode.

## Type of Change
- [x] Enhancement to existing feature

## Changes Made
- Restructured `availableInstruments` from flat `Map<string, number>` to `{ groupCounts, modeCounts }` in `JwstDataDashboard.tsx`
- Filter logic: `__MIRI` prefix selects all MIRI modes, `MIRI/IMAGE` selects exact mode
- `DashboardToolbar.tsx`: renders `<optgroup>` per instrument with mode sub-options (single-mode instruments render as flat option)
- `DataCard.tsx` / `LineageFileCard.tsx`: badge CSS class uses instrument prefix for correct color coding
- Updated tests for new data structure

## Test Plan
- [x] All 884 frontend unit tests pass
- [ ] Open library page — instrument dropdown shows grouped structure
- [ ] Select "All MIRI" — shows MIRI/IMAGE + MIRI/IFU + MIRI/CORON files
- [ ] Select "IMAGE" under MIRI — shows only MIRI/IMAGE files
- [ ] Select "NIRCAM" — shows all NIRCAM/IMAGE files
- [ ] Verify badge colors match instrument (MIRI=red, NIRCAM=blue, etc.)
- [ ] Verify cascading reset works when upstream filter removes all items for current instrument

## Documentation Checklist
- [x] No new controllers, services, or endpoints added
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — frontend-only, follows existing optgroup pattern from Type filter.
Rollback: Revert this single commit.

## Quality Checklist
- [x] Self-reviewed
- [x] Tests updated
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)