### PR TITLE
fix: auto-crop black borders from composite images

### DIFF
--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -63,18 +63,56 @@ async function rotateBlob(
     const w = Math.round(img.width * cos + img.height * sin);
     const h = Math.round(img.width * sin + img.height * cos);
 
-    const canvas = document.createElement('canvas');
-    canvas.width = w;
-    canvas.height = h;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) throw new Error('Failed to get 2D rendering context');
+    // Rotate onto an expanded canvas
+    const rotCanvas = document.createElement('canvas');
+    rotCanvas.width = w;
+    rotCanvas.height = h;
+    const rotCtx = rotCanvas.getContext('2d');
+    if (!rotCtx) throw new Error('Failed to get 2D rendering context');
 
-    ctx.translate(w / 2, h / 2);
-    ctx.rotate(rad);
-    ctx.drawImage(img, -img.width / 2, -img.height / 2);
+    rotCtx.translate(w / 2, h / 2);
+    rotCtx.rotate(rad);
+    rotCtx.drawImage(img, -img.width / 2, -img.height / 2);
+
+    // Auto-crop black borders after rotation
+    const imageData = rotCtx.getImageData(0, 0, w, h);
+    const { data } = imageData;
+    let top = h,
+      left = w,
+      bottom = 0,
+      right = 0;
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const i = (y * w + x) * 4;
+        // Non-black if any RGB channel > 2 (small threshold for compression artifacts)
+        if (data[i] > 2 || data[i + 1] > 2 || data[i + 2] > 2) {
+          if (y < top) top = y;
+          if (y > bottom) bottom = y;
+          if (x < left) left = x;
+          if (x > right) right = x;
+        }
+      }
+    }
+
+    // Fall back to full canvas if no content found
+    if (bottom <= top || right <= left) {
+      top = 0;
+      left = 0;
+      bottom = h - 1;
+      right = w - 1;
+    }
+
+    const cropW = right - left + 1;
+    const cropH = bottom - top + 1;
+    const cropCanvas = document.createElement('canvas');
+    cropCanvas.width = cropW;
+    cropCanvas.height = cropH;
+    const cropCtx = cropCanvas.getContext('2d');
+    if (!cropCtx) throw new Error('Failed to get 2D rendering context');
+    cropCtx.drawImage(rotCanvas, left, top, cropW, cropH, 0, 0, cropW, cropH);
 
     return await new Promise<Blob>((resolve, reject) => {
-      canvas.toBlob(
+      cropCanvas.toBlob(
         (b) => (b ? resolve(b) : reject(new Error('Canvas toBlob failed'))),
         format,
         format === 'image/jpeg' ? 0.92 : undefined

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -58,6 +58,31 @@ PREVIEW_OVERSAMPLE = 4  # 4x oversampling gives good quality for the final resiz
 MIN_PREVIEW_PIXELS = 500_000  # floor to avoid too-tiny intermediates
 
 
+def _auto_crop(rgb: np.ndarray, threshold: float = 0.005) -> np.ndarray:
+    """Crop black borders from an RGB float array.
+
+    Finds the bounding box of pixels where any channel exceeds the
+    threshold and returns the cropped region.  Falls back to the
+    original array if no non-black pixels are found.
+    """
+    mask = np.any(rgb > threshold, axis=2)
+    rows = np.any(mask, axis=1)
+    cols = np.any(mask, axis=0)
+
+    if not rows.any() or not cols.any():
+        return rgb
+
+    r_min, r_max = np.where(rows)[0][[0, -1]]
+    c_min, c_max = np.where(cols)[0][[0, -1]]
+
+    cropped = rgb[r_min : r_max + 1, c_min : c_max + 1]
+    if cropped.shape != rgb.shape:
+        logger.info(
+            f"Auto-crop: {rgb.shape[1]}x{rgb.shape[0]} → {cropped.shape[1]}x{cropped.shape[0]}"
+        )
+    return cropped
+
+
 def downscale_for_composite(
     data: np.ndarray, wcs: WCS, max_pixels: int = MAX_INPUT_PIXELS
 ) -> tuple[np.ndarray, WCS]:
@@ -540,12 +565,23 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
         # Flip vertically for correct astronomical orientation
         rgb_array = np.flipud(rgb_array)
 
+        # Auto-crop black borders from WCS reprojection padding.
+        # The reprojected grid is aligned to celestial North, so rotated
+        # detector data leaves black triangular corners that waste space.
+        rgb_array = _auto_crop(rgb_array)
+
         # Convert to 8-bit image
         rgb_8bit = (np.clip(rgb_array, 0, 1) * 255).astype(np.uint8)
         image = Image.fromarray(rgb_8bit, mode="RGB")
 
-        if (image.width, image.height) != (request.width, request.height):
-            image = image.resize((request.width, request.height), Image.Resampling.LANCZOS)
+        # Resize to fit within requested dimensions, preserving aspect ratio.
+        # Scale the cropped image so its largest side matches the requested bound.
+        target_w, target_h = request.width, request.height
+        scale = min(target_w / image.width, target_h / image.height)
+        new_w = max(1, round(image.width * scale))
+        new_h = max(1, round(image.height * scale))
+        if (new_w, new_h) != (image.width, image.height):
+            image = image.resize((new_w, new_h), Image.Resampling.LANCZOS)
 
         buf = io.BytesIO()
         if request.output_format == "jpeg":


### PR DESCRIPTION
## Summary
Auto-crop black WCS reprojection padding from composite images so they fill the preview frame and export as tight rectangles.

No linked issue (addresses user-reported issue with composite not filling frame and exports being tilted)

## Why
When JWST detector data is reprojected onto a celestial-North-aligned WCS grid, the rotated detector footprint leaves black triangular corners. This wastes space in the preview (image doesn't fill the frame) and makes exports appear tilted with large black borders.

## Changes Made
- **Backend** (`processing-engine/app/composite/routes.py`):
  - Added `_auto_crop()` function that detects the bounding box of non-black pixels (threshold 0.005) and crops the RGB array
  - Applied after flipud, before resize
  - Resize now preserves the cropped aspect ratio instead of forcing to requested width/height square
- **Frontend** (`frontend/jwst-frontend/src/components/guided/ResultStep.tsx`):
  - Updated `rotateBlob()` to auto-crop black borders after canvas rotation
  - Scans pixel data for non-black content (threshold > 2 per channel) and crops to tight bounding box
  - Prevents the rotation from expanding the canvas with more black space

## Test Plan
- [x] All 870 Python tests pass (including composite tests)
- [x] All 878 frontend tests pass
- [x] Pre-commit hooks pass (ESLint, Prettier, Ruff)
- [ ] CI passes
- [ ] Manual test: generate a composite and verify preview fills the frame
- [ ] Manual test: export with rotation and verify tight rectangle output

## Documentation Checklist
- [x] No new endpoints or API changes — no doc updates needed

## Tech Debt Impact
- [x] Reduces tech debt — fixes a visual quality issue
- [ ] No impact on tech debt
- [ ] Increases tech debt

## Risk & Rollback
Risk: Low — auto-crop only removes pure-black borders (threshold 0.005). If all pixels are black, falls back to the full array. Aspect-ratio-preserving resize is standard behavior.
Rollback: Revert the commit to restore the previous stretch-to-square behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)