### PR TITLE
fix: verify FITS files exist on disk in data availability check

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -2129,13 +2129,24 @@ namespace JwstDataAnalysis.API.Controllers
                         && !string.IsNullOrEmpty(r.FilePath)
                         && r.ProcessingLevel is ProcessingLevels.Level2a or ProcessingLevels.Level2b or ProcessingLevels.Level3).ToList();
 
-                    if (usable.Count > 0)
+                    // Verify files actually exist on disk — MongoDB records can outlive deleted files
+                    var verified = new List<JwstDataModel>(usable.Count);
+                    foreach (var r in usable)
+                    {
+                        var key = StorageKeyHelper.ToRelativeKey(r.FilePath!);
+                        if (await storageProvider.ExistsAsync(key))
+                        {
+                            verified.Add(r);
+                        }
+                    }
+
+                    if (verified.Count > 0)
                     {
                         response.Results[obsId] = new DataAvailabilityItem
                         {
                             Available = true,
-                            DataIds = [.. usable.Select(r => r.Id)],
-                            Filter = usable.FirstOrDefault()?.ImageInfo?.Filter,
+                            DataIds = [.. verified.Select(r => r.Id)],
+                            Filter = verified.FirstOrDefault()?.ImageInfo?.Filter,
                         };
                     }
                 }


### PR DESCRIPTION
## Summary

The `check-availability` endpoint now verifies that FITS files actually exist on disk before reporting data as available. Previously it only checked MongoDB records, causing the guided creation wizard to skip downloads for missing files.

No linked issue

## Why

Cartwheel Galaxy composite was failing with "Processing engine error" because the download step was skipped — MongoDB had records for the observation but the FITS files had been deleted from disk. The wizard thought data was available and jumped straight to processing, which then got 404s from the storage layer.

## Changes Made

- Added `storageProvider.ExistsAsync()` verification in `CheckDataAvailability` — each candidate record's file path is checked against actual storage before being included in the response
- Records with missing files are silently excluded, triggering re-download on the next guided creation attempt

## Test Plan

- [x] Backend builds with 0 errors
- [x] All 793 backend tests pass
- [ ] Delete a downloaded FITS file, then start guided creation for that target — should trigger download instead of skipping
- [ ] Cartwheel Galaxy "Create Composite" should now download missing files and process successfully

## Documentation Checklist

- [x] No new endpoints, controllers, or services added
- [x] No documentation updates needed — behavioral fix to existing endpoint

## Tech Debt Impact

- [x] No new tech debt introduced
- Note: The availability check now makes N storage existence checks per observation. For local storage this is negligible (stat calls). For S3 this could add latency — acceptable since availability is checked once before downloads, not in a hot path.

## Risk & Rollback

Risk: Low — adds a verification step that can only make the response more conservative (fewer false "available" results), never more permissive.
Rollback: Revert the commit; availability check will again report stale records as available, which leads to the original processing error.