### PR TITLE
feat: add Release Date column to MAST search results

### DIFF
--- a/frontend/jwst-frontend/src/components/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/MastSearch.tsx
@@ -1013,6 +1013,7 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete, importedObsId
                   <th className="col-filter">Filter</th>
                   <th className="col-exptime">Exp Time</th>
                   <th className="col-date">Obs Date</th>
+                  <th className="col-date">Release Date</th>
                   <th className="col-actions">Actions</th>
                 </tr>
               </thead>
@@ -1041,6 +1042,7 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete, importedObsId
                       </td>
                       <td className="col-exptime">{formatExposureTime(result.t_exptime)}</td>
                       <td className="col-date">{formatDate(result.t_min)}</td>
+                      <td className="col-date">{formatDate(result.t_obs_release)}</td>
                       <td className="col-actions">
                         {result.obs_id && importedObsIds?.has(result.obs_id) ? (
                           <button className="btn-base btn-standard import-btn imported" disabled>


### PR DESCRIPTION
No linked issue

## Summary

Adds a "Release Date" column to the MAST search results table, showing when each observation's data became publicly available (`t_obs_release`).

## Why

The release date helps users identify newly released observations vs older data. The field was already being fetched from MAST and defined in the TypeScript types — just not displayed.

## Changes Made

- Add "Release Date" column header and data cell to the MAST search results table in `MastSearch.tsx`
- Reuses existing `formatDate()` utility (MJD → locale date string) and `col-date` CSS class

## Test Plan

- [x] Lint, type check, and unit tests pass locally
- [x] E2E tests unaffected (no column-specific selectors)
- [x] Verified `t_obs_release` is already in `MastObservationResult` interface and returned by all MAST search endpoints

## Documentation Checklist

- [x] No documentation updates needed

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

- Risk: None — additive UI column, no backend changes
- Rollback: Revert commit