### PR TITLE
ci: pin .NET SDK to 10.0.200 to fix CI download failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x'
+        dotnet-version: '10.0.200'
 
     # Cache NuGet packages
     - name: Cache NuGet packages

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '10.0.200'
 
       - name: Cache NuGet packages
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary
- Pins .NET SDK version in CI workflows to `10.0.200` instead of `10.0.x`
- Fixes Backend Tests and CodeQL failures on all PRs

## Why
`setup-dotnet` resolves `10.0.x` to `10.0.201` which appears in the .NET release index but isn't downloadable from the CDN yet. This breaks every PR's CI.

No linked issue

## Changes Made
- `.github/workflows/ci.yml`: `10.0.x` → `10.0.200`
- `.github/workflows/security.yml`: `10.0.x` → `10.0.200`

## Test Plan
- [x] CI on this PR should pass Backend Tests (the whole point)

## Documentation Checklist
- [x] No documentation updates needed — CI config only

## Tech Debt Impact
- [ ] Reduces tech debt
- [x] No impact on tech debt
- [ ] Increases tech debt — explain:

## Risk & Rollback
Risk: None — pinning to a known-good version is safer than a wildcard.
Rollback: Revert to `10.0.x` when `10.0.201` is published to the CDN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)