### PR TITLE
fix: filter non-science observations from recipe generation

### DIFF
--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -328,6 +328,23 @@ def generate_recipes(observations: list[ObservationInput]) -> list[Recipe]:
     if not observations:
         return []
 
+    # Filter out non-science observations (calibration darks, flats, etc.).
+    # Only keep filters with a known wavelength — this excludes entries like
+    # OPAQUE;MIRROR, CLEAR, FLAT, GR150R, etc. that aren't imaging filters.
+    science_observations = [obs for obs in observations if resolve_wavelength(obs) is not None]
+    if len(science_observations) < len(observations):
+        dropped_filters = sorted(
+            {obs.filter for obs in observations if resolve_wavelength(obs) is None}
+        )
+        logger.info(
+            f"Filtered {len(observations) - len(science_observations)} non-science "
+            f"observation(s) with unknown filters: {', '.join(dropped_filters)}"
+        )
+    observations = science_observations
+
+    if not observations:
+        return []
+
     # Filter out proprietary observations (Option B safety net)
     today_mjd = (datetime.now(UTC) - _MJD_EPOCH).days
     public_observations = [

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -527,6 +527,68 @@ class TestRecipeDescriptions:
         assert "Stars and dust" in cross.description
 
 
+class TestNonScienceFilterExclusion:
+    """Tests for filtering non-science observations (calibration darks, flats, etc.)."""
+
+    def test_opaque_mirror_excluded(self):
+        """OPAQUE;MIRROR (calibration dark) should be filtered out."""
+        obs = [
+            ObservationInput(filter="OPAQUE;MIRROR", instrument="NIRCAM"),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        all_filters = {f for r in recipes for f in r.filters}
+        assert "OPAQUE;MIRROR" not in all_filters
+        assert "F200W" in all_filters
+        assert "F444W" in all_filters
+
+    def test_all_non_science_returns_empty(self):
+        """If all observations are non-science, return no recipes."""
+        obs = [
+            ObservationInput(filter="OPAQUE;MIRROR", instrument="NIRCAM"),
+            ObservationInput(filter="CLEAR", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        assert recipes == []
+
+    def test_mixed_science_and_non_science(self):
+        """Non-science filters excluded, science filters produce recipes."""
+        obs = [
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="OPAQUE;MIRROR", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+            ObservationInput(filter="FLAT", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        assert len(recipes) >= 1
+        all_filters = {f for r in recipes for f in r.filters}
+        assert all_filters == {"F200W", "F444W"}
+
+    def test_grism_filter_excluded(self):
+        """Grism/prism filters (GR150R, GR150C) should be excluded."""
+        obs = [
+            ObservationInput(filter="GR150R", instrument="NIRISS"),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        all_filters = {f for r in recipes for f in r.filters}
+        assert "GR150R" not in all_filters
+        assert "F200W" in all_filters
+
+    def test_known_science_filters_preserved(self):
+        """All standard imaging filters should pass through the filter."""
+        obs = [
+            ObservationInput(filter="F090W", instrument="NIRCAM"),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+            ObservationInput(filter="F770W", instrument="MIRI"),
+        ]
+        recipes = generate_recipes(obs)
+        all_filters = {f for r in recipes for f in r.filters}
+        assert all_filters == {"F090W", "F200W", "F444W", "F770W"}
+
+
 class TestSpatialGrouping:
     """Tests for spatial overlap detection and grouping."""
 


### PR DESCRIPTION
## Summary

Filter out non-science observations (calibration darks, flats, grism filters) from composite recipe generation. These observations have no downloadable FITS products and cause misleading warnings in the Create Composite wizard.

Closes #777

## Why

Users see "OPAQUE;MIRROR: no FITS products available at this calibration level" warnings when creating composites for targets that have calibration observations in MAST. These non-imaging filters should never appear in recipes.

## Changes Made

- Added non-science filter exclusion in `generate_recipes()` — observations with filters not in `FILTER_WAVELENGTHS` (e.g. `OPAQUE;MIRROR`, `CLEAR`, `FLAT`, `GR150R`) are dropped with an info log
- Added early return after spectral filtering (before the new filter) for clarity
- Added `TestNonScienceFilterExclusion` test class with 5 tests covering: OPAQUE;MIRROR exclusion, all-non-science → empty, mixed filtering, grism exclusion, science filter preservation

## Test Plan

- [x] Run `docker exec jwst-processing python -m pytest tests/test_recipe_engine.py -v` — all 62 tests pass
- [ ] Navigate to Create Composite for Cartwheel Galaxy — OPAQUE;MIRROR warning should no longer appear
- [ ] Verify other targets with known calibration observations no longer show non-science filters

## Documentation Checklist

- [x] No new endpoints, controllers, or services added
- [x] No documentation updates needed — internal filtering logic only

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — adds filtering upstream of recipe generation; only removes observations that would fail downstream anyway.
Rollback: Revert the commit; non-science filters will reappear in recipes (cosmetic issue, no data loss).