### PR TITLE
fix: update E2E test selectors to match current component structure

### DIFF
--- a/frontend/jwst-frontend/e2e/composite-wizard.spec.ts
+++ b/frontend/jwst-frontend/e2e/composite-wizard.spec.ts
@@ -19,12 +19,14 @@ test.describe('Composite wizard', () => {
   test('navigates to /composite via Composite button', async ({ page }) => {
     await page.getByRole('button', { name: /Composite/i }).click();
     await expect(page).toHaveURL(/\/composite/);
-    await expect(page.locator('.wizard-page')).toBeVisible();
+    // Wait for wizard-stepper specifically — the loading state shows .wizard-page but no stepper
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
   });
 
   test('displays 2-step wizard stepper', async ({ page }) => {
     await page.getByRole('button', { name: /Composite/i }).click();
-    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 10_000 });
+    // Wait for wizard-stepper specifically — the loading state shows .wizard-page but no stepper
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
 
     const steps = page.locator('.wizard-stepper .wizard-step');
     await expect(steps).toHaveCount(2);
@@ -34,7 +36,7 @@ test.describe('Composite wizard', () => {
 
   test('shows channel lanes on step 1', async ({ page }) => {
     await page.getByRole('button', { name: /Composite/i }).click();
-    await expect(page.locator('.channel-lanes')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.channel-lanes')).toBeVisible({ timeout: 15_000 });
 
     // Should have at least the default channel lanes (RGB preset starts with 3)
     const lanes = page.locator('.channel-lane');
@@ -43,7 +45,7 @@ test.describe('Composite wizard', () => {
 
   test('shows image pool with available images', async ({ page }) => {
     await page.getByRole('button', { name: /Composite/i }).click();
-    await expect(page.locator('.wizard-page')).toBeVisible();
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
 
     await expect(page.locator('.image-pool')).toBeVisible();
     // We uploaded 3 images — pool should show some cards
@@ -53,7 +55,7 @@ test.describe('Composite wizard', () => {
 
   test('navigates between steps (forward and back)', async ({ page }) => {
     await page.getByRole('button', { name: /Composite/i }).click();
-    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
 
     // Next should be disabled without images assigned
     const nextBtn = page.locator('.wizard-footer .btn-wizard.btn-primary');
@@ -81,7 +83,7 @@ test.describe('Composite wizard', () => {
 
   test('closes wizard via close button and navigates back', async ({ page }) => {
     await page.getByRole('button', { name: /Composite/i }).click();
-    await expect(page.locator('.wizard-page')).toBeVisible();
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
 
     await page.locator('.wizard-page-container .btn-close').click();
     await expect(page).toHaveURL(/\/library/);

--- a/frontend/jwst-frontend/e2e/guided-create.spec.ts
+++ b/frontend/jwst-frontend/e2e/guided-create.spec.ts
@@ -485,10 +485,9 @@ test.describe('Guided create — result step (step 3)', () => {
     const resultStep = page.locator('.result-step');
     await expect(resultStep).toBeVisible({ timeout: 30_000 });
 
-    // Preview image should be visible
-    const preview = resultStep.locator('.result-preview-image');
-    await expect(preview).toBeVisible();
-    await expect(preview).toHaveAttribute('alt', /composite/i);
+    // Export framing canvas should be visible (replaced img with canvas in ExportFramingPanel)
+    const canvas = resultStep.locator('.export-framing-canvas');
+    await expect(canvas).toBeVisible({ timeout: 10_000 });
   });
 
   test('shows target name and recipe in result info', async ({ page }) => {
@@ -749,9 +748,9 @@ test.describe('Guided create — anonymous user', () => {
     const resultStep = page.locator('.result-step');
     await expect(resultStep).toBeVisible({ timeout: 30_000 });
 
-    // Preview image should be visible
-    const preview = resultStep.locator('.result-preview-image');
-    await expect(preview).toBeVisible();
+    // Export framing canvas should be visible (replaced img with canvas in ExportFramingPanel)
+    const canvas = resultStep.locator('.export-framing-canvas');
+    await expect(canvas).toBeVisible({ timeout: 10_000 });
   });
 
   test('shows login gate when data needs downloading', async ({ page }) => {

--- a/frontend/jwst-frontend/e2e/mast-download.spec.ts
+++ b/frontend/jwst-frontend/e2e/mast-download.spec.ts
@@ -75,8 +75,9 @@ test.describe('MAST download UI', () => {
 
     // Open the MAST panel
     const mastToggle = page.locator('button.mast-search-btn');
+    await expect(mastToggle).toBeVisible({ timeout: 10_000 });
     await mastToggle.click();
-    await expect(page.locator('.mast-search')).toBeVisible();
+    await expect(page.locator('.mast-search')).toBeVisible({ timeout: 10_000 });
   });
 
   test('shows download source dropdown with three options', async ({ page }) => {

--- a/frontend/jwst-frontend/e2e/mast-search.spec.ts
+++ b/frontend/jwst-frontend/e2e/mast-search.spec.ts
@@ -13,8 +13,9 @@ test.describe('MAST search panel', () => {
 
     // Open the MAST panel for every test (use specific toggle button class)
     const mastToggle = page.locator('button.mast-search-btn');
+    await expect(mastToggle).toBeVisible({ timeout: 10_000 });
     await mastToggle.click();
-    await expect(page.locator('.mast-search')).toBeVisible();
+    await expect(page.locator('.mast-search')).toBeVisible({ timeout: 10_000 });
   });
 
   test('toggles MAST search panel open and close', async ({ page }) => {

--- a/frontend/jwst-frontend/e2e/mosaic-wizard.spec.ts
+++ b/frontend/jwst-frontend/e2e/mosaic-wizard.spec.ts
@@ -19,12 +19,13 @@ test.describe('Mosaic wizard', () => {
   test('navigates to /mosaic via WCS Mosaic button', async ({ page }) => {
     await page.getByRole('button', { name: /WCS Mosaic/i }).click();
     await expect(page).toHaveURL(/\/mosaic/);
-    await expect(page.locator('.wizard-page')).toBeVisible();
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
   });
 
   test('displays 2-step wizard stepper', async ({ page }) => {
     await page.getByRole('button', { name: /WCS Mosaic/i }).click();
-    await expect(page.locator('.wizard-page')).toBeVisible();
+    // Wait for wizard-stepper specifically — the loading state shows .wizard-page but no stepper
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
 
     const steps = page.locator('.wizard-stepper .wizard-step');
     await expect(steps).toHaveCount(2);
@@ -33,7 +34,7 @@ test.describe('Mosaic wizard', () => {
 
   test('shows file selection cards on step 1', async ({ page }) => {
     await page.getByRole('button', { name: /WCS Mosaic/i }).click();
-    await expect(page.locator('.wizard-page')).toBeVisible();
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
 
     // Wait for image cards to load
     const cards = page.locator('.mosaic-image-card');
@@ -43,7 +44,7 @@ test.describe('Mosaic wizard', () => {
 
   test('enables Next when 2+ files selected', async ({ page }) => {
     await page.getByRole('button', { name: /WCS Mosaic/i }).click();
-    await expect(page.locator('.wizard-page')).toBeVisible();
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
 
     const cards = page.locator('.mosaic-image-card');
     await expect(cards.first()).toBeVisible({ timeout: 10_000 });
@@ -59,7 +60,7 @@ test.describe('Mosaic wizard', () => {
 
   test('navigates to step 2 and shows generate button', async ({ page }) => {
     await page.getByRole('button', { name: /WCS Mosaic/i }).click();
-    await expect(page.locator('.wizard-page')).toBeVisible();
+    await expect(page.locator('.wizard-stepper')).toBeVisible({ timeout: 15_000 });
 
     const cards = page.locator('.mosaic-image-card');
     await expect(cards.first()).toBeVisible({ timeout: 10_000 });

--- a/frontend/jwst-frontend/e2e/session-persistence.spec.ts
+++ b/frontend/jwst-frontend/e2e/session-persistence.spec.ts
@@ -22,7 +22,7 @@ test.describe('Session persistence and token handling', () => {
     await loginWithTokens(page, auth);
     await page.reload();
     await expect(page).not.toHaveURL(/\/(login|register)/);
-    await expect(page.locator('.dashboard .controls')).toBeVisible();
+    await expect(page.locator('.dashboard .controls')).toBeVisible({ timeout: 15_000 });
   });
 
   test('auto-refreshes when access token is expired but refresh token is valid', async ({


### PR DESCRIPTION
## Summary
Fix 27 E2E test failures caused by stale selectors and insufficient timeouts.

## Why
- ResultStep replaced `<img class="result-preview-image">` with `ExportFramingPanel` using `<canvas class="export-framing-canvas">`, but tests still looked for the old selector
- Wizard tests waited for `.wizard-page` which appears in loading state (no stepper rendered), causing race conditions
- MAST and session tests had tight timeouts that failed under parallel load (especially Firefox)

Closes #No linked issue

## Changes Made
- **guided-create.spec.ts**: Replace `.result-preview-image` selector with `.export-framing-canvas`
- **mosaic-wizard.spec.ts**: Wait for `.wizard-stepper` instead of `.wizard-page` (loading state has no stepper)
- **composite-wizard.spec.ts**: Same `.wizard-stepper` wait fix, increase timeouts to 15s
- **session-persistence.spec.ts**: Add 15s timeout for `.dashboard .controls` after page reload
- **mast-search.spec.ts / mast-download.spec.ts**: Add explicit visibility waits before interacting with MAST toggle button

## Test Plan
- [x] Full E2E suite passes locally: 339 passed, 0 failed (81 skipped as expected)
- [x] Previously failing guided-create tests now pass across all browsers
- [x] Wizard stepper race condition resolved
- [x] Pre-commit hooks pass (lint + 865 unit tests)

## Documentation Checklist
- [x] No documentation updates needed — test-only changes

## Tech Debt Impact
- [x] Reduces tech debt — eliminates flaky test failures

## Risk & Rollback
Risk: Low — test-only changes, no production code modified
Rollback: Revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)