### PR TITLE
docs: fix stale documentation across project

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 - [ ] `docs/key-files.md` (new files/services)
 - [ ] `docs/standards/backend-development.md` (new endpoints/controllers)
 - [ ] `docs/quick-reference.md` (new API endpoints)
-- [ ] `docs/architecture.md` (new services/architectural changes)
+- [ ] `docs/architecture/` (new services/architectural changes)
 - [ ] `docs/development-plan.md` (milestone/phase changes)
 
 ## Tech Debt Impact

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -90,9 +90,17 @@ Visual polish, accessibility fixes, and compositing quality improvements needed 
 
 ### Compositing Quality
 
-| Issue | Description |
-|-------|-------------|
-| [#680](https://github.com/Snoww3d/jwst-data-analysis/issues/680) | **Spike**: Research compositing pipeline to match NASA press image quality |
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#680](https://github.com/Snoww3d/jwst-data-analysis/issues/680) | **Spike**: Research compositing pipeline to match NASA press image quality | Done (see `docs/plans/compositing-quality-spike.md`) |
+| [#687](https://github.com/Snoww3d/jwst-data-analysis/issues/687) | Optimize composite stretch defaults and add NASA-style presets | Done (#689) |
+| [#690](https://github.com/Snoww3d/jwst-data-analysis/issues/690) | Extract shared stretch types from composite and mosaic wizards | Done (#692) |
+| [#683](https://github.com/Snoww3d/jwst-data-analysis/issues/683) | Expose unsharp masking in composite pipeline | Open |
+| [#684](https://github.com/Snoww3d/jwst-data-analysis/issues/684) | Add saturation and vibrancy controls | Open |
+| [#685](https://github.com/Snoww3d/jwst-data-analysis/issues/685) | Add noise reduction pre-composite step | Open |
+| [#688](https://github.com/Snoww3d/jwst-data-analysis/issues/688) | Smart auto-stretch based on histogram analysis | Open |
+| [#686](https://github.com/Snoww3d/jwst-data-analysis/issues/686) | Multi-scale processing / star separation | Open (Phase 6+) |
+| [#691](https://github.com/Snoww3d/jwst-data-analysis/issues/691) | Add stretch presets to mosaic wizard | Open (deferred, low priority) |
 
 ---
 
@@ -146,7 +154,6 @@ Remaining features, tech debt, CI improvements, and release process.
 | Issue | Description |
 |-------|-------------|
 | [#610](https://github.com/Snoww3d/jwst-data-analysis/issues/610) | P19.6: Standardize micro buttons (18×18, 28×28) |
-| [#357](https://github.com/Snoww3d/jwst-data-analysis/issues/357) | Refine RGB composite default stretch |
 | [#253](https://github.com/Snoww3d/jwst-data-analysis/issues/253) | Add demo mode / sample data |
 | [#638](https://github.com/Snoww3d/jwst-data-analysis/issues/638) | Persistent download/import history in MongoDB |
 | [#639](https://github.com/Snoww3d/jwst-data-analysis/issues/639) | Periodic cleanup task for download state files |

--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -143,7 +143,8 @@ Quick reference for finding important files in the codebase.
 - `frontend/jwst-frontend/src/types/JwstDataTypes.ts` - Core JWST data types
 - `frontend/jwst-frontend/src/types/MastTypes.ts` - MAST search and import types
 - `frontend/jwst-frontend/src/types/MosaicTypes.ts` - Mosaic generation types
-- `frontend/jwst-frontend/src/types/CompositeTypes.ts` - RGB composite types
+- `frontend/jwst-frontend/src/types/StretchTypes.ts` - Shared stretch types (StretchMethod, STRETCH_OPTIONS, BaseStretchParams, DEFAULT_STRETCH_PARAMS)
+- `frontend/jwst-frontend/src/types/CompositeTypes.ts` - RGB composite types (extends BaseStretchParams, composite presets)
 - `frontend/jwst-frontend/src/types/AnalysisTypes.ts` - Region selection and statistics types
 - `frontend/jwst-frontend/src/types/AnnotationTypes.ts` - Annotation overlay types
 - `frontend/jwst-frontend/src/types/CurvesTypes.ts` - Tone curve types

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -46,7 +46,7 @@ Common patterns, API endpoints, troubleshooting, and MAST usage tips.
 
 **Main Data Operations**:
 - `GET /jwstdata` - List all | `GET /jwstdata/{id}` - Get one | `POST /jwstdata` - Create
-- `PUT /jwstdata/{id}` - Update | `DELETE /jwstdata/{id}` - Delete | `POST /jwstdata/{id}/process` - Process
+- `PUT /jwstdata/{id}` - Update | `DELETE /jwstdata/{id}` - Delete
 - `GET /jwstdata/type/{dataType}` - Filter by type | `GET /jwstdata/status/{status}` - Filter by status
 
 **Availability & Thumbnails**:
@@ -82,7 +82,7 @@ Common patterns, API endpoints, troubleshooting, and MAST usage tips.
   - `POST /mosaic/save` - Async mosaic FITS save-to-library via job queue (requires auth, returns 202 + jobId, creates new data record)
   - `POST /mosaic/footprint` - WCS footprint polygons
 - **Discovery**:
-  - `GET /api/discovery/featured` - Get featured targets (13 curated JWST targets with metadata)
+  - `GET /api/discovery/featured` - Get featured targets (12 curated JWST targets with metadata)
   - `POST /api/discovery/suggest-recipes` - Generate composite recipe suggestions from observations (proxies to Python recipe engine)
 - **Analysis**: `POST /analysis/region-statistics` - Compute statistics for rectangle/ellipse regions (mean, median, std, min, max, sum, pixel count)
   - `POST /analysis/detect-sources` - Detect astronomical sources (params: thresholdSigma, fwhm, method, npixels, deblend)

--- a/docs/standards/backend-development.md
+++ b/docs/standards/backend-development.md
@@ -72,7 +72,6 @@
 - POST /api/jwstdata - Create new data
 - PUT /api/jwstdata/{id} - Update data
 - DELETE /api/jwstdata/{id} - Delete data
-- POST /api/jwstdata/{id}/process - Process data
 - GET /api/jwstdata/lineage - Get all lineage groups
 - GET /api/jwstdata/lineage/{observationBaseId} - Get lineage for observation
 - POST /api/jwstdata/migrate/processing-levels - Backfill processing levels

--- a/frontend/jwst-frontend/README.md
+++ b/frontend/jwst-frontend/README.md
@@ -1,46 +1,28 @@
-# Getting Started with Create React App
+# JWST Data Analysis — Frontend
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+React + TypeScript frontend for the JWST Data Analysis application, built with Vite.
 
 ## Available Scripts
 
-In the project directory, you can run:
+### `npm run dev`
 
-### `npm start`
-
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Runs the app in development mode at [http://localhost:5173](http://localhost:5173).
 
 ### `npm run build`
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+Type-checks with TypeScript and builds for production via Vite.
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+### `npm test`
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+Runs the test suite with Vitest.
 
-### `npm run eject`
+### `npm run lint`
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+Lints the source with ESLint.
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+## Tech Stack
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+- **Framework**: React 18 with TypeScript
+- **Build Tool**: Vite
+- **Testing**: Vitest + React Testing Library + Playwright (E2E)
+- **Linting**: ESLint + Prettier


### PR DESCRIPTION
No linked issue

## Summary

Deep documentation audit found and fixed stale content across 6 files. Also closed #357 (resolved by #689).

## Changes Made

- **`frontend/jwst-frontend/README.md`** — Replace Create React App boilerplate with accurate Vite-based README
- **`docs/quick-reference.md`** — Fix featured targets count (13 → 12), remove stale `POST /jwstdata/{id}/process` endpoint
- **`docs/standards/backend-development.md`** — Remove stale `POST /jwstdata/{id}/process` endpoint (removed in PR #682)
- **`docs/key-files.md`** — Add `StretchTypes.ts` (new shared type file from PR #692)
- **`docs/development-plan.md`** — Add compositing quality issues (#683-#688, #691) spawned from spike #680; remove #357 (resolved)
- **`.github/PULL_REQUEST_TEMPLATE.md`** — Fix stale `docs/architecture.md` reference → `docs/architecture/`

## Test Plan

- [x] All 878 frontend tests pass
- [x] Pre-commit hooks pass
- [x] No code changes, docs only

## Documentation Checklist

- [x] `docs/key-files.md` (added StretchTypes.ts)
- [x] `docs/standards/backend-development.md` (removed stale endpoint)
- [x] `docs/quick-reference.md` (fixed count, removed stale endpoint)
- [x] `docs/development-plan.md` (added compositing issues)

## Tech Debt Impact

- [x] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback

Risk: None — documentation only
Rollback: Revert commit