### PR TITLE
fix: add focus-visible states to all interactive elements

### DIFF
--- a/frontend/jwst-frontend/src/components/CubeNavigator.css
+++ b/frontend/jwst-frontend/src/components/CubeNavigator.css
@@ -12,6 +12,11 @@
   border-color: var(--border-interactive-hover);
 }
 
+.cube-navigator:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
 .cube-navigator.collapsed {
   min-width: auto;
 }
@@ -164,6 +169,11 @@
   outline: none;
 }
 
+.cube-slider:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
 /* Controls */
 .cube-controls {
   display: flex;
@@ -258,6 +268,11 @@
 .speed-select:focus {
   outline: none;
   border-color: var(--accent-cyan);
+}
+
+.speed-select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
 }
 
 .speed-select option {

--- a/frontend/jwst-frontend/src/components/ExportOptionsPanel.css
+++ b/frontend/jwst-frontend/src/components/ExportOptionsPanel.css
@@ -169,6 +169,11 @@
   outline: none;
 }
 
+.export-slider:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
 .export-slider::-webkit-slider-runnable-track {
   height: 4px;
   border-radius: var(--radius-xs);
@@ -209,6 +214,11 @@
   outline: none;
   border-color: var(--accent-cyan);
   box-shadow: 0 0 0 2px var(--accent-cyan-subtle);
+}
+
+.export-select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
 }
 
 .export-select option {
@@ -255,6 +265,11 @@
 .export-dimension-input:focus {
   outline: none;
   border-color: var(--accent-cyan);
+}
+
+.export-dimension-input:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
 }
 
 .export-dimension-input::-webkit-outer-spin-button,

--- a/frontend/jwst-frontend/src/components/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/MastSearch.css
@@ -133,6 +133,11 @@
   border-color: var(--accent-interactive);
 }
 
+.download-source-select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
 .download-source-badge {
   color: var(--text-secondary);
   font-size: var(--text-base);
@@ -161,6 +166,11 @@
   outline: none;
   border-color: var(--accent-interactive);
   box-shadow: 0 0 0 2px var(--accent-interactive-subtle);
+}
+
+.search-inputs input:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
 }
 
 .search-inputs input::placeholder {
@@ -528,6 +538,11 @@
 .pagination-size select:focus {
   outline: none;
   border-color: var(--accent-interactive);
+}
+
+.pagination-size select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
 }
 
 /* Import Progress Indicator */

--- a/frontend/jwst-frontend/src/components/StretchControls.css
+++ b/frontend/jwst-frontend/src/components/StretchControls.css
@@ -127,6 +127,11 @@
   box-shadow: 0 0 0 2px var(--accent-cyan-subtle);
 }
 
+.stretch-select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
 .stretch-select option {
   background: var(--bg-wizard);
   color: var(--text-primary);
@@ -180,6 +185,11 @@
 
 .stretch-slider:focus {
   outline: none;
+}
+
+.stretch-slider:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }
 
 .stretch-slider::-webkit-slider-runnable-track {

--- a/frontend/jwst-frontend/src/components/WhatsNewPanel.css
+++ b/frontend/jwst-frontend/src/components/WhatsNewPanel.css
@@ -108,6 +108,11 @@
   border-color: var(--accent-interactive);
 }
 
+.instrument-select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
 .error-message {
   color: var(--color-error);
   padding: var(--space-3) var(--space-4);

--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.css
@@ -333,9 +333,23 @@
 }
 
 /* Focus States */
-.view-btn:focus-visible {
+.view-btn:focus-visible,
+.upload-btn:focus-visible,
+.mast-search-btn:focus-visible,
+.whats-new-btn:focus-visible,
+.archived-toggle:focus-visible,
+.composite-btn:focus-visible,
+.mosaic-open-btn:focus-visible,
+.compare-open-btn:focus-visible {
   outline: 2px solid var(--accent-primary);
   outline-offset: 2px;
+}
+
+.search-box input:focus-visible,
+.filter-box select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+  border-color: var(--accent-primary);
 }
 
 @media (max-width: 768px) {

--- a/frontend/jwst-frontend/src/components/discovery/SearchBar.css
+++ b/frontend/jwst-frontend/src/components/discovery/SearchBar.css
@@ -27,6 +27,11 @@
   outline: none;
 }
 
+.discovery-search-field:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
 .discovery-search-field::placeholder {
   color: var(--text-muted);
 }

--- a/frontend/jwst-frontend/src/components/search/SemanticSearchBar.css
+++ b/frontend/jwst-frontend/src/components/search/SemanticSearchBar.css
@@ -27,6 +27,11 @@
   border-color: var(--accent-primary);
 }
 
+.search-input:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
 .search-input::placeholder {
   color: var(--text-muted);
 }

--- a/frontend/jwst-frontend/src/components/wizard/ChannelAssignStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/ChannelAssignStep.css
@@ -380,6 +380,11 @@
   background: var(--bg-panel);
 }
 
+.lane-label-input:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
 .lane-label-input::placeholder {
   color: var(--text-muted);
 }

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.css
@@ -218,6 +218,11 @@
   border-color: var(--accent-interactive);
 }
 
+.overall-select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
 .overall-hint {
   font-size: var(--text-sm);
   color: var(--text-secondary);
@@ -333,6 +338,11 @@
 
 .weight-slider:focus {
   outline: none;
+}
+
+.weight-slider:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }
 
 .weight-value {
@@ -629,6 +639,11 @@
 .dimension-field input:focus {
   outline: none;
   border-color: var(--accent-interactive);
+}
+
+.dimension-field input:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
 }
 
 .dimension-separator {

--- a/frontend/jwst-frontend/src/index.css
+++ b/frontend/jwst-frontend/src/index.css
@@ -158,6 +158,23 @@ code {
 }
 
 /* ============================================
+   Global Focus-Visible Baseline
+   Keyboard navigation indicator for all interactive
+   elements. Components with custom :focus-visible
+   styles override this naturally via specificity.
+   ============================================ */
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+a[href]:focus-visible,
+[role='button']:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+/* ============================================
    Global Keyframe Animations
    ============================================ */
 

--- a/frontend/jwst-frontend/src/pages/AuthPages.css
+++ b/frontend/jwst-frontend/src/pages/AuthPages.css
@@ -95,6 +95,11 @@
   box-shadow: 0 0 0 3px var(--accent-primary-subtle);
 }
 
+.form-group input:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
 .form-group input:disabled {
   background: var(--auth-input-bg);
   cursor: not-allowed;


### PR DESCRIPTION
## Summary

Adds `:focus-visible` keyboard navigation indicators to all interactive elements across the app. Previously, many components stripped the default browser outline (`outline: none`) without providing a keyboard-visible replacement, making the app unusable for keyboard navigation (WCAG 2.1 violation).

Closes #665

## Why

Keyboard users had no visual indication of which element was focused when tabbing through the app. This is a WCAG 2.1 AA failure and blocks the accessibility goals in Phase 5b.

## Changes Made

- Added global `:focus-visible` baseline in `index.css` covering `button`, `input`, `select`, `textarea`, `a[href]`, `[role="button"]`, and `[tabindex]` elements
- Added explicit `:focus-visible` overrides to 11 component CSS files where existing `:focus` rules strip outlines:
  - **DashboardToolbar**: all buttons (upload, MAST search, What's New, archive toggle, composite, mosaic, compare), search input, filter selects
  - **SearchBar**: discovery search input
  - **MastSearch**: download source select, search inputs, pagination select
  - **StretchControls**: stretch select, stretch slider
  - **ExportOptionsPanel**: export slider, export select, dimension inputs
  - **CubeNavigator**: navigator container, cube slider, speed select
  - **SemanticSearchBar**: search input
  - **WhatsNewPanel**: instrument select
  - **AuthPages**: form inputs
  - **CompositePreviewStep**: overall select, weight slider, dimension inputs
  - **ChannelAssignStep**: lane label input
- Convention: `outline-offset: 2px` for buttons (outward ring), `outline-offset: -2px` for inputs/selects (inset)

## Test Plan

- [x] TypeScript compiles clean
- [x] All 865 unit tests pass
- [x] ESLint clean (3 pre-existing warnings in index.tsx)
- [x] No E2E selectors reference focus styles (verified with grep)
- [ ] Tab through Library page — every button, input, and select shows blue focus ring
- [ ] Tab through Discovery page — search input and search button show focus ring
- [ ] Tab through MAST Search modal — all inputs and selects show focus ring
- [ ] Tab through Composite wizard — stretch controls, weight sliders, selects all focusable
- [ ] Tab through Auth pages — login/register form inputs show focus ring

## Documentation Checklist

- [x] `docs/key-files.md` — no new files added
- [x] `docs/standards/backend-development.md` — no backend changes
- [x] `docs/architecture/` — no architectural changes
- [x] `docs/quick-reference.md` — no API changes
- [x] `docs/development-plan.md` — no task completions to mark

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Adds to existing tech debt
- [ ] Resolves existing tech debt

## Risk & Rollback

Risk: Low — CSS-only additions, no behavioral changes. All changes are additive `:focus-visible` rules that only activate during keyboard navigation.

Rollback: Revert commit. No data or state changes.