### PR TITLE
fix: raise backend coverage threshold to 40% and exclude generated code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,9 @@ jobs:
         /p:CollectCoverage=true
         /p:CoverletOutputFormat=cobertura
         /p:ThresholdType=line
-        /p:Threshold=20
+        /p:Threshold=40
         /p:Exclude="[*]Microsoft.AspNetCore.OpenApi.Generated.*%2c[*]System.Text.RegularExpressions.Generated.*%2c[*]System.Runtime.CompilerServices.*%2c[*]Program%2c[*]*.LoggerMessage"
+        /p:ExcludeByAttribute="System.CodeDom.Compiler.GeneratedCodeAttribute"
 
   frontend-test:
     name: Frontend Tests


### PR DESCRIPTION
## Summary
- Raises backend test coverage threshold from 20% to 40%
- Excludes source-generated code (`Logging.g.cs`) from coverage calculation using `ExcludeByAttribute`

## Why
15,470 lines of source-generated `LoggerMessage` code were counted in coverage, dragging real coverage (50.5%) down to 34.1%. The threshold was set to 20% to accommodate this — now that generated code is properly excluded, the threshold can reflect actual application coverage.

## Changes Made
- `.github/workflows/ci.yml`: bumped `/p:Threshold` from 20 to 40
- `.github/workflows/ci.yml`: added `/p:ExcludeByAttribute="System.CodeDom.Compiler.GeneratedCodeAttribute"` to filter source-generated code

## Test Plan
- [x] Ran `dotnet test` locally with both flags — 793 tests pass, line coverage 50.53% (above 40% threshold)
- [ ] CI Backend Tests job passes with the new threshold

## Documentation Checklist
- [x] No documentation updates needed (CI config only)

## Tech Debt Impact
- [x] Reduces tech debt — coverage threshold now reflects real code quality

## Risk & Rollback
Risk: Low — only changes CI coverage threshold and exclusion filters. No application code changes.
Rollback: Revert the commit.

No linked issue