### PR TITLE
fix: resolve 80+ StyleCop lint errors across backend tests and services

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
@@ -852,54 +852,6 @@ public class MastControllerTests
         response.UpdatedCount.Should().Be(1);
     }
 
-    /// <summary>
-    /// Sets up a mock HttpContext with the specified user claims.
-    /// </summary>
-    private void SetupAuthenticatedUser(string userId)
-    {
-        var claims = new List<Claim>
-        {
-            new(ClaimTypes.NameIdentifier, userId),
-            new("sub", userId),
-        };
-
-        var identity = new ClaimsIdentity(claims, "TestAuth");
-        var principal = new ClaimsPrincipal(identity);
-
-        var httpContext = new DefaultHttpContext
-        {
-            User = principal,
-        };
-
-        sut.ControllerContext = new ControllerContext
-        {
-            HttpContext = httpContext,
-        };
-    }
-
-    private void SetupAdminUser(string userId)
-    {
-        var claims = new List<Claim>
-        {
-            new(ClaimTypes.NameIdentifier, userId),
-            new("sub", userId),
-            new(ClaimTypes.Role, "Admin"),
-        };
-
-        var identity = new ClaimsIdentity(claims, "TestAuth");
-        var principal = new ClaimsPrincipal(identity);
-
-        var httpContext = new DefaultHttpContext
-        {
-            User = principal,
-        };
-
-        sut.ControllerContext = new ControllerContext
-        {
-            HttpContext = httpContext,
-        };
-    }
-
     // ========== SearchByTarget: happy path + alias resolution ==========
 
     /// <summary>
@@ -1606,6 +1558,7 @@ public class MastControllerTests
     {
         // Arrange
         SetupAdminUser(TestUserId);
+
         // Records exist, but none have source=MAST
         var records = new List<JwstDataModel>
         {
@@ -1687,5 +1640,53 @@ public class MastControllerTests
         var response = okResult.Value.Should().BeOfType<MetadataRefreshResponse>().Subject;
         response.UpdatedCount.Should().Be(1);
         response.Message.Should().Contain("Failed");
+    }
+
+    /// <summary>
+    /// Sets up a mock HttpContext with the specified user claims.
+    /// </summary>
+    private void SetupAuthenticatedUser(string userId)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId),
+            new("sub", userId),
+        };
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = principal,
+        };
+
+        sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext,
+        };
+    }
+
+    private void SetupAdminUser(string userId)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId),
+            new("sub", userId),
+            new(ClaimTypes.Role, "Admin"),
+        };
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = principal,
+        };
+
+        sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext,
+        };
     }
 }

--- a/backend/JwstDataAnalysis.API.Tests/Services/DataScanServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/DataScanServiceTests.cs
@@ -35,58 +35,9 @@ public class DataScanServiceTests
     private readonly EmbeddingQueue embeddingQueue = new();
     private readonly Mock<ILogger<DataScanService>> mockLogger = new();
 
-    // Helper — create the SUT with all mocked dependencies
-    private DataScanService CreateSut() =>
-        new(
-            mockMongo.Object,
-            mockMast.Object,
-            mockStorage.Object,
-            mockThumbnailQueue.Object,
-            embeddingQueue,
-            mockLogger.Object);
-
-    // Helper — configure the storage mock to behave like S3 (no local path support)
-    private void SetupS3Storage(IEnumerable<string>? keys = null)
-    {
-        mockStorage.Setup(s => s.SupportsLocalPath).Returns(false);
-        mockStorage
-            .Setup(s => s.ListAsync("mast/", It.IsAny<CancellationToken>()))
-            .Returns(ToAsyncEnumerable(keys ?? []));
-    }
-
-    // Helper — simple async enumerable from a sync sequence
-    private static async IAsyncEnumerable<string> ToAsyncEnumerable(
-        IEnumerable<string> source,
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        foreach (var item in source)
-        {
-            ct.ThrowIfCancellationRequested();
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-    // Helper — build a MastSearchResponse with one result entry
-    private static MastSearchResponse BuildMastResponse(string obsId, string targetName = "NGC-3132") =>
-        new()
-        {
-            Results =
-            [
-                new Dictionary<string, object?>
-                {
-                    { "target_name", targetName },
-                    { "instrument_name", "NIRCAM" },
-                    { "filters", "F200W" },
-                    { "t_exptime", "1200.0" },
-                },
-            ],
-        };
-
     // =========================================================================
     // ScanAndImportAsync — S3 path (SupportsLocalPath = false)
     // =========================================================================
-
     [Fact]
     public async Task ScanAndImportAsync_S3_NoFitsFilesFound_ReturnsEarlyWithZeroCounts()
     {
@@ -151,10 +102,12 @@ public class DataScanServiceTests
             .Which.Should().Be("jw02733001001_02101_00001_nrca1_cal.fits");
 
         // Verify MongoDB create was called with correct data
-        mockMongo.Verify(m => m.CreateAsync(It.Is<JwstDataModel>(d =>
-            d.FilePath == storageKey &&
-            d.IsPublic == true &&
-            d.FileFormat == FileFormats.FITS)), Times.Once);
+        mockMongo.Verify(
+            m => m.CreateAsync(It.Is<JwstDataModel>(d =>
+                d.FilePath == storageKey &&
+                d.IsPublic == true &&
+                d.FileFormat == FileFormats.FITS)),
+            Times.Once);
 
         // Thumbnail queue should have been poked
         mockThumbnailQueue.Verify(q => q.EnqueueBatch(It.IsAny<List<string>>()), Times.Once);
@@ -371,6 +324,7 @@ public class DataScanServiceTests
 
         // Assert
         result.ImportedCount.Should().Be(2);
+
         // MAST should only be called once per observation group, not once per file
         mockMast.Verify(
             m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()),
@@ -790,7 +744,6 @@ public class DataScanServiceTests
     // =========================================================================
     // ParseFileInfo — processing level and data type classification
     // =========================================================================
-
     [Theory]
     [InlineData("jw02733001001_02101_00001_nrca1_uncal.fits", "L1", "raw", true)]
     [InlineData("jw02733001001_02101_00001_nrca1_rate.fits", "L2a", "sensor", true)]
@@ -850,7 +803,6 @@ public class DataScanServiceTests
     // =========================================================================
     // BuildMastMetadata
     // =========================================================================
-
     [Fact]
     public void BuildMastMetadata_WithNullObsMeta_ReturnsDictWithBaseKeys()
     {
@@ -938,7 +890,6 @@ public class DataScanServiceTests
     // =========================================================================
     // ConvertJsonElement
     // =========================================================================
-
     [Fact]
     public void ConvertJsonElement_String_ReturnsString()
     {
@@ -1013,7 +964,6 @@ public class DataScanServiceTests
     // =========================================================================
     // CreateImageMetadata
     // =========================================================================
-
     [Fact]
     public void CreateImageMetadata_NullObsMeta_ReturnsNull()
     {
@@ -1212,5 +1162,53 @@ public class DataScanServiceTests
         // Assert
         result.Should().NotBeNull();
         result!.CalibrationLevel.Should().BeNull();
+    }
+
+    // Helper — simple async enumerable from a sync sequence
+    private static async IAsyncEnumerable<string> ToAsyncEnumerable(
+        IEnumerable<string> source,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var item in source)
+        {
+            ct.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+    // Helper — build a MastSearchResponse with one result entry
+    private static MastSearchResponse BuildMastResponse(string obsId, string targetName = "NGC-3132") =>
+        new()
+        {
+            Results =
+            [
+                new Dictionary<string, object?>
+                {
+                    { "target_name", targetName },
+                    { "instrument_name", "NIRCAM" },
+                    { "filters", "F200W" },
+                    { "t_exptime", "1200.0" },
+                },
+            ],
+        };
+
+    // Helper — create the SUT with all mocked dependencies
+    private DataScanService CreateSut() =>
+        new(
+            mockMongo.Object,
+            mockMast.Object,
+            mockStorage.Object,
+            mockThumbnailQueue.Object,
+            embeddingQueue,
+            mockLogger.Object);
+
+    // Helper — configure the storage mock to behave like S3 (no local path support)
+    private void SetupS3Storage(IEnumerable<string>? keys = null)
+    {
+        mockStorage.Setup(s => s.SupportsLocalPath).Returns(false);
+        mockStorage
+            .Setup(s => s.ListAsync("mast/", It.IsAny<CancellationToken>()))
+            .Returns(ToAsyncEnumerable(keys ?? []));
     }
 }

--- a/backend/JwstDataAnalysis.API.Tests/Services/JobReaperBackgroundServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/JobReaperBackgroundServiceTests.cs
@@ -323,23 +323,6 @@ public class JobReaperBackgroundServiceTests : IDisposable
         await act.Should().NotThrowAsync();
     }
 
-    /// <summary>
-    /// Sets up FindAsync on the mock collection to return the given list.
-    /// FindAsync is a proper interface method (not an extension), so Moq can mock it.
-    /// The cursor's ToListAsync is an extension that calls MoveNextAsync + Current.
-    /// </summary>
-    private void SetupFind(List<JobStatus> jobs)
-    {
-        var mockCursor = BuildCursor(jobs);
-
-        mockCollection
-            .Setup(c => c.FindAsync(
-                It.IsAny<FilterDefinition<JobStatus>>(),
-                It.IsAny<FindOptions<JobStatus, JobStatus>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(mockCursor.Object);
-    }
-
     private static Mock<IAsyncCursor<JobStatus>> BuildCursor(List<JobStatus> jobs)
     {
         var mockCursor = new Mock<IAsyncCursor<JobStatus>>();
@@ -373,6 +356,23 @@ public class JobReaperBackgroundServiceTests : IDisposable
             });
 
         return mockCursor;
+    }
+
+    /// <summary>
+    /// Sets up FindAsync on the mock collection to return the given list.
+    /// FindAsync is a proper interface method (not an extension), so Moq can mock it.
+    /// The cursor's ToListAsync is an extension that calls MoveNextAsync + Current.
+    /// </summary>
+    private void SetupFind(List<JobStatus> jobs)
+    {
+        var mockCursor = BuildCursor(jobs);
+
+        mockCollection
+            .Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<JobStatus>>(),
+                It.IsAny<FindOptions<JobStatus, JobStatus>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockCursor.Object);
     }
 
     /// <summary>

--- a/backend/JwstDataAnalysis.API.Tests/Services/MongoDBServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/MongoDBServiceTests.cs
@@ -720,7 +720,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetManyAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetManyAsync_ReturnsAllMatchingDocuments()
     {
@@ -753,7 +752,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetByUserIdAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetByUserIdAsync_ReturnsDocumentsForUser()
     {
@@ -792,7 +790,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetByFileFormatAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetByFileFormatAsync_ReturnsMatchingDocuments()
     {
@@ -822,7 +819,6 @@ public class MongoDBServiceTests
     // on IAsyncCursorSource does NOT route through the IMongoCollection.FindAsync mock path —
     // it calls a different internal batch-check method that dereferences driver-internal state
     // not present on a Moq mock cursor. This method is covered indirectly by integration tests.
-
     [Fact]
     public async Task ExistsByFileNameAsync_DelegatesFind_WhenSearchingByFileName()
     {
@@ -843,7 +839,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetByFileNameAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetByFileNameAsync_ReturnsDocument_WhenFileExists()
     {
@@ -875,7 +870,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // UpdateValidationStatusAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task UpdateValidationStatusAsync_SetsValidatedTrue()
     {
@@ -933,7 +927,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // UpdateLastAccessedAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task UpdateLastAccessedAsync_UpdatesTimestamp()
     {
@@ -964,7 +957,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetArchivedAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetArchivedAsync_ReturnsOnlyArchivedDocuments()
     {
@@ -1002,7 +994,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetByProcessingLevelAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetByProcessingLevelAsync_ReturnsMatchingDocuments()
     {
@@ -1027,7 +1018,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetLineageGroupedAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetLineageGroupedAsync_GroupsByObservationBaseId()
     {
@@ -1064,7 +1054,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // UpdateLineageAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task UpdateLineageAsync_UpdatesParentAndDerivedFrom()
     {
@@ -1095,7 +1084,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // RemoveByObservationBaseIdAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task RemoveByObservationBaseIdAsync_DeletesMatchingDocuments()
     {
@@ -1152,7 +1140,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetByObservationAndLevelAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetByObservationAndLevelAsync_ReturnsMatchingDocuments()
     {
@@ -1213,7 +1200,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // RemoveByObservationAndLevelAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task RemoveByObservationAndLevelAsync_DeletesMatchingDocuments()
     {
@@ -1265,7 +1251,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // ArchiveByObservationAndLevelAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task ArchiveByObservationAndLevelAsync_ArchivesMatchingDocuments()
     {
@@ -1330,7 +1315,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // CreateVersionAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task CreateVersionAsync_InsertsNewVersionAndReturnsId()
     {
@@ -1408,7 +1392,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetAccessibleDataAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetAccessibleDataAsync_AdminReceivesAllData()
     {
@@ -1447,7 +1430,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetAccessibleDataByIdAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetAccessibleDataByIdAsync_ReturnsData_WhenUserIsOwner()
     {
@@ -1547,7 +1529,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // ClaimOrphanedDataAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task ClaimOrphanedDataAsync_ReturnsModifiedCount()
     {
@@ -1600,7 +1581,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // UpdateThumbnailAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task UpdateThumbnailAsync_UpdatesThumbnailData()
     {
@@ -1632,7 +1612,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetThumbnailAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetThumbnailAsync_ReturnsThumbnailData_WhenPresent()
     {
@@ -1674,7 +1653,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // GetViewableWithoutThumbnailIdsAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetViewableWithoutThumbnailIdsAsync_ReturnsIdsOfViewableRecordsWithNoThumbnail()
     {
@@ -1720,7 +1698,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // BulkUpdateTagsAsync (replace mode — append = false)
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task BulkUpdateTagsAsync_ReplacesTagsWhenAppendFalse()
     {
@@ -1753,7 +1730,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // MarkMastDataPublicAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task MarkMastDataPublicAsync_ReturnsModifiedCount()
     {
@@ -1813,7 +1789,7 @@ public class MongoDBServiceTests
                 It.IsAny<UpdateDefinition<JwstDataModel>>(),
                 It.IsAny<UpdateOptions>(),
                 It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new Exception("database connection lost"));
+            .ThrowsAsync(new InvalidOperationException("database connection lost"));
 
         // Act
         var result = await sut.MarkMastDataPublicAsync();
@@ -1825,7 +1801,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // User management — requires the two-collection constructor
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GetUserByIdAsync_ReturnsUser_WhenExists()
     {
@@ -2081,7 +2056,6 @@ public class MongoDBServiceTests
     // -------------------------------------------------------------------------
     // EnsureIndexesAsync
     // -------------------------------------------------------------------------
-
     [Fact]
     public async Task EnsureIndexesAsync_CreatesIndexesWithoutThrowing()
     {
@@ -2131,7 +2105,7 @@ public class MongoDBServiceTests
             .Setup(m => m.CreateManyAsync(
                 It.IsAny<IEnumerable<CreateIndexModel<JwstDataModel>>>(),
                 It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new Exception("index options conflict"));
+            .ThrowsAsync(new InvalidOperationException("index options conflict"));
 
         mockCollection
             .Setup(c => c.Indexes)
@@ -2182,18 +2156,6 @@ public class MongoDBServiceTests
         return mockCursor;
     }
 
-    private void SetupFindWithCursor(List<JwstDataModel> data)
-    {
-        var mockCursor = SetupMockCursor(data);
-
-        mockCollection
-            .Setup(c => c.FindAsync(
-                It.IsAny<FilterDefinition<JwstDataModel>>(),
-                It.IsAny<FindOptions<JwstDataModel, JwstDataModel>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(mockCursor.Object);
-    }
-
     private static void SetupUserCursor(Mock<IMongoCollection<User>> mockUsers, List<User> data)
     {
         var mockCursor = new Mock<IAsyncCursor<User>>();
@@ -2233,6 +2195,18 @@ public class MongoDBServiceTests
             .Setup(c => c.FindAsync(
                 It.IsAny<FilterDefinition<User>>(),
                 It.IsAny<FindOptions<User, User>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockCursor.Object);
+    }
+
+    private void SetupFindWithCursor(List<JwstDataModel> data)
+    {
+        var mockCursor = SetupMockCursor(data);
+
+        mockCollection
+            .Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<JwstDataModel>>(),
+                It.IsAny<FindOptions<JwstDataModel, JwstDataModel>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockCursor.Object);
     }

--- a/backend/JwstDataAnalysis.API.Tests/Services/SemanticSearchServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/SemanticSearchServiceTests.cs
@@ -1065,7 +1065,6 @@ public class SemanticSearchServiceTests
     }
 
     // ===== Helpers =====
-
     private static JwstDataModel BuildDoc(
         string id,
         bool isPublic,

--- a/backend/JwstDataAnalysis.API/Services/JobReaperBackgroundService.cs
+++ b/backend/JwstDataAnalysis.API/Services/JobReaperBackgroundService.cs
@@ -34,6 +34,7 @@ namespace JwstDataAnalysis.API.Services
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="JobReaperBackgroundService"/> class.
         /// Internal constructor for testing — accepts a pre-configured collection.
         /// </summary>
         internal JobReaperBackgroundService(

--- a/backend/JwstDataAnalysis.API/Services/StartupScanBackgroundService.cs
+++ b/backend/JwstDataAnalysis.API/Services/StartupScanBackgroundService.cs
@@ -18,7 +18,7 @@ namespace JwstDataAnalysis.API.Services
         private readonly ILogger<StartupScanBackgroundService> logger = logger;
 
         /// <summary>
-        /// How long to wait before starting the scan. Overridable for testing.
+        /// Gets or sets how long to wait before starting the scan. Overridable for testing.
         /// </summary>
         internal TimeSpan InitialDelay { get; set; } = TimeSpan.FromSeconds(5);
 


### PR DESCRIPTION
## Summary

Fix all StyleCop and CA2201 analyzer errors introduced in PRs #834 and #835 that were caught by `dotnet build --warnaserror` but not by CI (which doesn't use `--warnaserror`).

No linked issue

## Why

The compliance check (`/compliance-check full`) flagged 80+ StyleCop violations on main. These are all mechanical formatting/ordering issues — no logic bugs, but they block the `--warnaserror` build gate.

## Changes Made

- **SA1202** (public before private): Reordered members in `MastControllerTests`, `DataScanServiceTests`
- **SA1204** (static before non-static): Reordered members in `DataScanServiceTests`, `MongoDBServiceTests`, `JobReaperBackgroundServiceTests`
- **SA1512** (comment followed by blank line): Removed blank lines after section-divider comments in `MongoDBServiceTests`, `DataScanServiceTests`, `SemanticSearchServiceTests`
- **SA1515** (comment not preceded by blank line): Added blank lines before inline comments in `MastControllerTests`, `DataScanServiceTests`
- **SA1116/SA1117** (parameter formatting): Fixed multi-line `Verify()` call in `DataScanServiceTests`
- **SA1623** (property doc text): Fixed doc comment in `StartupScanBackgroundService`
- **SA1642** (constructor doc text): Fixed doc comment in `JobReaperBackgroundService`
- **CA2201** (specific exception types): Changed `new Exception()` to `new InvalidOperationException()` in `MongoDBServiceTests`

## Test Plan

- [x] `dotnet build --warnaserror --no-incremental` passes with 0 warnings, 0 errors
- [x] All 1019 backend tests pass
- [x] No `#pragma warning disable` or suppressions added — all fixes are structural

## Documentation Checklist

- [x] No documentation updates needed (formatting-only changes)

## Tech Debt Impact

- [x] Reduces tech debt (cleans up analyzer violations)
- [ ] No impact on tech debt
- [ ] Increases tech debt (explain why)

## Risk & Rollback

Risk: None — all changes are whitespace, member ordering, and doc comment text. Zero logic changes.
Rollback: Revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)