### PR TITLE
fix: include all branches in git log for devblog commit detection

### DIFF
--- a/scripts/generate-session-blog.sh
+++ b/scripts/generate-session-blog.sh
@@ -66,7 +66,7 @@ fetch_data() {
   fi
 
   echo "Collecting git log..."
-  git -C "$PROJECT_ROOT" log --format='%H|%ad|%s' --date=short > "$CACHE_DIR/git-log.txt"
+  git -C "$PROJECT_ROOT" log --all --format='%H|%ad|%s' --date=short > "$CACHE_DIR/git-log.txt"
   echo "  $(wc -l < "$CACHE_DIR/git-log.txt" | tr -d ' ') commits"
 }
 


### PR DESCRIPTION
## Summary

Fix the devblog generator showing 0 commits on days when work exists only on unmerged feature branches.

## Why

\`git log\` without \`--all\` only traverses commits reachable from \`main\`. On days when commits are on a feature branch that hasn't been merged yet, the count comes back 0 — even though real work was done that day.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- \`scripts/generate-session-blog.sh\`: Added \`--all\` flag to the \`git log\` command so commit detection includes all local branches, not just \`main\`

## Test Plan

- [x] Run \`./scripts/generate-session-blog.sh --date <today>\` while on a feature branch with commits — commit count should now be non-zero
- [ ] Run without \`--refresh\` on a date with only merged commits — output should be unchanged

## Documentation Checklist

- [x] No documentation updates needed

## Tech Debt Impact

- [x] No tech debt impact

## Risk & Rollback

Risk: Low — single-flag addition to a local git command. Only affects devblog scripts, no application code.
Rollback: Remove \`--all\` from the \`git log\` call in \`scripts/generate-session-blog.sh\`.

## Quality Checklist

- [x] Code follows project conventions
- [x] No new dependencies introduced