### PR TITLE
feat: add stretch preset selector to discovery result step

### DIFF
--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -129,6 +129,67 @@
   text-align: center;
 }
 
+/* Stretch presets */
+.result-presets {
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.result-presets-header {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.result-presets-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.result-preset-btn {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-canvas);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.result-preset-btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+  border-color: var(--accent-primary);
+  color: var(--text-primary);
+}
+
+.result-preset-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.result-preset-btn:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+.result-preset-btn.active {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
 /* Channel colors */
 .result-channels {
   padding: var(--space-2) var(--space-3);

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -9,6 +9,7 @@ import {
   NASA_PALETTE,
 } from '../../utils/wavelengthUtils';
 import type { CompositePageState, NChannelConfigPayload } from '../../types/CompositeTypes';
+import { COMPOSITE_PRESETS } from '../../types/CompositeTypes';
 import './ResultStep.css';
 
 interface ResultStepProps {
@@ -29,6 +30,10 @@ interface ResultStepProps {
   channels: NChannelConfigPayload[];
   /** Callback when channels are modified (color or weight) */
   onChannelsChange: (channels: NChannelConfigPayload[]) => void;
+  /** Currently active stretch preset ID */
+  activePresetId: string;
+  /** Callback when user selects a different stretch preset */
+  onPresetChange: (presetId: string) => void;
   /** State to pass to the Composite Creator page */
   compositePageState?: CompositePageState;
 }
@@ -94,6 +99,8 @@ export function ResultStep({
   onAdjust,
   channels,
   onChannelsChange,
+  activePresetId,
+  onPresetChange,
   compositePageState,
 }: ResultStepProps) {
   const [brightness, setBrightness] = useState(50);
@@ -103,6 +110,18 @@ export function ResultStep({
 
   // Local channel state for immediate UI feedback before debounced regeneration
   const [localChannels, setLocalChannels] = useState<NChannelConfigPayload[] | null>(null);
+
+  // Reset quick adjustment sliders and local channels when preset changes
+  const prevPresetRef = useRef(activePresetId);
+  useEffect(() => {
+    if (prevPresetRef.current !== activePresetId) {
+      prevPresetRef.current = activePresetId;
+      setBrightness(50);
+      setContrast(50);
+      setSaturation(50);
+      setLocalChannels(null);
+    }
+  }, [activePresetId]);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const adjustDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -253,6 +272,25 @@ export function ResultStep({
           </div>
 
           {exportError && <p className="result-export-error">{exportError}</p>}
+
+          <div className="result-presets">
+            <h4 className="result-presets-header">Stretch Preset</h4>
+            <div className="result-presets-row" role="group" aria-label="Stretch presets">
+              {COMPOSITE_PRESETS.map((preset) => (
+                <button
+                  key={preset.id}
+                  type="button"
+                  className={`btn-base result-preset-btn${activePresetId === preset.id ? ' active' : ''}`}
+                  title={preset.description}
+                  aria-pressed={activePresetId === preset.id}
+                  disabled={isExporting}
+                  onClick={() => onPresetChange(preset.id)}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          </div>
 
           {displayChannels.length > 0 && (
             <div className="result-channels">

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -16,7 +16,11 @@ import { apiClient } from '../services/apiClient';
 import { useAuth } from '../context/useAuth';
 import type { ImportJobStatus, MastObservationResult } from '../types/MastTypes';
 import type { CompositeRecipe } from '../types/DiscoveryTypes';
-import type { NChannelConfigPayload, OverallAdjustments } from '../types/CompositeTypes';
+import type {
+  NChannelConfigPayload,
+  OverallAdjustments,
+  CompositePreset,
+} from '../types/CompositeTypes';
 import { COMPOSITE_PRESETS } from '../types/CompositeTypes';
 import { chromaticOrderHues, hueToHex, hexToRgb, rgbToHue } from '../utils/wavelengthUtils';
 import { toObservationInputs } from '../utils/observationUtils';
@@ -49,9 +53,7 @@ const BICOLOR_WEIGHTS: [number, number, number][] = [
   [1.0, 0.5, 0], // long wavelength → red + half green
 ];
 
-/** Guided create uses the NASA Press preset — tuned for visual appeal with
- *  background neutralization and S-curve tone mapping. */
-const GUIDED_PRESET = COMPOSITE_PRESETS.find((p) => p.id === 'nasa')!;
+const DEFAULT_PRESET = COMPOSITE_PRESETS.find((p) => p.id === 'nasa')!;
 
 /**
  * Build NChannelConfigPayload array from recipe + imported data mappings.
@@ -60,7 +62,8 @@ const GUIDED_PRESET = COMPOSITE_PRESETS.find((p) => p.id === 'nasa')!;
  */
 function buildChannelPayloads(
   recipe: CompositeRecipe,
-  filterDataMap: Map<string, string[]>
+  filterDataMap: Map<string, string[]>,
+  preset: CompositePreset = DEFAULT_PRESET
 ): NChannelConfigPayload[] {
   const isBicolor = recipe.filters.length === 2;
 
@@ -85,7 +88,7 @@ function buildChannelPayloads(
       dataIds,
       color,
       label: filter,
-      ...GUIDED_PRESET.channelParams,
+      ...preset.channelParams,
     });
   }
   return payloads;
@@ -147,6 +150,7 @@ export function GuidedCreate() {
   const [isExporting, setIsExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [channelPayloads, setChannelPayloads] = useState<NChannelConfigPayload[]>([]);
+  const [activePreset, setActivePreset] = useState<CompositePreset>(DEFAULT_PRESET);
 
   // Refs for cleanup
   const subscriptionsRef = useRef<Array<{ unsubscribe: () => void }>>([]);
@@ -500,8 +504,8 @@ export function GuidedCreate() {
           COMPOSITE_OUTPUT.quality,
           COMPOSITE_OUTPUT.width,
           COMPOSITE_OUTPUT.height,
-          GUIDED_PRESET.overall,
-          GUIDED_PRESET.backgroundNeutralization
+          activePreset.overall,
+          activePreset.backgroundNeutralization
         );
 
         const sub = subscribeToJobProgress(
@@ -535,8 +539,8 @@ export function GuidedCreate() {
         // Anonymous: use synchronous endpoint (AllowAnonymous)
         const blob = await generateNChannelComposite({
           channels,
-          overall: GUIDED_PRESET.overall,
-          backgroundNeutralization: GUIDED_PRESET.backgroundNeutralization,
+          overall: activePreset.overall,
+          backgroundNeutralization: activePreset.backgroundNeutralization,
           ...COMPOSITE_OUTPUT,
         });
         setProcessComplete(true);
@@ -568,7 +572,7 @@ export function GuidedCreate() {
           COMPOSITE_OUTPUT.width,
           COMPOSITE_OUTPUT.height,
           overall,
-          GUIDED_PRESET.backgroundNeutralization
+          activePreset.backgroundNeutralization
         );
 
         const sub = subscribeToJobProgress(
@@ -601,7 +605,7 @@ export function GuidedCreate() {
         const blob = await generateNChannelComposite({
           channels,
           overall,
-          backgroundNeutralization: GUIDED_PRESET.backgroundNeutralization,
+          backgroundNeutralization: activePreset.backgroundNeutralization,
           ...COMPOSITE_OUTPUT,
         });
         applyBlobPreview(blob);
@@ -631,9 +635,9 @@ export function GuidedCreate() {
     }));
 
     const overall: OverallAdjustments = {
-      ...GUIDED_PRESET.overall,
-      blackPoint: Math.max(0, GUIDED_PRESET.overall.blackPoint - bOffset),
-      whitePoint: Math.min(1, GUIDED_PRESET.overall.whitePoint + bOffset),
+      ...activePreset.overall,
+      blackPoint: Math.max(0, activePreset.overall.blackPoint - bOffset),
+      whitePoint: Math.min(1, activePreset.overall.whitePoint + bOffset),
       gamma,
     };
 
@@ -646,7 +650,33 @@ export function GuidedCreate() {
    */
   function handleChannelsChange(channels: NChannelConfigPayload[]) {
     setChannelPayloads(channels);
-    regenerateComposite(channels, GUIDED_PRESET.overall);
+    regenerateComposite(channels, activePreset.overall);
+  }
+
+  /**
+   * Handle stretch preset change from ResultStep.
+   * Rebuilds channel payloads with the new preset's stretch params and regenerates.
+   */
+  function handlePresetChange(presetId: string) {
+    const preset = COMPOSITE_PRESETS.find((p) => p.id === presetId);
+    if (!preset || !recipe) return;
+
+    setActivePreset(preset);
+
+    // Rebuild channels with new preset's stretch params, preserving colors/weights
+    const updatedChannels = channelPayloads.map((ch) => ({
+      ...ch,
+      ...preset.channelParams,
+      // Preserve per-channel color and weight customizations
+      color: ch.color,
+      weight: ch.weight,
+      label: ch.label,
+      dataIds: ch.dataIds,
+    }));
+
+    setChannelPayloads(updatedChannels);
+    // Reset quick adjustments by using the preset's overall directly
+    regenerateComposite(updatedChannels, preset.overall);
   }
 
   // Error state before flow starts
@@ -801,6 +831,8 @@ export function GuidedCreate() {
             onAdjust={handleAdjust}
             channels={channelPayloads}
             onChannelsChange={handleChannelsChange}
+            activePresetId={activePreset.id}
+            onPresetChange={handlePresetChange}
             compositePageState={
               recipe
                 ? {


### PR DESCRIPTION
## Summary
- Adds stretch preset buttons (NASA Press, High Contrast, Faint Emission, Natural, Scientific) to the discovery flow result step
- Previously hardcoded to NASA Press — now users can switch presets without opening the advanced editor

## Why
The discovery flow locked users into a single stretch preset. Different targets need different processing — a galaxy like NGC 5134 may look better with High Contrast or Natural than the default NASA Press. Users had to "Open in Advanced Editor" just to change the stretch, breaking the guided flow's simplicity.

## Changes Made
- **GuidedCreate.tsx**: Replaced hardcoded `GUIDED_PRESET` constant with `activePreset` state. Added `handlePresetChange` that rebuilds channel payloads with new stretch params while preserving color/weight customizations. Passes `activePresetId` and `onPresetChange` to ResultStep.
- **ResultStep.tsx**: Added preset selector button row with `aria-pressed` for accessibility. Resets quick adjustment sliders and local channel state when preset changes to avoid stale UI.
- **ResultStep.css**: Styles for the preset button row — matches existing card/section pattern, buttons highlight active selection.

## Test Plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] ESLint passes (0 errors, warnings are pre-existing)
- [x] All 878 unit tests pass
- [x] E2E selectors checked — no existing tests reference new elements, no breakage
- [ ] Manual: navigate to discovery flow → process a target → verify preset buttons appear on result step
- [ ] Manual: click each preset → verify image regenerates with different stretch
- [ ] Manual: adjust channel colors → switch preset → verify colors preserved but stretch changes
- [ ] Manual: adjust brightness/contrast/saturation → switch preset → verify sliders reset to center

## Documentation Checklist
- [x] No new endpoints, controllers, or services
- [x] No API changes — uses existing composite generation endpoint with different params
- [x] No docs updates needed — this is a UI-only enhancement to an existing page

No linked issue — this is a UX improvement identified during manual testing of NGC 5134.

## Tech Debt Impact
- [x] Reduces tech debt — removes hardcoded preset assumption from discovery flow

## Risk & Rollback
Risk: Low — frontend-only change, uses existing preset infrastructure and API.
Rollback: Revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)