### PR TITLE
fix: resolve E2E test failures in guided-create and mast-download suites

### DIFF
--- a/frontend/jwst-frontend/e2e/guided-create.spec.ts
+++ b/frontend/jwst-frontend/e2e/guided-create.spec.ts
@@ -85,12 +85,14 @@ async function mockRecipeResolution(page: Page): Promise<void> {
  * Strategy:
  * 1. Mock MAST search + recipe resolution
  * 2. Mock checkDataAvailability → all data already exists (skip download)
- * 3. Mock composite export async → returns a jobId
- * 4. Mock SignalR long-polling protocol → delivers JobCompleted event
- * 5. Mock job result blob endpoint → returns a tiny PNG
- *
- * The SignalR mock implements the full long-polling handshake:
- *   negotiate → initial poll → handshake ack → blocking poll → JobCompleted
+ * 3. Mock BOTH composite endpoints:
+ *    - generate-nchannel (sync, anonymous) — returns PNG blob directly
+ *    - export-nchannel (async, authenticated) + SignalR → delivers JobCompleted
+ *    The frontend may use either path depending on auth context timing.
+ *    When all data already exists, the pipeline starts immediately and
+ *    isAuthenticated may still be false (auth context reads localStorage
+ *    asynchronously). Mocking both ensures the test passes either way.
+ * 4. Mock job result blob endpoint → returns a tiny PNG
  */
 async function mockFullPipelineToResultStep(page: Page): Promise<void> {
   const MOCK_JOB_ID = 'mock-composite-job-001';
@@ -120,7 +122,16 @@ async function mockFullPipelineToResultStep(page: Page): Promise<void> {
     });
   });
 
-  // 3. Composite async export → return job ID
+  // 3a. Synchronous composite (anonymous path) → return PNG blob directly
+  await page.route('**/api/composite/generate-nchannel', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: TINY_PNG,
+    });
+  });
+
+  // 3b. Async composite export (authenticated path) → return job ID
   await page.route('**/api/composite/export-nchannel', async (route: Route) => {
     await route.fulfill({
       status: 200,
@@ -138,10 +149,11 @@ async function mockFullPipelineToResultStep(page: Page): Promise<void> {
     });
   });
 
-  // 5. SignalR long-polling mock
+  // 5. SignalR long-polling mock (for authenticated path)
   //    The negotiate route must be registered before the catch-all hub route
   //    because Playwright matches in registration order.
-  let pollCount = 0;
+  let handshakeDone = false;
+  let subscribeReceived = false;
 
   await page.route('**/hubs/job-progress/negotiate**', async (route: Route) => {
     await route.fulfill({
@@ -165,23 +177,20 @@ async function mockFullPipelineToResultStep(page: Page): Promise<void> {
     }
 
     if (method === 'POST') {
-      // Handles handshake send + SubscribeToJob invocations
-      // For SubscribeToJob, reply with a Completion acknowledgement on the next poll
+      // Track when SubscribeToJob is sent so we deliver the event on the
+      // next GET poll — avoids a race where poll 3 fires before invoke().
+      const body = route.request().postData() ?? '';
+      if (body.includes('SubscribeToJob')) {
+        subscribeReceived = true;
+      }
       await route.fulfill({ status: 200 });
       return;
     }
 
     if (method === 'GET') {
-      pollCount++;
-
-      if (pollCount === 1) {
-        // Initial connect — empty body
-        await route.fulfill({ status: 200, body: '' });
-        return;
-      }
-
-      if (pollCount === 2) {
-        // Handshake acknowledgement
+      if (!handshakeDone) {
+        // First non-empty GET response: handshake acknowledgement
+        handshakeDone = true;
         await route.fulfill({
           status: 200,
           contentType: 'text/plain',
@@ -190,8 +199,9 @@ async function mockFullPipelineToResultStep(page: Page): Promise<void> {
         return;
       }
 
-      if (pollCount === 3) {
-        // Deliver the SubscribeToJob completion + JobCompleted event together
+      if (subscribeReceived) {
+        // SubscribeToJob was sent — deliver completion + JobCompleted event
+        subscribeReceived = false; // only deliver once
         const subscribeCompletion = JSON.stringify({ type: 3, invocationId: '0' });
         const jobCompleted = JSON.stringify({
           type: 1,
@@ -214,7 +224,7 @@ async function mockFullPipelineToResultStep(page: Page): Promise<void> {
         return;
       }
 
-      // Subsequent polls — return empty to keep connection alive
+      // Keep-alive: empty response until SubscribeToJob is received
       await route.fulfill({ status: 200, body: '' });
     }
   });

--- a/frontend/jwst-frontend/e2e/mast-download.spec.ts
+++ b/frontend/jwst-frontend/e2e/mast-download.spec.ts
@@ -1,35 +1,42 @@
 import { test, expect, Page, Route } from '@playwright/test';
-import { apiRegisterUser, loginWithTokens, ApiAuthResult } from './helpers';
+import { apiRegisterUser, loginWithTokens, uniqueId, ApiAuthResult } from './helpers';
 
 let auth: ApiAuthResult;
 
 /**
- * Mock MAST search to return a fixed set of results so we can test
- * the download UI without depending on external MAST services.
+ * Generate mock MAST search results with unique observation IDs per test run.
+ * This prevents "Imported" button state caused by matching obs_ids that were
+ * imported in previous test runs (data persists in MongoDB across runs).
  */
-const MOCK_SEARCH_RESULTS = {
-  results: [
-    {
-      obs_id: 'jw02736-o001_t001_nircam_clear-f444w',
-      target_name: 'NGC 3132',
-      instrument_name: 'NIRCAM',
-      filters: 'F444W',
-      t_exptime: 128.8,
-      t_min: 60123.5,
-      calib_level: 3,
-    },
-    {
-      obs_id: 'jw02736-o001_t001_nircam_clear-f200w',
-      target_name: 'NGC 3132',
-      instrument_name: 'NIRCAM',
-      filters: 'F200W',
-      t_exptime: 128.8,
-      t_min: 60123.5,
-      calib_level: 3,
-    },
-  ],
-  total: 2,
-};
+function createMockSearchResults(suffix: string) {
+  return {
+    results: [
+      {
+        obs_id: `jw99999-o001_t001_nircam_clear-f444w-${suffix}`,
+        target_name: 'NGC 3132',
+        instrument_name: 'NIRCAM',
+        filters: 'F444W',
+        t_exptime: 128.8,
+        t_min: 60123.5,
+        calib_level: 3,
+      },
+      {
+        obs_id: `jw99999-o001_t001_nircam_clear-f200w-${suffix}`,
+        target_name: 'NGC 3132',
+        instrument_name: 'NIRCAM',
+        filters: 'F200W',
+        t_exptime: 128.8,
+        t_min: 60123.5,
+        calib_level: 3,
+      },
+    ],
+    total: 2,
+  };
+}
+
+/** Unique suffix per test suite run — prevents obs_id collisions with prior runs. */
+const testRunSuffix = uniqueId();
+const MOCK_SEARCH_RESULTS = createMockSearchResults(testRunSuffix);
 
 async function mockSearchRoute(page: Page): Promise<void> {
   await page.route('**/api/mast/search/**', async (route: Route) => {
@@ -50,7 +57,7 @@ async function mockImportRoute(page: Page): Promise<Route[]> {
       contentType: 'application/json',
       body: JSON.stringify({
         jobId: 'mock-job-001',
-        obsId: 'jw02736-o001_t001_nircam_clear-f444w',
+        obsId: MOCK_SEARCH_RESULTS.results[0].obs_id,
         status: 'started',
       }),
     });
@@ -147,7 +154,7 @@ test.describe('MAST download UI', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           jobId: 'mock-job-001',
-          obsId: 'jw02736-o001_t001_nircam_clear-f444w',
+          obsId: MOCK_SEARCH_RESULTS.results[0].obs_id,
           stage: 'discovering',
           progress: 0,
           status: 'running',
@@ -162,7 +169,7 @@ test.describe('MAST download UI', () => {
     const importRequest = await importPromise;
     const body = importRequest.postDataJSON();
     expect(body.downloadSource).toBe('s3');
-    expect(body.obsId).toBe('jw02736-o001_t001_nircam_clear-f444w');
+    expect(body.obsId).toBe(MOCK_SEARCH_RESULTS.results[0].obs_id);
   });
 
   test('Import button shows Importing state while active', async ({ page }) => {
@@ -182,7 +189,7 @@ test.describe('MAST download UI', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           jobId: 'mock-job-002',
-          obsId: 'jw02736-o001_t001_nircam_clear-f444w',
+          obsId: MOCK_SEARCH_RESULTS.results[0].obs_id,
           status: 'started',
         }),
       });
@@ -194,7 +201,7 @@ test.describe('MAST download UI', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           jobId: 'mock-job-002',
-          obsId: 'jw02736-o001_t001_nircam_clear-f444w',
+          obsId: MOCK_SEARCH_RESULTS.results[0].obs_id,
           stage: 'discovering',
           progress: 0,
           status: 'running',


### PR DESCRIPTION
## Summary
Fixes 12 E2E test failures (9 guided-create step 3, 3 mast-download) that were failing across all browsers.

## Why
- **Guided create**: When all MAST data already exists, the pipeline starts immediately before the auth context loads from localStorage. `isAuthenticated` is `false`, so the anonymous `generate-nchannel` endpoint is called — which wasn't mocked, causing a 500 error and "Composite generation failed" state.
- **MAST download**: Fixed observation IDs (`jw02736-*`) matched data imported in previous test runs (persisted in MongoDB), so Import buttons showed "Imported" (disabled) instead of "Import" (enabled).

## Changes Made
- **guided-create.spec.ts**: Mock both `generate-nchannel` (sync/anonymous) and `export-nchannel` (async/authenticated) composite endpoints so tests pass regardless of auth context timing. Replaced fragile `pollCount`-based SignalR mock with state-tracked approach (`handshakeDone` + `subscribeReceived`) to prevent race conditions.
- **mast-download.spec.ts**: Generate unique observation IDs per test run using `uniqueId()` instead of hardcoded IDs. Replace all hardcoded `jw02736-*` references with dynamic references to `MOCK_SEARCH_RESULTS`.

## Test Plan
- [x] All 22 guided-create tests pass (chromium)
- [x] All 8 mast-download tests pass (chromium)
- [x] Full cross-browser run: 90/90 pass (chromium + firefox + webkit)
- [x] Frontend unit tests: 878/878 pass
- [x] Pre-commit hooks pass (lint, tests)

## Documentation Checklist
- [x] `docs/key-files.md`: no new files
- [x] `docs/standards/backend-development.md`: no new endpoints
- [x] `docs/architecture/`: no architectural changes
- [x] `docs/quick-reference.md`: no new API endpoints

## Tech Debt Impact
- [x] Reduces existing tech debt
- [ ] No new tech debt introduced
- [ ] Adds tech debt (justified because: ...)

## Risk & Rollback
Risk: Low — test-only changes, no production code modified.
Rollback: Revert this commit.

No linked issue