### PR TITLE
fix: improve Result step layout and UX

### DIFF
--- a/frontend/jwst-frontend/e2e/guided-create.spec.ts
+++ b/frontend/jwst-frontend/e2e/guided-create.spec.ts
@@ -286,7 +286,7 @@ test.describe('Guided create — page structure', () => {
     await page.goto('/create?target=Test%20Target&recipe=2-filter%20NIRCAM');
     await expect(page.locator('.guided-create')).toBeVisible({ timeout: 15_000 });
 
-    const backLinks = page.locator('.guided-create-back .back-link');
+    const backLinks = page.locator('.guided-create-header .back-link');
     await expect(backLinks.first()).toBeVisible();
   });
 

--- a/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.css
+++ b/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.css
@@ -2,7 +2,7 @@
 .export-framing {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-2);
 }
 
 .export-framing-header {
@@ -115,24 +115,11 @@
   text-align: right;
 }
 
-/* Preset categories */
+/* Preset grid — compact single-flow layout */
 .export-framing-presets {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-}
-
-.export-framing-preset-category {
-  display: flex;
-  flex-direction: column;
   gap: var(--space-1);
-}
-
-.export-framing-preset-label {
-  font-size: var(--text-xs);
-  color: var(--text-faint);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
 
 .export-framing-preset-row {

--- a/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.tsx
@@ -22,8 +22,6 @@ interface ExportFramingPanelProps {
   onExport: (result: ExportFramingResult) => void;
 }
 
-const PRESET_CATEGORIES = ['Desktop', 'Phone', 'Tablet', 'Social'] as const;
-
 /**
  * Scan the canvas to find the bounding box of non-black content,
  * then compute optimal zoom + center to fill the target aspect ratio.
@@ -136,6 +134,9 @@ export function ExportFramingPanel({
   const targetW = selectedPreset?.width ?? customW;
   const targetH = selectedPreset?.height ?? customH;
 
+  // Max canvas height — prevent portrait presets from making the canvas enormous
+  const MAX_CANVAS_HEIGHT = 500;
+
   // Track container width for responsive canvas sizing
   useEffect(() => {
     const wrap = wrapRef.current;
@@ -148,14 +149,19 @@ export function ExportFramingPanel({
     return () => observer.disconnect();
   }, []);
 
+  // Note: The canvas preview operates on the 2000×2000 preview image,
+  // while the server export processes the raw composite. The framing math
+  // uses normalized coordinates (crop_center 0-1, crop_zoom multiplier)
+  // so results should be resolution-independent, but minor differences in
+  // auto-crop or content detection between preview and full-res can cause
+  // slight framing mismatches — especially at high zoom or extreme aspect ratios.
   const drawCanvas = useCallback(() => {
     const canvas = canvasRef.current;
     const img = imgRef.current;
     if (!canvas || !img) return;
 
-    // Canvas size: fit target aspect ratio into available container width
-    const maxDisplayW = containerWidth;
-    const displayScale = Math.min(maxDisplayW / targetW, maxDisplayW / targetH);
+    // Canvas size: fit target aspect ratio into available space (width + height capped)
+    const displayScale = Math.min(containerWidth / targetW, MAX_CANVAS_HEIGHT / targetH);
     const displayW = Math.round(targetW * displayScale);
     const displayH = Math.round(targetH * displayScale);
     canvas.width = displayW;
@@ -301,16 +307,8 @@ export function ExportFramingPanel({
     });
   }
 
-  // Group presets by category
-  const presetsByCategory = PRESET_CATEGORIES.map((cat) => ({
-    category: cat,
-    presets: WALLPAPER_PRESETS.filter((p) => p.category === cat),
-  }));
-
   return (
     <div className="export-framing">
-      <h4 className="export-framing-header">Export</h4>
-
       {/* Framing canvas — serves as the main preview */}
       <div className="export-framing-canvas-wrap" ref={wrapRef} onPointerDown={handlePointerDown}>
         {previewUrl ? (
@@ -339,72 +337,58 @@ export function ExportFramingPanel({
         <span className="export-framing-zoom-value">{cropZoom.toFixed(1)}x</span>
       </div>
 
-      {/* Resolution presets */}
+      {/* Resolution presets — compact single-flow grid */}
       <div className="export-framing-presets">
-        {presetsByCategory.map(({ category, presets }) => (
-          <div key={category} className="export-framing-preset-category">
-            <span className="export-framing-preset-label">{category}</span>
-            <div className="export-framing-preset-row">
-              {presets.map((preset) => (
-                <button
-                  key={preset.id}
-                  type="button"
-                  className={`btn-base export-framing-preset-btn${selectedPreset?.id === preset.id ? ' active' : ''}`}
-                  title={`${preset.width}×${preset.height}`}
-                  onClick={() => handlePresetSelect(preset)}
-                >
-                  {preset.label}
-                </button>
-              ))}
-            </div>
-          </div>
-        ))}
-
-        {/* Custom */}
-        <div className="export-framing-preset-category">
-          <span className="export-framing-preset-label">Custom</span>
-          <div className="export-framing-custom">
+        <div className="export-framing-preset-row">
+          {WALLPAPER_PRESETS.map((preset) => (
             <button
+              key={preset.id}
               type="button"
-              className={`btn-base export-framing-preset-btn${selectedPreset === null ? ' active' : ''}`}
-              onClick={handleCustom}
+              className={`btn-base export-framing-preset-btn${selectedPreset?.id === preset.id ? ' active' : ''}`}
+              title={`${preset.category} — ${preset.width}×${preset.height}`}
+              onClick={() => handlePresetSelect(preset)}
             >
-              Custom
+              {preset.label}
             </button>
-            {selectedPreset === null && (
-              <>
-                <input
-                  type="number"
-                  className="export-framing-custom-input"
-                  value={customW}
-                  min={100}
-                  max={4096}
-                  onChange={(e) => {
-                    const val = Number(e.target.value);
-                    if (!isNaN(val)) setCustomW(Math.max(100, Math.min(4096, val)));
-                  }}
-                />
-                <span className="export-framing-custom-x">&times;</span>
-                <input
-                  type="number"
-                  className="export-framing-custom-input"
-                  value={customH}
-                  min={100}
-                  max={4096}
-                  onChange={(e) => {
-                    const val = Number(e.target.value);
-                    if (!isNaN(val)) setCustomH(Math.max(100, Math.min(4096, val)));
-                  }}
-                />
-              </>
-            )}
-          </div>
+          ))}
+          <button
+            type="button"
+            className={`btn-base export-framing-preset-btn${selectedPreset === null ? ' active' : ''}`}
+            onClick={handleCustom}
+          >
+            Custom
+          </button>
         </div>
-      </div>
-
-      {/* Resolution display */}
-      <div className="export-framing-resolution">
-        {targetW} &times; {targetH}
+        {selectedPreset === null && (
+          <div className="export-framing-custom">
+            <input
+              type="number"
+              className="export-framing-custom-input"
+              value={customW}
+              min={100}
+              max={4096}
+              onChange={(e) => {
+                const val = Number(e.target.value);
+                if (!isNaN(val)) setCustomW(Math.max(100, Math.min(4096, val)));
+              }}
+            />
+            <span className="export-framing-custom-x">&times;</span>
+            <input
+              type="number"
+              className="export-framing-custom-input"
+              value={customH}
+              min={100}
+              max={4096}
+              onChange={(e) => {
+                const val = Number(e.target.value);
+                if (!isNaN(val)) setCustomH(Math.max(100, Math.min(4096, val)));
+              }}
+            />
+          </div>
+        )}
+        <div className="export-framing-resolution">
+          {targetW} &times; {targetH}
+        </div>
       </div>
 
       {/* Format + Export */}

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -1,7 +1,7 @@
 .result-step {
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-2);
 }
 
 /* Sidebar split layout — preview left, controls right */
@@ -17,14 +17,14 @@
   min-width: 0;
 }
 
-/* Controls sidebar */
+/* Controls sidebar — sticky, no overflow clipping (popover needs to escape) */
 .result-sidebar {
   flex: 0 0 280px;
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  max-height: 100%;
-  overflow: visible;
+  position: sticky;
+  top: var(--space-3);
 }
 
 /* Mobile: stack vertically */
@@ -265,9 +265,7 @@
 }
 
 .result-channel-picker-popover {
-  position: absolute;
-  top: calc(100% + 8px);
-  left: 50%;
+  position: fixed;
   transform: translateX(-50%);
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
@@ -412,7 +410,7 @@
 
 .result-slider-label span {
   flex-shrink: 0;
-  width: 72px;
+  width: 84px;
 }
 
 .result-slider {
@@ -575,9 +573,9 @@
   border-color: var(--accent-primary-hover, #4b8df8);
 }
 
-/* Advanced editor link */
+/* Advanced editor link — inside info section */
 .result-advanced-link {
-  text-align: left;
+  margin-top: var(--space-1);
 }
 
 .result-advanced-link a {

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { Link } from 'react-router-dom';
 import {
   channelColorToHex,
@@ -104,13 +105,36 @@ export function ResultStep({
     [onChannelsChange]
   );
 
-  // Color picker popover state
+  // Color picker popover state — rendered via portal to escape overflow containers
   const [openPickerIndex, setOpenPickerIndex] = useState<number | null>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
+  const swatchBtnRef = useRef<Map<number, globalThis.HTMLButtonElement>>(new Map());
+  const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null);
+
+  // Position popover via useLayoutEffect — setState before paint is the standard
+  // pattern for portal positioning (no alternative without layout shift).
+  useLayoutEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect, @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- must measure DOM before paint to position portal-rendered popover; no alternative without layout shift */
+    if (openPickerIndex === null) {
+      setPopoverPos(null);
+      return;
+    }
+    const btn = swatchBtnRef.current.get(openPickerIndex);
+    if (!btn) return;
+    const rect = btn.getBoundingClientRect();
+    setPopoverPos({
+      top: rect.bottom + 8,
+      left: rect.left + rect.width / 2,
+    });
+    /* eslint-enable react-hooks/set-state-in-effect, @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
+  }, [openPickerIndex]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (pickerRef.current && !pickerRef.current.contains(event.target as HTMLElement)) {
+        // Also check if click was on a swatch button (toggle handled by onClick)
+        const target = event.target as HTMLElement;
+        if (target.closest('.result-channel-swatch-btn')) return;
         setOpenPickerIndex(null);
       }
     }
@@ -217,6 +241,11 @@ export function ResultStep({
                 </span>
               ))}
             </p>
+            <div className="result-advanced-link">
+              <Link to="/composite" state={compositePageState}>
+                Open in Advanced Editor &rarr;
+              </Link>
+            </div>
           </div>
 
           {exportError && <p className="result-export-error">{exportError}</p>}
@@ -247,17 +276,17 @@ export function ResultStep({
                 {displayChannels.map((ch, i) => {
                   const hex = channelColorToHex(ch.color);
                   const weightPercent = Math.round(ch.weight * 100);
-                  const currentHue = ch.color.hue ?? (ch.color.rgb ? rgbToHue(...ch.color.rgb) : 0);
                   return (
                     <div key={ch.label ?? i} className="result-channel-row">
-                      <div
-                        className="result-channel-picker-wrap"
-                        ref={openPickerIndex === i ? pickerRef : undefined}
-                      >
+                      <div className="result-channel-picker-wrap">
                         <button
                           type="button"
                           className="btn-base result-channel-swatch-btn"
                           title="Change color"
+                          ref={(el) => {
+                            if (el) swatchBtnRef.current.set(i, el);
+                            else swatchBtnRef.current.delete(i);
+                          }}
                           onClick={() => setOpenPickerIndex(openPickerIndex === i ? null : i)}
                         >
                           <span
@@ -265,43 +294,6 @@ export function ResultStep({
                             style={{ backgroundColor: hex }}
                           />
                         </button>
-                        {openPickerIndex === i && (
-                          <div className="result-channel-picker-popover">
-                            <div className="result-channel-preset-row">
-                              {NASA_PALETTE.map((preset) => {
-                                const presetHex = hueToHex(preset.hue);
-                                const isActive = Math.abs(currentHue - preset.hue) < 5;
-                                return (
-                                  <button
-                                    key={preset.name}
-                                    type="button"
-                                    className={`btn-base result-channel-preset${isActive ? ' active' : ''}`}
-                                    style={{ backgroundColor: presetHex }}
-                                    title={preset.name}
-                                    onClick={() => handlePresetSelect(i, preset.hue)}
-                                  />
-                                );
-                              })}
-                            </div>
-                            <div className="result-channel-picker-divider" />
-                            <label className="result-channel-custom-row">
-                              <span className="result-channel-custom-label">Custom</span>
-                              <span
-                                className="result-channel-custom-swatch"
-                                style={{ backgroundColor: hex }}
-                              />
-                              <input
-                                type="color"
-                                value={hex}
-                                onChange={(e) => {
-                                  handleChannelColorChange(i, e.target.value);
-                                  setOpenPickerIndex(null);
-                                }}
-                                className="result-channel-color-input"
-                              />
-                            </label>
-                          </div>
-                        )}
                       </div>
                       <span className="result-channel-name">{ch.label}</span>
                       <input
@@ -320,6 +312,58 @@ export function ResultStep({
               </div>
             </div>
           )}
+
+          {/* Color picker popover — rendered via portal to escape overflow containers */}
+          {openPickerIndex !== null &&
+            popoverPos &&
+            (() => {
+              const ch = displayChannels[openPickerIndex];
+              if (!ch) return null;
+              const hex = channelColorToHex(ch.color);
+              const currentHue = ch.color.hue ?? (ch.color.rgb ? rgbToHue(...ch.color.rgb) : 0);
+              return createPortal(
+                <div
+                  ref={pickerRef}
+                  className="result-channel-picker-popover"
+                  style={{ top: popoverPos.top, left: popoverPos.left }}
+                >
+                  <div className="result-channel-preset-row">
+                    {NASA_PALETTE.map((preset) => {
+                      const presetHex = hueToHex(preset.hue);
+                      const isActive = Math.abs(currentHue - preset.hue) < 5;
+                      return (
+                        <button
+                          key={preset.name}
+                          type="button"
+                          className={`btn-base result-channel-preset${isActive ? ' active' : ''}`}
+                          style={{ backgroundColor: presetHex }}
+                          title={preset.name}
+                          onClick={() => handlePresetSelect(openPickerIndex, preset.hue)}
+                        />
+                      );
+                    })}
+                  </div>
+                  <div className="result-channel-picker-divider" />
+                  <label className="result-channel-custom-row">
+                    <span className="result-channel-custom-label">Custom</span>
+                    <span
+                      className="result-channel-custom-swatch"
+                      style={{ backgroundColor: hex }}
+                    />
+                    <input
+                      type="color"
+                      value={hex}
+                      onChange={(e) => {
+                        handleChannelColorChange(openPickerIndex, e.target.value);
+                        setOpenPickerIndex(null);
+                      }}
+                      className="result-channel-color-input"
+                    />
+                  </label>
+                </div>,
+                document.body
+              );
+            })()}
 
           <div className="result-adjustments">
             <h4 className="result-adjustments-header">Quick Adjustments</h4>
@@ -413,12 +457,6 @@ export function ResultStep({
                 </button>
               )}
             </div>
-          </div>
-
-          <div className="result-advanced-link">
-            <Link to="/composite" state={compositePageState}>
-              Open in Advanced Editor &rarr;
-            </Link>
           </div>
         </div>
       </div>

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.css
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.css
@@ -3,6 +3,36 @@
   margin: 0 auto;
 }
 
+/* Widen on step 3 to give the two-column layout room */
+.guided-create.guided-create--wide {
+  max-width: 1200px;
+}
+
+/* Compact header: breadcrumb + title (+ stepper on step 3) on one line */
+.guided-create-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.guided-create-header h2 {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+/* Stepper inline in header on step 3 — push right, shrink to fit */
+.guided-create-header .wizard-stepper {
+  margin-left: auto;
+  margin-bottom: 0;
+  align-self: center;
+  transform: scale(0.85);
+  transform-origin: right center;
+}
+
+/* Fallback for pages that still use the old separate layout */
 .guided-create-back {
   margin-bottom: var(--space-4);
 }
@@ -16,12 +46,12 @@
 
 /* Stepper spacing */
 .guided-create .wizard-stepper {
-  margin-bottom: var(--space-6);
+  margin-bottom: var(--space-4);
 }
 
 /* Step content area */
 .guided-create-content {
-  margin-top: var(--space-2);
+  margin-top: 0;
 }
 
 /* Init error state */

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -57,7 +57,7 @@ const BICOLOR_WEIGHTS: [number, number, number][] = [
   [1.0, 0.5, 0], // long wavelength → red + half green
 ];
 
-const DEFAULT_PRESET = COMPOSITE_PRESETS.find((p) => p.id === 'nasa') ?? COMPOSITE_PRESETS[0];
+const DEFAULT_PRESET = COMPOSITE_PRESETS.find((p) => p.id === 'natural') ?? COMPOSITE_PRESETS[0];
 
 /**
  * Build NChannelConfigPayload array from recipe + imported data mappings.
@@ -844,22 +844,22 @@ export function GuidedCreate() {
   }
 
   return (
-    <div className="guided-create">
-      <div className="guided-create-back">
+    <div className={`guided-create${currentStep === 3 ? ' guided-create--wide' : ''}`}>
+      <div className="guided-create-header">
         {target ? (
           <Link to={`/target/${encodeURIComponent(target)}`} className="back-link">
-            &larr; Back to {target}
+            &larr; {target}
           </Link>
         ) : (
           <Link to="/" className="back-link">
-            &larr; Back to Discovery
+            &larr; Discovery
           </Link>
         )}
+        <h2>Create Composite</h2>
+        {currentStep === 3 && <WizardStepper steps={WIZARD_STEPS} currentStep={currentStep} />}
       </div>
 
-      <h2>Create Composite</h2>
-
-      <WizardStepper steps={WIZARD_STEPS} currentStep={currentStep} />
+      {currentStep !== 3 && <WizardStepper steps={WIZARD_STEPS} currentStep={currentStep} />}
 
       {resolving && !initError && (
         <div className="guided-create-init-skeleton" role="status" aria-label="Loading recipe">

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -108,8 +108,7 @@ export const WALLPAPER_PRESETS: WallpaperPreset[] = [
   { id: 'qhd', label: 'QHD', category: 'Desktop', width: 2560, height: 1440 },
   { id: 'fhd', label: 'FHD', category: 'Desktop', width: 1920, height: 1080 },
   { id: 'ultrawide', label: 'Ultrawide', category: 'Desktop', width: 3440, height: 1440 },
-  { id: 'iphone', label: 'iPhone', category: 'Phone', width: 1290, height: 2796 },
-  { id: 'android', label: 'Android', category: 'Phone', width: 1440, height: 3120 },
+  { id: 'mobile', label: 'Mobile', category: 'Phone', width: 1080, height: 1920 },
   { id: 'ipad', label: 'iPad', category: 'Tablet', width: 2048, height: 2732 },
   { id: 'square', label: 'Square', category: 'Social', width: 2000, height: 2000 },
 ];
@@ -160,6 +159,28 @@ export interface CompositePreset {
  * Others offer useful starting points for different science/presentation goals.
  */
 export const COMPOSITE_PRESETS: CompositePreset[] = [
+  {
+    id: 'natural',
+    label: 'Natural',
+    description: 'Gentle stretch for a more photographic look',
+    channelParams: {
+      stretch: 'sqrt',
+      blackPoint: 0.01,
+      whitePoint: 1.0,
+      gamma: 1.0,
+      asinhA: 0.1,
+      curve: 'linear',
+      weight: 1.0,
+    },
+    overall: {
+      stretch: 'linear',
+      blackPoint: 0.0,
+      whitePoint: 1.0,
+      gamma: 1.0,
+      asinhA: 0.1,
+    },
+    backgroundNeutralization: true,
+  },
   {
     id: 'nasa',
     label: 'NASA Press',
@@ -222,28 +243,6 @@ export const COMPOSITE_PRESETS: CompositePreset[] = [
       blackPoint: 0.0,
       whitePoint: 1.0,
       gamma: 1.3,
-      asinhA: 0.1,
-    },
-    backgroundNeutralization: true,
-  },
-  {
-    id: 'natural',
-    label: 'Natural',
-    description: 'Gentle stretch for a more photographic look',
-    channelParams: {
-      stretch: 'sqrt',
-      blackPoint: 0.01,
-      whitePoint: 1.0,
-      gamma: 1.0,
-      asinhA: 0.1,
-      curve: 'linear',
-      weight: 1.0,
-    },
-    overall: {
-      stretch: 'linear',
-      blackPoint: 0.0,
-      whitePoint: 1.0,
-      gamma: 1.0,
       asinhA: 0.1,
     },
     backgroundNeutralization: true,


### PR DESCRIPTION
## Summary
- Compact the guided create Result step to eliminate unnecessary scrolling
- Fix color picker popover clipping, Edge Feather label wrapping, and portrait canvas overflow
- Consolidate mobile presets and reorder stretch presets

No linked issue

## Why
The Result step required scrolling to reach the Export button and Advanced Editor link. The page header took two rows, the sidebar overflowed with many channels, the Edge Feather label wrapped to two lines, and portrait presets (Mobile/iPad) made the canvas enormous. The color picker popover was also clipped by the sidebar overflow.

## Changes Made
- **`GuidedCreate.tsx/.css`**: Combine breadcrumb + title into single header row. Widen container to 1200px on step 3. Inline wizard stepper in header on step 3 (scaled 0.85x, right-aligned). Remove step content top margin.
- **`ResultStep.tsx/.css`**: Move Advanced Editor link into info section (always visible). Render color picker popover via React portal to escape overflow containers. Fix slider label width (72px → 84px) for "Edge Feather". Reduce result-step gap. Make sidebar sticky.
- **`ExportFramingPanel.tsx/.css`**: Remove "EXPORT" header label. Compact presets into single wrapped row (removed 5 separate category sections). Cap canvas height at 500px for portrait presets. Reduce panel gap.
- **`CompositeTypes.ts`**: Replace iPhone + Android presets with single Mobile (1080×1920). Move Natural preset to first position.
- **`GuidedCreate.tsx`**: Change default stretch preset from NASA Press to Natural.
- **`guided-create.spec.ts`**: Update E2E selector for new header structure.

## Test Plan
- [x] All frontend tests pass (865/865)
- [x] ESLint clean
- [ ] Navigate to Result step with 3-channel composite — verify no scrolling needed to see Export button
- [ ] Navigate with 8-channel composite — verify sidebar handles many channels, Advanced Editor visible
- [ ] Click a channel color swatch — verify popover renders above all content (no clipping)
- [ ] Select Mobile preset — verify canvas stays compact (max 500px height)
- [ ] Verify breadcrumb + title + stepper all fit on one header line on step 3
- [ ] Verify steps 1-2 still show stepper on its own row

## Documentation Checklist
- [x] No documentation updates needed — layout/UX improvements only

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Adds tech debt (explain below)
- [ ] Reduces existing tech debt

## Risk & Rollback
Risk: Low. CSS/layout changes and preset reordering. No API or data model changes.
Rollback: Revert this commit.