### PR TITLE
docs: update March 4 blog post with evening session

### DIFF
--- a/docs/blog/posts/2026-03-04.md
+++ b/docs/blog/posts/2026-03-04.md
@@ -22,7 +22,7 @@ authors:
 
 <!-- enriched -->
 
-A marathon session: 18 pull requests merged (7 features, 7 fixes, 1 docs, 1 refactor, 2 maintenance). Major work on the composite imaging pipeline.
+A marathon session: 19 pull requests merged (7 features, 7 fixes, 2 docs, 1 refactor, 2 maintenance) plus a full roadmap restructure and codebase security audit. Major work on the composite imaging pipeline, then project management in the evening.
 
 <!-- more -->
 
@@ -45,6 +45,8 @@ Running that validation script on AWS surfaced some real issues. NIRCam had to b
 ![Full prefetch validation report showing 3.30 GB across 12 targets with 36 of 36 composite validations passing](../images/2026-03-04/image-6.png)
 
 Later in the day, the library page got instrument filtering — first as a flat dropdown, then upgraded to a grouped tree structure matching how JWST instruments actually work (MIRI/IMAGE, NIRCAM/CORON, etc.), plus color-coded instrument badges on every file card. Wrapped up with a quick design system cleanup, standardizing the last two hardcoded 30px icon buttons into the shared `.btn-icon-sm` class.
+
+The evening session shifted to project management. The development roadmap had grown to 711 lines — 280 of 318 items checked off, mostly historical noise. Restructured it into a slim 154-line strategy doc with three forward-looking phases (Production Readiness, Observability, Polish & Community Release) and archived Phases 1–5 into a separate file. Created 13 new GitHub issues for roadmap items that had never been tracked, added `phase:6/7/8` labels to all 39 open issues, and finally got the roadmap and issue tracker in sync. Then ran a codebase audit that surfaced 11 pre-Phase 6 issues — auth race conditions, silent error swallowing, hardcoded timeouts, and four security issues that were actively leaking information on the staging server. Shut down staging until those are fixed. Tomorrow's agenda: harden auth, patch the security leaks, bring staging back up clean.
 
 ## Highlights
 
@@ -86,9 +88,10 @@ Fix composite wizard opening with empty channels when only 2 images are selected
 
 - [#633](https://github.com/Snoww3d/jwst-data-analysis/pull/633) standardize 30px icon buttons with .btn-icon-sm class
 
-### Documentation (1)
+### Documentation (2)
 
 - [#623](https://github.com/Snoww3d/jwst-data-analysis/pull/623) add deploy workflow review to Phase 7 roadmap
+- [#653](https://github.com/Snoww3d/jwst-data-analysis/pull/653) restructure development roadmap into slim 3-phase strategy
 
 ### Maintenance (2)
 
@@ -101,6 +104,8 @@ Fix composite wizard opening with empty channels when only 2 images are selected
 
 - [#617](https://github.com/Snoww3d/jwst-data-analysis/issues/617) — feat: add localStorage caching for searchByTarget and suggestRecipes
 - [#627](https://github.com/Snoww3d/jwst-data-analysis/issues/627) — fix: Jupiter target fails MAST resolution (solar system object)
+- [#640](https://github.com/Snoww3d/jwst-data-analysis/issues/640)–[#652](https://github.com/Snoww3d/jwst-data-analysis/issues/652) — 13 roadmap issues (H-series email, O-series observability, admin dashboard, infrastructure)
+- [#654](https://github.com/Snoww3d/jwst-data-analysis/issues/654)–[#660](https://github.com/Snoww3d/jwst-data-analysis/issues/660) — 7 pre-Phase 6 bugs (auth hardening, API client, SignalR timeout, stale stubs)
 
 **Closed:**
 
@@ -109,5 +114,5 @@ Fix composite wizard opening with empty channels when only 2 images are selected
 - [#627](https://github.com/Snoww3d/jwst-data-analysis/issues/627) — fix: Jupiter target fails MAST resolution (solar system object)
 
 ---
-34 commits across 18 pull requests.
+35 commits across 19 pull requests.
 *Latest session.*


### PR DESCRIPTION
## Summary

Update the March 4 blog post to include the evening session: roadmap restructuring, codebase audit, security triage, and staging shutdown.

## Why

The blog post only covered the morning/afternoon work (18 PRs). The evening session added significant project management work that should be captured.

## Type of Change

- [x] Documentation update

## Changes Made

- Added paragraph about roadmap restructuring (711→154 lines), issue triage, and security audit
- Updated PR count (18→19) and summary line
- Added #653 to Documentation section
- Added 20 new issues (#640-#660) to Issues section

## Test Plan

- [x] Blog post renders correctly in markdown preview

## Documentation Checklist

- [x] No documentation updates needed
- [ ] `docs/standards/backend-development.md` — no changes needed
- [ ] `docs/architecture.md` — no changes needed
- [ ] `docs/quick-reference.md` — no changes needed
- [ ] `docs/tech-debt.md` — no changes needed

## Tech Debt Impact

- [x] No tech debt added

## Risk & Rollback

Risk: None — blog post content only.
Rollback: Revert commit.

## Quality Checklist

- [x] I have performed a self-review of my changes
- [x] Documentation has been updated accordingly
- [x] No breaking changes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)