### PR TITLE
fix: invalidate stale recipe cache after spatial overlap update

### DIFF
--- a/frontend/jwst-frontend/src/services/discoveryService.test.ts
+++ b/frontend/jwst-frontend/src/services/discoveryService.test.ts
@@ -115,7 +115,7 @@ describe('discoveryService', () => {
         ],
       });
 
-      expect(getCached).toHaveBeenCalledWith('recipes:m51:obs-1,obs-2', expect.any(Number));
+      expect(getCached).toHaveBeenCalledWith('recipes:v2:m51:obs-1,obs-2', expect.any(Number));
     });
 
     it('should handle observations without observationId in cache key', async () => {
@@ -130,7 +130,7 @@ describe('discoveryService', () => {
       });
 
       expect(getCached).toHaveBeenCalledWith(
-        'recipes:m51:MIRI:F150W,NIRCam:F200W',
+        'recipes:v2:m51:MIRI:F150W,NIRCam:F200W',
         expect.any(Number)
       );
     });

--- a/frontend/jwst-frontend/src/services/discoveryService.ts
+++ b/frontend/jwst-frontend/src/services/discoveryService.ts
@@ -13,6 +13,7 @@ import type {
 } from '../types/DiscoveryTypes';
 
 const RECIPE_CACHE_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
+const RECIPE_CACHE_VERSION = 2; // Bump when recipe format changes to invalidate stale entries
 
 export interface RecipeCacheOptions {
   skipCache?: boolean;
@@ -42,7 +43,7 @@ export async function suggestRecipes(
     .map((o) => o.observationId ?? `${o.instrument}:${o.filter}`)
     .sort()
     .join(',');
-  const cacheKey = `recipes:${(request.targetName ?? '').toLowerCase()}:${sortedObsIds}`;
+  const cacheKey = `recipes:v${RECIPE_CACHE_VERSION}:${(request.targetName ?? '').toLowerCase()}:${sortedObsIds}`;
 
   if (!options?.skipCache) {
     const fresh = getCached<SuggestRecipesResponse>(cacheKey, RECIPE_CACHE_TTL_MS);


### PR DESCRIPTION
## Summary
- Add version segment to recipe cache key so old pre-spatial-awareness entries are invalidated

## Why
The recipe cache has a 48h TTL keyed by target name + observation IDs. After #763 added spatial overlap awareness, returning users would still get the old broken recipes from cache (same obs IDs, different output). Bumping the cache version ensures a cache miss and fresh API call.

No linked issue

## Changes Made
- `discoveryService.ts`: Added `RECIPE_CACHE_VERSION = 2` constant, included `v2:` segment in cache key
- `discoveryService.test.ts`: Updated 2 tests that assert on exact cache key format

## Test Plan
- [x] `npx vitest run src/services/discoveryService.test.ts` — 7 tests pass
- [x] Pre-commit hooks pass (878 frontend tests, ESLint clean)

## Documentation Checklist
- [x] No documentation updates needed — cache behavior is internal

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Reduces existing tech debt
- [ ] Adds tech debt (explain below)

## Risk & Rollback
Risk: None. Old cache entries simply miss — users get a fresh API call (which they'd get anyway after 48h). No data loss.
Rollback: Revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)