### PR TITLE
fix: add 60s timeout to background estimation in source detection

### DIFF
--- a/processing-engine/app/analysis/routes.py
+++ b/processing-engine/app/analysis/routes.py
@@ -4,6 +4,8 @@ FastAPI routes for region selection and statistics computation.
 
 import logging
 import math
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 
 import numpy as np
 from astropy.io import fits
@@ -285,11 +287,27 @@ def detect_sources_endpoint(request: SourceDetectionRequest):
                 fill_val = float(np.nanmedian(data))
                 data = np.nan_to_num(data, nan=fill_val, posinf=fill_val, neginf=0.0)
 
-            # Estimate background (pass NaN mask as coverage_mask to exclude filled regions)
+            # Estimate background with timeout to prevent indefinite hangs
+            # on pathological data where the iterative algorithm won't converge.
+            BACKGROUND_TIMEOUT_SECS = 60
             try:
-                background, background_rms = estimate_background(
-                    data, coverage_mask=nan_mask if has_nan else None
+                with ThreadPoolExecutor(max_workers=1) as pool:
+                    future = pool.submit(
+                        estimate_background,
+                        data,
+                        coverage_mask=nan_mask if has_nan else None,
+                    )
+                    background, background_rms = future.result(timeout=BACKGROUND_TIMEOUT_SECS)
+            except FuturesTimeoutError:
+                logger.warning(
+                    f"2D background estimation timed out after {BACKGROUND_TIMEOUT_SECS}s, "
+                    "using simple estimate"
                 )
+                from app.processing.background import estimate_background_simple
+
+                bkg_val, bkg_rms = estimate_background_simple(data)
+                background = np.full_like(data, bkg_val)
+                background_rms = np.full_like(data, bkg_rms)
             except Exception as bkg_err:
                 logger.warning(f"2D background estimation failed: {bkg_err}, using simple estimate")
                 from app.processing.background import estimate_background_simple


### PR DESCRIPTION
## Summary
Add a 60-second timeout to the `estimate_background()` call in the source detection endpoint to prevent indefinite hangs.

Closes #751

## Why
The iterative 2D background estimation algorithm (`photutils.Background2D`) can fail to converge on pathological data, causing the request to hang forever with no timeout.

## Changes Made
- Wrapped `estimate_background()` in `detect_sources_endpoint` with a `ThreadPoolExecutor` and 60-second timeout
- On timeout, gracefully falls back to the simple sigma-clipped stats estimator (same fallback used for other estimation failures)
- Added `concurrent.futures` imports

## Test Plan
- [x] All 870 Python tests pass
- [x] Pre-commit hooks pass (ruff lint + format)
- [ ] CI passes

## Documentation Checklist
- [x] No new endpoints or API changes — no doc updates needed

## Tech Debt Impact
- [x] Reduces tech debt — eliminates a hang condition
- [ ] No impact on tech debt
- [ ] Increases tech debt

## Risk & Rollback
Risk: Low — timeout only triggers after 60 seconds of no response, and falls back to the same simple estimator already used for other failures.
Rollback: Revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)