### PR TITLE
fix: View button always disabled due to filePath never in API response

### DIFF
--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -28,7 +28,7 @@ const DataCard: React.FC<DataCardProps> = ({
   onTagClick,
 }) => {
   const fitsInfo = getFitsFileInfo(item.fileName);
-  const hasFile = !!item.filePath;
+  const hasFile = item.isViewable !== false;
   const canSelect = fitsInfo.viewable;
 
   return (
@@ -139,7 +139,7 @@ const DataCard: React.FC<DataCardProps> = ({
           disabled={!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table')}
           title={
             !hasFile
-              ? 'FITS file not available on disk'
+              ? 'This file type cannot be viewed'
               : isSpectralFile(item.fileName)
                 ? 'View spectrum'
                 : fitsInfo.viewable

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
@@ -24,7 +24,7 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
   onArchive,
 }) => {
   const fitsInfo = getFitsFileInfo(item.fileName);
-  const hasFile = !!item.filePath;
+  const hasFile = item.isViewable !== false;
   const canSelect = fitsInfo.viewable;
 
   return (
@@ -111,7 +111,7 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
             disabled={!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table')}
             title={
               !hasFile
-                ? 'FITS file not available on disk'
+                ? 'This file type cannot be viewed'
                 : isSpectralFile(item.fileName)
                   ? 'View spectrum'
                   : fitsInfo.viewable


### PR DESCRIPTION
## Summary
Fix the View/Spectrum/Table button being permanently disabled on DataCard and LineageFileCard components.

Closes #N/A — No linked issue

## Why
The `DataResponse` DTO intentionally omits `FilePath` (it's an internal server path that shouldn't be exposed to clients). However, both card components were checking `!!item.filePath` to determine if a file could be viewed. Since the API never returns `filePath`, this was always `undefined`, making every View button disabled.

## Changes Made
- **DataCard.tsx**: Changed `const hasFile = !!item.filePath` to `const hasFile = item.isViewable !== false` — uses the `isViewable` field that the API actually returns
- **LineageFileCard.tsx**: Same fix applied
- Updated tooltip text from `'FITS file not available on disk'` to `'This file type cannot be viewed'` (more accurate for the user-facing context)

## Test Plan
- [x] All 878 frontend tests pass
- [ ] Open My Library, verify View/Spectrum buttons are clickable on viewable FITS files
- [ ] Verify non-viewable file types (catalogs, etc.) still show disabled state
- [ ] Open a target lineage view and verify View buttons work on LineageFileCard

## Documentation Checklist
- [x] No new endpoints, components, or API changes — existing behavior corrected
- [x] No documentation updates needed (bug fix only)

## Tech Debt Impact
- [x] Reduces tech debt — fixes a bug where frontend relied on a field the API intentionally doesn't expose
- [ ] No impact on tech debt
- [ ] Increases tech debt (explain below)

## Risk & Rollback
Risk: Low — two-line change using an existing API field, all tests pass.
Rollback: Revert commit to restore previous (broken) behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)