### PR TITLE
test: add unit tests for MosaicService, SemanticSearchService, DataScanService

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/DataScanServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/DataScanServiceTests.cs
@@ -2,24 +2,795 @@
 // Licensed under the MIT License.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 
 using FluentAssertions;
 
+using JwstDataAnalysis.API.Controllers;
 using JwstDataAnalysis.API.Models;
 using JwstDataAnalysis.API.Services;
+using JwstDataAnalysis.API.Services.Storage;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
 
 namespace JwstDataAnalysis.API.Tests.Services;
 
 /// <summary>
-/// Unit tests for the internal static helper methods of DataScanService.
-/// Accessible via InternalsVisibleTo in the main project.
+/// Unit tests for DataScanService — both the static helper methods (accessible via
+/// InternalsVisibleTo) and the async ScanAndImportAsync orchestration logic.
 /// </summary>
 public class DataScanServiceTests
 {
+    // ── Shared constant used in ConvertJsonElement array test ──────────────────
     private static readonly int[] TestArray = [1, 2, 3];
 
-    // ========== ParseFileInfo Tests ==========
+    // ── Mocks used by ScanAndImportAsync tests ─────────────────────────────────
+    private readonly Mock<IMongoDBService> mockMongo = new();
+    private readonly Mock<IMastService> mockMast = new();
+    private readonly Mock<IStorageProvider> mockStorage = new();
+    private readonly Mock<IThumbnailQueue> mockThumbnailQueue = new();
+    private readonly EmbeddingQueue embeddingQueue = new();
+    private readonly Mock<ILogger<DataScanService>> mockLogger = new();
+
+    // Helper — create the SUT with all mocked dependencies
+    private DataScanService CreateSut() =>
+        new(
+            mockMongo.Object,
+            mockMast.Object,
+            mockStorage.Object,
+            mockThumbnailQueue.Object,
+            embeddingQueue,
+            mockLogger.Object);
+
+    // Helper — configure the storage mock to behave like S3 (no local path support)
+    private void SetupS3Storage(IEnumerable<string>? keys = null)
+    {
+        mockStorage.Setup(s => s.SupportsLocalPath).Returns(false);
+        mockStorage
+            .Setup(s => s.ListAsync("mast/", It.IsAny<CancellationToken>()))
+            .Returns(ToAsyncEnumerable(keys ?? []));
+    }
+
+    // Helper — simple async enumerable from a sync sequence
+    private static async IAsyncEnumerable<string> ToAsyncEnumerable(
+        IEnumerable<string> source,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var item in source)
+        {
+            ct.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+    // Helper — build a MastSearchResponse with one result entry
+    private static MastSearchResponse BuildMastResponse(string obsId, string targetName = "NGC-3132") =>
+        new()
+        {
+            Results =
+            [
+                new Dictionary<string, object?>
+                {
+                    { "target_name", targetName },
+                    { "instrument_name", "NIRCAM" },
+                    { "filters", "F200W" },
+                    { "t_exptime", "1200.0" },
+                },
+            ],
+        };
+
+    // =========================================================================
+    // ScanAndImportAsync — S3 path (SupportsLocalPath = false)
+    // =========================================================================
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_NoFitsFilesFound_ReturnsEarlyWithZeroCounts()
+    {
+        // Arrange — S3 with no FITS keys
+        SetupS3Storage([]);
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert
+        result.ImportedCount.Should().Be(0);
+        result.SkippedCount.Should().Be(0);
+        result.ErrorCount.Should().Be(0);
+        result.Message.Should().Contain("No FITS files found");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_NonFitsKeysIgnored_ReturnsZero()
+    {
+        // Arrange — S3 returns keys that are not FITS
+        SetupS3Storage(["mast/obs1/catalog.csv", "mast/obs1/readme.txt"]);
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert — non-FITS files should be silently ignored, triggering the "empty" early return
+        result.ImportedCount.Should().Be(0);
+        result.Message.Should().Contain("No FITS files found");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_NewFile_ImportsAndEnqueuesJobs()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(2048L);
+
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert
+        result.ImportedCount.Should().Be(1);
+        result.SkippedCount.Should().Be(0);
+        result.ErrorCount.Should().Be(0);
+        result.ImportedFiles.Should().ContainSingle()
+            .Which.Should().Be("jw02733001001_02101_00001_nrca1_cal.fits");
+
+        // Verify MongoDB create was called with correct data
+        mockMongo.Verify(m => m.CreateAsync(It.Is<JwstDataModel>(d =>
+            d.FilePath == storageKey &&
+            d.IsPublic == true &&
+            d.FileFormat == FileFormats.FITS)), Times.Once);
+
+        // Thumbnail queue should have been poked
+        mockThumbnailQueue.Verify(q => q.EnqueueBatch(It.IsAny<List<string>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_DuplicateFile_SkipsImport()
+    {
+        // Arrange — database already contains the file
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        var existing = new JwstDataModel
+        {
+            Id = "existing-id",
+            FilePath = storageKey,
+            IsPublic = true,
+            ProcessingLevel = ProcessingLevels.Level2b,
+            ImageInfo = new ImageMetadata { TargetName = "NGC-3132" },
+        };
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([existing]);
+
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert
+        result.ImportedCount.Should().Be(0);
+        result.SkippedCount.Should().Be(1);
+        result.SkippedFiles.Should().ContainSingle()
+            .Which.Should().Be("jw02733001001_02101_00001_nrca1_cal.fits");
+
+        // No creates, no thumbnail queue
+        mockMongo.Verify(m => m.CreateAsync(It.IsAny<JwstDataModel>()), Times.Never);
+        mockThumbnailQueue.Verify(q => q.EnqueueBatch(It.IsAny<List<string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_ExistingFileWithMissingMetadata_RefreshesMetadata()
+    {
+        // Arrange — file exists but lacks ImageInfo.TargetName (metadata refresh candidate)
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        var existing = new JwstDataModel
+        {
+            Id = "existing-id",
+            FilePath = storageKey,
+            IsPublic = true,
+            ProcessingLevel = ProcessingLevels.Unknown,       // triggers refresh
+            ImageInfo = new ImageMetadata { TargetName = null }, // triggers refresh
+        };
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([existing]);
+        mockMongo.Setup(m => m.UpdateAsync(It.IsAny<string>(), It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert — file was skipped for import but metadata was refreshed
+        result.ImportedCount.Should().Be(0);
+        result.SkippedCount.Should().Be(1);
+        result.Message.Should().Contain("refreshed metadata for 1");
+
+        mockMongo.Verify(m => m.UpdateAsync("existing-id", It.IsAny<JwstDataModel>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_ExistingFileWithIsPublicFalseAndNoOwner_FixesVisibility()
+    {
+        // Arrange — record imported before IsPublic was set (IsPublic=false, no UserId)
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        var existing = new JwstDataModel
+        {
+            Id = "legacy-id",
+            FilePath = storageKey,
+            IsPublic = false,
+            UserId = null,
+            ProcessingLevel = ProcessingLevels.Level2b,
+            ImageInfo = new ImageMetadata { TargetName = "NGC-3132" },
+        };
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([existing]);
+        mockMongo.Setup(m => m.UpdateAsync(It.IsAny<string>(), It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+
+        // No MAST metadata — no metadata refresh, only visibility fix
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync((MastSearchResponse?)null!);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert — visibility was fixed
+        mockMongo.Verify(m => m.UpdateAsync("legacy-id", It.Is<JwstDataModel>(d => d.IsPublic)), Times.Once);
+        result.SkippedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_StorageGetSizeThrows_RecordsError()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        mockStorage
+            .Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("S3 unreachable"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert — error captured, not thrown
+        result.ImportedCount.Should().Be(0);
+        result.ErrorCount.Should().Be(1);
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Contain("S3 unreachable");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_MongoCreateThrows_RecordsError()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(1024L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        mockMongo
+            .Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .ThrowsAsync(new InvalidOperationException("MongoDB write failed"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert
+        result.ImportedCount.Should().Be(0);
+        result.ErrorCount.Should().Be(1);
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Contain("MongoDB write failed");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_MastServiceThrows_ContinuesWithBasicMetadata()
+    {
+        // Arrange — MAST throws, file should still be imported with basic metadata
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(512L);
+
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ThrowsAsync(new HttpRequestException("MAST unreachable"));
+
+        var sut = CreateSut();
+
+        // Act — should not throw
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert — file imported despite MAST failure
+        result.ImportedCount.Should().Be(1);
+        result.ErrorCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_MultipleFiles_SameObservation_AllImported()
+    {
+        // Arrange — two files under the same observation ID
+        var key1 = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        var key2 = "mast/jw02733001001/jw02733001001_02101_00002_nrca2_cal.fits";
+        SetupS3Storage([key1, key2]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+        mockStorage.Setup(s => s.GetSizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(1024L);
+
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert
+        result.ImportedCount.Should().Be(2);
+        // MAST should only be called once per observation group, not once per file
+        mockMast.Verify(
+            m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_MultipleObservations_MastCalledPerObservation()
+    {
+        // Arrange — two files under different observation IDs
+        var key1 = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        var key2 = "mast/jw02734001001/jw02734001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([key1, key2]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+        mockStorage.Setup(s => s.GetSizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(1024L);
+
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("obs"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert — MAST called once per distinct observation group
+        result.ImportedCount.Should().Be(2);
+        mockMast.Verify(
+            m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_NircamKeyword_AddsNircamTag()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_nircam_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(1024L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        JwstDataModel? capturedModel = null;
+        mockMongo
+            .Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => capturedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.ScanAndImportAsync();
+
+        // Assert
+        capturedModel.Should().NotBeNull();
+        capturedModel!.Tags.Should().Contain("NIRCam");
+        capturedModel.Tags.Should().Contain("mast-import");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_MiriKeyword_AddsMiriTag()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_miri_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(1024L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        JwstDataModel? capturedModel = null;
+        mockMongo
+            .Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => capturedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.ScanAndImportAsync();
+
+        // Assert
+        capturedModel!.Tags.Should().Contain("MIRI");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_NirspecKeyword_AddsNirspecTag()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_nirspec_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(1024L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        JwstDataModel? capturedModel = null;
+        mockMongo
+            .Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => capturedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        await sut.ScanAndImportAsync();
+
+        capturedModel!.Tags.Should().Contain("NIRSpec");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_NirissKeyword_AddsNirissTag()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_niriss_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(1024L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        JwstDataModel? capturedModel = null;
+        mockMongo
+            .Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => capturedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        await sut.ScanAndImportAsync();
+
+        capturedModel!.Tags.Should().Contain("NIRISS");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_NewFile_SetsObsIdTag()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(1024L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        JwstDataModel? capturedModel = null;
+        mockMongo
+            .Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => capturedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        await sut.ScanAndImportAsync();
+
+        capturedModel!.Tags.Should().Contain("jw02733001001");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_NewFile_SetsProcessingStatusPending()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_i2d.fits";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(1024L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        JwstDataModel? capturedModel = null;
+        mockMongo
+            .Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => capturedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        await sut.ScanAndImportAsync();
+
+        capturedModel!.ProcessingStatus.Should().Be(ProcessingStatuses.Pending);
+        capturedModel.ProcessingLevel.Should().Be(ProcessingLevels.Level3);
+        capturedModel.DataType.Should().Be(DataTypes.Image);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_GzFitsFile_IsImported()
+    {
+        // Arrange — .fits.gz extension
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_uncal.fits.gz";
+        SetupS3Storage([storageKey]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(512L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert
+        result.ImportedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_ImportedFilesExceed50_ResponseCappedAt50()
+    {
+        // Arrange — 55 unique files
+        var keys = Enumerable.Range(1, 55)
+            .Select(i => $"mast/obs{i:D3}/file{i:D3}_cal.fits")
+            .ToList();
+
+        SetupS3Storage(keys);
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+        mockStorage
+            .Setup(s => s.GetSizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1024L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(new MastSearchResponse { Results = [] });
+        mockThumbnailQueue
+            .Setup(q => q.EnqueueBatch(It.IsAny<List<string>>()));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert — all 55 imported but ImportedFiles list is capped at 50
+        result.ImportedCount.Should().Be(55);
+        result.ImportedFiles.Should().HaveCount(50);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_SkippedFilesExceed20_ResponseCappedAt20()
+    {
+        // Arrange — 25 pre-existing files
+        var keys = Enumerable.Range(1, 25)
+            .Select(i => $"mast/obs/file{i:D3}_cal.fits")
+            .ToList();
+
+        var existingRecords = keys.Select(k => new JwstDataModel
+        {
+            Id = $"id-{k}",
+            FilePath = k,
+            IsPublic = true,
+            ProcessingLevel = ProcessingLevels.Level2b,
+            ImageInfo = new ImageMetadata { TargetName = "X" },
+        }).ToList();
+
+        SetupS3Storage(keys);
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync(existingRecords);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("obs"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert — all 25 skipped but SkippedFiles list is capped at 20
+        result.SkippedCount.Should().Be(25);
+        result.SkippedFiles.Should().HaveCount(20);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_NoNewFiles_DoesNotEnqueueThumbnails()
+    {
+        // Arrange — all files already in DB
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        var existing = new JwstDataModel
+        {
+            Id = "exists",
+            FilePath = storageKey,
+            IsPublic = true,
+            ProcessingLevel = ProcessingLevels.Level2b,
+            ImageInfo = new ImageMetadata { TargetName = "NGC-3132" },
+        };
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([existing]);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.ScanAndImportAsync();
+
+        // Assert — no new IDs means no queue calls
+        mockThumbnailQueue.Verify(q => q.EnqueueBatch(It.IsAny<List<string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_MessageIncludesRefreshedCount_WhenRefreshOccurs()
+    {
+        // Arrange
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        var existing = new JwstDataModel
+        {
+            Id = "old-id",
+            FilePath = storageKey,
+            IsPublic = true,
+            ProcessingLevel = ProcessingLevels.Unknown, // triggers refresh
+            ImageInfo = new ImageMetadata { TargetName = null },
+        };
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([existing]);
+        mockMongo.Setup(m => m.UpdateAsync(It.IsAny<string>(), It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert
+        result.Message.Should().Contain("refreshed metadata for 1");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_MessageDoesNotMentionRefresh_WhenNoneOccur()
+    {
+        // Arrange — nothing imported, nothing refreshed
+        SetupS3Storage([]);
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert
+        result.Message.Should().NotContain("refreshed metadata");
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_ExistingFileAlreadyPublicWithOwner_NoUpdate()
+    {
+        // Arrange — record is already correctly public with an owner, no refresh needed
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        var existing = new JwstDataModel
+        {
+            Id = "clean-id",
+            FilePath = storageKey,
+            IsPublic = true,
+            UserId = "some-user",
+            ProcessingLevel = ProcessingLevels.Level2b,
+            ImageInfo = new ImageMetadata { TargetName = "NGC-3132" },
+        };
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([existing]);
+
+        // Return null results (no obsMeta) so metadata refresh path won't apply
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(new MastSearchResponse { Results = [] });
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.ScanAndImportAsync();
+
+        // Assert — no update triggered
+        mockMongo.Verify(m => m.UpdateAsync(It.IsAny<string>(), It.IsAny<JwstDataModel>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_S3_ErrorsExceed10_ResponseCappedAt10()
+    {
+        // Arrange — 15 files all fail with storage errors
+        var keys = Enumerable.Range(1, 15)
+            .Select(i => $"mast/obs/file{i:D3}_cal.fits")
+            .ToList();
+
+        SetupS3Storage(keys);
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("obs"));
+
+        mockStorage
+            .Setup(s => s.GetSizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("Storage failure"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ScanAndImportAsync();
+
+        // Assert
+        result.ErrorCount.Should().Be(15);
+        result.Errors.Should().HaveCount(10);
+    }
+
+    // =========================================================================
+    // ParseFileInfo — processing level and data type classification
+    // =========================================================================
+
     [Theory]
     [InlineData("jw02733001001_02101_00001_nrca1_uncal.fits", "L1", "raw", true)]
     [InlineData("jw02733001001_02101_00001_nrca1_rate.fits", "L2a", "sensor", true)]
@@ -76,7 +847,10 @@ public class DataScanServiceTests
         result.ExposureId.Should().BeNull();
     }
 
-    // ========== BuildMastMetadata Tests ==========
+    // =========================================================================
+    // BuildMastMetadata
+    // =========================================================================
+
     [Fact]
     public void BuildMastMetadata_WithNullObsMeta_ReturnsDictWithBaseKeys()
     {
@@ -161,7 +935,10 @@ public class DataScanServiceTests
         result.Should().NotContainKey("mast_null_field");
     }
 
-    // ========== ConvertJsonElement Tests ==========
+    // =========================================================================
+    // ConvertJsonElement
+    // =========================================================================
+
     [Fact]
     public void ConvertJsonElement_String_ReturnsString()
     {
@@ -233,7 +1010,10 @@ public class DataScanServiceTests
         ((string)result).Should().Contain("key");
     }
 
-    // ========== CreateImageMetadata Tests ==========
+    // =========================================================================
+    // CreateImageMetadata
+    // =========================================================================
+
     [Fact]
     public void CreateImageMetadata_NullObsMeta_ReturnsNull()
     {
@@ -395,5 +1175,42 @@ public class DataScanServiceTests
         result!.WCS.Should().NotBeNull();
         result.WCS!.Should().ContainKey("CRVAL1").WhoseValue.Should().Be(53.1625);
         result.WCS.Should().ContainKey("CRVAL2").WhoseValue.Should().Be(-27.7914);
+    }
+
+    [Fact]
+    public void CreateImageMetadata_DateFallsBackToTmax_WhenTminIsZero()
+    {
+        // Arrange — t_min is zero (rejected), t_max has a valid MJD
+        var obsMeta = new Dictionary<string, object?>
+        {
+            { "t_min", "0" },
+            { "t_max", "59800.0" },
+        };
+
+        // Act
+        var result = DataScanService.CreateImageMetadata(obsMeta);
+
+        // Assert — should fall back to t_max
+        result.Should().NotBeNull();
+        result!.ObservationDate.Should().NotBeNull();
+        var expectedDate = new DateTime(1858, 11, 17, 0, 0, 0, DateTimeKind.Utc).AddDays(59800.0);
+        result.ObservationDate.Should().Be(expectedDate);
+    }
+
+    [Fact]
+    public void CreateImageMetadata_InvalidCalibrationLevel_DoesNotSetCalibrationLevel()
+    {
+        // Arrange
+        var obsMeta = new Dictionary<string, object?>
+        {
+            { "calib_level", "not-an-int" },
+        };
+
+        // Act
+        var result = DataScanService.CreateImageMetadata(obsMeta);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.CalibrationLevel.Should().BeNull();
     }
 }

--- a/backend/JwstDataAnalysis.API.Tests/Services/MosaicServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/MosaicServiceTests.cs
@@ -1,0 +1,1444 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using JwstDataAnalysis.API.Models;
+using JwstDataAnalysis.API.Services;
+using JwstDataAnalysis.API.Services.Storage;
+using JwstDataAnalysis.API.Tests.Fixtures;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace JwstDataAnalysis.API.Tests.Services;
+
+/// <summary>
+/// Unit tests for MosaicService.
+/// </summary>
+public class MosaicServiceTests
+{
+    private readonly Mock<IMongoDBService> mockMongo = new();
+    private readonly Mock<IStorageProvider> mockStorage = new();
+    private readonly Mock<IThumbnailQueue> mockThumbnailQueue = new();
+    private readonly Mock<ILogger<MosaicService>> mockLogger = new();
+    private readonly IConfiguration configuration;
+
+    public MosaicServiceTests()
+    {
+        configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ProcessingEngine:BaseUrl", "http://test-engine:8000" },
+            })
+            .Build();
+
+        // Default GetManyAsync delegates to per-id GetAsync setups
+        mockMongo.Setup(m => m.GetManyAsync(It.IsAny<IEnumerable<string>>()))
+            .Returns<IEnumerable<string>>(async ids =>
+            {
+                var results = new List<JwstDataModel>();
+                foreach (var id in ids)
+                {
+                    var item = await mockMongo.Object.GetAsync(id);
+                    if (item != null)
+                    {
+                        results.Add(item);
+                    }
+                }
+
+                return results;
+            });
+
+        // Default storage stubs — tests that need specific behaviour override these
+        mockStorage.Setup(s => s.WriteAsync(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        mockStorage.Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        mockStorage.Setup(s => s.GetSizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1024L);
+        mockStorage.Setup(s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    // ==================== GenerateMosaicAsync ====================
+
+    /// <summary>
+    /// Happy path: returns image bytes when the processing engine responds with 200.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_ReturnsImageBytes_OnSuccess()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits");
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var expectedBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 }; // PNG header
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(expectedBytes),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var result = await sut.GenerateMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedBytes);
+    }
+
+    /// <summary>
+    /// The service calls POST /mosaic/generate on the configured engine URL.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_CallsCorrectEndpoint()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits");
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        HttpRequestMessage? captured = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1]) },
+            req => captured = req);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        await sut.GenerateMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.RequestUri!.ToString().Should().Be("http://test-engine:8000/mosaic/generate");
+        captured.Method.Should().Be(HttpMethod.Post);
+    }
+
+    /// <summary>
+    /// Verifies the request body forwarded to the processing engine includes the stripped
+    /// relative path (no /app/data/ prefix) and the per-file stretch parameters.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_SendsRelativeFilePaths_ToEngine()
+    {
+        // Arrange — absolute path with the /app/data/ prefix
+        var data1 = CreateDataModel("data-1", filePath: "/app/data/mast/obs1/file1.fits");
+        var data2 = CreateDataModel("data-2", filePath: "/app/data/mast/obs1/file2.fits");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        HttpRequestMessage? captured = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1]) },
+            req => captured = req);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        await sut.GenerateMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        var body = await captured!.Content!.ReadAsStringAsync();
+        body.Should().Contain("mast/obs1/file1.fits");
+        body.Should().Contain("mast/obs1/file2.fits");
+        body.Should().NotContain("/app/data/");
+    }
+
+    /// <summary>
+    /// Throws KeyNotFoundException when a requested data ID does not exist in MongoDB.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_ThrowsKeyNotFound_WhenDataMissing()
+    {
+        // Arrange
+        mockMongo.Setup(m => m.GetManyAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync([]);
+
+        var sut = CreateService();
+        var request = CreateMosaicRequest(["missing-1", "missing-2"]);
+
+        // Act
+        var act = () => sut.GenerateMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<KeyNotFoundException>()
+            .WithMessage("*not found*");
+    }
+
+    /// <summary>
+    /// Throws UnauthorizedAccessException when the caller cannot access a private record.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_ThrowsUnauthorized_WhenAccessDenied()
+    {
+        // Arrange — private data owned by someone else
+        var private1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: false, userId: "other");
+        var private2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits", isPublic: false, userId: "other");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(private1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(private2);
+
+        var sut = CreateService();
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var act = () => sut.GenerateMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<UnauthorizedAccessException>()
+            .WithMessage("*Access denied*");
+    }
+
+    /// <summary>
+    /// Throws InvalidOperationException when a record has no FilePath.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_ThrowsInvalidOperation_WhenNoFilePath()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: null);
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var sut = CreateService();
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var act = () => sut.GenerateMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no file path*");
+    }
+
+    /// <summary>
+    /// Throws HttpRequestException with the engine's detail message on a non-success status.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_ThrowsHttpRequestException_OnEngineError()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits");
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("{\"detail\":\"Projection failed\"}", Encoding.UTF8, "application/json"),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var act = () => sut.GenerateMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert — exception message should contain the parsed detail string
+        var ex = await act.Should().ThrowAsync<HttpRequestException>();
+        ex.Which.Message.Should().Contain("Projection failed");
+        ex.Which.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+
+    /// <summary>
+    /// Admin can access private data owned by another user.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_AdminAccessesPrivateData_Succeeds()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: false, userId: "other");
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits", isPublic: false, userId: "other");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1, 2, 3]),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var result = await sut.GenerateMosaicAsync(request, "admin-user", isAuthenticated: true, isAdmin: true);
+
+        // Assert
+        result.Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// Unauthenticated callers can access public data.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_UnauthenticatedCanAccessPublicData()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: true);
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits", isPublic: true);
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var result = await sut.GenerateMosaicAsync(request, null, isAuthenticated: false, isAdmin: false);
+
+        // Assert
+        result.Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// Unauthenticated callers cannot access private data.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_UnauthenticatedCannotAccessPrivateData()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: false);
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits", isPublic: false);
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var sut = CreateService();
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var act = () => sut.GenerateMosaicAsync(request, null, isAuthenticated: false, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    /// <summary>
+    /// Owner can access their own private data.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_OwnerAccessesOwnPrivateData_Succeeds()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: false, userId: "owner");
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits", isPublic: false, userId: "owner");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var result = await sut.GenerateMosaicAsync(request, "owner", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        result.Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// Users in SharedWith can access data even though they are not the owner.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_SharedWithUserCanAccess()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: false, userId: "owner");
+        data1.SharedWith = ["shared-user"];
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits", isPublic: false, userId: "owner");
+        data2.SharedWith = ["shared-user"];
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var result = await sut.GenerateMosaicAsync(request, "shared-user", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        result.Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// Falls back to the raw error body when the engine returns non-JSON.
+    /// </summary>
+    [Fact]
+    public async Task GenerateMosaicAsync_ParsesPlainTextError_AsRawBody()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits");
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.BadGateway)
+        {
+            Content = new StringContent("Engine unavailable", Encoding.UTF8, "text/plain"),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var act = () => sut.GenerateMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        var ex = await act.Should().ThrowAsync<HttpRequestException>();
+        ex.Which.Message.Should().Contain("Engine unavailable");
+    }
+
+    /// <summary>
+    /// Uses the default URL (http://localhost:8000) when no config is provided.
+    /// </summary>
+    [Fact]
+    public void Constructor_UsesDefaultUrl_WhenConfigMissing()
+    {
+        // Arrange
+        var emptyConfig = new ConfigurationBuilder().Build();
+
+        // Act — should not throw
+        var sut = new MosaicService(
+            new HttpClient(),
+            mockMongo.Object,
+            mockStorage.Object,
+            mockThumbnailQueue.Object,
+            mockLogger.Object,
+            emptyConfig);
+
+        // Assert
+        sut.Should().NotBeNull();
+    }
+
+    // ==================== GenerateAndSaveMosaicAsync ====================
+
+    /// <summary>
+    /// Happy path: saves the FITS stream, creates a MongoDB record, enqueues thumbnail,
+    /// and returns the correct DTO.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_ReturnsSavedDto_OnSuccess()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var fitsBytes = new byte[] { 0x53, 0x49, 0x4D, 0x50 }; // "SIMP"
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(fitsBytes),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var result = await sut.GenerateAndSaveMosaicAsync(
+            request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.FileName.Should().EndWith("_i2d.fits");
+        result.FileSize.Should().Be(1024L); // from mock GetSizeAsync
+        result.FileFormat.Should().Be(FileFormats.FITS);
+        result.ProcessingLevel.Should().Be(ProcessingLevels.Level3);
+        result.DerivedFrom.Should().Contain("data-1").And.Contain("data-2");
+    }
+
+    /// <summary>
+    /// Creates a MongoDB record and enqueues the thumbnail job after saving.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_CreatesMongoRecordAndEnqueuesThumbnail()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1, 2, 3]),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        await sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        mockMongo.Verify(m => m.CreateAsync(It.IsAny<JwstDataModel>()), Times.Once);
+        mockThumbnailQueue.Verify(q => q.EnqueueBatch(It.IsAny<List<string>>()), Times.Once);
+    }
+
+    /// <summary>
+    /// The saved record is marked as private when the caller is authenticated.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_SetsUserIdOnRecord_WhenAuthenticated()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        JwstDataModel? savedModel = null;
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => savedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        await sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        savedModel.Should().NotBeNull();
+        savedModel!.UserId.Should().Be("user-1");
+    }
+
+    /// <summary>
+    /// The saved record has no UserId when the caller is unauthenticated.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_NullUserId_WhenUnauthenticated()
+    {
+        // Arrange — public data accessible without auth
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: true);
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits", isPublic: true);
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        JwstDataModel? savedModel = null;
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => savedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        await sut.GenerateAndSaveMosaicAsync(request, null, isAuthenticated: false, isAdmin: false);
+
+        // Assert
+        savedModel.Should().NotBeNull();
+        savedModel!.UserId.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Throws InvalidOperationException when no valid source IDs are provided.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_ThrowsInvalidOperation_WhenNoSourceIds()
+    {
+        // Arrange
+        var sut = CreateService();
+        var request = new MosaicRequestDto
+        {
+            Files = [new MosaicFileConfigDto { DataId = "   " }, new MosaicFileConfigDto { DataId = string.Empty }],
+        };
+
+        // Act
+        var act = () => sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*No valid source data IDs*");
+    }
+
+    /// <summary>
+    /// Throws KeyNotFoundException when a data ID cannot be resolved.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_ThrowsKeyNotFound_WhenDataMissing()
+    {
+        // Arrange
+        mockMongo.Setup(m => m.GetAsync("missing")).ReturnsAsync((JwstDataModel?)null);
+
+        var sut = CreateService();
+        var request = CreateMosaicRequest(["missing", "missing-2"]);
+
+        // Act
+        var act = () => sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    /// <summary>
+    /// Throws InvalidOperationException when a source record has no FilePath.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_ThrowsInvalidOperation_WhenNoFilePath()
+    {
+        // Arrange
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(
+            CreateDataModel("data-1", filePath: null));
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(
+            CreateDataModel("data-2", filePath: "mast/obs1/file2.fits"));
+
+        var sut = CreateService();
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var act = () => sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no file path*");
+    }
+
+    /// <summary>
+    /// Throws HttpRequestException on processing engine failure.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_ThrowsHttpRequestException_OnEngineError()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
+        {
+            Content = new StringContent("{\"detail\":\"WCS mismatch\"}", Encoding.UTF8, "application/json"),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var act = () => sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        var ex = await act.Should().ThrowAsync<HttpRequestException>();
+        ex.Which.Message.Should().Contain("WCS mismatch");
+    }
+
+    /// <summary>
+    /// Deletes the stored file and throws when the storage provider reports the file
+    /// has zero bytes after writing.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_DeletesFileAndThrows_WhenSizeIsZero()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        mockStorage.Setup(s => s.GetSizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0L);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var act = () => sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*empty*");
+        mockStorage.Verify(s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Throws when ExistsAsync returns false immediately after writing.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_Throws_WhenFileDoesNotExistAfterWrite()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        mockStorage.Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        var act = () => sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*empty*");
+    }
+
+    /// <summary>
+    /// Always forces OutputFormat=fits and ignores the request OutputFormat field.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_ForcesFitsOutputFormat()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        string? capturedBody = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1]) },
+            req => capturedBody = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult());
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+        request.OutputFormat = "png"; // should be overridden
+
+        // Act
+        await sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        capturedBody.Should().NotBeNull();
+        using var doc = JsonDocument.Parse(capturedBody!);
+        doc.RootElement.GetProperty("output_format").GetString().Should().Be("fits");
+    }
+
+    /// <summary>
+    /// The generated record inherits IsPublic=true only when all sources are public.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_SetsIsPublicFalse_WhenAnySourceIsPrivate()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: true, userId: "user-1");
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits", isPublic: false, userId: "user-1");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        JwstDataModel? savedModel = null;
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => savedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        await sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        savedModel!.IsPublic.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The saved record tags always include "mosaic-generated", "mosaic", "generated", "fits".
+    /// </summary>
+    [Fact]
+    public async Task GenerateAndSaveMosaicAsync_RecordContainsMosaicTags()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        JwstDataModel? savedModel = null;
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => savedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateMosaicRequest(["data-1", "data-2"]);
+
+        // Act
+        await sut.GenerateAndSaveMosaicAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        savedModel!.Tags.Should().Contain("mosaic-generated")
+            .And.Contain("mosaic")
+            .And.Contain("generated")
+            .And.Contain("fits");
+    }
+
+    // ==================== GenerateObservationMosaicAsync ====================
+
+    /// <summary>
+    /// Happy path: calls /mosaic/generate-observation and persists the result.
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_ReturnsSavedDto_OnSuccess()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1, 2, 3]),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+
+        // Act
+        var result = await sut.GenerateObservationMosaicAsync(
+            ["data-1", "data-2"],
+            "jw01234-o001_t001_nircam",
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.FileName.Should().EndWith("_i2d.fits");
+        result.FileFormat.Should().Be(FileFormats.FITS);
+        result.ProcessingLevel.Should().Be(ProcessingLevels.Level3);
+        result.DerivedFrom.Should().Contain("data-1").And.Contain("data-2");
+    }
+
+    /// <summary>
+    /// Calls the correct /mosaic/generate-observation endpoint.
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_CallsCorrectEndpoint()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        HttpRequestMessage? captured = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1]) },
+            req => captured = req);
+
+        var sut = CreateService(new HttpClient(handler));
+
+        // Act
+        await sut.GenerateObservationMosaicAsync(
+            ["data-1", "data-2"],
+            "jw01234",
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false);
+
+        // Assert
+        captured!.RequestUri!.ToString().Should().Be("http://test-engine:8000/mosaic/generate-observation");
+        captured.Method.Should().Be(HttpMethod.Post);
+    }
+
+    /// <summary>
+    /// Observation mosaic record is tagged "observation-mosaic", not "generated".
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_RecordContainsObservationMosaicTag()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        JwstDataModel? savedModel = null;
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => savedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateService(new HttpClient(handler));
+
+        // Act
+        await sut.GenerateObservationMosaicAsync(
+            ["data-1", "data-2"],
+            "jw01234",
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false);
+
+        // Assert
+        savedModel!.Tags.Should().Contain("observation-mosaic").And.Contain("mosaic-generated");
+    }
+
+    /// <summary>
+    /// Stores the correct observationBaseId on the saved record.
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_SetsObservationBaseId_OnRecord()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        JwstDataModel? savedModel = null;
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>()))
+            .Callback<JwstDataModel>(m => savedModel = m)
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateService(new HttpClient(handler));
+        const string obsId = "jw01234-o001_t001_nircam";
+
+        // Act
+        await sut.GenerateObservationMosaicAsync(
+            ["data-1", "data-2"],
+            obsId,
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false);
+
+        // Assert
+        savedModel!.ObservationBaseId.Should().Be(obsId);
+    }
+
+    /// <summary>
+    /// Throws KeyNotFoundException when a source data ID is not found in MongoDB.
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_ThrowsKeyNotFound_WhenDataMissing()
+    {
+        // Arrange
+        mockMongo.Setup(m => m.GetManyAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync([]);
+
+        var sut = CreateService();
+
+        // Act
+        var act = () => sut.GenerateObservationMosaicAsync(
+            ["missing-1", "missing-2"],
+            "obs-1",
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    /// <summary>
+    /// Throws UnauthorizedAccessException when access is denied to a source record.
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_ThrowsUnauthorized_WhenAccessDenied()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: false, userId: "other");
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits", isPublic: false, userId: "other");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var sut = CreateService();
+
+        // Act
+        var act = () => sut.GenerateObservationMosaicAsync(
+            ["data-1", "data-2"],
+            "obs-1",
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    /// <summary>
+    /// Throws InvalidOperationException when a source record has no FilePath.
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_ThrowsInvalidOperation_WhenNoFilePath()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: null);
+        var data2 = CreateDataModel("data-2", filePath: "mast/obs1/file2.fits");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+        mockMongo.Setup(m => m.GetAsync("data-2")).ReturnsAsync(data2);
+
+        var sut = CreateService();
+
+        // Act
+        var act = () => sut.GenerateObservationMosaicAsync(
+            ["data-1", "data-2"],
+            "obs-1",
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no file path*");
+    }
+
+    /// <summary>
+    /// Throws HttpRequestException on engine failure.
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_ThrowsHttpRequestException_OnEngineError()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("{\"detail\":\"Out of memory\"}", Encoding.UTF8, "application/json"),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+
+        // Act
+        var act = () => sut.GenerateObservationMosaicAsync(
+            ["data-1", "data-2"],
+            "obs-1",
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false);
+
+        // Assert
+        var ex = await act.Should().ThrowAsync<HttpRequestException>();
+        ex.Which.Message.Should().Contain("Out of memory");
+    }
+
+    /// <summary>
+    /// Deletes the stored file and throws when GetSizeAsync returns zero.
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_DeletesFileAndThrows_WhenSizeIsZero()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        mockStorage.Setup(s => s.GetSizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0L);
+
+        var sut = CreateService(new HttpClient(handler));
+
+        // Act
+        var act = () => sut.GenerateObservationMosaicAsync(
+            ["data-1", "data-2"],
+            "obs-1",
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*empty*");
+        mockStorage.Verify(s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Respects CancellationToken: passes it through to storage and HTTP calls.
+    /// </summary>
+    [Fact]
+    public async Task GenerateObservationMosaicAsync_RespectsCancel_WithAlreadyCancelledToken()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Override storage write to throw when cancelled
+        mockStorage.Setup(s => s.WriteAsync(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1]),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+
+        // Act
+        var act = () => sut.GenerateObservationMosaicAsync(
+            ["data-1", "data-2"],
+            "obs-1",
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false,
+            cts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // ==================== GetFootprintsAsync ====================
+
+    /// <summary>
+    /// Happy path: returns a FootprintResponseDto when engine responds with 200.
+    /// </summary>
+    [Fact]
+    public async Task GetFootprintsAsync_ReturnsFootprintDto_OnSuccess()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+        SetupSingleGetAsync("data-2", "mast/obs1/file2.fits");
+
+        var footprintJson = """
+            {
+              "footprints": [
+                { "file_path": "mast/obs1/file1.fits", "corners_ra": [1.0,2.0,3.0,4.0], "corners_dec": [5.0,6.0,7.0,8.0], "center_ra": 2.5, "center_dec": 6.5 },
+                { "file_path": "mast/obs1/file2.fits", "corners_ra": [9.0,10.0,11.0,12.0], "corners_dec": [13.0,14.0,15.0,16.0], "center_ra": 10.5, "center_dec": 14.5 }
+              ],
+              "bounding_box": { "min_ra": 1.0, "max_ra": 12.0, "min_dec": 5.0, "max_dec": 16.0 },
+              "n_files": 2
+            }
+            """;
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(footprintJson, Encoding.UTF8, "application/json"),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = new FootprintRequestDto { DataIds = ["data-1", "data-2"] };
+
+        // Act
+        var result = await sut.GetFootprintsAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.NFiles.Should().Be(2);
+        result.Footprints.Should().HaveCount(2);
+        result.BoundingBox.Should().ContainKey("min_ra");
+    }
+
+    /// <summary>
+    /// Calls POST /mosaic/footprint on the configured engine URL.
+    /// </summary>
+    [Fact]
+    public async Task GetFootprintsAsync_CallsCorrectEndpoint()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+
+        HttpRequestMessage? captured = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"footprints\":[],\"bounding_box\":{},\"n_files\":1}",
+                    Encoding.UTF8,
+                    "application/json"),
+            },
+            req => captured = req);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = new FootprintRequestDto { DataIds = ["data-1"] };
+
+        // Act
+        await sut.GetFootprintsAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        captured!.RequestUri!.ToString().Should().Be("http://test-engine:8000/mosaic/footprint");
+        captured.Method.Should().Be(HttpMethod.Post);
+    }
+
+    /// <summary>
+    /// Sends the relative file paths (prefix stripped) in the request body.
+    /// </summary>
+    [Fact]
+    public async Task GetFootprintsAsync_SendsRelativeFilePaths_ToEngine()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "/app/data/mast/obs1/file1.fits");
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+
+        HttpRequestMessage? captured = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"footprints\":[],\"bounding_box\":{},\"n_files\":1}",
+                    Encoding.UTF8,
+                    "application/json"),
+            },
+            req => captured = req);
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = new FootprintRequestDto { DataIds = ["data-1"] };
+
+        // Act
+        await sut.GetFootprintsAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        var body = await captured!.Content!.ReadAsStringAsync();
+        body.Should().Contain("mast/obs1/file1.fits");
+        body.Should().NotContain("/app/data/");
+    }
+
+    /// <summary>
+    /// Throws KeyNotFoundException when a requested data ID is missing.
+    /// </summary>
+    [Fact]
+    public async Task GetFootprintsAsync_ThrowsKeyNotFound_WhenDataMissing()
+    {
+        // Arrange
+        mockMongo.Setup(m => m.GetManyAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync([]);
+
+        var sut = CreateService();
+        var request = new FootprintRequestDto { DataIds = ["missing"] };
+
+        // Act
+        var act = () => sut.GetFootprintsAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    /// <summary>
+    /// Throws UnauthorizedAccessException when access is denied to a data record.
+    /// </summary>
+    [Fact]
+    public async Task GetFootprintsAsync_ThrowsUnauthorized_WhenAccessDenied()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: false, userId: "other");
+        data1.SharedWith = [];
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+
+        var sut = CreateService();
+        var request = new FootprintRequestDto { DataIds = ["data-1"] };
+
+        // Act
+        var act = () => sut.GetFootprintsAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    /// <summary>
+    /// Throws InvalidOperationException when a record has no FilePath.
+    /// </summary>
+    [Fact]
+    public async Task GetFootprintsAsync_ThrowsInvalidOperation_WhenNoFilePath()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: null);
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+
+        var sut = CreateService();
+        var request = new FootprintRequestDto { DataIds = ["data-1"] };
+
+        // Act
+        var act = () => sut.GetFootprintsAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no file path*");
+    }
+
+    /// <summary>
+    /// Throws HttpRequestException on engine failure and includes the detail message.
+    /// </summary>
+    [Fact]
+    public async Task GetFootprintsAsync_ThrowsHttpRequestException_OnEngineError()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("{\"detail\":\"Footprint error\"}", Encoding.UTF8, "application/json"),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = new FootprintRequestDto { DataIds = ["data-1"] };
+
+        // Act
+        var act = () => sut.GetFootprintsAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        var ex = await act.Should().ThrowAsync<HttpRequestException>();
+        ex.Which.Message.Should().Contain("Footprint error");
+    }
+
+    /// <summary>
+    /// Throws InvalidOperationException when the engine returns a null/empty response body.
+    /// </summary>
+    [Fact]
+    public async Task GetFootprintsAsync_ThrowsInvalidOperation_WhenResponseDeserializesToNull()
+    {
+        // Arrange
+        SetupSingleGetAsync("data-1", "mast/obs1/file1.fits");
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = new FootprintRequestDto { DataIds = ["data-1"] };
+
+        // Act
+        var act = () => sut.GetFootprintsAsync(request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*deserialize footprint response*");
+    }
+
+    /// <summary>
+    /// Admin can access private data in footprint calculation.
+    /// </summary>
+    [Fact]
+    public async Task GetFootprintsAsync_AdminAccessesPrivateData_Succeeds()
+    {
+        // Arrange
+        var data1 = CreateDataModel("data-1", filePath: "mast/obs1/file1.fits", isPublic: false, userId: "other");
+        data1.SharedWith = [];
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data1);
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                "{\"footprints\":[],\"bounding_box\":{},\"n_files\":1}",
+                Encoding.UTF8,
+                "application/json"),
+        });
+
+        var sut = CreateService(new HttpClient(handler));
+        var request = new FootprintRequestDto { DataIds = ["data-1"] };
+
+        // Act
+        var result = await sut.GetFootprintsAsync(
+            request, "admin-user", isAuthenticated: true, isAdmin: true);
+
+        // Assert
+        result.Should().NotBeNull();
+    }
+
+    // ==================== Helper methods
+    private static JwstDataModel CreateDataModel(
+        string id = "data-1",
+        string? filePath = "mast/obs1/file.fits",
+        bool isPublic = true,
+        string? userId = "owner-user")
+    {
+        var model = TestDataFixtures.CreateSampleData(id: id);
+        model.FilePath = filePath;
+        model.IsPublic = isPublic;
+        model.UserId = userId;
+        model.SharedWith = [];
+        return model;
+    }
+
+    private static MosaicRequestDto CreateMosaicRequest(List<string> dataIds)
+    {
+        return new MosaicRequestDto
+        {
+            Files = dataIds
+                .Select(id => new MosaicFileConfigDto
+                {
+                    DataId = id,
+                    Stretch = "asinh",
+                    BlackPoint = 0.0,
+                    WhitePoint = 1.0,
+                    Gamma = 1.0,
+                    AsinhA = 0.1,
+                })
+                .ToList(),
+            OutputFormat = "png",
+            Quality = 95,
+            Width = 1000,
+            Height = 1000,
+            CombineMethod = "mean",
+            Cmap = "grayscale",
+        };
+    }
+
+    private MosaicService CreateService(HttpClient? httpClient = null)
+    {
+        return new MosaicService(
+            httpClient ?? new HttpClient(),
+            mockMongo.Object,
+            mockStorage.Object,
+            mockThumbnailQueue.Object,
+            mockLogger.Object,
+            configuration);
+    }
+
+    private void SetupSingleGetAsync(string id, string? filePath)
+    {
+        mockMongo.Setup(m => m.GetAsync(id))
+            .ReturnsAsync(CreateDataModel(id, filePath: filePath));
+    }
+
+    /// <summary>
+    /// Lightweight HttpMessageHandler for testing HTTP calls without a real network.
+    /// </summary>
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage response;
+        private readonly Action<HttpRequestMessage>? onSend;
+
+        public FakeHttpMessageHandler(
+            HttpResponseMessage response,
+            Action<HttpRequestMessage>? onSend = null)
+        {
+            this.response = response;
+            this.onSend = onSend;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            onSend?.Invoke(request);
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/backend/JwstDataAnalysis.API.Tests/Services/SemanticSearchServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/SemanticSearchServiceTests.cs
@@ -1,0 +1,1121 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using JwstDataAnalysis.API.Models;
+using JwstDataAnalysis.API.Services;
+using JwstDataAnalysis.API.Tests.Fixtures;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+using Moq.Protected;
+
+namespace JwstDataAnalysis.API.Tests.Services;
+
+/// <summary>
+/// Unit tests for SemanticSearchService.
+/// </summary>
+public class SemanticSearchServiceTests
+{
+    // Static field appears before instance fields to satisfy SA1204
+    private static readonly JsonSerializerOptions SnakeCaseOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly Mock<HttpMessageHandler> mockHandler = new();
+    private readonly Mock<IMongoDBService> mockMongoService = new();
+    private readonly Mock<ILogger<SemanticSearchService>> mockLogger = new();
+    private readonly SemanticSearchService sut;
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="SemanticSearchServiceTests"/> class.
+    /// </summary>
+    public SemanticSearchServiceTests()
+    {
+        var httpClient = new HttpClient(mockHandler.Object);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ProcessingEngine:BaseUrl", "http://localhost:8000" },
+            })
+            .Build();
+
+        sut = new SemanticSearchService(
+            httpClient,
+            mockMongoService.Object,
+            mockLogger.Object,
+            config);
+    }
+
+    // ===== SearchAsync — happy path =====
+
+    /// <summary>
+    /// Returns enriched results when Python engine succeeds and MongoDB records are accessible.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_ReturnsEnrichedResults_OnSuccess()
+    {
+        // Arrange
+        var doc = BuildDoc("file-1", isPublic: true);
+
+        var pythonPayload = BuildPythonSearchJson(
+            query: "nebula",
+            results: [("file-1", 0.92, "A bright nebula")],
+            embedMs: 12.1,
+            searchMs: 5.3,
+            totalIndexed: 42);
+
+        SetupMockResponse(HttpStatusCode.OK, pythonPayload);
+        mockMongoService.Setup(m => m.GetAsync("file-1")).ReturnsAsync(doc);
+
+        // Act
+        var result = await sut.SearchAsync("nebula", topK: 5, minScore: 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Query.Should().Be("nebula");
+        result.EmbedTimeMs.Should().Be(12.1);
+        result.SearchTimeMs.Should().Be(5.3);
+        result.TotalIndexed.Should().Be(42);
+        result.ResultCount.Should().Be(1);
+        result.Results.Should().HaveCount(1);
+
+        var r = result.Results[0];
+        r.Id.Should().Be(doc.Id);
+        r.FileName.Should().Be(doc.FileName);
+        r.Score.Should().Be(0.92);
+        r.MatchedText.Should().Be("A bright nebula");
+        r.TargetName.Should().Be(doc.ImageInfo!.TargetName);
+        r.Instrument.Should().Be(doc.ImageInfo.Instrument);
+        r.Filter.Should().Be(doc.ImageInfo.Filter);
+        r.ProcessingLevel.Should().Be(doc.ProcessingLevel);
+    }
+
+    /// <summary>
+    /// Sends query, top_k, and min_score in the POST body to the correct URL.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_PostsToCorrectUrl_WithExpectedBody()
+    {
+        // Arrange
+        HttpRequestMessage? captured = null;
+        string? capturedBody = null;
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(
+                async (req, ct) =>
+                {
+                    captured = req;
+                    capturedBody = await req.Content!.ReadAsStringAsync(ct);
+                })
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    BuildPythonSearchJson("star cluster", [], 0, 0, 0),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        // Act
+        await sut.SearchAsync("star cluster", topK: 10, minScore: 0.75, userId: "u1", isAdmin: false);
+
+        // Assert
+        captured!.RequestUri!.ToString().Should().Be("http://localhost:8000/semantic/search");
+        captured.Method.Should().Be(HttpMethod.Post);
+
+        capturedBody.Should().NotBeNull();
+        using var doc = JsonDocument.Parse(capturedBody!);
+        doc.RootElement.GetProperty("query").GetString().Should().Be("star cluster");
+        doc.RootElement.GetProperty("top_k").GetInt32().Should().Be(10);
+        doc.RootElement.GetProperty("min_score").GetDouble().Should().Be(0.75);
+    }
+
+    /// <summary>
+    /// Returns an empty result list when Python returns no results.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_ReturnsEmptyList_WhenPythonReturnsNoResults()
+    {
+        // Arrange
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson("galaxy", [], embedMs: 5, searchMs: 2, totalIndexed: 100));
+
+        // Act
+        var result = await sut.SearchAsync("galaxy", topK: 5, minScore: 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        result.Results.Should().BeEmpty();
+        result.ResultCount.Should().Be(0);
+        result.TotalIndexed.Should().Be(100);
+    }
+
+    // ===== SearchAsync — access control =====
+
+    /// <summary>
+    /// Skips private documents that do not belong to the requesting user.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_ExcludesPrivateDoc_WhenUserIsNotOwner()
+    {
+        // Arrange
+        var doc = BuildDoc("file-private", isPublic: false, userId: "other-user");
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson("test", [("file-private", 0.9, "match")], 0, 0, 1));
+        mockMongoService.Setup(m => m.GetAsync("file-private")).ReturnsAsync(doc);
+
+        // Act
+        var result = await sut.SearchAsync("test", 5, 0.5, userId: "requesting-user", isAdmin: false);
+
+        // Assert
+        result.Results.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Includes private documents owned by the requesting user.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_IncludesPrivateDoc_WhenUserIsOwner()
+    {
+        // Arrange
+        var doc = BuildDoc("file-owned", isPublic: false, userId: "owner-user");
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson("test", [("file-owned", 0.88, "match")], 0, 0, 1));
+        mockMongoService.Setup(m => m.GetAsync("file-owned")).ReturnsAsync(doc);
+
+        // Act
+        var result = await sut.SearchAsync("test", 5, 0.5, userId: "owner-user", isAdmin: false);
+
+        // Assert
+        result.Results.Should().HaveCount(1);
+        result.Results[0].Id.Should().Be(doc.Id);
+    }
+
+    /// <summary>
+    /// Admin bypasses access control and sees private documents owned by others.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_IncludesPrivateDoc_WhenCallerIsAdmin()
+    {
+        // Arrange
+        var doc = BuildDoc("file-private", isPublic: false, userId: "owner-user");
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson("test", [("file-private", 0.95, "match")], 0, 0, 1));
+        mockMongoService.Setup(m => m.GetAsync("file-private")).ReturnsAsync(doc);
+
+        // Act
+        var result = await sut.SearchAsync("test", 5, 0.5, userId: "admin-user", isAdmin: true);
+
+        // Assert
+        result.Results.Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// User in SharedWith list can see the private document.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_IncludesPrivateDoc_WhenUserIsInSharedWithList()
+    {
+        // Arrange
+        var doc = BuildDoc("file-shared", isPublic: false, userId: "owner-user");
+        doc.SharedWith = ["shared-user", "another-user"];
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson("test", [("file-shared", 0.8, "match")], 0, 0, 1));
+        mockMongoService.Setup(m => m.GetAsync("file-shared")).ReturnsAsync(doc);
+
+        // Act
+        var result = await sut.SearchAsync("test", 5, 0.5, userId: "shared-user", isAdmin: false);
+
+        // Assert
+        result.Results.Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// Unauthenticated callers (null userId) cannot see private documents.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_ExcludesPrivateDoc_WhenCallerIsAnonymous()
+    {
+        // Arrange
+        var doc = BuildDoc("file-private", isPublic: false, userId: "owner-user");
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson("test", [("file-private", 0.9, "match")], 0, 0, 1));
+        mockMongoService.Setup(m => m.GetAsync("file-private")).ReturnsAsync(doc);
+
+        // Act
+        var result = await sut.SearchAsync("test", 5, 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        result.Results.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Skips a result silently when the corresponding MongoDB document is not found.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_SkipsResult_WhenMongoDocNotFound()
+    {
+        // Arrange
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson("test", [("missing-id", 0.9, "match")], 0, 0, 1));
+        mockMongoService.Setup(m => m.GetAsync("missing-id")).ReturnsAsync((JwstDataModel?)null);
+
+        // Act
+        var result = await sut.SearchAsync("test", 5, 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        result.Results.Should().BeEmpty();
+        result.ResultCount.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Continues processing remaining results when MongoDB throws for one file.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_ContinuesEnrichment_WhenSingleMongoFetchThrows()
+    {
+        // Arrange
+        var goodDoc = BuildDoc("file-good", isPublic: true);
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson(
+                "test",
+                [("file-bad", 0.95, "bad"), ("file-good", 0.80, "good")],
+                embedMs: 1,
+                searchMs: 1,
+                totalIndexed: 2));
+
+        mockMongoService.Setup(m => m.GetAsync("file-bad"))
+            .ThrowsAsync(new InvalidOperationException("Mongo timeout"));
+        mockMongoService.Setup(m => m.GetAsync("file-good"))
+            .ReturnsAsync(goodDoc);
+
+        // Act
+        var result = await sut.SearchAsync("test", 5, 0.5, userId: null, isAdmin: false);
+
+        // Assert — bad file is skipped, good file is returned
+        result.Results.Should().HaveCount(1);
+        result.Results[0].Id.Should().Be(goodDoc.Id);
+    }
+
+    // ===== SearchAsync — error handling =====
+
+    /// <summary>
+    /// Throws HttpRequestException when Python returns a non-success status code.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_ThrowsHttpRequestException_WhenEngineReturnsError()
+    {
+        // Arrange
+        SetupMockResponse(HttpStatusCode.InternalServerError, "{\"detail\":\"engine failure\"}");
+
+        // Act
+        var act = () => sut.SearchAsync("galaxy", 5, 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("*Semantic search error*");
+    }
+
+    /// <summary>
+    /// Throws HttpRequestException when Python returns 503 (service unavailable).
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_ThrowsHttpRequestException_WhenEngineIsDown()
+    {
+        // Arrange
+        SetupMockResponse(HttpStatusCode.ServiceUnavailable, string.Empty);
+
+        // Act
+        var act = () => sut.SearchAsync("galaxy", 5, 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    /// <summary>
+    /// Throws InvalidOperationException when Python returns a null/empty body.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_ThrowsInvalidOperation_WhenEngineReturnsNullBody()
+    {
+        // Arrange
+        SetupMockResponse(HttpStatusCode.OK, "null");
+
+        // Act
+        var act = () => sut.SearchAsync("galaxy", 5, 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*null search response*");
+    }
+
+    // ===== GetIndexStatusAsync =====
+
+    /// <summary>
+    /// Returns parsed status when Python returns a successful response.
+    /// </summary>
+    [Fact]
+    public async Task GetIndexStatusAsync_ReturnsStatus_OnSuccess()
+    {
+        // Arrange
+        var payload = JsonSerializer.Serialize(new
+        {
+            total_indexed = 128,
+            model_loaded = true,
+            index_file_exists = true,
+            model_name = "all-MiniLM-L6-v2",
+            embedding_dim = 384,
+        });
+
+        SetupMockResponse(HttpStatusCode.OK, payload);
+
+        // Act
+        var result = await sut.GetIndexStatusAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalIndexed.Should().Be(128);
+        result.ModelLoaded.Should().BeTrue();
+        result.IndexFileExists.Should().BeTrue();
+        result.ModelName.Should().Be("all-MiniLM-L6-v2");
+        result.EmbeddingDim.Should().Be(384);
+    }
+
+    /// <summary>
+    /// Hits the correct URL for the index-status endpoint.
+    /// </summary>
+    [Fact]
+    public async Task GetIndexStatusAsync_CallsCorrectUrl()
+    {
+        // Arrange
+        HttpRequestMessage? captured = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new
+                    {
+                        total_indexed = 0,
+                        model_loaded = false,
+                        index_file_exists = false,
+                        model_name = string.Empty,
+                        embedding_dim = 0,
+                    }),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        // Act
+        await sut.GetIndexStatusAsync();
+
+        // Assert
+        captured!.RequestUri!.ToString().Should().Be("http://localhost:8000/semantic/index-status");
+        captured.Method.Should().Be(HttpMethod.Get);
+    }
+
+    /// <summary>
+    /// Throws HttpRequestException when Python returns a non-success status code.
+    /// </summary>
+    [Fact]
+    public async Task GetIndexStatusAsync_ThrowsHttpRequestException_OnEngineError()
+    {
+        // Arrange
+        SetupMockResponse(HttpStatusCode.InternalServerError, "{\"detail\":\"index error\"}");
+
+        // Act
+        var act = () => sut.GetIndexStatusAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("*Index status error*");
+    }
+
+    /// <summary>
+    /// Throws InvalidOperationException when Python returns a null body.
+    /// </summary>
+    [Fact]
+    public async Task GetIndexStatusAsync_ThrowsInvalidOperation_WhenEngineReturnsNullBody()
+    {
+        // Arrange
+        SetupMockResponse(HttpStatusCode.OK, "null");
+
+        // Act
+        var act = () => sut.GetIndexStatusAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*null index status*");
+    }
+
+    // ===== EmbedBatchAsync =====
+
+    /// <summary>
+    /// Returns embedded count when MongoDB documents are found and engine succeeds.
+    /// </summary>
+    [Fact]
+    public async Task EmbedBatchAsync_ReturnsResult_OnSuccess()
+    {
+        // Arrange
+        var doc1 = BuildDoc("file-1", isPublic: true);
+        var doc2 = BuildDoc("file-2", isPublic: true);
+
+        mockMongoService.Setup(m => m.GetAsync("file-1")).ReturnsAsync(doc1);
+        mockMongoService.Setup(m => m.GetAsync("file-2")).ReturnsAsync(doc2);
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(new { embedded_count = 2, total_indexed = 10, errors = Array.Empty<string>() }));
+
+        // Act
+        var result = await sut.EmbedBatchAsync(["file-1", "file-2"]);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.EmbeddedCount.Should().Be(2);
+        result.TotalIndexed.Should().Be(10);
+    }
+
+    /// <summary>
+    /// Returns zero counts without calling the engine when no MongoDB documents are found.
+    /// </summary>
+    [Fact]
+    public async Task EmbedBatchAsync_ReturnsZeroCount_WhenNoDocsFound()
+    {
+        // Arrange
+        mockMongoService.Setup(m => m.GetAsync(It.IsAny<string>()))
+            .ReturnsAsync((JwstDataModel?)null);
+
+        // Act
+        var result = await sut.EmbedBatchAsync(["missing-1", "missing-2"]);
+
+        // Assert
+        result.EmbeddedCount.Should().Be(0);
+        result.TotalIndexed.Should().Be(0);
+
+        // Engine should NOT be called
+        mockHandler.Protected()
+            .Verify(
+                "SendAsync",
+                Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Sends only the documents that were successfully retrieved from MongoDB.
+    /// </summary>
+    [Fact]
+    public async Task EmbedBatchAsync_SendsOnlyFoundDocs_WhenSomeIdsAreMissing()
+    {
+        // Arrange
+        var doc = BuildDoc("file-found", isPublic: true);
+
+        mockMongoService.Setup(m => m.GetAsync("file-found")).ReturnsAsync(doc);
+        mockMongoService.Setup(m => m.GetAsync("file-missing")).ReturnsAsync((JwstDataModel?)null);
+
+        string? capturedBody = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(
+                async (req, ct) =>
+                {
+                    capturedBody = await req.Content!.ReadAsStringAsync(ct);
+                })
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new { embedded_count = 1, total_indexed = 5, errors = Array.Empty<string>() }),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        // Act
+        await sut.EmbedBatchAsync(["file-found", "file-missing"]);
+
+        // Assert — only the found document's metadata is in the body
+        capturedBody.Should().NotBeNull();
+        using var parsed = JsonDocument.Parse(capturedBody!);
+        var items = parsed.RootElement.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("file_id").GetString().Should().Be(doc.Id);
+    }
+
+    /// <summary>
+    /// Posts to the correct embed-batch URL.
+    /// </summary>
+    [Fact]
+    public async Task EmbedBatchAsync_PostsToCorrectUrl()
+    {
+        // Arrange
+        var doc = BuildDoc("file-1", isPublic: true);
+        mockMongoService.Setup(m => m.GetAsync("file-1")).ReturnsAsync(doc);
+
+        HttpRequestMessage? captured = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new { embedded_count = 1, total_indexed = 1, errors = Array.Empty<string>() }),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        // Act
+        await sut.EmbedBatchAsync(["file-1"]);
+
+        // Assert
+        captured!.RequestUri!.ToString().Should().Be("http://localhost:8000/semantic/embed-batch");
+        captured.Method.Should().Be(HttpMethod.Post);
+    }
+
+    /// <summary>
+    /// Skips a file ID silently when MongoDB throws during EmbedBatch.
+    /// </summary>
+    [Fact]
+    public async Task EmbedBatchAsync_SkipsFileId_WhenMongoThrows()
+    {
+        // Arrange
+        var goodDoc = BuildDoc("file-good", isPublic: true);
+
+        mockMongoService.Setup(m => m.GetAsync("file-throw"))
+            .ThrowsAsync(new InvalidOperationException("Mongo unreachable"));
+        mockMongoService.Setup(m => m.GetAsync("file-good")).ReturnsAsync(goodDoc);
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(new { embedded_count = 1, total_indexed = 1, errors = Array.Empty<string>() }));
+
+        // Act
+        var result = await sut.EmbedBatchAsync(["file-throw", "file-good"]);
+
+        // Assert — should still return a result (from the good doc)
+        result.EmbeddedCount.Should().Be(1);
+    }
+
+    /// <summary>
+    /// Throws HttpRequestException when Python returns an error for embed-batch.
+    /// </summary>
+    [Fact]
+    public async Task EmbedBatchAsync_ThrowsHttpRequestException_OnEngineError()
+    {
+        // Arrange
+        var doc = BuildDoc("file-1", isPublic: true);
+        mockMongoService.Setup(m => m.GetAsync("file-1")).ReturnsAsync(doc);
+        SetupMockResponse(HttpStatusCode.InternalServerError, "{\"detail\":\"embed error\"}");
+
+        // Act
+        var act = () => sut.EmbedBatchAsync(["file-1"]);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("*Embed batch error*");
+    }
+
+    /// <summary>
+    /// Maps all ImageMetadata fields into the embedding payload correctly.
+    /// </summary>
+    [Fact]
+    public async Task EmbedBatchAsync_MapsAllMetadataFields_ToEmbeddingPayload()
+    {
+        // Arrange
+        var obsDate = new DateTime(2023, 7, 15, 0, 0, 0, DateTimeKind.Utc);
+        var doc = new JwstDataModel
+        {
+            Id = "rich-file",
+            FileName = "rich.fits",
+            DataType = "image",
+            ProcessingLevel = "L2b",
+            ImageInfo = new ImageMetadata
+            {
+                TargetName = "Carina Nebula",
+                Instrument = "NIRCAM",
+                Filter = "F200W",
+                ExposureTime = 3600.0,
+                WavelengthRange = "INFRARED",
+                CalibrationLevel = 2,
+                ObservationDate = obsDate,
+                ProposalPi = "Jane Smith",
+                ProposalId = "1234",
+                ObservationTitle = "Deep NIRCam Survey",
+            },
+        };
+
+        mockMongoService.Setup(m => m.GetAsync("rich-file")).ReturnsAsync(doc);
+
+        string? capturedBody = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(
+                async (req, ct) =>
+                {
+                    capturedBody = await req.Content!.ReadAsStringAsync(ct);
+                })
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new { embedded_count = 1, total_indexed = 1, errors = Array.Empty<string>() }),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        // Act
+        await sut.EmbedBatchAsync(["rich-file"]);
+
+        // Assert
+        capturedBody.Should().NotBeNull();
+        using var parsed = JsonDocument.Parse(capturedBody!);
+        var item = parsed.RootElement.GetProperty("items")[0];
+
+        item.GetProperty("file_id").GetString().Should().Be("rich-file");
+        item.GetProperty("target_name").GetString().Should().Be("Carina Nebula");
+        item.GetProperty("instrument").GetString().Should().Be("NIRCAM");
+        item.GetProperty("filter_name").GetString().Should().Be("F200W");
+        item.GetProperty("exposure_time").GetDouble().Should().Be(3600.0);
+        item.GetProperty("wavelength_range").GetString().Should().Be("INFRARED");
+        item.GetProperty("calibration_level").GetInt32().Should().Be(2);
+        item.GetProperty("observation_date").GetString().Should().Be("2023-07-15");
+        item.GetProperty("proposal_pi").GetString().Should().Be("Jane Smith");
+        item.GetProperty("proposal_id").GetString().Should().Be("1234");
+        item.GetProperty("observation_title").GetString().Should().Be("Deep NIRCam Survey");
+        item.GetProperty("data_type").GetString().Should().Be("image");
+        item.GetProperty("file_name").GetString().Should().Be("rich.fits");
+        item.GetProperty("processing_level").GetString().Should().Be("L2b");
+    }
+
+    // ===== ReindexAllAsync =====
+
+    /// <summary>
+    /// Returns result when all documents are successfully fetched and embedded.
+    /// </summary>
+    [Fact]
+    public async Task ReindexAllAsync_ReturnsResult_OnSuccess()
+    {
+        // Arrange
+        var docs = TestDataFixtures.CreateSampleDataList(3);
+        mockMongoService.Setup(m => m.GetAsync()).ReturnsAsync(docs);
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(new { embedded_count = 3, total_indexed = 3, errors = Array.Empty<string>() }));
+
+        // Act
+        var result = await sut.ReindexAllAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.EmbeddedCount.Should().Be(3);
+        result.TotalIndexed.Should().Be(3);
+    }
+
+    /// <summary>
+    /// Returns zero counts without calling the engine when the collection is empty.
+    /// </summary>
+    [Fact]
+    public async Task ReindexAllAsync_ReturnsZeroCounts_WhenCollectionIsEmpty()
+    {
+        // Arrange
+        mockMongoService.Setup(m => m.GetAsync()).ReturnsAsync([]);
+
+        // Act
+        var result = await sut.ReindexAllAsync();
+
+        // Assert
+        result.EmbeddedCount.Should().Be(0);
+        result.TotalIndexed.Should().Be(0);
+
+        // Engine should NOT be called
+        mockHandler.Protected()
+            .Verify(
+                "SendAsync",
+                Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Maps all documents from the collection into the embed-batch payload.
+    /// </summary>
+    [Fact]
+    public async Task ReindexAllAsync_SendsAllDocuments_ToEmbedBatch()
+    {
+        // Arrange
+        var docs = TestDataFixtures.CreateSampleDataList(4);
+        mockMongoService.Setup(m => m.GetAsync()).ReturnsAsync(docs);
+
+        string? capturedBody = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(
+                async (req, ct) =>
+                {
+                    capturedBody = await req.Content!.ReadAsStringAsync(ct);
+                })
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new { embedded_count = 4, total_indexed = 4, errors = Array.Empty<string>() }),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        // Act
+        await sut.ReindexAllAsync();
+
+        // Assert
+        capturedBody.Should().NotBeNull();
+        using var parsed = JsonDocument.Parse(capturedBody!);
+        parsed.RootElement.GetProperty("items").GetArrayLength().Should().Be(4);
+    }
+
+    /// <summary>
+    /// Throws HttpRequestException when Python returns an error during reindex.
+    /// </summary>
+    [Fact]
+    public async Task ReindexAllAsync_ThrowsHttpRequestException_OnEngineError()
+    {
+        // Arrange
+        var docs = TestDataFixtures.CreateSampleDataList(2);
+        mockMongoService.Setup(m => m.GetAsync()).ReturnsAsync(docs);
+        SetupMockResponse(HttpStatusCode.InternalServerError, "{\"detail\":\"reindex error\"}");
+
+        // Act
+        var act = () => sut.ReindexAllAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("*Embed batch error*");
+    }
+
+    /// <summary>
+    /// Throws InvalidOperationException when Python returns a null body during reindex.
+    /// </summary>
+    [Fact]
+    public async Task ReindexAllAsync_ThrowsInvalidOperation_WhenEngineReturnsNullBody()
+    {
+        // Arrange
+        var docs = TestDataFixtures.CreateSampleDataList(1);
+        mockMongoService.Setup(m => m.GetAsync()).ReturnsAsync(docs);
+        SetupMockResponse(HttpStatusCode.OK, "null");
+
+        // Act
+        var act = () => sut.ReindexAllAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*null embed response*");
+    }
+
+    // ===== Configuration =====
+
+    /// <summary>
+    /// Uses the default base URL when configuration is missing the ProcessingEngine:BaseUrl key.
+    /// </summary>
+    [Fact]
+    public async Task Constructor_UsesDefaultBaseUrl_WhenConfigKeyMissing()
+    {
+        // Arrange
+        var httpClient = new HttpClient(mockHandler.Object);
+        var emptyConfig = new ConfigurationBuilder().Build();
+        var service = new SemanticSearchService(
+            httpClient, mockMongoService.Object, mockLogger.Object, emptyConfig);
+
+        HttpRequestMessage? captured = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new
+                    {
+                        total_indexed = 0,
+                        model_loaded = false,
+                        index_file_exists = false,
+                        model_name = string.Empty,
+                        embedding_dim = 0,
+                    }),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        // Act
+        await service.GetIndexStatusAsync();
+
+        // Assert — default URL is http://localhost:8000
+        captured!.RequestUri!.Host.Should().Be("localhost");
+        captured.RequestUri.Port.Should().Be(8000);
+    }
+
+    /// <summary>
+    /// Uses a custom base URL when configuration supplies one.
+    /// </summary>
+    [Fact]
+    public async Task Constructor_UsesCustomBaseUrl_WhenConfigKeyProvided()
+    {
+        // Arrange
+        var httpClient = new HttpClient(mockHandler.Object);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ProcessingEngine:BaseUrl", "http://engine.internal:9000" },
+            })
+            .Build();
+
+        var service = new SemanticSearchService(
+            httpClient, mockMongoService.Object, mockLogger.Object, config);
+
+        HttpRequestMessage? captured = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new
+                    {
+                        total_indexed = 0,
+                        model_loaded = false,
+                        index_file_exists = false,
+                        model_name = string.Empty,
+                        embedding_dim = 0,
+                    }),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        // Act
+        await service.GetIndexStatusAsync();
+
+        // Assert
+        captured!.RequestUri!.ToString().Should().StartWith("http://engine.internal:9000");
+    }
+
+    // ===== SearchAsync — metadata enrichment =====
+
+    /// <summary>
+    /// Enriches results with all available ImageInfo fields from MongoDB.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_EnrichesResult_WithAllImageInfoFields()
+    {
+        // Arrange
+        var doc = new JwstDataModel
+        {
+            Id = "enriched-file",
+            FileName = "enriched.fits",
+            ProcessingLevel = "L2b",
+            IsPublic = true,
+            SharedWith = [],
+            ImageInfo = new ImageMetadata
+            {
+                TargetName = "Pillars of Creation",
+                Instrument = "MIRI",
+                Filter = "F770W",
+                WavelengthRange = "MID-IR",
+                ExposureTime = 7200.0,
+            },
+            ThumbnailData = [0x89, 0x50, 0x4E, 0x47],
+        };
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson("pillars", [("enriched-file", 0.98, "bright feature")], 10, 3, 50));
+        mockMongoService.Setup(m => m.GetAsync("enriched-file")).ReturnsAsync(doc);
+
+        // Act
+        var result = await sut.SearchAsync("pillars", 5, 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        var r = result.Results.Should().ContainSingle().Subject;
+        r.TargetName.Should().Be("Pillars of Creation");
+        r.Instrument.Should().Be("MIRI");
+        r.Filter.Should().Be("F770W");
+        r.WavelengthRange.Should().Be("MID-IR");
+        r.ExposureTime.Should().Be(7200.0);
+        r.ProcessingLevel.Should().Be("L2b");
+        r.ThumbnailData.Should().Equal([0x89, 0x50, 0x4E, 0x47]);
+    }
+
+    /// <summary>
+    /// Handles results for documents that have no ImageInfo (all nullable fields remain null).
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_HandlesDocWithNoImageInfo_GracefullyNullsFields()
+    {
+        // Arrange
+        var doc = new JwstDataModel
+        {
+            Id = "bare-file",
+            FileName = "bare.fits",
+            IsPublic = true,
+            SharedWith = [],
+            ImageInfo = null,
+        };
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson("test", [("bare-file", 0.7, "bare match")], 0, 0, 1));
+        mockMongoService.Setup(m => m.GetAsync("bare-file")).ReturnsAsync(doc);
+
+        // Act
+        var result = await sut.SearchAsync("test", 5, 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        var r = result.Results.Should().ContainSingle().Subject;
+        r.TargetName.Should().BeNull();
+        r.Instrument.Should().BeNull();
+        r.Filter.Should().BeNull();
+        r.WavelengthRange.Should().BeNull();
+        r.ExposureTime.Should().BeNull();
+    }
+
+    // ===== SearchAsync — multiple result handling =====
+
+    /// <summary>
+    /// Returns multiple enriched results when Python returns multiple matches.
+    /// </summary>
+    [Fact]
+    public async Task SearchAsync_ReturnsMultipleResults_WithCorrectScores()
+    {
+        // Arrange
+        var doc1 = BuildDoc("file-a", isPublic: true);
+        var doc2 = BuildDoc("file-b", isPublic: true);
+
+        SetupMockResponse(
+            HttpStatusCode.OK,
+            BuildPythonSearchJson(
+                "binary star",
+                [("file-a", 0.95, "match A"), ("file-b", 0.80, "match B")],
+                embedMs: 8,
+                searchMs: 4,
+                totalIndexed: 200));
+
+        mockMongoService.Setup(m => m.GetAsync("file-a")).ReturnsAsync(doc1);
+        mockMongoService.Setup(m => m.GetAsync("file-b")).ReturnsAsync(doc2);
+
+        // Act
+        var result = await sut.SearchAsync("binary star", 10, 0.5, userId: null, isAdmin: false);
+
+        // Assert
+        result.Results.Should().HaveCount(2);
+        result.ResultCount.Should().Be(2);
+        result.Results[0].Score.Should().Be(0.95);
+        result.Results[0].MatchedText.Should().Be("match A");
+        result.Results[1].Score.Should().Be(0.80);
+        result.Results[1].MatchedText.Should().Be("match B");
+    }
+
+    // ===== Helpers =====
+
+    private static JwstDataModel BuildDoc(
+        string id,
+        bool isPublic,
+        string userId = "owner-user")
+    {
+        var sample = TestDataFixtures.CreateSampleData(id: id);
+        sample.IsPublic = isPublic;
+        sample.UserId = userId;
+        sample.SharedWith = [];
+        return sample;
+    }
+
+    /// <summary>
+    /// Serialises a PythonSearchResponse payload using snake_case naming to match what the
+    /// real Python engine sends over the wire.
+    /// </summary>
+    private static string BuildPythonSearchJson(
+        string query,
+        IEnumerable<(string FileId, double Score, string MatchedText)> results,
+        double embedMs,
+        double searchMs,
+        int totalIndexed)
+    {
+        var payload = new
+        {
+            results = results.Select(r => new
+            {
+                file_id = r.FileId,
+                score = r.Score,
+                matched_text = r.MatchedText,
+            }).ToArray(),
+            query,
+            embed_time_ms = embedMs,
+            search_time_ms = searchMs,
+            total_indexed = totalIndexed,
+        };
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private void SetupMockResponse(HttpStatusCode statusCode, string content)
+    {
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(content, Encoding.UTF8, "application/json"),
+            });
+    }
+}


### PR DESCRIPTION
## Summary
Adds 107 new backend unit tests covering the three largest untested services, improving backend code coverage from 32% to 38.5%.

No linked issue

## Why
Backend coverage was at 32% — below the 40% threshold flagged during compliance checks. The three largest untested services (MosaicService, SemanticSearchService, DataScanService) accounted for ~2,500 lines at 0% coverage.

## Changes Made
- **MosaicServiceTests.cs** (new, 42 tests): Mosaic generation, footprint retrieval, observation mosaics, access control enforcement, output format override, visibility inheritance, error handling for HTTP/missing data
- **SemanticSearchServiceTests.cs** (new, 38 tests): Semantic search, reindex operations, index status, result enrichment with MongoDB, error paths for processing engine failures, admin-only operations
- **DataScanServiceTests.cs** (27 new tests added to existing file): S3 scan/import pipeline, file deduplication, metadata refresh for unknown processing levels, visibility fixes, instrument tag detection, error handling for storage/MongoDB/MAST failures, response list capping

## Test Plan
- [x] All 900 backend tests pass (793 existing + 107 new)
- [x] Zero test failures
- [x] Coverage: 32.1% → 38.5% (+6.4pp)

## Documentation Checklist
- [x] No documentation updates needed — test-only change

## Tech Debt Impact
- [ ] No new tech debt introduced
- [ ] Creates tech debt (explain below)
- [x] Reduces existing tech debt

## Risk & Rollback
Risk: None — test-only change, no production code modified.
Rollback: Revert commit.