### PR TITLE
fix: disable View button for files with pending processing status

### DIFF
--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.test.tsx
@@ -37,6 +37,7 @@ const mockItem: JwstDataModel = {
   dataType: 'image',
   fileSize: 5242880,
   processingStatus: 'completed',
+  filePath: '/app/data/mast/test/test_cal.fits',
   uploadDate: '2026-01-01T00:00:00Z',
   tags: ['nircam', 'deep-field'],
   description: 'Test description',

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -28,7 +28,7 @@ const DataCard: React.FC<DataCardProps> = ({
   onTagClick,
 }) => {
   const fitsInfo = getFitsFileInfo(item.fileName);
-  const isReady = item.processingStatus === 'completed';
+  const hasFile = !!item.filePath;
   const canSelect = fitsInfo.viewable;
 
   return (
@@ -135,11 +135,11 @@ const DataCard: React.FC<DataCardProps> = ({
       <div className="card-actions">
         <button
           onClick={() => onView(item)}
-          className={`btn-base btn-compact view-file-btn ${!isReady || (!fitsInfo.viewable && fitsInfo.type !== 'table') ? 'disabled' : ''}`}
-          disabled={!isReady || (!fitsInfo.viewable && fitsInfo.type !== 'table')}
+          className={`btn-base btn-compact view-file-btn ${!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table') ? 'disabled' : ''}`}
+          disabled={!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table')}
           title={
-            !isReady
-              ? `File is ${item.processingStatus} — not yet viewable`
+            !hasFile
+              ? 'FITS file not available on disk'
               : isSpectralFile(item.fileName)
                 ? 'View spectrum'
                 : fitsInfo.viewable

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.test.tsx
@@ -37,6 +37,7 @@ const mockItem: JwstDataModel = {
   dataType: 'image',
   fileSize: 5242880,
   processingStatus: 'completed',
+  filePath: '/app/data/mast/test/test_cal.fits',
   uploadDate: '2026-01-01T00:00:00Z',
   tags: ['nircam'],
   description: 'Test description',

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
@@ -24,7 +24,7 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
   onArchive,
 }) => {
   const fitsInfo = getFitsFileInfo(item.fileName);
-  const isReady = item.processingStatus === 'completed';
+  const hasFile = !!item.filePath;
   const canSelect = fitsInfo.viewable;
 
   return (
@@ -107,11 +107,11 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
         <div className="file-actions">
           <button
             onClick={() => onView(item)}
-            className={`btn-base view-file-btn ${!isReady || (!fitsInfo.viewable && fitsInfo.type !== 'table') ? 'disabled' : ''}`}
-            disabled={!isReady || (!fitsInfo.viewable && fitsInfo.type !== 'table')}
+            className={`btn-base view-file-btn ${!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table') ? 'disabled' : ''}`}
+            disabled={!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table')}
             title={
-              !isReady
-                ? `File is ${item.processingStatus} — not yet viewable`
+              !hasFile
+                ? 'FITS file not available on disk'
                 : isSpectralFile(item.fileName)
                   ? 'View spectrum'
                   : fitsInfo.viewable


### PR DESCRIPTION
## Summary
Fixes a bug where clicking "View" on a file with no FITS data on disk shows "Preview failed (404)".

## Why
The View button only checked file type (`fitsInfo.viewable`) but not whether the actual FITS file exists. Files imported from MAST can have a thumbnail (from MAST's JPEG URL) and DB record but `filePath: null` — no local FITS file. The backend forwards null to the processing engine which returns 404.

The initial fix incorrectly checked `processingStatus === 'completed'`, but regular imported files never transition from `pending` (only mosaics do). This would have disabled View for all imported files.

Closes #718

## Changes Made
- Added `hasFile` check (`!!item.filePath`) to View button in `DataCard.tsx` and `LineageFileCard.tsx`
- Button is disabled with tooltip "FITS file not available on disk" when filePath is null/empty
- Added `filePath` to test fixtures

## Test Plan
- [x] All 878 frontend unit tests pass
- [ ] Find a file with `filePath: null` in the DB — verify View button is disabled
- [ ] Verify files with valid `filePath` still have a working View button

## Documentation Checklist
- [x] No new endpoints, controllers, or services added
- [ ] `docs/tech-debt.md` updated (if applicable)

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Existing tech debt addressed
- [ ] New tech debt added (tracked in docs/tech-debt.md)

## Risk & Rollback
Risk: Low — only changes disabled state logic on two buttons, no backend changes.
Rollback: Revert the commits.