### PR TITLE
fix: composite/mosaic ready state too subtle

### DIFF
--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.css
@@ -246,12 +246,15 @@
 
 .composite-btn:not(:disabled) {
   cursor: pointer;
+  color: var(--accent-teal);
+  border-color: var(--accent-teal);
+  background-color: var(--accent-teal-subtle);
 }
 
 .composite-btn:not(:disabled):hover {
-  background-color: var(--bg-surface-hover);
-  color: var(--text-primary);
-  border-color: var(--border-strong);
+  background-color: rgba(78, 205, 196, 0.2);
+  color: var(--accent-teal);
+  border-color: var(--accent-teal);
 }
 
 .composite-icon {
@@ -277,17 +280,17 @@
 }
 
 .mosaic-open-btn.ready {
-  background-color: transparent;
-  color: var(--text-secondary);
-  border-color: var(--border-default);
+  color: var(--accent-interactive);
+  border-color: var(--accent-interactive);
+  background-color: var(--accent-interactive-subtle);
   cursor: pointer;
 }
 
 .mosaic-open-btn.ready:hover,
 .mosaic-open-btn:hover {
-  background-color: var(--bg-surface-hover);
-  color: var(--text-primary);
-  border-color: var(--border-strong);
+  background-color: rgba(74, 144, 217, 0.2);
+  color: var(--accent-interactive);
+  border-color: var(--accent-interactive);
 }
 
 .mosaic-icon {


### PR DESCRIPTION
## Summary

Makes the composite and mosaic buttons' "ready" state clearly distinct from their disabled state using accent colors and tinted backgrounds.

Closes #673

**Note:** This PR is based on `fix/standardize-disabled-states` (#822) which changed composite-btn to use HTML `disabled`.

## Why

The composite and mosaic buttons' ready state was nearly identical to disabled — both used neutral text and default borders. Users didn't notice when they could create composites after selecting enough images.

## Changes Made

- **Composite button (enabled)**: teal accent — `color: var(--accent-teal)`, `border-color: var(--accent-teal)`, `background: var(--accent-teal-subtle)`. Hover deepens the tint.
- **Mosaic button (.ready)**: interactive-blue accent — `color: var(--accent-interactive)`, `border-color: var(--accent-interactive)`, `background: var(--accent-interactive-subtle)`. Hover deepens the tint.
- Both use the existing `transition: all var(--transition-fast)` for smooth state changes
- FloatingAnalysisBar inherits the same styles via shared CSS classes

## Test Plan

- [x] All 865 unit tests pass
- [ ] Select < 3 files — composite button appears dimmed/disabled
- [ ] Select 3+ files — composite button lights up teal with accent border
- [ ] Select < 2 files — mosaic button appears neutral
- [ ] Select 2+ files — mosaic button lights up blue with accent border
- [ ] FloatingAnalysisBar buttons match the same pattern

## Documentation Checklist

- [x] No documentation updates needed — CSS-only change

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Adds to existing tech debt
- [ ] Resolves existing tech debt

## Risk & Rollback

Risk: Low — CSS-only color changes.

Rollback: Revert commit.