### PR TITLE
refactor: extract shared stretch types from composite and mosaic wizards

### DIFF
--- a/frontend/jwst-frontend/src/components/StretchControls.test.tsx
+++ b/frontend/jwst-frontend/src/components/StretchControls.test.tsx
@@ -133,6 +133,6 @@ describe('StretchControls', () => {
 
   it('shows stretch description hint', () => {
     renderControls();
-    expect(screen.getByText('Automatic robust scaling (default)')).toBeInTheDocument();
+    expect(screen.getByText('Automatic robust scaling')).toBeInTheDocument();
   });
 });

--- a/frontend/jwst-frontend/src/components/StretchControls.tsx
+++ b/frontend/jwst-frontend/src/components/StretchControls.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { STRETCH_OPTIONS } from '../types/StretchTypes';
 import { ToneCurve } from '../types/CompositeTypes';
 import './StretchControls.css';
 
@@ -18,16 +19,6 @@ interface StretchControlsProps {
   collapsed?: boolean;
   onToggleCollapse?: () => void;
 }
-
-const STRETCH_OPTIONS = [
-  { value: 'zscale', label: 'ZScale', description: 'Automatic robust scaling (default)' },
-  { value: 'asinh', label: 'Asinh', description: 'High dynamic range, preserves faint detail' },
-  { value: 'log', label: 'Logarithmic', description: 'Extended emission, nebulae' },
-  { value: 'sqrt', label: 'Square Root', description: 'Moderate compression' },
-  { value: 'power', label: 'Power Law', description: 'Customizable with gamma' },
-  { value: 'histeq', label: 'Histogram Eq.', description: 'Maximum contrast' },
-  { value: 'linear', label: 'Linear', description: 'No compression' },
-];
 
 const CURVE_OPTIONS: Array<{
   value: ToneCurve;

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -12,6 +12,7 @@ import {
   StretchMethod,
   COMPOSITE_PRESETS,
   CompositePreset,
+  STRETCH_OPTIONS,
 } from '../../types/CompositeTypes';
 import { compositeService } from '../../services';
 import { getFilterLabel, channelColorToHex } from '../../utils/wavelengthUtils';
@@ -20,16 +21,6 @@ import { useSimulatedProgress } from '../../hooks/useSimulatedProgress';
 import { apiClient } from '../../services/apiClient';
 import StretchControls, { StretchParams } from '../StretchControls';
 import './CompositePreviewStep.css';
-
-const STRETCH_OPTIONS: Array<{ value: StretchMethod; label: string; description: string }> = [
-  { value: 'zscale', label: 'ZScale', description: 'Automatic robust scaling (default)' },
-  { value: 'asinh', label: 'Asinh', description: 'High dynamic range, preserves faint detail' },
-  { value: 'log', label: 'Logarithmic', description: 'Extended emission, nebulae' },
-  { value: 'sqrt', label: 'Square Root', description: 'Moderate compression' },
-  { value: 'power', label: 'Power Law', description: 'Customizable with gamma' },
-  { value: 'histeq', label: 'Histogram Eq.', description: 'Maximum contrast' },
-  { value: 'linear', label: 'Linear', description: 'No compression' },
-];
 
 interface CompositePreviewStepProps {
   selectedImages: JwstDataModel[];

--- a/frontend/jwst-frontend/src/components/wizard/MosaicPreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/MosaicPreviewStep.tsx
@@ -16,9 +16,9 @@ import {
   DEFAULT_MOSAIC_FILE_PARAMS,
   COMBINE_METHODS,
   MOSAIC_COLORMAPS,
-  MOSAIC_STRETCH_OPTIONS,
-  MosaicStretchMethod,
+  STRETCH_OPTIONS,
 } from '../../types/MosaicTypes';
+import type { StretchMethod } from '../../types/StretchTypes';
 import { ApiError } from '../../services/ApiError';
 import * as mosaicService from '../../services/mosaicService';
 import { useJobProgress } from '../../hooks/useJobProgress';
@@ -76,7 +76,7 @@ export const MosaicPreviewStep = ({
   // Mosaic settings
   const [combineMethod, setCombineMethod] = useState<MosaicRequest['combineMethod']>('mean');
   const [cmap, setCmap] = useState<MosaicRequest['cmap']>('grayscale');
-  const [stretch, setStretch] = useState<MosaicStretchMethod>('asinh');
+  const [stretch, setStretch] = useState<StretchMethod>('asinh');
 
   // Export options
   const [outputFormat, setOutputFormat] = useState<'png' | 'jpeg'>('png');
@@ -643,9 +643,9 @@ export const MosaicPreviewStep = ({
           <select
             id="mosaic-stretch"
             value={stretch}
-            onChange={(e) => setStretch(e.target.value as MosaicStretchMethod)}
+            onChange={(e) => setStretch(e.target.value as StretchMethod)}
           >
-            {MOSAIC_STRETCH_OPTIONS.map((option) => (
+            {STRETCH_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label} - {option.description}
               </option>

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -2,18 +2,18 @@
  * TypeScript types for composite creator wizard
  */
 
+import type { BaseStretchParams } from './StretchTypes';
+
+export type { StretchMethod } from './StretchTypes';
+export { DEFAULT_STRETCH_PARAMS, STRETCH_OPTIONS } from './StretchTypes';
+export type { BaseStretchParams } from './StretchTypes';
+
 export type ToneCurve = 'linear' | 's_curve' | 'inverse_s' | 'shadows' | 'highlights';
-export type StretchMethod = 'zscale' | 'asinh' | 'log' | 'sqrt' | 'power' | 'histeq' | 'linear';
 
 /**
- * Per-channel stretch parameters
+ * Per-channel stretch parameters — extends base with composite-specific fields.
  */
-export interface ChannelStretchParams {
-  stretch: StretchMethod;
-  blackPoint: number;
-  whitePoint: number;
-  gamma: number;
-  asinhA: number;
+export interface ChannelStretchParams extends BaseStretchParams {
   curve: ToneCurve;
   weight: number; // 0.0-2.0
 }
@@ -21,13 +21,7 @@ export interface ChannelStretchParams {
 /**
  * Global post-stack levels and stretch adjustments.
  */
-export interface OverallAdjustments {
-  stretch: StretchMethod;
-  blackPoint: number;
-  whitePoint: number;
-  gamma: number;
-  asinhA: number;
-}
+export type OverallAdjustments = BaseStretchParams;
 
 /**
  * Export options for the final composite

--- a/frontend/jwst-frontend/src/types/MosaicTypes.ts
+++ b/frontend/jwst-frontend/src/types/MosaicTypes.ts
@@ -2,17 +2,11 @@
  * TypeScript types for WCS Mosaic Creator wizard
  */
 
-/**
- * Supported stretch methods for single-channel mosaic rendering.
- */
-export type MosaicStretchMethod =
-  | 'zscale'
-  | 'asinh'
-  | 'log'
-  | 'sqrt'
-  | 'power'
-  | 'histeq'
-  | 'linear';
+import type { StretchMethod } from './StretchTypes';
+import { DEFAULT_STRETCH_PARAMS } from './StretchTypes';
+
+export type { StretchMethod } from './StretchTypes';
+export { STRETCH_OPTIONS } from './StretchTypes';
 
 /**
  * Supported combine methods for overlapping mosaic pixels.
@@ -37,7 +31,7 @@ export type MosaicColormap =
  */
 export interface MosaicFileConfig {
   dataId: string;
-  stretch: MosaicStretchMethod;
+  stretch: StretchMethod;
   blackPoint: number; // 0.0-1.0
   whitePoint: number; // 0.0-1.0
   gamma: number; // 0.1-5.0
@@ -106,32 +100,11 @@ export interface MosaicLimits {
 export type MosaicWizardStep = 1 | 2;
 
 /**
- * Default file stretch parameters
+ * Default file stretch parameters — uses shared defaults.
  */
 export const DEFAULT_MOSAIC_FILE_PARAMS = {
-  stretch: 'asinh',
-  blackPoint: 0.0,
-  whitePoint: 1.0,
-  gamma: 1.0,
-  asinhA: 0.1,
+  ...DEFAULT_STRETCH_PARAMS,
 } satisfies Omit<MosaicFileConfig, 'dataId'>;
-
-/**
- * Available stretch methods.
- */
-export const MOSAIC_STRETCH_OPTIONS: ReadonlyArray<{
-  value: MosaicStretchMethod;
-  label: string;
-  description: string;
-}> = [
-  { value: 'asinh', label: 'Asinh', description: 'High dynamic range, preserves faint detail' },
-  { value: 'zscale', label: 'ZScale', description: 'Automatic robust scaling' },
-  { value: 'log', label: 'Logarithmic', description: 'Highlights faint extended structure' },
-  { value: 'sqrt', label: 'Square Root', description: 'Moderate contrast boost' },
-  { value: 'power', label: 'Power Law', description: 'Gamma-driven intensity shaping' },
-  { value: 'histeq', label: 'Histogram Eq.', description: 'Maximum local contrast' },
-  { value: 'linear', label: 'Linear', description: 'No nonlinear stretch' },
-];
 
 /**
  * Available combine methods

--- a/frontend/jwst-frontend/src/types/StretchTypes.ts
+++ b/frontend/jwst-frontend/src/types/StretchTypes.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared stretch types used by both composite and mosaic wizards.
+ */
+
+export type StretchMethod = 'zscale' | 'asinh' | 'log' | 'sqrt' | 'power' | 'histeq' | 'linear';
+
+/**
+ * Base stretch parameters shared between composite channels and mosaic files.
+ */
+export interface BaseStretchParams {
+  stretch: StretchMethod;
+  blackPoint: number;
+  whitePoint: number;
+  gamma: number;
+  asinhA: number;
+}
+
+export const DEFAULT_STRETCH_PARAMS: BaseStretchParams = {
+  stretch: 'asinh',
+  blackPoint: 0.0,
+  whitePoint: 1.0,
+  gamma: 1.0,
+  asinhA: 0.05,
+};
+
+export const STRETCH_OPTIONS: ReadonlyArray<{
+  value: StretchMethod;
+  label: string;
+  description: string;
+}> = [
+  { value: 'zscale', label: 'ZScale', description: 'Automatic robust scaling' },
+  { value: 'asinh', label: 'Asinh', description: 'High dynamic range, preserves faint detail' },
+  { value: 'log', label: 'Logarithmic', description: 'Extended emission, nebulae' },
+  { value: 'sqrt', label: 'Square Root', description: 'Moderate compression' },
+  { value: 'power', label: 'Power Law', description: 'Customizable with gamma' },
+  { value: 'histeq', label: 'Histogram Eq.', description: 'Maximum contrast' },
+  { value: 'linear', label: 'Linear', description: 'No compression' },
+];


### PR DESCRIPTION
## Summary

Consolidates duplicated stretch types between composite and mosaic wizards into a single shared module.

## Why

`StretchMethod` type, `STRETCH_OPTIONS` array, and base stretch params were duplicated in three places (`CompositeTypes.ts`, `MosaicTypes.ts`, `StretchControls.tsx`). Changes had to be made in multiple files to stay in sync.

## Changes Made

- **New `StretchTypes.ts`**: Single source of truth for `StretchMethod`, `BaseStretchParams`, `DEFAULT_STRETCH_PARAMS`, and `STRETCH_OPTIONS`
- **`CompositeTypes.ts`**: Removed local `StretchMethod`, re-exports from shared. `ChannelStretchParams extends BaseStretchParams`. `OverallAdjustments` is now a type alias for `BaseStretchParams`.
- **`MosaicTypes.ts`**: Removed `MosaicStretchMethod` and `MOSAIC_STRETCH_OPTIONS`. Re-exports from shared. `DEFAULT_MOSAIC_FILE_PARAMS` spreads `DEFAULT_STRETCH_PARAMS` (asinhA now 0.05, was 0.1).
- **`StretchControls.tsx`**: Removed local `STRETCH_OPTIONS`, imports from shared.
- **`CompositePreviewStep.tsx`**: Removed local `STRETCH_OPTIONS`, imports via `CompositeTypes` re-export.
- **`MosaicPreviewStep.tsx`**: Updated imports from `StretchMethod`/`STRETCH_OPTIONS` (shared).
- **`StretchControls.test.tsx`**: Updated expected description text (removed "(default)" from ZScale).

**Net: -76 lines removed, +63 added (13 lines shorter), 0 type duplications.**

## Test Plan

- [x] Frontend: 878/878 tests pass
- [x] TypeScript compiles clean
- [x] ESLint + Prettier pass
- [x] Pre-commit hooks pass

## Documentation Checklist

- [x] No new endpoints, components, or API changes — frontend type consolidation only
- [ ] `docs/key-files.md` updated
- [ ] `docs/standards/backend-development.md` updated

## Tech Debt Impact

- [x] Reduces tech debt — eliminates 3-way type/constant duplication

## Risk & Rollback

Risk: Low — frontend-only refactor, types are structurally identical.
Rollback: Revert commit.

Closes #690