### PR TITLE
fix: prevent download progress bar from jumping backwards

### DIFF
--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -363,21 +363,31 @@ export function GuidedCreate() {
       const totalSpeed = allStatuses.reduce((sum, s) => sum + (s.speedBytesPerSec ?? 0), 0);
       const overallPercent =
         totalObs > 0 ? allStatuses.reduce((sum, s) => sum + (s.progress ?? 0), 0) / totalObs : 0;
+      const downloadPercent = totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0;
 
-      setDownloadProgress({
+      // Use callback form to enforce monotonic progress — never allow bars to jump backwards
+      setDownloadProgress((prev) => ({
         jobId: 'merged',
         obsId: 'merged',
-        progress: overallPercent,
+        progress: Math.max(overallPercent, prev?.progress ?? 0),
         stage: `Downloading (${completedCount}/${totalObs} complete)`,
         message: '',
         isComplete: false,
         startedAt: '',
         totalBytes,
-        downloadedBytes,
-        downloadProgressPercent: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
+        downloadedBytes: Math.max(downloadedBytes, prev?.downloadedBytes ?? 0),
+        downloadProgressPercent: Math.max(downloadPercent, prev?.downloadProgressPercent ?? 0),
         speedBytesPerSec: totalSpeed,
-        fileProgress: allFiles,
-      });
+        fileProgress: allFiles.map((f) => {
+          const prevFile = prev?.fileProgress?.find((pf) => pf.filename === f.filename);
+          if (!prevFile) return f;
+          return {
+            ...f,
+            downloadedBytes: Math.max(f.downloadedBytes, prevFile.downloadedBytes),
+            progressPercent: Math.max(f.progressPercent, prevFile.progressPercent),
+          };
+        }),
+      }));
     }
 
     function checkAllDone() {


### PR DESCRIPTION
## Summary
Enforce monotonic progress so download bars only move forward, never backwards.

No linked issue

## Why
SignalR updates can report fluctuating byte counts between updates, causing the overall progress bar and individual file progress bars to jump up and down during downloads. This is visually jarring and makes it hard to gauge actual progress.

## Changes Made
- **GuidedCreate.tsx `mergeProgress()`**: Use `setDownloadProgress` callback form to compare against previous state. Apply `Math.max()` high-water marks on:
  - `progress` (overall percentage)
  - `downloadedBytes` (aggregate bytes)
  - `downloadProgressPercent` (aggregate percentage)
  - Per-file `downloadedBytes` and `progressPercent` (matched by filename)
- Speed (`speedBytesPerSec`) is intentionally NOT clamped — it should reflect current throughput accurately

## Test Plan
- [x] All 878 frontend tests pass
- [ ] Start a multi-file download (e.g. Stephan's Quintet composite)
- [ ] Verify progress bars move smoothly forward, never jumping backwards
- [ ] Verify completed file count still increments correctly
- [ ] Verify speed display still updates dynamically

## Documentation Checklist
- [x] Single-file bug fix — no documentation updates needed

## Tech Debt Impact
- [x] Reduces tech debt — fixes a UX issue with flickering progress
- [ ] No impact on tech debt
- [ ] Increases tech debt (explain below)

## Risk & Rollback
Risk: Low — only affects how merged progress values are displayed, does not change download logic.
Rollback: Revert commit to restore previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)