### PR TITLE
chore: suppress no-console lint warnings in debug utilities

### DIFF
--- a/frontend/jwst-frontend/src/index.tsx
+++ b/frontend/jwst-frontend/src/index.tsx
@@ -9,16 +9,17 @@ import { clearAllCache, getCacheStats } from './utils/cacheUtils';
 // Expose cache utilities on window for admin/debugging use:
 //   jwst.clearCache() — clear all cached MAST/recipe data
 //   jwst.cacheStats() — show cache entries and sizes
+// TODO(v1): Remove window.jwst debug helpers before community release (see #840)
 (window as unknown as Record<string, unknown>).jwst = {
   clearCache: () => {
     const count = clearAllCache();
-    console.log(`Cleared ${count} cached entries. Reload the page to fetch fresh data.`);
+    console.log(`Cleared ${count} cached entries. Reload the page to fetch fresh data.`); // eslint-disable-line no-console -- debug utility output
     return count;
   },
   cacheStats: () => {
     const stats = getCacheStats();
-    console.table(stats.entries);
-    console.log(`Total: ${stats.entryCount} entries, ${(stats.totalBytes / 1024).toFixed(1)} KB`);
+    console.table(stats.entries); // eslint-disable-line no-console -- debug utility output
+    console.log(`Total: ${stats.entryCount} entries, ${(stats.totalBytes / 1024).toFixed(1)} KB`); // eslint-disable-line no-console -- debug utility output
     return stats;
   },
 };


### PR DESCRIPTION
## Summary

Suppress the 3 `no-console` ESLint warnings in `src/index.tsx` debug utilities and add a TODO for v1 removal.

Closes #840

## Why

The `window.jwst.clearCache()` and `window.jwst.cacheStats()` debug helpers intentionally use `console.log` and `console.table` — that's their purpose. Suppressing the warnings cleans up lint output (0 errors, 0 warnings now).

## Changes Made

- Added `eslint-disable-line no-console` with explanatory comments to the 3 console calls
- Added `TODO(v1)` comment linking to #840 for removal before community release

## Test Plan

- [x] `npm run lint` reports 0 errors, 0 warnings
- [x] 868 frontend unit tests pass

## Documentation Checklist

- [x] No documentation updates needed

## Tech Debt Impact

- [x] No impact on tech debt

## Risk & Rollback

Risk: None — comment-only changes.
Rollback: Revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)