### PR TITLE
docs: add blog posts for March 13-15

### DIFF
--- a/docs/blog/posts/2026-03-13.md
+++ b/docs/blog/posts/2026-03-13.md
@@ -1,0 +1,53 @@
+---
+date:
+  created: 2026-03-13
+categories:
+  - Bug Fix
+  - Data Pipeline
+tags:
+  - recipes
+  - mast-integration
+  - data-availability
+  - deduplication
+authors:
+  - shanon
+---
+
+# March 13: The c-Prefix Problem
+
+Four PRs today, all circling the same issue: MAST's observation naming conventions are more complicated than they look, and our recipe engine was tripping over them.
+
+<!-- more -->
+
+## Developer Journal
+
+### Observation prefixes: o vs c
+
+MAST has two kinds of observation IDs for the same program. The `o`-prefix observations are the individual detector exposures — the raw building blocks. The `c`-prefix observations are pre-combined mosaics that STScI has already stitched together. Both show up in search results for the same target.
+
+Our recipe engine was naively pulling both. In some cases it would download all the individual parts *and* the combined mosaic — doubling the download time and confusing the composite pipeline. Worse, the c-prefix mosaics are enormous files that MAST doesn't always put on S3, so they'd fall back to slow HTTP downloads or fail entirely with unhelpful "no products available" errors.
+
+The fix came in stages across the day:
+
+**First** (#801): filtered discovery searches to L3 calibration level to match what we actually download. Previously we'd find filters at L2b that had no L3 products, then fail at download time.
+
+**Second** (#803): added deduplication logic to the recipe engine — when both `c`-prefix and `o`-prefix observations exist for the same filter, keep only one. But which one?
+
+**Third** (#804): switched from filtering downloads against raw MAST search results to using the recipe's own `observation_ids` list. The recipe already knows which observations it wants — we were second-guessing it with a broader MAST query that pulled in duplicates.
+
+**Fourth** (#808): settled the preference question — always prefer `o`-prefix observations over `c`-prefix. The individual exposures are smaller, consistently available on S3, and our composite pipeline is designed to combine them anyway. The pre-combined mosaics are useful for quick previews but not for building custom composites.
+
+### The cascade pattern
+
+This is a pattern I've noticed: data pipeline bugs rarely come alone. You fix the obvious symptom (downloads failing), which reveals the next layer (duplicate observations), which reveals the assumption underneath (we trusted MAST search results to be de-duplicated). Four PRs in one day isn't scope creep — it's peeling back the onion.
+
+## What shipped
+
+| PR | Title |
+|-----|-------|
+| #801 | fix: filter discovery search to L3 calibration level to match downloads |
+| #803 | fix: deduplicate c-prefix mosaic vs o-prefix observations in recipe engine |
+| #804 | fix: use recipe observation_ids to filter downloads instead of raw MAST results |
+| #808 | fix: always prefer o-prefix observations over c-prefix in deduplication |
+
+<!-- enriched -->

--- a/docs/blog/posts/2026-03-14.md
+++ b/docs/blog/posts/2026-03-14.md
@@ -1,0 +1,66 @@
+---
+date:
+  created: 2026-03-14
+categories:
+  - UX Polish
+  - Accessibility
+  - Maintenance
+tags:
+  - ux-sprint
+  - accessibility
+  - wcag
+  - design-system
+  - dependencies
+authors:
+  - shanon
+---
+
+# March 14: UX Sprint Day One
+
+The recipe fixes stabilized. Time to shift gears — the UX sprint officially kicked off today with six issues closed and a wave of dependency updates.
+
+<!-- more -->
+
+## Developer Journal
+
+### The accessibility batch
+
+Started with the accessibility issues from the Phase 5b audit. These are the kind of fixes that individually seem small but collectively determine whether keyboard and assistive technology users can use the app at all.
+
+**Focus-visible states** (#821, closes #665): The app had `outline: none` scattered across component CSS files — the classic "make it look clean" move that silently breaks keyboard navigation. Added `:focus-visible` rules to every interactive element across 11 component CSS files, with a global baseline in `index.css`. Convention: `outline-offset: 2px` for buttons (outward blue ring), `-2px` for inputs (inset). One PR, 11 files, WCAG 2.1 AA compliance restored.
+
+**Disabled state standardization** (#822, closes #666): Disabled buttons and inputs had inconsistent styling — some dimmed text, some reduced opacity, some did nothing. Standardized to `opacity: 0.5` + `cursor: not-allowed` + muted colors across the design system.
+
+**Badge contrast** (closes #667): Instrument badges (MIRI, NIRCam, etc.) were failing WCAG AA contrast ratios against the dark background. Adjusted the badge color palette to meet 4.5:1 minimum.
+
+### Visual polish
+
+**Empty state for dashboard** (#823, closes #670): The Library page with zero files just showed... nothing. Blank space. Added an illustrated empty state with a telescope icon and guidance to either upload data or search MAST. Small thing, but it's the first impression for new users.
+
+**UserMenu dropdown** (#824, closes #677): The user menu dropdown was nearly invisible — dark background on dark background with no border or shadow. Added `border: 1px solid var(--border-default)` and `box-shadow`. Obvious in hindsight.
+
+**Ready state visibility** (#826, closes #673): The composite and mosaic buttons' "ready" state was indistinguishable from disabled. Both were neutral gray text with default borders. Now composite lights up teal when you have 3+ files selected, mosaic goes blue at 2+. The color change gives immediate feedback that you've unlocked an action.
+
+### Dependency maintenance
+
+Eight dependabot PRs merged — a mix of CI tooling (dorny/paths-filter v3→v4), linting (ruff, eslint-parser), type definitions (@types/node), and backend packages (AWSSDK.S3, JwtBearer, Resilience, NetAnalyzers). Nothing breaking, all CI-green. Keeping dependencies current is less glamorous than feature work but it's the difference between a smooth upgrade path and a "we're 47 versions behind" crisis.
+
+## What shipped
+
+| PR | Title |
+|-----|-------|
+| #821 | fix: add focus-visible states to all interactive elements |
+| #822 | fix: standardize disabled state styling across components |
+| #823 | feat: add empty state for dashboard card list |
+| #824 | fix: UserMenu dropdown blends into dark background |
+| #826 | fix: composite/mosaic ready state too subtle |
+| #809 | chore(deps): Bump dorny/paths-filter from 3 to 4 |
+| #810 | chore(deps-dev): Bump @typescript-eslint/parser 8.56.1 → 8.57.0 |
+| #811 | chore(deps): Bump ruff 0.15.5 → 0.15.6 |
+| #812 | chore(deps-dev): Bump @types/node 25.3.5 → 25.5.0 |
+| #815 | Bump AWSSDK.S3 4.0.18.7 → 4.0.19 |
+| #817 | Bump JwtBearer 10.0.3 → 10.0.5 |
+| #819 | Bump NetAnalyzers 10.0.103 → 10.0.201 |
+| #820 | Bump Http.Resilience 10.3.0 → 10.4.0 |
+
+<!-- enriched -->

--- a/docs/blog/posts/2026-03-15.md
+++ b/docs/blog/posts/2026-03-15.md
@@ -1,0 +1,63 @@
+---
+date:
+  created: 2026-03-15
+categories:
+  - UX Polish
+  - Performance
+  - Maintenance
+tags:
+  - ux-sprint
+  - navigation
+  - e2e-tests
+  - dependencies
+authors:
+  - shanon
+---
+
+# March 15: Where Am I?
+
+UX sprint day two. Today's focus: navigation wayfinding — making it obvious which page you're on and what you can do.
+
+<!-- more -->
+
+## Developer Journal
+
+### Navigation wayfinding
+
+The dark theme made the active nav link nearly invisible. Blue text on a dark background with a barely-there tinted background — you had to look carefully to tell which page was selected. The Library page had no page title at all. And the view mode toggle (Lineage vs By Target) was buried in the secondary actions row where nobody noticed it.
+
+PR #828 addresses all four acceptance criteria from #671:
+
+**Active nav indicator**: Added a 2px blue underline below the active link, bumped text to full brightness (`--text-primary`) and `font-weight: 600`. The underline sits at the bottom of the nav link, just above the header border. Small visual change, big orientation improvement.
+
+**Library page header**: Added `<h1>My Library</h1>` with a subtitle ("Your imported FITS files, composites, and mosaics"), matching the pattern SearchPage already uses. Also set `document.title` on all three main pages so the browser tab tells you where you are.
+
+**Selection context**: The FloatingAnalysisBar now shows "N files selected" before the action buttons. Previously it just showed buttons with counts in parentheses — no explicit label telling you this was about your selection. Added a separator between the label and the buttons.
+
+**View mode toggle**: Wrapped in a labeled group with "View:" prefix, and strengthened the active state with `accent-primary-subtle` background and bolder text. The label makes it scannable — you see "View: Lineage" or "View: By Target" at a glance.
+
+Found a pre-existing bug during self-review: the composite button in the floating bar never applied the `ready` CSS class. The CSS rules existed but the JSX didn't conditionally add the class. Dead code since the button was created. Fixed.
+
+### E2E performance
+
+PR #827 doubled the E2E Playwright workers from 3 to 6. The tests were already parallelizable — just hadn't bumped the worker count. Halves the E2E wall time in CI.
+
+### Dependency bumps
+
+Two more dependabot PRs merged: @typescript-eslint/eslint-plugin 8.56.1→8.57.0 and Microsoft.AspNetCore.OpenApi 10.0.3→10.0.5. Two others (#813 vite 7→8, #814 plugin-react 5→6) have breaking CI failures — major version bumps that need investigation.
+
+## What shipped
+
+| PR | Title |
+|-----|-------|
+| #827 | perf: increase E2E Playwright workers from 3 to 6 |
+| #816 | chore(deps-dev): Bump eslint-plugin 8.56.1 → 8.57.0 |
+| #818 | Bump OpenApi 10.0.3 → 10.0.5 |
+
+### In review
+
+| PR | Title |
+|-----|-------|
+| #828 | fix: improve navigation wayfinding with stronger active states and page context |
+
+<!-- enriched -->


### PR DESCRIPTION
## Summary
Adds dev blog posts covering March 13-15.

No linked issue

## Why
Keeping the dev blog current — covers recipe deduplication fixes, UX sprint kickoff, and navigation wayfinding work.

## Changes Made
- **2026-03-13**: The c-prefix problem — four PRs fixing MAST observation deduplication (o-prefix vs c-prefix), L3 filtering, and download reliability
- **2026-03-14**: UX sprint day one — 6 UX issues closed (focus-visible, disabled states, badge contrast, empty state, UserMenu dropdown, ready state visibility) + 8 dependency bumps
- **2026-03-15**: Navigation wayfinding (PR #828), E2E workers doubled, 2 more dep bumps

## Test Plan
- [x] Blog posts render correctly in markdown preview
- [x] All dates, PR numbers, and issue references verified against git history

## Documentation Checklist
- [x] No documentation updates needed — blog content only

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Creates tech debt (explain below)
- [ ] Reduces existing tech debt

## Risk & Rollback
Risk: None — docs-only change.
Rollback: Revert commit.