### PR TITLE
fix: UserMenu dropdown blends into dark background

### DIFF
--- a/frontend/jwst-frontend/src/components/UserMenu.css
+++ b/frontend/jwst-frontend/src/components/UserMenu.css
@@ -64,7 +64,7 @@
   top: calc(100% + 8px);
   right: 0;
   background: var(--bg-surface);
-  border: 1px solid var(--border-default);
+  border: 1px solid var(--border-strong);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   min-width: 260px;


### PR DESCRIPTION
## Summary

Upgrades the UserMenu dropdown border from `--border-default` (10% white opacity) to `--border-strong` (18% white opacity) for clearer visual separation against the dark page background.

Closes #677

## Why

The dropdown used `rgba(255, 255, 255, 0.1)` for its border, making it nearly invisible against the dark theme. Users couldn't immediately see the dropdown as a distinct overlay.

## Changes Made

- `UserMenu.css`: Changed `.user-menu-dropdown` border from `var(--border-default)` to `var(--border-strong)`

## Test Plan

- [x] All 865 unit tests pass
- [ ] Open UserMenu dropdown — border is clearly visible against dark background

## Documentation Checklist

- [x] No documentation updates needed — single CSS property change

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Adds to existing tech debt
- [ ] Resolves existing tech debt

## Risk & Rollback

Risk: Minimal — single CSS property change.

Rollback: Revert commit.