### PR TITLE
fix: add scroll shadows to channel colors list for overflow indication

### DIFF
--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -201,6 +201,23 @@
 .result-channels-list {
   max-height: 280px;
   overflow-y: auto;
+  /* Pure-CSS scroll shadows — visible only when content overflows */
+  background:
+    /* Top shadow cover (scrolls with content) */
+    linear-gradient(var(--bg-surface) 30%, transparent) center top,
+    /* Bottom shadow cover (scrolls with content) */
+    linear-gradient(transparent, var(--bg-surface) 70%) center bottom,
+    /* Top shadow (fixed) */
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.3), transparent) center top,
+    /* Bottom shadow (fixed) */
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.3), transparent) center bottom;
+  background-repeat: no-repeat;
+  background-size:
+    100% 20px,
+    100% 20px,
+    100% 8px,
+    100% 8px;
+  background-attachment: local, local, scroll, scroll;
 }
 
 .result-channels-header {


### PR DESCRIPTION
## Summary
Adds pure-CSS scroll shadows to the channel colors list so users can visually tell when the list is scrollable (7+ filters). Shadows appear at top/bottom edges only when there's more content in that direction.

No linked issue

## Why
With 13 filters (e.g. Cartwheel Galaxy), the channel colors panel overflows. PR #784 added `max-height: 280px` with `overflow-y: auto`, but there was no visual indication that the list is scrollable — users may not realize there are more channels below.

## Changes Made
- Added Lea Verou's pure-CSS scroll shadow technique using `background-attachment: local` vs `scroll`
- Shadows auto-appear when content overflows and auto-hide at scroll boundaries
- No JavaScript required

## Test Plan
- [x] Frontend tests pass (865/865)
- [ ] Manual: Open a 7+ filter composite and verify shadow appears at bottom of channel list
- [ ] Manual: Scroll to bottom and verify bottom shadow disappears, top shadow appears

## Documentation Checklist
- [x] `docs/key-files.md` — no changes needed
- [x] `docs/standards/backend-development.md` — no changes needed
- [x] `docs/architecture/` — no changes needed
- [x] `docs/quick-reference.md` — no changes needed
- [x] `docs/tech-debt.md` — no changes needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Adds tech debt (explain below)
- [ ] Reduces tech debt (explain below)

## Risk & Rollback
Risk: None — CSS-only change, no behavioral impact.
Rollback: Revert this PR.