### PR TITLE
fix: prevent OOM on large composite requests by filtering files and scaling memory

### DIFF
--- a/backend/JwstDataAnalysis.API/Services/CompositeService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.Log.cs
@@ -57,5 +57,11 @@ namespace JwstDataAnalysis.API.Services
             Level = LogLevel.Information,
             Message = "Generating N-channel composite: {ChannelCount} channel(s)")]
         private partial void LogGeneratingNChannelComposite(int channelCount);
+
+        [LoggerMessage(
+            EventId = 10,
+            Level = LogLevel.Information,
+            Message = "Filtered to {Suffix} files: {FilteredCount} of {TotalCount} total")]
+        private partial void LogFilteredToPreferredFileType(string suffix, int filteredCount, int totalCount);
     }
 }

--- a/backend/JwstDataAnalysis.API/Services/CompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 using JwstDataAnalysis.API.Models;
 using JwstDataAnalysis.API.Services.Storage;
@@ -194,7 +195,7 @@ namespace JwstDataAnalysis.API.Services
             var records = await mongoDBService.GetManyAsync(dataIds);
             var recordsById = records.ToDictionary(r => r.Id!);
 
-            var filePaths = new List<string>(dataIds.Count);
+            var allPaths = new List<(string Path, string Suffix)>(dataIds.Count);
             foreach (var dataId in dataIds)
             {
                 if (!recordsById.TryGetValue(dataId, out var data))
@@ -217,10 +218,32 @@ namespace JwstDataAnalysis.API.Services
 
                 var relativePath = StorageKeyHelper.ToRelativeKey(data.FilePath);
                 LogResolvedPath(dataId, data.FilePath, relativePath);
-                filePaths.Add(relativePath);
+
+                // Extract JWST file type suffix (e.g. _i2d, _cal, _rate)
+                var match = Regex.Match(relativePath, @"_(i2d|cal|rate|rateints|uncal|crf|s2d)\.fits$", RegexOptions.IgnoreCase);
+                allPaths.Add((relativePath, match.Success ? match.Groups[1].Value.ToLowerInvariant() : string.Empty));
             }
 
-            return filePaths;
+            // For composite generation, prefer _i2d files (drizzle-combined, fully calibrated).
+            // Fall back to _cal, then _s2d, then all files if no preferred types exist.
+            // This prevents OOM from loading hundreds of intermediate calibration products.
+            var preferredSuffixes = new[] { "i2d", "cal", "s2d" };
+            foreach (var suffix in preferredSuffixes)
+            {
+                var filtered = allPaths.Where(p => p.Suffix == suffix).Select(p => p.Path).ToList();
+                if (filtered.Count > 0)
+                {
+                    if (filtered.Count < allPaths.Count)
+                    {
+                        LogFilteredToPreferredFileType(suffix, filtered.Count, allPaths.Count);
+                    }
+
+                    return filtered;
+                }
+            }
+
+            // No preferred types found — return all paths as-is
+            return allPaths.Select(p => p.Path).ToList();
         }
     }
 }

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -415,12 +415,24 @@ async def generate_nchannel_composite(request: NChannelCompositeRequest):
                 local_paths = [resolve_fits_path(fp) for fp in ch_config.file_paths]
                 logger.info(f"Loading channel {ch_name}: {len(local_paths)} file(s)")
 
+                # Scale per-file budget by file count to cap total memory.
+                # With 158 files at 16M px each, raw arrays alone would need ~19 GB.
+                # Dividing by file count keeps total pre-mosaic memory bounded.
+                n_files = len(local_paths)
+                per_file_budget = max(input_budget // max(n_files, 1), MIN_PREVIEW_PIXELS)
+                if n_files > 1:
+                    logger.info(
+                        f"Channel {ch_name}: {n_files} files, "
+                        f"per-file budget={per_file_budget:,} px "
+                        f"(total budget={input_budget:,} px)"
+                    )
+
                 file_data = []
                 for p in local_paths:
                     try:
                         file_data.append(
                             downscale_for_composite(
-                                *load_fits_2d_with_wcs(p), max_pixels=input_budget
+                                *load_fits_2d_with_wcs(p), max_pixels=per_file_budget
                             )
                         )
                     except ValueError as e:


### PR DESCRIPTION
## Summary

Fix processing engine OOM crashes on large targets (e.g. NGC 3324) by filtering out intermediate calibration products and scaling per-file memory budget.

## Why

NGC 3324 composite creation was sending 628+ files per channel to the processing engine, including raw (`_uncal`), rate (`_rate`, `_rateints`), and cosmic-ray flagged (`_crf`) files — none of which should be used for composite generation. Even after filtering to `_i2d.fits` only, 158 files at 16M pixels each would need ~19 GB RAM. The container only has 4 GB.

Closes #728

## Changes Made

- **Backend (`CompositeService.cs`)**: Filter resolved file paths to prefer `_i2d.fits` (drizzle-combined) files, with fallback to `_cal.fits` then `_s2d.fits`. Intermediate calibration products are excluded. For NGC 3324 F090W: 710 → 162 files (77% reduction).
- **Backend (`CompositeService.Log.cs`)**: Added `LogFilteredToPreferredFileType` log message
- **Processing engine (`composite/routes.py`)**: Scale per-file pixel budget by file count. Previously each of 158 files got 16M px budget (~19 GB total). Now budget is divided across files: 16M / 158 ≈ 101K px per file (~126 MB total). The mosaic combining step handles spatial coverage.

## Test Plan

- [x] Backend build succeeds with no warnings
- [x] All 793 backend tests pass
- [x] Ruff lint passes
- [x] Local Docker rebuild successful
- [ ] Create NGC 3324 3-channel composite in guided create — should complete without OOM
- [ ] Create a small target composite (e.g. 1-2 files per channel) — verify no regression in quality
- [ ] Check `docker logs jwst-backend` shows "Filtered to i2d files" log message
- [ ] Check `docker logs jwst-processing` shows per-file budget log + memory checkpoints

## Documentation Checklist

- [x] No new endpoints or API changes
- [x] No documentation updates needed (internal behavior change)

## Tech Debt Impact

- [x] Addresses existing tech debt (OOM crash on large targets)
- [ ] Adds new tech debt
- [ ] No impact

## Risk & Rollback

Risk: Medium — changes which files are sent to the processing engine. The `_i2d.fits` preference is correct for composite generation (these are the science-ready products), but edge cases where only `_cal.fits` or `_rate.fits` exist would fall through to the fallback.
Rollback: Revert commit. The per-file budget scaling is safe to keep regardless.