### PR TITLE
ci: add docs-only fast path to skip code checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,40 @@ on:
   workflow_dispatch:
 
 jobs:
-  # All jobs run in parallel for maximum speed
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            code:
+              - 'backend/**'
+              - 'frontend/**'
+              - 'processing-engine/**'
+              - 'docker/**'
+              - '.github/workflows/ci.yml'
+              - 'scripts/**'
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: detect-changes
     steps:
     - uses: actions/checkout@v6
 
     - name: Check Documentation Consistency
       run: ./scripts/check-docs-consistency.sh
 
-    # Frontend Linting
+    # Code linting only runs when code files changed
     - name: Setup Node.js
+      if: needs.detect-changes.outputs.code == 'true'
       uses: actions/setup-node@v6
       with:
         node-version: '22'
@@ -28,38 +49,45 @@ jobs:
         cache-dependency-path: frontend/jwst-frontend/package-lock.json
 
     - name: Install Frontend Dependencies
+      if: needs.detect-changes.outputs.code == 'true'
       run: npm ci
       working-directory: frontend/jwst-frontend
 
     - name: Lint Frontend (ESLint)
+      if: needs.detect-changes.outputs.code == 'true'
       run: npm run lint
       working-directory: frontend/jwst-frontend
 
     - name: Check Frontend Formatting (Prettier)
+      if: needs.detect-changes.outputs.code == 'true'
       run: npm run format:check
       working-directory: frontend/jwst-frontend
 
-    # Processing Engine Linting
     - name: Set up Python
+      if: needs.detect-changes.outputs.code == 'true'
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
     - name: Install Ruff
+      if: needs.detect-changes.outputs.code == 'true'
       run: pip install ruff
 
     - name: Lint Processing Engine (Ruff)
+      if: needs.detect-changes.outputs.code == 'true'
       run: ruff check .
       working-directory: processing-engine
 
     - name: Check Processing Engine Formatting (Ruff)
+      if: needs.detect-changes.outputs.code == 'true'
       run: ruff format --check .
       working-directory: processing-engine
 
   backend-test:
     name: Backend Tests
     runs-on: ubuntu-latest
-    # No 'needs' - runs in parallel with other jobs
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
 
     steps:
     - uses: actions/checkout@v6
@@ -98,7 +126,8 @@ jobs:
   frontend-test:
     name: Frontend Tests
     runs-on: ubuntu-latest
-    # No 'needs' - runs in parallel with other jobs
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
 
     steps:
     - uses: actions/checkout@v6
@@ -125,7 +154,8 @@ jobs:
   python-test:
     name: Python Tests
     runs-on: ubuntu-latest
-    # No 'needs' - runs in parallel with other jobs
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
 
     steps:
     - uses: actions/checkout@v6
@@ -150,7 +180,8 @@ jobs:
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest
-    # No 'needs' - runs in parallel with other jobs
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
 
     steps:
     - uses: actions/checkout@v6
@@ -320,3 +351,42 @@ jobs:
     - name: Stop Docker Stack
       if: always()
       run: docker compose -f docker/docker-compose.yml down
+
+  # Single gate job for branch protection — skipped jobs count as passing
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [lint, backend-test, frontend-test, python-test, docker-build, e2e-test]
+    steps:
+      - name: Check job results
+        run: |
+          echo "lint: ${{ needs.lint.result }}"
+          echo "backend-test: ${{ needs.backend-test.result }}"
+          echo "frontend-test: ${{ needs.frontend-test.result }}"
+          echo "python-test: ${{ needs.python-test.result }}"
+          echo "docker-build: ${{ needs.docker-build.result }}"
+          echo "e2e-test: ${{ needs.e2e-test.result }}"
+
+          # Required jobs must pass or be skipped (docs-only path)
+          for job in lint backend-test frontend-test python-test docker-build; do
+            result="${{ needs.lint.result }}"
+            case "$job" in
+              lint) result="${{ needs.lint.result }}" ;;
+              backend-test) result="${{ needs.backend-test.result }}" ;;
+              frontend-test) result="${{ needs.frontend-test.result }}" ;;
+              python-test) result="${{ needs.python-test.result }}" ;;
+              docker-build) result="${{ needs.docker-build.result }}" ;;
+            esac
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "::error::Required job '$job' failed with result: $result"
+              exit 1
+            fi
+          done
+
+          # E2E is informational — warn but don't block
+          if [[ "${{ needs.e2e-test.result }}" == "failure" ]]; then
+            echo "::warning::E2E tests failed (non-blocking)"
+          fi
+
+          echo "All required checks passed!"


### PR DESCRIPTION
## Summary

Docs-only PRs now skip all code-related CI jobs (backend tests, frontend tests, Python tests, Docker builds, E2E) and run only the Lint job (docs consistency check). A new `CI Gate` merge gate evaluates all upstream jobs, treating skipped-due-to-path as passing.

No linked issue — infrastructure improvement requested by maintainer.

## Why

Every docs PR currently waits 3-5 minutes for backend builds, frontend builds, Python tests, and Docker image builds that are completely irrelevant. This cuts docs PR CI time to ~30 seconds.

## Changes Made

- Added `detect-changes` job using `dorny/paths-filter@v3` to detect code vs docs-only changes
- Code paths: `backend/**`, `frontend/**`, `processing-engine/**`, `docker/**`, `.github/workflows/ci.yml`, `scripts/**`
- Push-to-main and workflow_dispatch always run full CI (conservative)
- Lint job always runs docs consistency check; code linting steps conditionally skipped
- Backend Tests, Frontend Tests, Python Tests, Docker Build jobs skip entirely for docs-only PRs
- E2E Tests inherits skip via `needs: docker-build`
- Added `CI Gate` job that evaluates all required jobs — passes if all are success or skipped, fails if any failed
- E2E failures logged as warnings in CI Gate (non-blocking, same as current policy)

## Test Plan

- [x] Verify CI triggers and runs all jobs on this code-change PR
- [ ] After merge, verify a docs-only PR skips code jobs and CI Gate passes
- [ ] Verify `workflow_dispatch` runs full CI

## Post-merge: Branch Protection Update

After the first CI run creates the `CI Gate` check name, update branch protection:

**Remove** these 5 required checks:
- `Lint`
- `Backend Tests`
- `Frontend Tests`
- `Python Tests`
- `Docker Build`

**Add** this 1 required check:
- `CI Gate`

**Keep** (unchanged):
- `Validate PR Standards` (separate workflow)

## Documentation Checklist

- [x] No documentation changes needed — CI-only change

## Tech Debt Impact

- [x] Reduces tech debt (faster CI feedback loop for docs work)
- [ ] No change to tech debt
- [ ] Adds tech debt (explain below)

## Risk & Rollback

Risk: Low — additive change. Existing jobs unchanged, only conditionally skipped. Push-to-main always runs full CI.
Rollback: Revert this commit and restore the 5 individual required checks in branch protection.

Closes: N/A