### PR TITLE
fix: add missing mast-proxy Docker build to E2E CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,16 @@ jobs:
         cache-from: type=gha,scope=processing
         cache-to: type=gha,mode=max,scope=processing
 
+    - name: Build MAST Proxy Docker Image
+      uses: docker/build-push-action@v7
+      with:
+        context: ./processing-engine
+        file: ./processing-engine/Dockerfile.mast
+        push: false
+        tags: jwst-mast-proxy:test
+        cache-from: type=gha,scope=mast-proxy
+        cache-to: type=gha,mode=max,scope=mast-proxy
+
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest
@@ -216,6 +226,13 @@ jobs:
           --cache-from type=gha,scope=processing \
           -t docker-processing-engine \
           -f processing-engine/Dockerfile \
+          processing-engine
+
+        docker buildx build \
+          --load \
+          --cache-from type=gha,scope=mast-proxy \
+          -t docker-mast-proxy \
+          -f processing-engine/Dockerfile.mast \
           processing-engine
 
     - name: Setup Node.js


### PR DESCRIPTION
## Summary
Add the missing mast-proxy Docker image build to the CI pipeline so E2E tests can start the full Docker stack.

No linked issue

## Why
The `docker-build` job builds and caches backend, frontend, and processing-engine images, but was missing `mast-proxy`. The E2E job then runs `docker compose up -d --no-build`, which fails with `No such image: docker-mast-proxy:latest` because the image was never built.

## Changes Made
- Added "Build MAST Proxy Docker Image" step to the `docker-build` job (builds from `processing-engine/Dockerfile.mast`, caches as `mast-proxy` scope)
- Added mast-proxy buildx load step to the E2E "Pre-build Docker Images" step (loads from GHA cache, tags as `docker-mast-proxy`)

## Test Plan
- [x] CI workflow syntax is valid YAML
- [ ] E2E Tests job should now pass the "Start Docker Stack" step (previously failing at mast-proxy)

## Documentation Checklist
- [x] CI-only change — no documentation updates needed

## Tech Debt Impact
- [x] Reduces tech debt — fixes broken E2E pipeline
- [ ] No impact on tech debt
- [ ] Increases tech debt (explain below)

## Risk & Rollback
Risk: Low — adds a build step to CI only, no application code changes.
Rollback: Revert commit to remove the mast-proxy build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)