### PR TITLE
fix: standardize disabled state styling across components

### DIFF
--- a/frontend/jwst-frontend/e2e/helpers.ts
+++ b/frontend/jwst-frontend/e2e/helpers.ts
@@ -235,9 +235,9 @@ export async function openImageViewer(page: Page, fileName?: string): Promise<bo
     if ((await card.count()) === 0) {
       return false;
     }
-    viewButton = card.locator('.view-file-btn:not(.disabled)');
+    viewButton = card.locator('.view-file-btn:not(:disabled)');
   } else {
-    viewButton = page.locator('.view-file-btn:not(.disabled)').first();
+    viewButton = page.locator('.view-file-btn:not(:disabled)').first();
   }
 
   if ((await viewButton.count()) === 0) {

--- a/frontend/jwst-frontend/src/components/ExportOptionsPanel.css
+++ b/frontend/jwst-frontend/src/components/ExportOptionsPanel.css
@@ -371,8 +371,9 @@
 }
 
 .export-btn-primary:disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .export-spinner {

--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.css
@@ -239,27 +239,19 @@
   color: var(--text-muted);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
-  cursor: not-allowed;
   font-size: var(--text-base);
   font-weight: 500;
   transition: all var(--transition-fast);
 }
 
-.composite-btn.ready {
-  background-color: transparent;
-  color: var(--text-secondary);
-  border-color: var(--border-default);
+.composite-btn:not(:disabled) {
   cursor: pointer;
 }
 
-.composite-btn.ready:hover {
+.composite-btn:not(:disabled):hover {
   background-color: var(--bg-surface-hover);
   color: var(--text-primary);
   border-color: var(--border-strong);
-}
-
-.composite-btn:disabled {
-  opacity: 0.7;
 }
 
 .composite-icon {

--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
@@ -295,8 +295,9 @@ const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
 
         <div className="controls-row controls-row-analysis-actions" ref={analysisRowRef}>
           <button
-            className={`btn-base composite-btn ${selectedCount >= 3 ? 'ready' : ''}`}
+            className="btn-base composite-btn"
             onClick={onOpenCompositeWizard}
+            disabled={selectedCount < 3}
             title="Create composite image"
           >
             <span className="composite-icon">

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.css
@@ -275,7 +275,7 @@
 }
 
 .card-actions .archive-btn:disabled {
-  opacity: 0.7;
+  opacity: 0.5;
   cursor: wait;
   animation: archive-pulse 1.2s ease-in-out infinite;
 }
@@ -301,15 +301,14 @@
   transition: all var(--transition-fast);
 }
 
-.view-file-btn:hover:not(.disabled) {
+.view-file-btn:hover:not(:disabled) {
   background-color: var(--accent-primary-hover);
 }
 
-.view-file-btn.disabled {
+.view-file-btn:disabled {
   background-color: var(--bg-elevated);
   color: var(--text-faint);
   border-color: var(--border-subtle);
-  cursor: not-allowed;
 }
 
 /* Composite selection button on cards */
@@ -347,8 +346,9 @@
 }
 
 .composite-select-btn:disabled {
-  opacity: 0.4;
+  opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 /* Selected card highlight */

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -135,7 +135,7 @@ const DataCard: React.FC<DataCardProps> = ({
       <div className="card-actions">
         <button
           onClick={() => onView(item)}
-          className={`btn-base btn-compact view-file-btn ${!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table') ? 'disabled' : ''}`}
+          className="btn-base btn-compact view-file-btn"
           disabled={!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table')}
           title={
             !hasFile

--- a/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.test.tsx
@@ -52,6 +52,7 @@ describe('FloatingAnalysisBar', () => {
     render(
       <FloatingAnalysisBar
         {...defaultProps}
+        selectedCount={3}
         onOpenCompositeWizard={onOpenCompositeWizard}
         onOpenMosaicWizard={onOpenMosaicWizard}
         onOpenComparisonPicker={onOpenComparisonPicker}
@@ -68,18 +69,18 @@ describe('FloatingAnalysisBar', () => {
     expect(onOpenComparisonPicker).toHaveBeenCalledOnce();
   });
 
-  it('composite button has ready class when selectedCount >= 3', () => {
+  it('composite button is enabled when selectedCount >= 3', () => {
     const { container } = render(<FloatingAnalysisBar {...defaultProps} selectedCount={3} />);
 
     const compositeBtn = container.querySelector('.composite-btn');
-    expect(compositeBtn).toHaveClass('ready');
+    expect(compositeBtn).not.toBeDisabled();
   });
 
-  it('composite button does not have ready class when selectedCount < 3', () => {
+  it('composite button is disabled when selectedCount < 3', () => {
     const { container } = render(<FloatingAnalysisBar {...defaultProps} selectedCount={2} />);
 
     const compositeBtn = container.querySelector('.composite-btn');
-    expect(compositeBtn).not.toHaveClass('ready');
+    expect(compositeBtn).toBeDisabled();
   });
 
   it('mosaic button has ready class when selectedCount >= 2', () => {

--- a/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.tsx
@@ -20,8 +20,9 @@ const FloatingAnalysisBar: React.FC<FloatingAnalysisBarProps> = ({
     <div className={`floating-analysis-bar ${visible ? 'visible' : ''}`} aria-hidden={!visible}>
       <div className="floating-analysis-inner">
         <button
-          className={`btn-base composite-btn ${selectedCount >= 3 ? 'ready' : ''}`}
+          className="btn-base composite-btn"
           onClick={onOpenCompositeWizard}
+          disabled={selectedCount < 3}
           title="Create composite image"
         >
           <span className="composite-icon">

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
@@ -107,7 +107,7 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
         <div className="file-actions">
           <button
             onClick={() => onView(item)}
-            className={`btn-base view-file-btn ${!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table') ? 'disabled' : ''}`}
+            className="btn-base view-file-btn"
             disabled={!hasFile || (!fitsInfo.viewable && fitsInfo.type !== 'table')}
             title={
               !hasFile

--- a/frontend/jwst-frontend/src/components/discovery/SearchBar.css
+++ b/frontend/jwst-frontend/src/components/discovery/SearchBar.css
@@ -52,6 +52,7 @@
 }
 
 .discovery-search-btn:disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }

--- a/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.css
+++ b/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.css
@@ -261,6 +261,7 @@
 .export-framing-export-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .export-framing-export-btn:focus-visible {

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -167,6 +167,7 @@
 .result-preset-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .result-preset-btn:focus-visible {
@@ -539,6 +540,7 @@
 .result-export-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .result-export-btn:focus-visible {

--- a/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.css
@@ -92,9 +92,10 @@
   box-shadow: 0 0 20px var(--accent-teal-subtle);
 }
 
-.image-card.disabled {
+.image-card:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .image-card-content {

--- a/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/ImageSelectionStep.tsx
@@ -84,10 +84,8 @@ export const ImageSelectionStep: React.FC<ImageSelectionStepProps> = ({
             return (
               <button
                 key={img.id}
-                className={`btn-base image-card ${isSelected ? 'selected' : ''} ${
-                  !canSelect ? 'disabled' : ''
-                }`}
-                onClick={() => canSelect && handleImageClick(img.id)}
+                className={`btn-base image-card ${isSelected ? 'selected' : ''}`}
+                onClick={() => handleImageClick(img.id)}
                 disabled={!canSelect}
                 type="button"
               >

--- a/frontend/jwst-frontend/src/index.css
+++ b/frontend/jwst-frontend/src/index.css
@@ -286,7 +286,9 @@ code {
 }
 
 .btn-base:disabled {
+  opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 /* Padding tiers — apply one alongside btn-base */
@@ -333,7 +335,7 @@ code {
 }
 
 .btn-icon:disabled {
-  opacity: 0.3;
+  opacity: 0.5;
   cursor: not-allowed;
   pointer-events: none;
 }
@@ -360,6 +362,7 @@ code {
 .btn-action:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .btn-action.btn-secondary {
@@ -399,8 +402,9 @@ code {
 }
 
 .btn-export:disabled:not(.exporting) {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .btn-export.exporting {


### PR DESCRIPTION
## Summary

Standardizes disabled button/element styling to a single consistent pattern: `opacity: 0.5`, `cursor: not-allowed`, `pointer-events: none`. Previously, opacity ranged from 0.3 to 0.7, some buttons used CSS `.disabled` class instead of HTML `disabled`, and `pointer-events: none` was missing from most disabled states.

Closes #666

## Why

Disabled buttons looked inconsistent across the app — some barely dimmed (0.7), others nearly invisible (0.3). Some showed `cursor: not-allowed` but remained clickable because they weren't actually HTML-disabled. This makes the UI feel unpolished and confuses keyboard/assistive technology users.

## Changes Made

- **Standardized `opacity: 0.5`** across all disabled states (was 0.3–0.7):
  - `index.css`: `.btn-base:disabled`, `.btn-icon:disabled`, `.btn-export:disabled`
  - `DataCard.css`: `.composite-select-btn:disabled`, `.archive-btn:disabled`
  - `SearchBar.css`: `.discovery-search-btn:disabled`
  - `ExportOptionsPanel.css`: `.export-btn-primary:disabled`
- **Added `pointer-events: none`** to all disabled rules that were missing it:
  - `.btn-base:disabled`, `.btn-action:disabled`, `.btn-export:disabled`
  - `.composite-select-btn:disabled`, `.discovery-search-btn:disabled`
  - `.result-preset-btn:disabled`, `.result-export-btn:disabled`
  - `.export-btn-primary:disabled`, `.export-framing-export-btn:disabled`
  - `.image-card:disabled`
- **Converted CSS `.disabled` class to HTML `disabled` attribute**:
  - `.composite-btn`: Added `disabled={selectedCount < 3}` in DashboardToolbar.tsx and FloatingAnalysisBar.tsx, removed `.ready` class pattern, replaced CSS with `:not(:disabled)` selectors
  - `.view-file-btn`: Removed redundant `.disabled` class from DataCard.tsx and LineageFileCard.tsx (HTML `disabled` was already present), changed CSS from `.disabled` to `:disabled`
  - `.image-card`: Removed redundant `.disabled` class from ImageSelectionStep.tsx, changed CSS from `.disabled` to `:disabled`, removed guard in onClick (HTML `disabled` handles it)
- **Updated E2E selectors**: `.view-file-btn:not(.disabled)` → `.view-file-btn:not(:disabled)` in helpers.ts
- **Updated tests**: FloatingAnalysisBar tests now check `toBeDisabled()` instead of `toHaveClass('ready')`

## Test Plan

- [x] TypeScript compiles clean
- [x] All 865 unit tests pass (including updated FloatingAnalysisBar tests)
- [x] ESLint clean (3 pre-existing warnings)
- [x] E2E selectors updated for `.view-file-btn`
- [ ] Visually verify disabled composite button dims to 0.5 opacity when < 3 files selected
- [ ] Verify disabled view buttons on non-viewable file cards look consistent
- [ ] Verify archive-in-progress button still pulses with wait cursor
- [ ] Tab through Library — disabled buttons are skipped (pointer-events: none)

## Documentation Checklist

- [x] `docs/key-files.md` — no new files
- [x] `docs/standards/backend-development.md` — no backend changes
- [x] `docs/architecture/` — no architectural changes
- [x] `docs/quick-reference.md` — no API changes
- [x] `docs/development-plan.md` — no task completions to mark

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Adds to existing tech debt
- [ ] Resolves existing tech debt

## Risk & Rollback

Risk: Low — CSS standardization + minor JSX changes. Behavioral change: composite button is now properly HTML-disabled when < 3 files selected (was only visually styled, still clickable).

Rollback: Revert commit. No data or state changes.