### PR TITLE
feat: improve recipe quality with curated NGC 346, Best-N selection, and wavelength pruning

### DIFF
--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -68,6 +68,11 @@ FILTER_WAVELENGTHS: dict[str, float] = {
 # Base processing time per filter in seconds
 BASE_TIME_PER_FILTER = 8
 
+# Best-N selection constants
+MAX_FILTERS_FOR_BEST_N = 7  # Threshold: > this triggers Best-N / pruning
+DEMOTED_ALL_RANK = 10  # Rank for demoted "all data" recipes
+WAVELENGTH_REDUNDANCY_RATIO = 1.3  # Adjacent filters within 30% are redundant
+
 # Known JWST instrument FOV radii (arcminutes) — conservative estimates
 INSTRUMENT_FOV_RADIUS_ARCMIN = {
     "NIRCAM": 1.1,  # ~2.2' square field
@@ -282,6 +287,33 @@ CURATED_RECIPES: dict[str, list[dict]] = {
             "description": "NASA press-release color assignment for Webb's First Deep Field",
         },
     ],
+    "ngc 346": [
+        {
+            "name": "NASA NIRCam (NGC 346)",
+            "filters": ["F200W", "F277W", "F335M", "F444W"],
+            "color_mapping": {
+                "F200W": "#0000ff",  # Blue
+                "F277W": "#00ffff",  # Cyan
+                "F335M": "#ff8000",  # Orange
+                "F444W": "#ff0000",  # Red
+            },
+            "instruments": ["NIRCAM"],
+            "description": "NASA press-release color assignment for NGC 346 (STScI 2023-101)",
+        },
+        {
+            "name": "NASA MIRI (NGC 346)",
+            "filters": ["F770W", "F1000W", "F1130W", "F1500W", "F2100W"],
+            "color_mapping": {
+                "F770W": "#0000ff",  # Blue
+                "F1000W": "#00ffff",  # Cyan
+                "F1130W": "#00ff00",  # Green
+                "F1500W": "#ffff00",  # Yellow
+                "F2100W": "#ff0000",  # Red
+            },
+            "instruments": ["MIRI"],
+            "description": "NASA press-release color assignment for NGC 346 (STScI 2023-145)",
+        },
+    ],
     "m16": [
         {
             "name": "NASA Pillars of Creation",
@@ -324,6 +356,198 @@ def is_broadband(filter_name: str) -> bool:
     """Check if a filter is broadband (W suffix convention)."""
     upper = filter_name.upper()
     return upper.endswith("W") or upper.endswith("W2")
+
+
+def is_medium_band(filter_name: str) -> bool:
+    """Check if a filter is medium-band (M suffix convention)."""
+    return filter_name.upper().rstrip("0123456789").endswith("M") or filter_name.upper().endswith(
+        "M"
+    )
+
+
+def _bandpass_priority(filter_name: str) -> int:
+    """Return bandpass priority: 0 (broadband W) > 1 (medium M) > 2 (narrowband N)."""
+    if is_broadband(filter_name):
+        return 0
+    if is_medium_band(filter_name):
+        return 1
+    return 2
+
+
+def select_best_n_filters(
+    filters_sorted: list[str],
+    filter_instruments: dict[str, str],
+    target_count: int = 6,
+    min_per_instrument: int = 2,
+) -> list[str]:
+    """Select the best N filters from a large filter set using log-spaced wavelength bins.
+
+    Strategy:
+    1. Create target_count log-spaced wavelength bins spanning the filter range
+    2. Assign each filter to its nearest bin
+    3. Pick one filter per bin, preferring broadband > medium > narrowband
+    4. Ensure minimum representation from each instrument
+    5. Clamp result to 5-7 range
+
+    Args:
+        filters_sorted: Filter names sorted by wavelength.
+        filter_instruments: Map of filter name → instrument name.
+        target_count: Target number of output filters.
+        min_per_instrument: Minimum filters from each instrument.
+
+    Returns:
+        Selected filter names sorted by wavelength.
+    """
+    if len(filters_sorted) <= 5:
+        return list(filters_sorted)
+
+    # Get wavelengths
+    wavelengths = {}
+    for f in filters_sorted:
+        wl = FILTER_WAVELENGTHS.get(f.upper())
+        if wl is not None:
+            wavelengths[f] = wl
+
+    if len(wavelengths) < 3:
+        return list(filters_sorted)
+
+    # Create log-spaced bins
+    wl_values = [wavelengths[f] for f in filters_sorted if f in wavelengths]
+    log_min = math.log10(min(wl_values))
+    log_max = math.log10(max(wl_values))
+
+    if target_count <= 1:
+        bin_centers = [10 ** ((log_min + log_max) / 2)]
+    else:
+        bin_centers = [
+            10 ** (log_min + i * (log_max - log_min) / (target_count - 1))
+            for i in range(target_count)
+        ]
+
+    # Assign filters to nearest bin
+    bins: dict[int, list[str]] = {i: [] for i in range(len(bin_centers))}
+    for f in filters_sorted:
+        if f not in wavelengths:
+            continue
+        wl = wavelengths[f]
+        log_wl = math.log10(wl)
+        nearest_bin = min(
+            range(len(bin_centers)), key=lambda i: abs(log_wl - math.log10(bin_centers[i]))
+        )
+        bins[nearest_bin].append(f)
+
+    # Pick one per bin: prefer broadband, break ties by closest to bin center
+    selected: list[str] = []
+    for i, center in enumerate(bin_centers):
+        candidates = bins[i]
+        if not candidates:
+            continue
+        # Sort by priority (broadband first), then by distance to bin center
+        log_center = math.log10(center)
+        best = min(
+            candidates,
+            key=lambda f: (_bandpass_priority(f), abs(math.log10(wavelengths[f]) - log_center)),
+        )
+        selected.append(best)
+
+    # Ensure min_per_instrument from each instrument
+    instruments_in_set = set(filter_instruments.values())
+    for inst in instruments_in_set:
+        inst_selected = [f for f in selected if filter_instruments.get(f) == inst]
+        inst_available = [
+            f for f in filters_sorted if filter_instruments.get(f) == inst and f in wavelengths
+        ]
+        if len(inst_selected) < min_per_instrument and len(inst_available) >= min_per_instrument:
+            # Add more from this instrument, preferring broadband
+            remaining = [f for f in inst_available if f not in selected]
+            remaining.sort(key=lambda f: (_bandpass_priority(f), wavelengths[f]))
+            while len(inst_selected) < min_per_instrument and remaining:
+                pick = remaining.pop(0)
+                selected.append(pick)
+                inst_selected.append(pick)
+
+    # Clamp to 5-7 range
+    if len(selected) > 7:
+        # Trim lowest-priority filters while preserving min_per_instrument
+        selected.sort(key=lambda f: wavelengths.get(f, 0))
+        # Score each filter: higher = more expendable (worse priority, closer to neighbors)
+        expendable = sorted(
+            selected,
+            key=lambda f: (-_bandpass_priority(f), wavelengths[f]),  # worst priority first
+        )
+        while len(selected) > 7:
+            for candidate in expendable:
+                inst = filter_instruments.get(candidate)
+                inst_count = sum(1 for s in selected if filter_instruments.get(s) == inst)
+                if inst_count > min_per_instrument:
+                    selected.remove(candidate)
+                    expendable.remove(candidate)
+                    break
+            else:
+                # Can't remove without violating instrument constraint — just truncate
+                selected = selected[:7]
+                break
+    if len(selected) < 5:
+        # Add more filters that maximize wavelength spread from current selection
+        remaining = [f for f in filters_sorted if f not in selected and f in wavelengths]
+        remaining.sort(key=lambda f: _bandpass_priority(f))
+        while len(selected) < 5 and remaining:
+            selected.append(remaining.pop(0))
+
+    # Sort by wavelength
+    selected.sort(key=lambda f: wavelengths.get(f, 0))
+    return selected
+
+
+def prune_redundant_filters(
+    filters_sorted: list[str],
+    wavelength_ratio_threshold: float = WAVELENGTH_REDUNDANCY_RATIO,
+) -> list[str]:
+    """Remove wavelength-redundant filters from a sorted filter list.
+
+    Single left-to-right pass: when two adjacent kept filters have
+    wavelength ratio < threshold, keep the one with better bandpass priority.
+    Iterate until stable (no more removals).
+
+    Args:
+        filters_sorted: Filter names sorted by wavelength.
+        wavelength_ratio_threshold: Maximum wavelength ratio for "redundant" pair.
+
+    Returns:
+        Pruned filter list sorted by wavelength.
+    """
+    wavelengths = {}
+    for f in filters_sorted:
+        wl = FILTER_WAVELENGTHS.get(f.upper())
+        if wl is not None:
+            wavelengths[f] = wl
+
+    # Filters without known wavelengths are kept as-is
+    unknown = [f for f in filters_sorted if f not in wavelengths]
+    known = [f for f in filters_sorted if f in wavelengths]
+
+    if len(known) <= 1:
+        return list(filters_sorted)
+
+    changed = True
+    while changed:
+        changed = False
+        result: list[str] = [known[0]]
+        for i in range(1, len(known)):
+            prev = result[-1]
+            curr = known[i]
+            ratio = wavelengths[curr] / wavelengths[prev]
+            if ratio < wavelength_ratio_threshold:
+                # Redundant pair — keep the one with better priority
+                if _bandpass_priority(curr) < _bandpass_priority(prev):
+                    result[-1] = curr
+                # else keep prev (already in result)
+                changed = True
+            else:
+                result.append(curr)
+        known = result
+
+    return known + unknown
 
 
 def hue_to_hex(hue: float) -> str:
@@ -530,8 +754,6 @@ def _normalize_target_name(name: str) -> str:
     Handles common variations: case, whitespace, missing spaces in catalog IDs
     (e.g. "NGC3132" → "ngc 3132"), and resolves aliases.
     """
-    import re
-
     key = name.strip().lower()
     # Insert space between letter prefix and number if missing (e.g. "ngc3132" → "ngc 3132")
     key = re.sub(r"([a-z])(\d)", r"\1 \2", key)
@@ -706,21 +928,60 @@ def generate_recipes(
                 filter_instruments = {f: all_obs_map[f].instrument.upper() for f in combined_sorted}
                 needs_mosaic = _has_multiple_pointings(group)
 
-                all_recipes.append(
-                    Recipe(
-                        name=f"{len(combined_sorted)}-filter {'+'.join(group_instruments)}",
-                        rank=1,
-                        filters=combined_sorted,
-                        color_mapping=build_cross_instrument_color_mapping(
-                            combined_sorted, filter_instruments
+                if len(combined_sorted) > MAX_FILTERS_FOR_BEST_N:
+                    best = select_best_n_filters(combined_sorted, filter_instruments)
+                    all_recipes.append(
+                        Recipe(
+                            name=f"Best {len(best)}-filter {'+'.join(group_instruments)}",
+                            rank=1,
+                            filters=best,
+                            color_mapping=build_cross_instrument_color_mapping(
+                                best, filter_instruments
+                            ),
+                            instruments=group_instruments,
+                            requires_mosaic=needs_mosaic,
+                            estimated_time_seconds=estimate_time(len(best), needs_mosaic),
+                            observation_ids=all_obs_ids or None,
+                            description="Optimally spaced filters for best color separation",
+                            tag="Recommended",
                         ),
-                        instruments=group_instruments,
-                        requires_mosaic=needs_mosaic,
-                        estimated_time_seconds=estimate_time(len(combined_sorted), needs_mosaic),
-                        observation_ids=all_obs_ids or None,
-                        description="Stars and dust \u2014 full near- to mid-infrared wavelength coverage",
-                    ),
-                )
+                    )
+                    all_recipes.append(
+                        Recipe(
+                            name=f"{len(combined_sorted)}-filter {'+'.join(group_instruments)}",
+                            rank=DEMOTED_ALL_RANK,
+                            filters=combined_sorted,
+                            color_mapping=build_cross_instrument_color_mapping(
+                                combined_sorted, filter_instruments
+                            ),
+                            instruments=group_instruments,
+                            requires_mosaic=needs_mosaic,
+                            estimated_time_seconds=estimate_time(
+                                len(combined_sorted), needs_mosaic
+                            ),
+                            observation_ids=all_obs_ids or None,
+                            description="Stars and dust \u2014 full near- to mid-infrared wavelength coverage",
+                            tag="All data",
+                        ),
+                    )
+                else:
+                    all_recipes.append(
+                        Recipe(
+                            name=f"{len(combined_sorted)}-filter {'+'.join(group_instruments)}",
+                            rank=1,
+                            filters=combined_sorted,
+                            color_mapping=build_cross_instrument_color_mapping(
+                                combined_sorted, filter_instruments
+                            ),
+                            instruments=group_instruments,
+                            requires_mosaic=needs_mosaic,
+                            estimated_time_seconds=estimate_time(
+                                len(combined_sorted), needs_mosaic
+                            ),
+                            observation_ids=all_obs_ids or None,
+                            description="Stars and dust \u2014 full near- to mid-infrared wavelength coverage",
+                        ),
+                    )
 
             # If no cross-instrument overlap groups found, don't create cross-instrument recipe
             cross_inst_count = len([r for r in all_recipes if len(r.instruments) > 1])
@@ -742,22 +1003,59 @@ def generate_recipes(
             all_obs_ids = [obs.observation_id for obs in observations if obs.observation_id]
             filter_instruments = {f: all_obs_map[f].instrument.upper() for f in combined_sorted}
 
-            all_recipes.append(
-                Recipe(
-                    name=f"{len(combined_sorted)}-filter {'+'.join(all_instruments)}",
-                    rank=1,
-                    filters=combined_sorted,
-                    color_mapping=build_cross_instrument_color_mapping(
-                        combined_sorted, filter_instruments
+            if len(combined_sorted) > MAX_FILTERS_FOR_BEST_N:
+                best = select_best_n_filters(combined_sorted, filter_instruments)
+                all_recipes.append(
+                    Recipe(
+                        name=f"Best {len(best)}-filter {'+'.join(all_instruments)}",
+                        rank=1,
+                        filters=best,
+                        color_mapping=build_cross_instrument_color_mapping(
+                            best, filter_instruments
+                        ),
+                        instruments=all_instruments,
+                        requires_mosaic=False,
+                        estimated_time_seconds=estimate_time(len(best), False),
+                        observation_ids=all_obs_ids or None,
+                        description="Optimally spaced filters for best color separation",
+                        overlap_warning="No coordinate data \u2014 spatial overlap assumed. Result may combine non-overlapping pointings.",
+                        tag="Recommended",
                     ),
-                    instruments=all_instruments,
-                    requires_mosaic=False,
-                    estimated_time_seconds=estimate_time(len(combined_sorted), False),
-                    observation_ids=all_obs_ids or None,
-                    description="Stars and dust \u2014 full near- to mid-infrared wavelength coverage",
-                    overlap_warning="No coordinate data \u2014 spatial overlap assumed. Result may combine non-overlapping pointings.",
-                ),
-            )
+                )
+                all_recipes.append(
+                    Recipe(
+                        name=f"{len(combined_sorted)}-filter {'+'.join(all_instruments)}",
+                        rank=DEMOTED_ALL_RANK,
+                        filters=combined_sorted,
+                        color_mapping=build_cross_instrument_color_mapping(
+                            combined_sorted, filter_instruments
+                        ),
+                        instruments=all_instruments,
+                        requires_mosaic=False,
+                        estimated_time_seconds=estimate_time(len(combined_sorted), False),
+                        observation_ids=all_obs_ids or None,
+                        description="Stars and dust \u2014 full near- to mid-infrared wavelength coverage",
+                        overlap_warning="No coordinate data \u2014 spatial overlap assumed. Result may combine non-overlapping pointings.",
+                        tag="All data",
+                    ),
+                )
+            else:
+                all_recipes.append(
+                    Recipe(
+                        name=f"{len(combined_sorted)}-filter {'+'.join(all_instruments)}",
+                        rank=1,
+                        filters=combined_sorted,
+                        color_mapping=build_cross_instrument_color_mapping(
+                            combined_sorted, filter_instruments
+                        ),
+                        instruments=all_instruments,
+                        requires_mosaic=False,
+                        estimated_time_seconds=estimate_time(len(combined_sorted), False),
+                        observation_ids=all_obs_ids or None,
+                        description="Stars and dust \u2014 full near- to mid-infrared wavelength coverage",
+                        overlap_warning="No coordinate data \u2014 spatial overlap assumed. Result may combine non-overlapping pointings.",
+                    ),
+                )
 
     for instrument, obs_list in instrument_groups.items():
         # Deduplicate by filter name and sort by wavelength
@@ -780,21 +1078,67 @@ def generate_recipes(
         if n_filters == 0:
             continue
 
-        # Recipe: All available filters for this instrument
+        # Recipe: All available filters for this instrument (with pruning for large sets)
         inst_needs_mosaic = _has_multiple_pointings(obs_list)
-        all_recipes.append(
-            Recipe(
-                name=f"{n_filters}-filter {instrument}",
-                rank=1 + rank_offset,
-                filters=sorted_filters,
-                color_mapping=build_color_mapping(sorted_filters),
-                instruments=[instrument],
-                requires_mosaic=inst_needs_mosaic,
-                estimated_time_seconds=estimate_time(n_filters, inst_needs_mosaic),
-                observation_ids=obs_ids or None,
-                description=f"All {n_filters} {instrument} filters for maximum detail",
+        if n_filters > MAX_FILTERS_FOR_BEST_N:
+            pruned = prune_redundant_filters(sorted_filters)
+            if len(pruned) < n_filters:
+                all_recipes.append(
+                    Recipe(
+                        name=f"{len(pruned)}-filter {instrument}",
+                        rank=1 + rank_offset,
+                        filters=pruned,
+                        color_mapping=build_color_mapping(pruned),
+                        instruments=[instrument],
+                        requires_mosaic=inst_needs_mosaic,
+                        estimated_time_seconds=estimate_time(len(pruned), inst_needs_mosaic),
+                        observation_ids=obs_ids or None,
+                        description=f"{len(pruned)} {instrument} filters — redundant wavelengths removed",
+                    )
+                )
+                all_recipes.append(
+                    Recipe(
+                        name=f"{n_filters}-filter {instrument}",
+                        rank=DEMOTED_ALL_RANK + rank_offset,
+                        filters=sorted_filters,
+                        color_mapping=build_color_mapping(sorted_filters),
+                        instruments=[instrument],
+                        requires_mosaic=inst_needs_mosaic,
+                        estimated_time_seconds=estimate_time(n_filters, inst_needs_mosaic),
+                        observation_ids=obs_ids or None,
+                        description=f"All {n_filters} {instrument} filters for maximum detail",
+                        tag="All data",
+                    )
+                )
+            else:
+                # Pruning didn't remove anything — keep single recipe
+                all_recipes.append(
+                    Recipe(
+                        name=f"{n_filters}-filter {instrument}",
+                        rank=1 + rank_offset,
+                        filters=sorted_filters,
+                        color_mapping=build_color_mapping(sorted_filters),
+                        instruments=[instrument],
+                        requires_mosaic=inst_needs_mosaic,
+                        estimated_time_seconds=estimate_time(n_filters, inst_needs_mosaic),
+                        observation_ids=obs_ids or None,
+                        description=f"All {n_filters} {instrument} filters for maximum detail",
+                    )
+                )
+        else:
+            all_recipes.append(
+                Recipe(
+                    name=f"{n_filters}-filter {instrument}",
+                    rank=1 + rank_offset,
+                    filters=sorted_filters,
+                    color_mapping=build_color_mapping(sorted_filters),
+                    instruments=[instrument],
+                    requires_mosaic=inst_needs_mosaic,
+                    estimated_time_seconds=estimate_time(n_filters, inst_needs_mosaic),
+                    observation_ids=obs_ids or None,
+                    description=f"All {n_filters} {instrument} filters for maximum detail",
+                )
             )
-        )
 
         # Recipe: Classic 3-color (if 3+ filters with known wavelengths)
         known_wl = [f for f in sorted_filters if resolve_wavelength(filter_map[f]) is not None]

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -6,7 +6,9 @@ from app.discovery.models import ObservationInput
 from app.discovery.recipe_engine import (
     _MJD_EPOCH,
     CURATED_RECIPES,
+    DEMOTED_ALL_RANK,
     _angular_separation_arcmin,
+    _bandpass_priority,
     _inject_curated_recipes,
     _is_c_prefix,
     _is_o_prefix,
@@ -17,8 +19,11 @@ from app.discovery.recipe_engine import (
     group_by_spatial_overlap,
     hue_to_hex,
     is_broadband,
+    is_medium_band,
     is_narrowband,
+    prune_redundant_filters,
     resolve_wavelength,
+    select_best_n_filters,
 )
 
 
@@ -1169,3 +1174,335 @@ class TestDeduplicateMosaicObservations:
         all_recipe = recipes[0]
         assert set(all_recipe.filters) == {"F200W", "F444W"}
         assert len(all_recipe.observation_ids) == 2
+
+
+class TestMediumBandAndPriority:
+    """Tests for medium-band detection and bandpass priority."""
+
+    def test_medium_band_filters(self):
+        assert is_medium_band("F335M")
+        assert is_medium_band("F410M")
+        assert is_medium_band("F140M")
+        assert is_medium_band("F480M")
+
+    def test_non_medium_band(self):
+        assert not is_medium_band("F444W")
+        assert not is_medium_band("F187N")
+        assert not is_medium_band("F090W")
+
+    def test_bandpass_priority_broadband_best(self):
+        assert _bandpass_priority("F444W") == 0
+        assert _bandpass_priority("F200W") == 0
+
+    def test_bandpass_priority_medium_middle(self):
+        assert _bandpass_priority("F335M") == 1
+        assert _bandpass_priority("F410M") == 1
+
+    def test_bandpass_priority_narrowband_lowest(self):
+        assert _bandpass_priority("F187N") == 2
+        assert _bandpass_priority("F470N") == 2
+
+    def test_bandpass_priority_ordering(self):
+        assert _bandpass_priority("F200W") < _bandpass_priority("F335M")
+        assert _bandpass_priority("F335M") < _bandpass_priority("F187N")
+
+
+class TestCuratedNGC346:
+    """Tests for NGC 346 curated recipe."""
+
+    def test_ngc346_nircam_recipe(self):
+        """NGC 346 with NIRCam filters should get the STScI 2023-101 recipe."""
+        obs = [
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F277W", instrument="NIRCAM"),
+            ObservationInput(filter="F335M", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs, target_name="NGC 346")
+        curated = [r for r in recipes if r.tag == "NASA-style"]
+        assert len(curated) == 1
+        assert curated[0].name == "NASA NIRCam (NGC 346)"
+        assert curated[0].color_mapping["F200W"] == "#0000ff"
+        assert curated[0].color_mapping["F444W"] == "#ff0000"
+
+    def test_ngc346_miri_recipe(self):
+        """NGC 346 with MIRI filters should get the STScI 2023-145 recipe."""
+        obs = [
+            ObservationInput(filter="F770W", instrument="MIRI"),
+            ObservationInput(filter="F1000W", instrument="MIRI"),
+            ObservationInput(filter="F1130W", instrument="MIRI"),
+            ObservationInput(filter="F1500W", instrument="MIRI"),
+            ObservationInput(filter="F2100W", instrument="MIRI"),
+        ]
+        recipes = generate_recipes(obs, target_name="NGC 346")
+        curated = [r for r in recipes if r.tag == "NASA-style"]
+        assert len(curated) == 1
+        assert curated[0].name == "NASA MIRI (NGC 346)"
+        assert curated[0].color_mapping["F1130W"] == "#00ff00"
+
+    def test_ngc346_both_instruments(self):
+        """NGC 346 with both NIRCam and MIRI should get both curated recipes."""
+        obs = [
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F277W", instrument="NIRCAM"),
+            ObservationInput(filter="F335M", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+            ObservationInput(filter="F770W", instrument="MIRI"),
+            ObservationInput(filter="F1000W", instrument="MIRI"),
+            ObservationInput(filter="F1130W", instrument="MIRI"),
+            ObservationInput(filter="F1500W", instrument="MIRI"),
+            ObservationInput(filter="F2100W", instrument="MIRI"),
+        ]
+        recipes = generate_recipes(obs, target_name="NGC 346")
+        curated = [r for r in recipes if r.tag == "NASA-style"]
+        assert len(curated) == 2
+        names = {r.name for r in curated}
+        assert "NASA NIRCam (NGC 346)" in names
+        assert "NASA MIRI (NGC 346)" in names
+
+    def test_ngc346_no_space_normalization(self):
+        """'NGC346' without space should still match."""
+        obs = [
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F277W", instrument="NIRCAM"),
+            ObservationInput(filter="F335M", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+        ]
+        result = _inject_curated_recipes("NGC346", obs)
+        assert len(result) == 1
+
+    def test_ngc346_partial_filter_skip(self):
+        """NGC 346 with only some MIRI filters should skip that curated recipe."""
+        obs = [
+            ObservationInput(filter="F770W", instrument="MIRI"),
+            ObservationInput(filter="F1000W", instrument="MIRI"),
+            # Missing F1130W, F1500W, F2100W
+        ]
+        recipes = generate_recipes(obs, target_name="NGC 346")
+        curated = [r for r in recipes if r.tag == "NASA-style"]
+        assert len(curated) == 0
+
+
+class TestSelectBestNFilters:
+    """Tests for the Best-N filter selection algorithm."""
+
+    def test_best_n_returns_5_to_7(self):
+        """Result should be clamped to 5-7 filters."""
+        # 13 NIRCam filters — should select 5-7
+        filters = [
+            "F090W",
+            "F115W",
+            "F150W",
+            "F200W",
+            "F277W",
+            "F335M",
+            "F356W",
+            "F410M",
+            "F444W",
+            "F460M",
+            "F480M",
+            "F140M",
+            "F182M",
+        ]
+        instruments = dict.fromkeys(filters, "NIRCAM")
+        result = select_best_n_filters(filters, instruments)
+        assert 5 <= len(result) <= 7
+
+    def test_best_n_not_generated_when_few_filters(self):
+        """When <= MAX_FILTERS_FOR_BEST_N, returns all filters."""
+        filters = ["F090W", "F200W", "F444W"]
+        instruments = dict.fromkeys(filters, "NIRCAM")
+        result = select_best_n_filters(filters, instruments)
+        assert result == filters
+
+    def test_best_n_prefers_broadband(self):
+        """Broadband filters should be preferred over medium/narrow at same wavelength."""
+        filters = [
+            "F090W",
+            "F140M",
+            "F150W",
+            "F200W",
+            "F277W",
+            "F335M",
+            "F356W",
+            "F410M",
+            "F444W",
+        ]
+        instruments = dict.fromkeys(filters, "NIRCAM")
+        result = select_best_n_filters(filters, instruments)
+        # At ~3.5µm, F356W (broadband) should be preferred over F335M (medium)
+        # At ~4.1µm, F444W (broadband) should be preferred over F410M (medium)
+        broadband_count = sum(1 for f in result if is_broadband(f))
+        medium_count = sum(1 for f in result if is_medium_band(f))
+        assert broadband_count >= medium_count
+
+    def test_best_n_instrument_representation(self):
+        """Both instruments should be represented with min_per_instrument."""
+        nircam = ["F090W", "F115W", "F150W", "F200W", "F277W", "F356W", "F444W"]
+        miri = ["F770W", "F1000W", "F1500W", "F2100W"]
+        all_filters = nircam + miri
+        instruments = dict.fromkeys(nircam, "NIRCAM")
+        instruments.update(dict.fromkeys(miri, "MIRI"))
+        result = select_best_n_filters(all_filters, instruments)
+        nircam_selected = [f for f in result if instruments[f] == "NIRCAM"]
+        miri_selected = [f for f in result if instruments[f] == "MIRI"]
+        assert len(nircam_selected) >= 2
+        assert len(miri_selected) >= 2
+
+    def test_best_n_sorted_by_wavelength(self):
+        """Result should be sorted by wavelength."""
+        from app.discovery.recipe_engine import FILTER_WAVELENGTHS
+
+        filters = [
+            "F090W",
+            "F115W",
+            "F150W",
+            "F200W",
+            "F277W",
+            "F335M",
+            "F356W",
+            "F410M",
+            "F444W",
+        ]
+        instruments = dict.fromkeys(filters, "NIRCAM")
+        result = select_best_n_filters(filters, instruments)
+        wavelengths = [FILTER_WAVELENGTHS[f] for f in result]
+        assert wavelengths == sorted(wavelengths)
+
+    def test_best_n_cross_instrument_integration(self):
+        """Full NGC 346-like scenario: many filters → Best-N generated."""
+        # Simulate 21-filter cross-instrument set
+        nircam = [
+            "F090W",
+            "F115W",
+            "F150W",
+            "F162M",
+            "F200W",
+            "F210M",
+            "F277W",
+            "F300M",
+            "F335M",
+            "F356W",
+            "F410M",
+            "F444W",
+            "F480M",
+        ]
+        miri = [
+            "F560W",
+            "F770W",
+            "F1000W",
+            "F1130W",
+            "F1280W",
+            "F1500W",
+            "F1800W",
+            "F2100W",
+            "F2550W",
+        ]
+        obs = [ObservationInput(filter=f, instrument="NIRCAM") for f in nircam]
+        obs += [ObservationInput(filter=f, instrument="MIRI") for f in miri]
+        recipes = generate_recipes(obs)
+        best_n = [r for r in recipes if r.tag == "Recommended"]
+        all_data = [r for r in recipes if r.tag == "All data"]
+        assert len(best_n) >= 1
+        assert len(all_data) >= 1
+        assert best_n[0].rank == 1
+        assert all_data[0].rank == DEMOTED_ALL_RANK
+        assert 5 <= len(best_n[0].filters) <= 7
+
+    def test_no_best_n_when_few_cross_instrument(self):
+        """When cross-instrument has <= MAX_FILTERS_FOR_BEST_N, no Best-N generated."""
+        obs = [
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F277W", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+            ObservationInput(filter="F770W", instrument="MIRI"),
+            ObservationInput(filter="F1000W", instrument="MIRI"),
+        ]
+        recipes = generate_recipes(obs)
+        best_n = [r for r in recipes if r.tag == "Recommended"]
+        assert len(best_n) == 0
+        # Should have a single cross-instrument recipe at rank 1
+        cross = [r for r in recipes if len(r.instruments) > 1]
+        assert len(cross) == 1
+        assert cross[0].rank == 1
+
+
+class TestPruneRedundantFilters:
+    """Tests for wavelength redundancy pruning."""
+
+    def test_close_filters_pruned(self):
+        """F335M/F356W/F360M are very close — should prune to one."""
+        filters = ["F277W", "F335M", "F356W", "F360M", "F444W"]
+        result = prune_redundant_filters(filters)
+        # F335M (3.36), F356W (3.57), F360M (3.62) are within 30% ratios
+        # Should keep fewer filters in this range
+        assert len(result) < len(filters)
+        # Should still keep endpoints
+        assert "F277W" in result
+        assert "F444W" in result
+
+    def test_separated_filters_kept(self):
+        """Well-separated filters should all be kept."""
+        filters = ["F090W", "F200W", "F444W"]
+        result = prune_redundant_filters(filters)
+        assert result == filters
+
+    def test_broadband_preferred_in_prune(self):
+        """When pruning a pair, broadband should be preferred over medium."""
+        # F356W (broadband, 3.57) and F335M (medium, 3.36): ratio = 1.06 < 1.3
+        filters = ["F200W", "F335M", "F356W", "F770W"]
+        result = prune_redundant_filters(filters)
+        # Should keep F356W (broadband) over F335M (medium)
+        assert "F356W" in result
+        assert "F335M" not in result
+
+    def test_single_filter_unchanged(self):
+        """Single filter should pass through unchanged."""
+        result = prune_redundant_filters(["F444W"])
+        assert result == ["F444W"]
+
+    def test_empty_list(self):
+        """Empty list should return empty."""
+        result = prune_redundant_filters([])
+        assert result == []
+
+    def test_per_instrument_pruning_integration(self):
+        """13 NIRCam filters should produce a pruned recipe + demoted all-data recipe."""
+        filters = [
+            "F090W",
+            "F115W",
+            "F140M",
+            "F150W",
+            "F162M",
+            "F182M",
+            "F200W",
+            "F210M",
+            "F277W",
+            "F335M",
+            "F356W",
+            "F410M",
+            "F444W",
+        ]
+        obs = [ObservationInput(filter=f, instrument="NIRCAM") for f in filters]
+        recipes = generate_recipes(obs)
+        # Should have a pruned recipe and a demoted "All data" recipe
+        all_data = [r for r in recipes if r.tag == "All data"]
+        assert len(all_data) >= 1
+        # All-data recipe should have all 13 filters
+        assert len(all_data[0].filters) == 13
+        # Pruned recipe should have fewer
+        nircam_recipes = [r for r in recipes if "NIRCAM" in r.instruments and r.tag != "All data"]
+        pruned = [r for r in nircam_recipes if "redundant" in (r.description or "")]
+        assert len(pruned) >= 1
+        assert len(pruned[0].filters) < 13
+
+    def test_no_pruning_when_few_filters(self):
+        """When <= MAX_FILTERS_FOR_BEST_N filters, no pruning occurs."""
+        obs = [
+            ObservationInput(filter="F090W", instrument="NIRCAM"),
+            ObservationInput(filter="F200W", instrument="NIRCAM"),
+            ObservationInput(filter="F444W", instrument="NIRCAM"),
+        ]
+        recipes = generate_recipes(obs)
+        all_data = [r for r in recipes if r.tag == "All data"]
+        assert len(all_data) == 0  # No demoted recipe


### PR DESCRIPTION
## Summary
- Add curated NASA press-release recipes for NGC 346 (NIRCam + MIRI)
- Add Best-N filter selection for large cross-instrument filter sets (>7 filters)
- Add wavelength redundancy pruning for per-instrument "all" recipes
- Create GitHub issues #805 and #806 for future smart selection and overlap-aware filtering

## Why
NGC 346's 21-filter cross-instrument recipe produces muddy composites — too many channels with each contributing ~5%, plus spatial mismatch between NIRCam/MIRI footprints. NASA press releases use 3-5 carefully chosen filters for a reason. These changes bring recipe quality closer to that standard.

No linked issue

## Changes Made
- **NGC 346 curated recipes**: Added NIRCam (STScI 2023-101, 4 filters) and MIRI (STScI 2023-145, 5 filters) entries to `CURATED_RECIPES` dict
- **Best-N selection**: New `select_best_n_filters()` function using log-spaced wavelength bins with broadband preference and instrument representation. When cross-instrument filter count exceeds 7, generates a "Recommended" Best-N recipe at rank 1 and demotes the "all data" recipe to rank 10
- **Wavelength pruning**: New `prune_redundant_filters()` function that removes adjacent filters within 30% wavelength ratio, preferring broadband over medium/narrow. Applied to per-instrument recipes with >7 filters
- **Helper functions**: `is_medium_band()`, `_bandpass_priority()` for filter classification
- **Constants**: `MAX_FILTERS_FOR_BEST_N=7`, `DEMOTED_ALL_RANK=10`, `WAVELENGTH_REDUNDANCY_RATIO=1.3`
- **Bug fix**: Removed redundant `import re` inside `_normalize_target_name()` (already imported at module level)
- **25 new tests** across 4 test classes covering all new functionality

## Test Plan
- [x] All 122 recipe engine tests pass (`docker exec jwst-processing python -m pytest tests/test_recipe_engine.py -v`)
- [ ] NGC 346 guided create → curated NASA recipe should appear at rank 0 with correct colors
- [ ] Large multi-instrument target → Best-N recipe at rank 1 ("Recommended"), "All data" demoted
- [ ] Large single-instrument set (13+ NIRCam filters) → pruned recipe + demoted all-data recipe
- [ ] Small filter sets (≤7) → unchanged behavior, no Best-N or pruning

## Documentation Checklist
- [x] No new controllers, endpoints, or API changes — no doc updates needed
- [x] No changes to `docs/tech-debt.md`

## Tech Debt Impact
- [x] No impact on tech debt

## Risk & Rollback
Risk: Low — recipe generation only, no data model or API changes. New recipes appear alongside existing ones (demoted, not removed).
Rollback: Revert commit to restore previous recipe generation behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)