### PR TITLE
fix: use recipe observation_ids to filter downloads instead of raw MAST results

### DIFF
--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -257,10 +257,23 @@ export function GuidedCreate() {
 
         setRecipe(matched);
 
-        // Start downloads for each unique filter observation
+        // Use the recipe's deduplicated observation_ids when available.
+        // The recipe engine deduplicates c-prefix (pipeline mosaic) vs o-prefix
+        // observations, preferring c-prefix when downloadable. Without this,
+        // the frontend would pick arbitrary obs_ids from MAST results by filter
+        // name alone, often selecting c-prefix obs_ids that fail to download.
+        const recipeObsIdSet = matched.observationIds?.length
+          ? new Set(matched.observationIds)
+          : null;
+
         const recipeFilterSet = new Set(matched.filters.map((f) => f.toUpperCase()));
         const relevantObs = deduplicateByFilter(
-          observations.filter((o) => o.filters && recipeFilterSet.has(o.filters.toUpperCase()))
+          observations.filter((o) => {
+            if (!o.filters || !recipeFilterSet.has(o.filters.toUpperCase())) return false;
+            // If recipe specifies exact obs_ids, only include those
+            if (recipeObsIdSet && o.obs_id) return recipeObsIdSet.has(o.obs_id);
+            return true;
+          })
         );
 
         if (relevantObs.length === 0) {


### PR DESCRIPTION
## Summary
Fixes the root cause of c-prefix download failures (#802). The recipe engine correctly deduplicates c-prefix vs o-prefix observations, but the frontend was ignoring `recipe.observationIds` entirely — re-filtering the raw MAST search results by filter name alone, picking c-prefix obs_ids that 404 on download.

Closes #802

## Why
PR #803 added deduplication in the Python recipe engine and wired `observation_ids` into the recipe response. But `GuidedCreate.tsx` never used that field — it filtered `observations` (raw MAST results) by filter name only via `deduplicateByFilter()`, which keeps whichever obs_id it encounters first per filter. For NGC 346, that's the c-prefix mosaic obs_ids, which consistently fail to download.

## Changes Made
- **`GuidedCreate.tsx`**: When `matched.observationIds` is available, use it as an allowlist to filter which MAST observations are sent to the download step. Falls back to the existing filter-name-only dedup when `observationIds` is null (backward compatible).

## Test Plan
- [x] All 865 frontend unit tests pass
- [x] ESLint clean
- [x] E2E mock uses `observationIds: null` — backward-compatible path preserved
- [ ] Manual: NGC 346 guided create — should download o-prefix files (or c-prefix if available), not 404 on c-prefix files
- [ ] Manual: Verify a target navigated from TargetDetail (fast path with router state) also uses recipe obs_ids

## Documentation Checklist
- [x] No new endpoints, components, or types — no doc updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — single file change with null-safe fallback. When `observationIds` is null/empty, behavior is identical to before.
Rollback: Revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)