### PR TITLE
fix: add scroll shadow indicators to all bounded scrollable panels

### DIFF
--- a/frontend/jwst-frontend/src/components/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/MastSearch.css
@@ -704,6 +704,8 @@
   background: var(--overlay-light);
   border-radius: var(--radius-md);
   margin-bottom: var(--space-3);
+  /* scroll-shadow cover color — container is semi-transparent over wizard gradient */
+  --scroll-shadow-bg: var(--bg-wizard);
 }
 
 .file-progress-header {
@@ -974,6 +976,8 @@
   max-height: 250px;
   overflow-y: auto;
   margin-bottom: var(--space-4);
+  /* scroll-shadow cover color — container is semi-transparent over wizard gradient */
+  --scroll-shadow-bg: var(--bg-wizard);
 }
 
 .bulk-jobs-header {

--- a/frontend/jwst-frontend/src/components/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/MastSearch.tsx
@@ -1217,7 +1217,7 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete, importedObsId
                 const totalGroups = groups.length;
 
                 return (
-                  <div className="file-progress-list">
+                  <div className="file-progress-list scroll-shadow">
                     <div className="file-progress-header">
                       {commonPrefix ? (
                         <span className="file-progress-tree-root" title={commonPrefix}>
@@ -1461,7 +1461,7 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete, importedObsId
             </div>
 
             {/* Active Jobs List */}
-            <div className="bulk-jobs-list">
+            <div className="bulk-jobs-list scroll-shadow">
               <div className="bulk-jobs-header">Active Downloads</div>
               {Array.from(bulkImportStatus.jobs.entries()).map(([obsId, job], index) => {
                 // Extract unique identifier from obs_id (last two segments for uniqueness)

--- a/frontend/jwst-frontend/src/components/WhatsNewPanel.css
+++ b/frontend/jwst-frontend/src/components/WhatsNewPanel.css
@@ -465,6 +465,8 @@
   background: var(--overlay-light);
   border-radius: var(--radius-md);
   margin-bottom: var(--space-3);
+  /* scroll-shadow cover color — container is semi-transparent over wizard gradient */
+  --scroll-shadow-bg: var(--bg-wizard);
 }
 
 .whats-new-panel .file-progress-header {

--- a/frontend/jwst-frontend/src/components/WhatsNewPanel.tsx
+++ b/frontend/jwst-frontend/src/components/WhatsNewPanel.tsx
@@ -579,7 +579,7 @@ const WhatsNewPanel: React.FC<WhatsNewPanelProps> = ({ onImportComplete }) => {
                 const totalGroups = groups.length;
 
                 return (
-                  <div className="file-progress-list">
+                  <div className="file-progress-list scroll-shadow">
                     <div className="file-progress-header">
                       {commonPrefix ? (
                         <span className="file-progress-tree-root" title={commonPrefix}>

--- a/frontend/jwst-frontend/src/components/dashboard/DeleteConfirmationModal.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DeleteConfirmationModal.css
@@ -98,6 +98,8 @@
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   padding: var(--space-3) var(--space-3) var(--space-3) 30px;
+  /* scroll-shadow cover color matches the element's own background */
+  --scroll-shadow-bg: var(--bg-elevated);
 }
 
 .delete-file-list li {

--- a/frontend/jwst-frontend/src/components/dashboard/DeleteConfirmationModal.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DeleteConfirmationModal.tsx
@@ -57,7 +57,7 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
           </p>
           <div className="delete-file-list">
             <strong>Files to be deleted:</strong>
-            <ul>
+            <ul className="scroll-shadow">
               {fileNames.map((fileName) => (
                 <li key={fileName}>{fileName}</li>
               ))}

--- a/frontend/jwst-frontend/src/components/guided/DownloadStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/DownloadStep.tsx
@@ -151,7 +151,7 @@ export function DownloadStep({
       </p>
 
       {fileProgress.length > 0 && (
-        <div className="download-file-list" ref={containerRef}>
+        <div className="download-file-list scroll-shadow" ref={containerRef}>
           {fileProgress.map((file) => (
             <FileRow key={file.filename} file={file} />
           ))}

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -192,23 +192,7 @@
 .result-channels-list {
   max-height: 280px;
   overflow-y: auto;
-  /* Pure-CSS scroll shadows — visible only when content overflows */
-  background:
-    /* Top shadow cover (scrolls with content) */
-    linear-gradient(var(--bg-surface) 30%, transparent) center top,
-    /* Bottom shadow cover (scrolls with content) */
-    linear-gradient(transparent, var(--bg-surface) 70%) center bottom,
-    /* Top shadow (fixed) */
-    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.3), transparent) center top,
-    /* Bottom shadow (fixed) */
-    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.3), transparent) center bottom;
-  background-repeat: no-repeat;
-  background-size:
-    100% 20px,
-    100% 20px,
-    100% 8px,
-    100% 8px;
-  background-attachment: local, local, scroll, scroll;
+  /* Scroll shadow applied via shared .scroll-shadow utility class in index.css */
 }
 
 .result-channels-header {

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -272,7 +272,7 @@ export function ResultStep({
           {displayChannels.length > 0 && (
             <div className="result-channels">
               <h4 className="result-channels-header">Channel Colors</h4>
-              <div className="result-channels-list">
+              <div className="result-channels-list scroll-shadow">
                 {displayChannels.map((ch, i) => {
                   const hex = channelColorToHex(ch.color);
                   const weightPercent = Math.round(ch.weight * 100);

--- a/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.css
@@ -45,6 +45,8 @@
   gap: var(--space-4);
   overflow-y: auto;
   padding-right: var(--space-2);
+  /* scroll-shadow cover color approximates the wizard gradient top color */
+  --scroll-shadow-bg: var(--bg-wizard);
 }
 
 .image-grid::-webkit-scrollbar {

--- a/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.tsx
@@ -69,7 +69,7 @@ export const ImageSelectionStep: React.FC<ImageSelectionStepProps> = ({
         </div>
       </div>
 
-      <div className="image-grid">
+      <div className="image-grid scroll-shadow">
         {imageFiles.length === 0 ? (
           <div className="no-images">
             <p>No image files available.</p>

--- a/frontend/jwst-frontend/src/index.css
+++ b/frontend/jwst-frontend/src/index.css
@@ -188,6 +188,40 @@ code {
   }
 }
 
+/* ============================================
+   Scroll Shadow Utility
+   Pure-CSS scroll shadow indicator — shows top/bottom
+   shadows only when the container has overflowed content.
+   Uses background-attachment: local/scroll trick.
+
+   Usage: add class="scroll-shadow" to a scrollable element
+   that already has overflow-y: auto/scroll and a max-height.
+
+   The cover gradients must match the container's background.
+   Override --scroll-shadow-bg on the element if its background
+   differs from --bg-surface (e.g. modal containers on wizard
+   surfaces use --bg-wizard).
+   ============================================ */
+.scroll-shadow {
+  --scroll-shadow-bg: var(--bg-surface);
+  background:
+    /* Top cover — scrolls with content, hides shadow when at top */
+    linear-gradient(var(--scroll-shadow-bg) 30%, transparent) center top,
+    /* Bottom cover — scrolls with content, hides shadow when at bottom */
+    linear-gradient(transparent, var(--scroll-shadow-bg) 70%) center bottom,
+    /* Top shadow — stays fixed */
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.3), transparent) center top,
+    /* Bottom shadow — stays fixed */
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.3), transparent) center bottom;
+  background-repeat: no-repeat;
+  background-size:
+    100% 20px,
+    100% 20px,
+    100% 8px,
+    100% 8px;
+  background-attachment: local, local, scroll, scroll;
+}
+
 /* Shared skeleton loading block */
 .skeleton-block {
   background: linear-gradient(


### PR DESCRIPTION
## Summary

- Adds a shared `.scroll-shadow` CSS utility class to `index.css` using the pure-CSS `background-attachment: local/scroll` technique introduced in PR #785
- Applies the class to all bounded scrollable panels that were missing it
- Refactors `ResultStep.css` to remove the now-duplicated inline implementation

## Why

PR #785 added scroll shadows to only one panel (`.result-channels-list`). Issue #797 tracks applying the same pattern consistently across all bounded scrollable panels in the app. The pure-CSS technique requires no JavaScript and has zero runtime cost — it's a UX consistency fix.

## Changes Made

- `src/index.css` — new `.scroll-shadow` utility class with `--scroll-shadow-bg` CSS variable (defaults to `--bg-surface`); covers top/bottom with matching gradients so shadows only appear when content overflows
- `src/components/guided/ResultStep.css` — removed 14 lines of duplicated scroll shadow CSS; now relies on shared class
- `src/components/guided/ResultStep.tsx` — added `scroll-shadow` class to `.result-channels-list`
- `src/components/guided/DownloadStep.tsx` — added `scroll-shadow` class to `.download-file-list`
- `src/components/WhatsNewPanel.tsx` — added `scroll-shadow` class to `.file-progress-list`
- `src/components/WhatsNewPanel.css` — added `--scroll-shadow-bg: var(--bg-wizard)` override (container sits on wizard gradient, not `--bg-surface`)
- `src/components/MastSearch.tsx` — added `scroll-shadow` class to `.file-progress-list` and `.bulk-jobs-list`
- `src/components/MastSearch.css` — added `--scroll-shadow-bg: var(--bg-wizard)` override to both panels
- `src/components/dashboard/DeleteConfirmationModal.tsx` — added `scroll-shadow` class to `.delete-file-list ul`
- `src/components/dashboard/DeleteConfirmationModal.css` — added `--scroll-shadow-bg: var(--bg-elevated)` override (element background is `--bg-elevated`)
- `src/components/wizard/ImageSelectionStep.tsx` — added `scroll-shadow` class to `.image-grid`
- `src/components/wizard/ImageSelectionStep.css` — added `--scroll-shadow-bg: var(--bg-wizard)` override (grid is transparent over wizard gradient)

## Test Plan

- [x] 865 unit tests pass
- [ ] Navigate to Guided Create — Download step: populate with multiple files (or inspect with devtools overflow), verify top/bottom shadows appear when scrollable and hide at edges
- [ ] Navigate to Guided Create — Result step: with many channels, verify shadow appears when list overflows
- [ ] Open MAST Search, start a bulk import — verify file-progress-list and bulk-jobs-list show shadows when overflowing
- [ ] Open WhatsNewPanel, trigger an import — verify file-progress-list shadows appear
- [ ] Open Delete confirmation modal with multiple files — verify file list shows shadows
- [ ] Open Composite Wizard — Image Selection step: with many images (>grid viewport), verify scroll shadows appear at top/bottom of grid
- [ ] Verify no visual regressions on any of the above panels when content does NOT overflow (shadows should be invisible)

## Documentation Checklist

- [x] No new components, controllers, services, or endpoints were added — no doc updates required

## Tech Debt Impact

- [x] No tech debt added or removed

## Risk & Rollback

Risk: Low — purely visual CSS change. No logic changes, no API changes, no state changes. The `background-attachment: local/scroll` technique is well-supported in all modern browsers.

Rollback: Revert the PR. The only visible effect of rollback is loss of scroll shadow indicators.

Closes #797