### PR TITLE
docs: add NASA NGC 5134 image to March 5 blog post

### DIFF
--- a/docs/blog/posts/2026-03-05.md
+++ b/docs/blog/posts/2026-03-05.md
@@ -28,7 +28,8 @@ A slower day between interview prep and wrapping up Phase 5. Four pull requests 
 
 Started the morning expecting a light day. Interviews later, Phase 5 wrapping up, not much energy for deep feature work. But then a JWST ["space photo of the day"](https://www.space.com/astronomy/james-webb-space-telescope/spectacular-spiral-galaxy-revealed-by-james-webb-space-telescope-space-photo-of-the-day-for-march-4-2026) showed up — a spectacular spiral galaxy composited from eight wavelengths across both MIRI and NIRCam, taken back in June 2024 and only now reaching the public. The kind of image that makes you stop scrolling.
 
-![NASA JWST space photo of the day showing a spiral galaxy composited from 8 wavelengths](../images/2026-03-05/image.png)
+![Spiral galaxy NGC 5134 captured by the James Webb Space Telescope](https://cdn.mos.cms.futurecdn.net/fZ7W5cMZW9yigxY63qLDkP.jpg)
+*NGC 5134 — the JWST "space photo of the day" that started the compositing quality conversation. Credit: NASA/ESA/CSA/STScI*
 
 ![Screenshot from development session comparing NASA composite quality](../images/2026-03-05/image-2.png)
 


### PR DESCRIPTION
No linked issue

## Summary

- Replace local screenshot with full-resolution NASA/ESA/CSA image of NGC 5134 from Space.com CDN
- Add credit line

## Changes Made

- `docs/blog/posts/2026-03-05.md` — swap local image for CDN URL with attribution

## Test Plan

- [x] Blog post renders correctly with external image

## Documentation Checklist

- [x] No documentation updates needed

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

Risk: None — docs only
Rollback: Revert commit