### PR TITLE
feat: smart recipe ranking and cross-instrument color mapping

### DIFF
--- a/backend/JwstDataAnalysis.API/Models/DiscoveryModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/DiscoveryModels.cs
@@ -148,5 +148,8 @@ namespace JwstDataAnalysis.API.Models
 
         /// <summary>Gets or sets the observation IDs to use.</summary>
         public List<string>? ObservationIds { get; set; }
+
+        /// <summary>Gets or sets a short description of what this recipe highlights.</summary>
+        public string? Description { get; set; }
     }
 }

--- a/docs/architecture/discovery-recipe-flow.md
+++ b/docs/architecture/discovery-recipe-flow.md
@@ -49,6 +49,31 @@ sequenceDiagram
     end
 ```
 
+## Recipe Ranking
+
+The recipe engine generates ranked composites based on instrument coverage:
+
+### Multi-instrument targets (e.g. NIRCam + MIRI)
+
+| Rank | Recipe | Description |
+|------|--------|-------------|
+| 1 | Cross-instrument (all filters) | Stars and dust — full wavelength coverage. Uses instrument-aware color mapping: NIRCam → cool hues (blue-green), MIRI → warm hues (yellow-red) |
+| 2 | All filters (per instrument) | Maximum detail from a single instrument |
+| 3 | Classic 3-color | Three well-separated wavelengths |
+| 4 | Narrowband highlight | Emission-line filters for gas structures |
+| 5 | Broadband clean | Broadband filters for continuum view |
+
+### Single-instrument targets
+
+| Rank | Recipe |
+|------|--------|
+| 1 | All available filters |
+| 2 | Classic 3-color |
+| 3 | Narrowband highlight |
+| 4 | Broadband clean |
+
+The frontend marks array index 0 as "Recommended".
+
 ---
 
 [Back to Architecture Overview](index.md)

--- a/frontend/jwst-frontend/e2e/guided-create.spec.ts
+++ b/frontend/jwst-frontend/e2e/guided-create.spec.ts
@@ -54,6 +54,7 @@ const MOCK_RECIPES = {
       requiresMosaic: false,
       estimatedTimeSeconds: 16,
       observationIds: null,
+      description: 'All 2 NIRCAM filters for maximum detail',
     },
   ],
 };

--- a/frontend/jwst-frontend/e2e/target-detail.spec.ts
+++ b/frontend/jwst-frontend/e2e/target-detail.spec.ts
@@ -51,6 +51,8 @@ const MOCK_RECIPES = {
       requiresMosaic: false,
       estimatedTimeSeconds: 24,
       observationIds: null,
+      description:
+        'Stars and dust \u2014 full near- to mid-infrared wavelength coverage',
     },
     {
       name: '2-filter NIRCAM/IMAGE',
@@ -61,6 +63,7 @@ const MOCK_RECIPES = {
       requiresMosaic: false,
       estimatedTimeSeconds: 16,
       observationIds: null,
+      description: 'All 2 NIRCAM/IMAGE filters for maximum detail',
     },
   ],
 };

--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.css
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.css
@@ -36,6 +36,13 @@
   color: var(--text-primary);
 }
 
+.recipe-card-description {
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
 .recipe-card-filters {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
@@ -93,6 +93,7 @@ export function RecipeCard({
     <div className={`recipe-card ${isRecommended ? 'recipe-card-recommended' : ''}`}>
       {isRecommended && <span className="recipe-card-badge">Recommended</span>}
       <h4 className="recipe-card-name">{recipe.name}</h4>
+      {recipe.description && <p className="recipe-card-description">{recipe.description}</p>}
 
       <div className="recipe-card-filters">
         {recipe.filters.map((filter) => (

--- a/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
+++ b/frontend/jwst-frontend/src/types/DiscoveryTypes.ts
@@ -38,6 +38,7 @@ export interface CompositeRecipe {
   requiresMosaic: boolean;
   estimatedTimeSeconds: number;
   observationIds?: string[];
+  description?: string;
 }
 
 /** Target metadata returned with recipe suggestions */

--- a/processing-engine/app/discovery/models.py
+++ b/processing-engine/app/discovery/models.py
@@ -55,6 +55,9 @@ class Recipe(BaseModel):
     )
     estimated_time_seconds: int = Field(default=30, description="Estimated processing time")
     observation_ids: list[str] | None = Field(default=None, description="Observation IDs to use")
+    description: str | None = Field(
+        default=None, description="Short description of what this recipe highlights"
+    )
 
 
 class SuggestRecipesResponse(BaseModel):

--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -92,6 +92,59 @@ def hue_to_hex(hue: float) -> str:
     return f"#{int(r * 255):02x}{int(g * 255):02x}{int(b * 255):02x}"
 
 
+def build_cross_instrument_color_mapping(
+    filters_sorted: list[str],
+    filter_instruments: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build instrument-aware color mapping for cross-instrument recipes.
+
+    NIRCam filters get cool hues (blue 240° → green 120°) representing starlight.
+    MIRI filters get warm hues (yellow 60° → red 0°) representing dust emission.
+    This matches physical intuition and NASA/ESA convention.
+
+    Uses per-instrument "all" recipes keep the full chromatic range via
+    build_color_mapping(), while cross-instrument recipes constrain each
+    instrument to a distinct hue band so users can visually distinguish
+    stellar (NIRCam) from dust (MIRI) contributions.
+
+    Args:
+        filters_sorted: Filter names sorted by wavelength.
+        filter_instruments: Optional map of filter name → instrument name.
+            If provided, uses authoritative instrument data. Falls back to
+            wavelength-based inference (NIRCam < 5µm, MIRI >= 5µm).
+    """
+
+    def is_miri(f: str) -> bool:
+        if filter_instruments and f in filter_instruments:
+            return filter_instruments[f].upper().startswith("MIRI")
+        # Fallback: infer from wavelength lookup table
+        wl = FILTER_WAVELENGTHS.get(f.upper())
+        return wl is not None and wl >= 5.0
+
+    nircam = [f for f in filters_sorted if not is_miri(f)]
+    miri = [f for f in filters_sorted if is_miri(f)]
+
+    mapping: dict[str, str] = {}
+
+    # NIRCam: blue (240°) → green (120°), evenly spaced
+    if len(nircam) == 1:
+        mapping[nircam[0]] = hue_to_hex(180.0)  # cyan
+    else:
+        for i, f in enumerate(nircam):
+            hue = 240.0 - (120.0 * i / (len(nircam) - 1))
+            mapping[f] = hue_to_hex(hue)
+
+    # MIRI: yellow (60°) → red (0°), evenly spaced
+    if len(miri) == 1:
+        mapping[miri[0]] = hue_to_hex(30.0)  # orange
+    else:
+        for i, f in enumerate(miri):
+            hue = 60.0 - (60.0 * i / (len(miri) - 1))
+            mapping[f] = hue_to_hex(hue)
+
+    return mapping
+
+
 def build_color_mapping(filters_sorted: list[str]) -> dict[str, str]:
     """Build chromatic-ordered color mapping for a sorted filter list.
 
@@ -169,6 +222,45 @@ def generate_recipes(observations: list[ObservationInput]) -> list[Recipe]:
         instrument_groups.setdefault(inst, []).append(obs)
 
     all_recipes: list[Recipe] = []
+    multi_instrument = len(instrument_groups) > 1
+
+    # Rank offset: if multi-instrument, cross-instrument recipe takes rank 1,
+    # so single-instrument recipes shift up by 1.
+    rank_offset = 1 if multi_instrument else 0
+
+    # If multiple instruments, add combined recipe FIRST (rank 1 = recommended).
+    # Cross-instrument composites show the full wavelength story — starlight (NIRCam)
+    # plus dust emission (MIRI) — and are the most visually compelling result.
+    if multi_instrument:
+        all_obs_map: dict[str, ObservationInput] = {}
+        for obs in observations:
+            key = obs.filter.upper()
+            if key not in all_obs_map:
+                all_obs_map[key] = obs
+
+        combined_sorted = sorted(
+            all_obs_map.keys(),
+            key=lambda f: resolve_wavelength(all_obs_map[f]) or float("inf"),
+        )
+        all_instruments = sorted(instrument_groups.keys())
+        all_obs_ids = [obs.observation_id for obs in observations if obs.observation_id]
+        filter_instruments = {f: all_obs_map[f].instrument.upper() for f in combined_sorted}
+
+        all_recipes.append(
+            Recipe(
+                name=f"{len(combined_sorted)}-filter {'+'.join(all_instruments)}",
+                rank=1,
+                filters=combined_sorted,
+                color_mapping=build_cross_instrument_color_mapping(
+                    combined_sorted, filter_instruments
+                ),
+                instruments=all_instruments,
+                requires_mosaic=False,
+                estimated_time_seconds=estimate_time(len(combined_sorted), False),
+                observation_ids=all_obs_ids or None,
+                description="Stars and dust \u2014 full near- to mid-infrared wavelength coverage",
+            ),
+        )
 
     for instrument, obs_list in instrument_groups.items():
         # Deduplicate by filter name and sort by wavelength
@@ -191,21 +283,22 @@ def generate_recipes(observations: list[ObservationInput]) -> list[Recipe]:
         if n_filters == 0:
             continue
 
-        # Recipe 1: All available filters
+        # Recipe: All available filters for this instrument
         all_recipes.append(
             Recipe(
                 name=f"{n_filters}-filter {instrument}",
-                rank=1,
+                rank=1 + rank_offset,
                 filters=sorted_filters,
                 color_mapping=build_color_mapping(sorted_filters),
                 instruments=[instrument],
                 requires_mosaic=False,
                 estimated_time_seconds=estimate_time(n_filters, False),
                 observation_ids=obs_ids or None,
+                description=f"All {n_filters} {instrument} filters for maximum detail",
             )
         )
 
-        # Recipe 2: Classic 3-color (if 3+ filters with known wavelengths)
+        # Recipe: Classic 3-color (if 3+ filters with known wavelengths)
         known_wl = [f for f in sorted_filters if resolve_wavelength(filter_map[f]) is not None]
         if len(known_wl) >= 3:
             # Pick shortest, middle, longest
@@ -218,76 +311,49 @@ def generate_recipes(observations: list[ObservationInput]) -> list[Recipe]:
             all_recipes.append(
                 Recipe(
                     name=f"Classic 3-color {instrument}",
-                    rank=2,
+                    rank=2 + rank_offset,
                     filters=classic_filters,
                     color_mapping=build_color_mapping(classic_filters),
                     instruments=[instrument],
                     requires_mosaic=False,
                     estimated_time_seconds=estimate_time(3, False),
                     observation_ids=obs_ids or None,
+                    description="Three well-separated wavelengths for balanced color",
                 )
             )
 
-        # Recipe 3: Narrowband highlight (if 2+ narrowband filters, and different from "all")
+        # Recipe: Narrowband highlight (if 2+ narrowband filters, and different from "all")
         narrowband = [f for f in sorted_filters if is_narrowband(f)]
         if len(narrowband) >= 2 and narrowband != sorted_filters:
             all_recipes.append(
                 Recipe(
                     name=f"Narrowband {instrument}",
-                    rank=3,
+                    rank=3 + rank_offset,
                     filters=narrowband,
                     color_mapping=build_color_mapping(narrowband),
                     instruments=[instrument],
                     requires_mosaic=False,
                     estimated_time_seconds=estimate_time(len(narrowband), False),
                     observation_ids=obs_ids or None,
+                    description="Emission-line filters highlighting gas structures",
                 )
             )
 
-        # Recipe 4: Broadband clean (if 3+ broadband filters, and different from "all")
+        # Recipe: Broadband clean (if 3+ broadband filters, and different from "all")
         broadband = [f for f in sorted_filters if is_broadband(f)]
         if len(broadband) >= 3 and broadband != sorted_filters:
             all_recipes.append(
                 Recipe(
                     name=f"Broadband {instrument}",
-                    rank=4,
+                    rank=4 + rank_offset,
                     filters=broadband,
                     color_mapping=build_color_mapping(broadband),
                     instruments=[instrument],
                     requires_mosaic=False,
                     estimated_time_seconds=estimate_time(len(broadband), False),
                     observation_ids=obs_ids or None,
+                    description="Broadband filters for a clean continuum view",
                 )
             )
-
-    # If multiple instruments, add a combined "all instruments" recipe at low priority.
-    # Cross-instrument composites have resolution/FOV mismatches (e.g. NIRCam ~0.03"/px
-    # vs MIRI ~0.11"/px) so single-instrument recipes are preferred.
-    if len(instrument_groups) > 1:
-        all_obs_map: dict[str, ObservationInput] = {}
-        for obs in observations:
-            key = obs.filter.upper()
-            if key not in all_obs_map:
-                all_obs_map[key] = obs
-
-        combined_sorted = sorted(
-            all_obs_map.keys(),
-            key=lambda f: resolve_wavelength(all_obs_map[f]) or float("inf"),
-        )
-        all_instruments = sorted(instrument_groups.keys())
-        all_obs_ids = [obs.observation_id for obs in observations if obs.observation_id]
-
-        all_recipes.append(
-            Recipe(
-                name=f"{len(combined_sorted)}-filter {'+'.join(all_instruments)}",
-                rank=5,
-                filters=combined_sorted,
-                color_mapping=build_color_mapping(combined_sorted),
-                instruments=all_instruments,
-                requires_mosaic=False,
-                estimated_time_seconds=estimate_time(len(combined_sorted), False),
-                observation_ids=all_obs_ids or None,
-            ),
-        )
 
     return all_recipes

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -6,6 +6,7 @@ from app.discovery.models import ObservationInput
 from app.discovery.recipe_engine import (
     _MJD_EPOCH,
     build_color_mapping,
+    build_cross_instrument_color_mapping,
     generate_recipes,
     hue_to_hex,
     is_broadband,
@@ -157,7 +158,7 @@ class TestGenerateRecipes:
         broad = next(r for r in recipes if r.name == "Broadband NIRCAM")
         assert all(is_broadband(f) for f in broad.filters)
 
-    def test_multi_instrument_adds_combined_recipe_deprioritized(self):
+    def test_multi_instrument_cross_instrument_ranked_first(self):
         obs = [
             ObservationInput(filter="F200W", instrument="NIRCAM"),
             ObservationInput(filter="F444W", instrument="NIRCAM"),
@@ -167,12 +168,12 @@ class TestGenerateRecipes:
         recipes = generate_recipes(obs)
         combined = [r for r in recipes if "MIRI+NIRCAM" in r.name or "NIRCAM+MIRI" in r.name]
         assert len(combined) == 1
-        # Cross-instrument recipes are deprioritized (rank 5) due to resolution/FOV mismatch
-        assert combined[0].rank == 5
+        # Cross-instrument recipe is rank 1 (recommended) when multiple instruments present
+        assert combined[0].rank == 1
         assert len(combined[0].filters) == 4
-        # Single-instrument recipes should rank higher
+        # Single-instrument recipes should rank after cross-instrument
         single_inst = [r for r in recipes if len(r.instruments) == 1]
-        assert all(r.rank < combined[0].rank for r in single_inst)
+        assert all(r.rank > combined[0].rank for r in single_inst)
 
     def test_deduplicates_filters(self):
         obs = [
@@ -378,3 +379,147 @@ class TestSpectralFiltering:
         recipes = generate_recipes(obs)
         assert len(recipes) >= 1
         assert set(recipes[0].filters) == {"F200W", "F444W"}
+
+
+class TestCrossInstrumentColorMapping:
+    """Tests for instrument-aware cross-instrument color mapping."""
+
+    def test_nircam_cool_miri_warm(self):
+        """NIRCam filters should get cool hues (120-240), MIRI warm hues (0-60)."""
+        filters = ["F200W", "F444W", "F770W", "F1000W"]
+        mapping = build_cross_instrument_color_mapping(filters)
+        assert len(mapping) == 4
+
+        # NIRCam (F200W, F444W) should be blue-to-green range
+        # F200W → 240° (blue), F444W → 120° (green)
+        assert mapping["F200W"] == hue_to_hex(240.0)
+        assert mapping["F444W"] == hue_to_hex(120.0)
+        # MIRI (F770W, F1000W) should be yellow-to-red range
+        # F770W → 60° (yellow), F1000W → 0° (red)
+        assert mapping["F770W"] == hue_to_hex(60.0)
+        assert mapping["F1000W"] == hue_to_hex(0.0)
+
+    def test_single_nircam_single_miri(self):
+        """Single filter per instrument gets the midpoint hue."""
+        filters = ["F200W", "F770W"]
+        mapping = build_cross_instrument_color_mapping(filters)
+        assert mapping["F200W"] == hue_to_hex(180.0)  # cyan
+        assert mapping["F770W"] == hue_to_hex(30.0)  # orange
+
+    def test_cross_instrument_ngc5134(self):
+        """Real-world NGC 5134 PHANGS-JWST filter set."""
+        obs = [
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F300M", instrument="NIRCAM"),
+            ObservationInput(filter="F335M", instrument="NIRCAM"),
+            ObservationInput(filter="F360M", instrument="NIRCAM"),
+            ObservationInput(filter="F770W", instrument="MIRI"),
+            ObservationInput(filter="F2100W", instrument="MIRI"),
+        ]
+        recipes = generate_recipes(obs)
+
+        # Cross-instrument recipe should be first (rank 1)
+        assert recipes[0].rank == 1
+        assert len(recipes[0].instruments) == 2
+        assert len(recipes[0].filters) == 6
+
+        # Verify color separation: NIRCam filters have cool hues, MIRI warm
+        mapping = recipes[0].color_mapping
+        nircam_filters = ["F200W", "F300M", "F335M", "F360M"]
+        miri_filters = ["F770W", "F2100W"]
+
+        # All NIRCam and MIRI colors should be present
+        for f in nircam_filters + miri_filters:
+            assert f in mapping
+
+    def test_build_cross_instrument_color_mapping_three_nircam(self):
+        """Three NIRCam filters should span blue→green evenly."""
+        filters = ["F200W", "F300M", "F444W", "F770W"]
+        mapping = build_cross_instrument_color_mapping(filters)
+        # F200W → 240° (blue), F300M → 180° (cyan), F444W → 120° (green)
+        assert mapping["F200W"] == hue_to_hex(240.0)
+        assert mapping["F300M"] == hue_to_hex(180.0)
+        assert mapping["F444W"] == hue_to_hex(120.0)
+        # Single MIRI → 30° (orange)
+        assert mapping["F770W"] == hue_to_hex(30.0)
+
+    def test_uses_authoritative_instrument_data(self):
+        """When filter_instruments is provided, uses it instead of wavelength inference."""
+        filters = ["F200W", "F770W"]
+        # Override: pretend F770W is NIRCam (shouldn't happen, but tests the path)
+        mapping = build_cross_instrument_color_mapping(
+            filters, filter_instruments={"F200W": "NIRCAM", "F770W": "NIRCAM"}
+        )
+        # Both should get cool hues since both are "NIRCAM"
+        assert mapping["F200W"] == hue_to_hex(240.0)
+        assert mapping["F770W"] == hue_to_hex(120.0)
+
+    def test_fallback_when_no_instrument_data(self):
+        """Without filter_instruments, falls back to wavelength-based inference."""
+        filters = ["F200W", "F770W"]
+        mapping_no_inst = build_cross_instrument_color_mapping(filters)
+        mapping_with_inst = build_cross_instrument_color_mapping(
+            filters, filter_instruments={"F200W": "NIRCAM", "F770W": "MIRI"}
+        )
+        # Both paths should produce the same result for correct instrument data
+        assert mapping_no_inst == mapping_with_inst
+
+    def test_all_nircam_only_cool_hues(self):
+        """All-NIRCam filters should produce only cool hues."""
+        filters = ["F090W", "F200W", "F444W"]
+        mapping = build_cross_instrument_color_mapping(filters)
+        # Should span blue → green
+        assert mapping["F090W"] == hue_to_hex(240.0)
+        assert mapping["F200W"] == hue_to_hex(180.0)
+        assert mapping["F444W"] == hue_to_hex(120.0)
+
+
+class TestSingleInstrumentRankingUnchanged:
+    """Verify single-instrument targets are unaffected by ranking changes."""
+
+    def test_single_instrument_rank_starts_at_1(self):
+        obs = [
+            ObservationInput(filter="F090W", instrument="NIRCAM"),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        assert recipes[0].rank == 1
+        assert recipes[0].name == "3-filter NIRCAM"
+
+    def test_single_instrument_classic_rank_2(self):
+        obs = [
+            ObservationInput(filter="F090W", instrument="NIRCAM"),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        classic = next(r for r in recipes if "Classic" in r.name)
+        assert classic.rank == 2
+
+
+class TestRecipeDescriptions:
+    """Tests for recipe description field."""
+
+    def test_recipes_have_descriptions(self):
+        """All recipes should have non-None descriptions."""
+        obs = [
+            ObservationInput(filter="F090W", instrument="NIRCAM"),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+            ObservationInput(filter="F187N", instrument="NIRCAM"),
+            ObservationInput(filter="F470N", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        for recipe in recipes:
+            assert recipe.description is not None, f"Recipe '{recipe.name}' has no description"
+            assert len(recipe.description) > 0
+
+    def test_cross_instrument_description(self):
+        obs = [
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F770W", instrument="MIRI"),
+        ]
+        recipes = generate_recipes(obs)
+        cross = next(r for r in recipes if len(r.instruments) > 1)
+        assert "Stars and dust" in cross.description


### PR DESCRIPTION
## Summary
- Promotes cross-instrument recipes to rank 1 (recommended) when multiple instruments are present
- Adds instrument-aware color mapping: NIRCam → cool hues (blue-green), MIRI → warm hues (yellow-red)
- Adds short descriptions to all recipe types to help users choose

## Why
Cross-instrument composites (e.g. NIRCam + MIRI) show the full wavelength story — starlight plus dust emission — and are the most visually compelling result. Previously buried at rank 5, users missed them entirely. Color mapping now separates stellar from dust contributions visually.

## Changes Made
- **Recipe ranking**: Cross-instrument recipe moved to rank 1; single-instrument recipes shift to rank 2+
- **Color mapping**: New `build_cross_instrument_color_mapping()` assigns NIRCam filters to cool hues (240°→120°) and MIRI filters to warm hues (60°→0°), using authoritative instrument data with wavelength-based fallback
- **Descriptions**: All recipes include a 1-line description (nullable field, backward compatible)
- **Model updates**: Added `description` field across Python (`Recipe`), C# (`RecipeDto`), and TypeScript (`CompositeRecipe`)
- **Frontend**: RecipeCard renders description text below the recipe name
- **Tests**: 11 new tests covering ranking, color mapping, instrument inference, and descriptions
- **Docs**: Updated `docs/architecture/discovery-recipe-flow.md` with ranking tables
- **E2E mocks**: Updated mock recipes in target-detail and guided-create specs

No linked issue

## Test Plan
- [x] Python tests pass: 49/49 (11 new) via `docker exec jwst-processing python -m pytest tests/test_recipe_engine.py -v`
- [x] Frontend unit tests pass: 878/878
- [x] Backend tests pass: 793/793
- [x] TypeScript type check passes
- [x] Pre-commit hooks pass (ESLint, Ruff, Prettier)
- [ ] Manual: Navigate to a multi-instrument target (e.g. NGC 5134) → verify cross-instrument recipe is first with "Recommended" badge
- [ ] Manual: Verify NIRCam filters show cool colors, MIRI filters show warm colors in the recipe card
- [ ] Manual: Verify description text appears below recipe names

## Documentation Checklist
- [x] `docs/architecture/discovery-recipe-flow.md` — added ranking tables for multi- and single-instrument targets
- [x] No new controllers, services, or endpoints added
- [x] No removed endpoints or files
- [x] E2E mock data updated to include `description` field

## Tech Debt Impact
- [ ] Increases tech debt
- [x] Neutral
- [ ] Reduces tech debt

## Risk & Rollback

Risk: Low. All changes are additive — `description` is nullable (no API breaking change), ranking only affects display order, cross-instrument color mapping is a new code path that doesn't change single-instrument behavior.

Rollback: Revert this commit. No data migrations or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)