### PR TITLE
fix: add musl Linux binaries for Vite 8 Alpine Docker support

### DIFF
--- a/frontend/jwst-frontend/package-lock.json
+++ b/frontend/jwst-frontend/package-lock.json
@@ -8,10 +8,12 @@
       "name": "jwst-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@esbuild/linux-x64": "*",
+        "@esbuild/linux-x64": "^0.27.4",
         "@microsoft/signalr": "^10.0.0",
+        "@rolldown/binding-linux-x64-musl": "*",
         "@types/react-plotly.js": "^2.6.4",
         "fitsjs": "^0.6.6",
+        "lightningcss-linux-x64-musl": "*",
         "plotly.js-basic-dist-min": "^3.4.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -46,8 +48,10 @@
       "optionalDependencies": {
         "@esbuild/linux-x64": "^0.27.4",
         "@rolldown/binding-linux-x64-gnu": "^1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "^1.0.0-rc.9",
         "@rollup/rollup-linux-x64-gnu": "^4.59.0",
-        "lightningcss-linux-x64-gnu": "^1.32.0"
+        "lightningcss-linux-x64-gnu": "^1.32.0",
+        "lightningcss-linux-x64-musl": "^1.32.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -1086,6 +1090,22 @@
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
       "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
       "cpu": [
         "x64"
       ],
@@ -4377,6 +4397,26 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],

--- a/frontend/jwst-frontend/package.json
+++ b/frontend/jwst-frontend/package.json
@@ -56,7 +56,9 @@
   "optionalDependencies": {
     "@esbuild/linux-x64": "^0.27.4",
     "@rolldown/binding-linux-x64-gnu": "^1.0.0-rc.9",
+    "@rolldown/binding-linux-x64-musl": "^1.0.0-rc.9",
     "@rollup/rollup-linux-x64-gnu": "^4.59.0",
-    "lightningcss-linux-x64-gnu": "^1.32.0"
+    "lightningcss-linux-x64-gnu": "^1.32.0",
+    "lightningcss-linux-x64-musl": "^1.32.0"
   }
 }


### PR DESCRIPTION
## Summary
Adds musl-variant Linux native binaries to optional dependencies so Vite 8 works in Alpine-based Docker containers (E2E tests, frontend dev container).

No linked issue

## Why
E2E tests and the frontend dev container use `node:22-alpine` which is musl-based. PR #830 added glibc Linux binaries for CI (Ubuntu), but Docker uses Alpine (musl). The frontend container crashed with "Cannot find module @rolldown/binding-linux-x64-musl".

## Changes Made
- Added `@rolldown/binding-linux-x64-musl` and `lightningcss-linux-x64-musl` as optional dependencies
- Updated `package-lock.json` with resolved entries for both platforms

## Test Plan
- [x] All 868 unit tests pass locally
- [x] Build succeeds
- [ ] E2E tests pass in CI (the actual validation — this is what was broken)
- [ ] Frontend dev container starts without crashing

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Creates tech debt (explain below)
- [ ] Reduces existing tech debt

## Risk & Rollback
Risk: None — adds optional deps that are only installed on matching platforms.
Rollback: Revert commit.