### PR TITLE
docs: add Phase 9 — lightweight community edition plan

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -217,7 +217,7 @@ Remaining features, tech debt, CI improvements, and release process.
 
 ---
 
-## Phase 9: Lightweight Community Edition — "JWST Wallpapers"
+## Community Edition — "JWST Wallpapers"
 
 Self-contained app in the `community/` monorepo subdirectory — the version that actually ships to real users. Same core value (browse JWST data, composite beautiful images, download wallpapers) on a stack that costs ~$0/month to run indefinitely.
 
@@ -227,7 +227,7 @@ Self-contained app in the `community/` monorepo subdirectory — the version tha
 
 **Relationship to the main app**: This repo's main stack is the production-grade, portfolio-worthy architecture. The community edition is the **launch vehicle** — cheap enough to keep running without traction, simple enough to ship fast. If it gets real interest/community, that's the signal to invest in scaling up (either migrate to the full stack or bring features over).
 
-**Timing**: Can start after the 5b compositing quality items land (stretch presets, auto-stretch, saturation controls) — those algorithms directly benefit the community edition. Does not depend on phases 6-8 (production hardening, observability, polish are for the main app only).
+**Timing**: Can start after the 5b compositing quality items land (stretch presets, auto-stretch, saturation controls) — those algorithms directly benefit the community edition. Independent of phases 6-8 (production hardening, observability, polish are for the main app only).
 
 ### Key Decisions to Brainstorm
 
@@ -283,7 +283,7 @@ Self-contained app in the `community/` monorepo subdirectory — the version tha
 | 4 | Frontend & FITS Viewer | ✅ Complete | |
 | 5 | Scientific Processing | ✅ Complete | |
 | 5b | UI/UX Polish & Compositing | 🔄 Next | Compositing quality items first |
-| 9 | Community Edition ("JWST Wallpapers") | ⬚ Planned | After 5b compositing; `community/` dir |
+| CE | Community Edition ("JWST Wallpapers") | ⬚ Planned | After 5b compositing; `community/` dir |
 | 6 | Production Readiness | ⬚ Planned | Main app only |
 | 7 | Observability & Monitoring | ⬚ Planned | Main app only |
 | 8 | Polish & Community Release | ⬚ Planned | Main app only |


### PR DESCRIPTION
## Summary
- Adds Community Edition ("JWST Wallpapers") to the development roadmap
- Lives in `community/` monorepo subdirectory, independently deployable for ~$0/month
- Reorders roadmap: CE runs after 5b compositing quality, before phases 6-8
- Not numbered as a phase — it's a parallel product, not a phase of the main app

## Why
The current architecture costs $30-60/month to host with zero users. A lightweight community edition on Vercel/Cloudflare free tier acts as a launch vehicle — cheap enough to run indefinitely, signals when to invest in scaling the full stack.

## Changes Made
- Added Community Edition section to `docs/development-plan.md` with:
  - Goal, monorepo location (`community/`), and relationship to main app
  - Timing dependency (after 5b compositing quality items)
  - Key architectural decisions to brainstorm
  - Candidate feature set (search → composite → download wallpapers)
  - What gets cut vs. the full app
  - Monorepo boundary rules (self-contained, no cross-imports)
- Reordered Progress Summary: CE sits between 5b and 6
- Added Notes column to progress summary table

## Test Plan
- [x] Docs-only change, no functional impact
- [x] Markdown lint clean

## Documentation Checklist
- [x] `docs/development-plan.md` — updated (this is the change)
- [x] No new endpoints, controllers, or services

No linked issue — this is a planning/roadmap item.

## Tech Debt Impact
- [x] No tech debt impact

## Risk & Rollback
Risk: None — docs-only change.
Rollback: Revert the commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)