### PR TITLE
fix: move pytest coverage threshold to CI only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       working-directory: processing-engine
 
     - name: Test Processing Engine
-      run: pytest
+      run: pytest --cov-fail-under=60
       working-directory: processing-engine
 
   docker-build:

--- a/processing-engine/pyproject.toml
+++ b/processing-engine/pyproject.toml
@@ -91,6 +91,6 @@ testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=60"
+addopts = "-v --tb=short --cov=app --cov-report=term-missing"
 asyncio_mode = "auto"
 filterwarnings = []


### PR DESCRIPTION
## Summary
- Move `--cov-fail-under=60` from `pyproject.toml` addopts to CI workflow command only

## Why
Running a single test file (e.g. `pytest tests/test_recipe_engine.py`) falsely reported coverage failure at 12% because the threshold applied to all pytest runs regardless of scope. The full suite actually passes at 66%. This made local development annoying — every targeted test run showed a misleading red `FAIL` line.

No linked issue

## Changes Made
- `processing-engine/pyproject.toml`: Removed `--cov-fail-under=60` from `addopts`
- `.github/workflows/ci.yml`: Added `--cov-fail-under=60` to the CI pytest command

## Test Plan
- [x] Local single-file run: `pytest tests/test_recipe_engine.py` — passes without false coverage failure
- [x] Full suite: `pytest --cov-fail-under=60` — still enforces 60% threshold (66% actual)
- [ ] CI run confirms threshold still enforced in pipeline

## Documentation Checklist
- [x] No documentation updates needed — config-only change

## Tech Debt Impact
- [ ] No new tech debt introduced
- [x] Reduces existing tech debt
- [ ] Adds tech debt (explain below)

## Risk & Rollback
Risk: None. Coverage threshold still enforced in CI. Only local dev experience changes.
Rollback: Revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)