### PR TITLE
fix: bump recipe cache version to invalidate stale non-science recipes

### DIFF
--- a/frontend/jwst-frontend/src/services/discoveryService.test.ts
+++ b/frontend/jwst-frontend/src/services/discoveryService.test.ts
@@ -115,7 +115,7 @@ describe('discoveryService', () => {
         ],
       });
 
-      expect(getCached).toHaveBeenCalledWith('recipes:v2:m51:obs-1,obs-2', expect.any(Number));
+      expect(getCached).toHaveBeenCalledWith('recipes:v3:m51:obs-1,obs-2', expect.any(Number));
     });
 
     it('should handle observations without observationId in cache key', async () => {
@@ -130,7 +130,7 @@ describe('discoveryService', () => {
       });
 
       expect(getCached).toHaveBeenCalledWith(
-        'recipes:v2:m51:MIRI:F150W,NIRCam:F200W',
+        'recipes:v3:m51:MIRI:F150W,NIRCam:F200W',
         expect.any(Number)
       );
     });

--- a/frontend/jwst-frontend/src/services/discoveryService.ts
+++ b/frontend/jwst-frontend/src/services/discoveryService.ts
@@ -13,7 +13,7 @@ import type {
 } from '../types/DiscoveryTypes';
 
 const RECIPE_CACHE_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
-const RECIPE_CACHE_VERSION = 2; // Bump when recipe format changes to invalidate stale entries
+const RECIPE_CACHE_VERSION = 3; // Bump when recipe format changes to invalidate stale entries
 
 export interface RecipeCacheOptions {
   skipCache?: boolean;


### PR DESCRIPTION
## Summary

Bump the browser-side recipe cache version from v2 to v3 so stale cached recipes containing non-science filters (CLEAR;PRISM, OPAQUE;MIRROR) are discarded.

No linked issue — follow-up to #777/#778.

## Why

PR #778 fixed the recipe engine to exclude non-science filters, but the frontend caches recipes in localStorage for 48 hours. Users who visited before the fix would keep seeing the old recipes with `CLEAR;PRISM` etc. until the cache expired.

## Changes Made

- Bumped `RECIPE_CACHE_VERSION` from 2 to 3 in `discoveryService.ts`
- Updated cache key assertions in `discoveryService.test.ts` to match

## Test Plan

- [x] All 865 frontend unit tests pass locally
- [ ] Open Cartwheel Galaxy composite wizard — recipes should no longer include CLEAR;PRISM or OPAQUE;MIRROR

## Documentation Checklist

- [x] No documentation updates needed — config-only change

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

Risk: None — cache key change only affects stale data invalidation.
Rollback: Revert the version bump; users with stale cache entries will see old recipes until the 48h TTL expires naturally.