### PR TITLE
fix: add title to March 4 blog post

### DIFF
--- a/docs/blog/posts/2026-03-04.md
+++ b/docs/blog/posts/2026-03-04.md
@@ -18,7 +18,7 @@ authors:
   - shanon
 ---
 
-# March 4:
+# March 4: Signal From Noise
 
 <!-- enriched -->
 


### PR DESCRIPTION
## Summary
Add missing descriptive title to the March 4 blog post.

## Why
The generate script left the title as `# March 4:` with no subtitle. All other posts have descriptive titles (e.g., "March 3: The Intern's First Day").

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Changed title from `# March 4:` to `# March 4: Signal From Noise`

## Test Plan
- [x] Verify title renders on GitHub Pages blog

## Documentation Checklist
- [x] This is the documentation update

## Tech Debt Impact
- [x] No tech debt impact

## Risk & Rollback
Risk: None — single line docs change.
Rollback: Revert commit.

## Quality Checklist
- [x] No new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)