### PR TITLE
fix: enable Spectrum button for spectral files regardless of isViewable

### DIFF
--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -28,7 +28,7 @@ const DataCard: React.FC<DataCardProps> = ({
   onTagClick,
 }) => {
   const fitsInfo = getFitsFileInfo(item.fileName);
-  const hasFile = item.isViewable !== false;
+  const hasFile = item.isViewable !== false || isSpectralFile(item.fileName);
   const canSelect = fitsInfo.viewable;
 
   return (

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
@@ -24,7 +24,7 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
   onArchive,
 }) => {
   const fitsInfo = getFitsFileInfo(item.fileName);
-  const hasFile = item.isViewable !== false;
+  const hasFile = item.isViewable !== false || isSpectralFile(item.fileName);
   const canSelect = fitsInfo.viewable;
 
   return (


### PR DESCRIPTION
## Summary
Spectral files (_x1d, _c1d, _x1dints) had their Spectrum button permanently disabled because the backend sets `isViewable=false` on them (they aren't image data). The button's disabled condition checked `isViewable` before checking file type, blocking access to the spectral chart viewer.

No linked issue

## Why
Users couldn't open any spectral file in the Spectrum viewer — every Spectrum button was grayed out. The `isViewable` flag was designed for image viewing but was incorrectly gating spectral viewing too.

## Changes Made
- `LineageFileCard.tsx`: `hasFile` now includes `isSpectralFile()` check — spectral files are always considered "viewable" for the Spectrum action
- `DataCard.tsx`: Same fix applied to the By Target view card component

## Test Plan
- [x] All 868 unit tests pass
- [ ] Navigate to My Library → find a spectral file (_x1d) → Spectrum button should be clickable
- [ ] Click Spectrum → spectral chart viewer opens with plotly chart

## Documentation Checklist
- [x] No documentation updates needed — single-line bug fix

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Creates tech debt (explain below)
- [ ] Reduces existing tech debt

## Risk & Rollback
Risk: Low — two-line change, only affects disabled state of spectral file buttons.
Rollback: Revert commit.