### PR TITLE
fix: switch to By Target view in openImageViewer to fix 18 E2E skips

### DIFF
--- a/frontend/jwst-frontend/e2e/helpers.ts
+++ b/frontend/jwst-frontend/e2e/helpers.ts
@@ -219,23 +219,24 @@ export async function openImageViewer(page: Page, fileName?: string): Promise<bo
   // Wait for data cards to render
   await page.waitForTimeout(1000);
 
+  // The default Lineage view nests file cards inside collapsible processing
+  // levels that start collapsed — cards aren't in the DOM until expanded.
+  // Switch to "By Target" which renders flat .data-card elements for all files.
+  const byTargetBtn = page.getByRole('button', { name: /By Target/i });
+  if ((await byTargetBtn.count()) > 0) {
+    await byTargetBtn.click();
+    await page.waitForTimeout(1000);
+  }
+
   let viewButton;
 
   if (fileName) {
-    // Target the specific file's card by matching the filename text.
-    // DataCard renders the name in an <h4>, LineageFileCard in a .file-name span.
     const card = page.locator('.data-card', { hasText: fileName }).first();
     if ((await card.count()) === 0) {
       return false;
     }
     viewButton = card.locator('.view-file-btn:not(.disabled)');
   } else {
-    // Fallback: switch to "By Target" view and click the first viewable file
-    const byTargetBtn = page.getByRole('button', { name: /By Target/i });
-    if ((await byTargetBtn.count()) > 0) {
-      await byTargetBtn.click();
-      await page.waitForTimeout(1000);
-    }
     viewButton = page.locator('.view-file-btn:not(.disabled)').first();
   }
 


### PR DESCRIPTION
## Summary

Fixes 18 E2E test skips caused by `openImageViewer()` searching for `.data-card` elements that don't exist in the default Lineage view.

## Why

The Lineage view (default dashboard view) renders file cards as `.lineage-file-card` inside collapsible processing levels that **start collapsed** — meaning the file card elements aren't in the DOM at all until a user manually expands a level. `openImageViewer()` searched for `.data-card` (only rendered in the "By Target" view), so every filename-based lookup returned 0 matches and all dependent tests skipped with "No viewable data available."

## Changes Made

- Modified `openImageViewer()` in `e2e/helpers.ts` to always switch to "By Target" view before searching for file cards
- This was already the behavior for the no-filename fallback path; now it's consistent for both paths
- Removed the redundant view-switch from the else branch since it's now done unconditionally

## Test Plan

- [x] Single viewer test passes: `npx playwright test --project=chromium -g "opens viewer overlay"` → PASS
- [x] Full E2E suite: 135 passed, 0 skipped (was 7 passed, 18 skipped)
- [ ] 5 tests fail with preview timeout (processing engine slow to generate preview, not a selector issue — pre-existing flakiness)

## Documentation Checklist

- [x] No new endpoints, controllers, services, or components — E2E helper change only
- [x] No documentation updates needed

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — E2E test helper change only, no production code modified.
Rollback: Revert the single commit.

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)