### PR TITLE
perf: increase E2E Playwright workers from 3 to 6

### DIFF
--- a/frontend/jwst-frontend/playwright.config.ts
+++ b/frontend/jwst-frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
-    workers: process.env.CI ? 3 : undefined,
+    workers: process.env.CI ? 6 : undefined,
     reporter: 'html',
     use: {
         baseURL: 'http://localhost:3000',


### PR DESCRIPTION
## Summary

Doubles Playwright E2E worker count from 3 to 6 in CI. Workers are I/O-bound (waiting on browser responses), not CPU-bound, so more workers = more parallel waiting = faster total runtime.

No linked issue

## Why

E2E tests currently take 20-35 minutes with 3 workers processing 140 tests. Most time is spent waiting for page loads, network responses, and mocked processing results — not CPU computation.

## Changes Made

- `playwright.config.ts`: Changed CI workers from 3 to 6

## Test Plan

- [x] All 865 unit tests pass
- [x] Config change only affects CI (`process.env.CI` guard)
- [ ] Compare E2E duration on this PR vs previous runs

## Documentation Checklist

- [x] No documentation updates needed

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Adds to existing tech debt
- [ ] Resolves existing tech debt

## Risk & Rollback

Risk: Minimal — if 6 workers cause resource contention on the GHA runner, tests will fail/flake and we'll reduce back to 3-4.

Rollback: Change 6 back to 3.