### PR TITLE
docs: update March 9 blog with afternoon session

### DIFF
--- a/docs/blog/posts/2026-03-09.md
+++ b/docs/blog/posts/2026-03-09.md
@@ -4,22 +4,25 @@ date:
 categories:
   - Feature
   - Bug Fix
+  - Performance
 tags:
   - astronomy-data
   - ci
+  - composite-processing
   - e2e-tests
   - infrastructure
   - mast-data
+  - recipe-engine
   - ui
 authors:
   - shanon
 ---
 
-# March 9: Polish Day
+# March 9: Spatial Awareness and Bundle Diet
 
 <!-- enriched -->
 
-A cleanup session: five pull requests across coverage, visuals, and small bugs. Replaced the app background with a Webb-style deep field, fixed a permanently disabled View button, patched the E2E pipeline, and smoothed out download progress bars.
+A two-part day. Morning: visual polish, bug fixes, and infrastructure cleanup. Afternoon: the recipe engine learned to look at the sky — cross-instrument composites now only combine observations that actually overlap. Plus a 52% main bundle reduction by lazy-loading page routes.
 
 <!-- more -->
 
@@ -37,19 +40,59 @@ Last fix: download progress bars were jumping up and down because SignalR update
 
 Cleaned up 10 stale git stashes from the past two weeks — all either already merged or trivially reproducible.
 
+### Afternoon: Recipe Engine Gets Eyes
+
+The big feature of the day: **spatial overlap awareness** for the recipe engine. Testing NGC 5134 after #762 added cross-instrument ranking revealed a fundamental problem — the colors were correct (NIRCam cool, MIRI warm), but the composite image was broken. MIRI data appeared in one corner, NIRCam galaxy in another. They were different sky pointings combined into one recipe because the engine grouped by instrument/filter only, with zero spatial awareness.
+
+The fix threads `s_ra`/`s_dec` center coordinates through the full pipeline (frontend → .NET → Python), then uses a Vincenty formula for angular separation with union-find single-linkage clustering using known JWST instrument FOV radii. Cross-instrument recipes are now only generated for observation groups that actually overlap on the sky. When no coordinate data is available, it falls back to the old behavior (assume overlap) with a visible warning.
+
+Also set `requires_mosaic` properly — when the same filter appears at two distinct pointings more than 10 arcseconds apart, the recipe now flags it. 13 new tests cover the spatial math, clustering, chain-linking, and edge cases.
+
+Found a pre-existing bug during review: the C# `ObservationDto` was silently dropping `TObsRelease` and `DataProductType` during deserialization, meaning the Python engine's proprietary-observation and spectral-observation filtering was effectively dead code in production. Fixed in the same PR.
+
+### Cache, Coverage, and Bundle
+
+After merging spatial awareness, realized the 48-hour recipe cache would serve stale pre-spatial recipes to returning users. Added a version segment to the cache key so old entries miss automatically.
+
+Tackled the backend coverage numbers — 18,842 generated lines (OpenAPI support, RegexGenerator, Logging) were more than half the codebase and dragging coverage from 50% to 32%. Added a coverlet runsettings file to exclude `*.g.cs` and generated attributes. Coverage jumped to **60.1%** with zero new tests.
+
+The pytest coverage threshold was also misconfigured — `--cov-fail-under=60` in `pyproject.toml` applied even when running a single test file, falsely reporting 12% failure. Moved it to the CI command only.
+
+Last PR: lazy-loaded all 9 page routes in `App.tsx`. The barrel import (`from './pages'`) was pulling every page into the main chunk. Splitting at the route level dropped the main JS bundle from **188 KB to 90 KB gzip** (52% smaller). The plotly chunk (1.48 MB) now only loads when the user navigates to MyLibrary. Total chunks went from 2 to 22.
+
+Also resolved all 6 pre-existing ESLint warnings across the frontend — zero warnings, zero errors for the first time.
+
 ## What Changed
 
-### Features (1)
+### Features (3)
 
 - [#755](https://github.com/Snoww3d/jwst-data-analysis/pull/755) replace constellation background with Webb deep field
+- [#761](https://github.com/Snoww3d/jwst-data-analysis/pull/761) add stretch preset selector to discovery result step
+- [#763](https://github.com/Snoww3d/jwst-data-analysis/pull/763) add spatial overlap awareness to recipe engine
 
-### Bug Fixes (4)
+### Bug Fixes (5)
 
-- [#754](https://github.com/Snoww3d/jwst-data-analysis/pull/754) raise backend coverage threshold to 40% and exclude generated code
 - [#756](https://github.com/Snoww3d/jwst-data-analysis/pull/756) View button always disabled due to filePath never in API response
 - [#757](https://github.com/Snoww3d/jwst-data-analysis/pull/757) add missing mast-proxy Docker build to E2E CI pipeline
 - [#758](https://github.com/Snoww3d/jwst-data-analysis/pull/758) prevent download progress bar from jumping backwards
+- [#764](https://github.com/Snoww3d/jwst-data-analysis/pull/764) move pytest coverage threshold to CI only
+- [#765](https://github.com/Snoww3d/jwst-data-analysis/pull/765) invalidate stale recipe cache after spatial overlap update
+
+### Performance (1)
+
+- [#767](https://github.com/Snoww3d/jwst-data-analysis/pull/767) lazy-load all page routes to split main bundle (188 KB → 90 KB gzip)
+
+### Infrastructure (2)
+
+- [#754](https://github.com/Snoww3d/jwst-data-analysis/pull/754) raise backend coverage threshold to 40% and exclude generated code
+- [#766](https://github.com/Snoww3d/jwst-data-analysis/pull/766) add coverlet exclusions for generated .NET backend code
+
+### Docs (3)
+
+- [#759](https://github.com/Snoww3d/jwst-data-analysis/pull/759) enrich blog posts for March 6-9 with Slack journal and images
+- [#760](https://github.com/Snoww3d/jwst-data-analysis/pull/760) add Phase 9 — lightweight community edition plan
+- [#762](https://github.com/Snoww3d/jwst-data-analysis/pull/762) smart recipe ranking and cross-instrument color mapping
 
 ---
-8 commits across 5 pull requests.
+14 commits across 14 pull requests.
 *Next: March 10, 2026.*


### PR DESCRIPTION
## Summary
- Update March 9 blog post to cover all 14 PRs from the full day (was only covering the first 5)

## Why
The blog post was written during the morning session. The afternoon added spatial overlap awareness, cache invalidation, coverage fixes, and lazy-load bundle optimization.

No linked issue

## Changes Made
- `docs/blog/posts/2026-03-09.md`: Added afternoon journal section covering spatial overlap, cache, coverage, and bundle work. Updated PR listing from 5 to 14.

## Test Plan
- [x] Blog renders correctly in markdown preview

## Documentation Checklist
- [x] Blog post updated

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Reduces existing tech debt
- [ ] Adds tech debt (explain below)

## Risk & Rollback
Risk: None. Docs only.
Rollback: Revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)