### PR TITLE
fix: improve archive feedback and toast duration behavior

### DIFF
--- a/frontend/jwst-frontend/src/App.tsx
+++ b/frontend/jwst-frontend/src/App.tsx
@@ -70,6 +70,7 @@ function App() {
     <>
       <Toaster
         position="bottom-right"
+        duration={4000}
         toastOptions={{
           style: {
             background: 'var(--bg-surface)',
@@ -78,6 +79,7 @@ function App() {
             borderRadius: 'var(--radius-lg)',
             boxShadow: 'var(--shadow-lg)',
           },
+          classNames: { error: 'toast-error' },
         }}
       />
       <Suspense fallback={<PageLoadingFallback />}>

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -318,9 +318,9 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     } catch (error) {
       console.error('Error uploading file:', error);
       if (ApiError.isApiError(error)) {
-        toast.error(`Upload failed: ${error.message}`);
+        toast.error(`Upload failed: ${error.message}`, { duration: Infinity });
       } else {
-        toast.error('Error uploading file');
+        toast.error('Error uploading file', { duration: Infinity });
       }
     }
   };
@@ -330,17 +330,19 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     try {
       if (isCurrentlyArchived) {
         await jwstDataService.unarchive(dataId);
+        toast.success('File unarchived');
       } else {
         await jwstDataService.archive(dataId);
+        toast.success('File archived');
       }
       onDataUpdate();
     } catch (error) {
       console.error(`Error ${isCurrentlyArchived ? 'unarchiving' : 'archiving'} data:`, error);
       const action = isCurrentlyArchived ? 'unarchive' : 'archive';
       if (ApiError.isApiError(error)) {
-        toast.error(`Failed to ${action} file: ${error.message}`);
+        toast.error(`Failed to ${action} file: ${error.message}`, { duration: Infinity });
       } else {
-        toast.error('Error updating archive status');
+        toast.error('Error updating archive status', { duration: Infinity });
       }
     } finally {
       setArchivingIds((prev) => {
@@ -362,9 +364,9 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     } catch (error) {
       console.error('Error fetching delete preview:', error);
       if (ApiError.isApiError(error)) {
-        toast.error(`Failed to get observation info: ${error.message}`);
+        toast.error(`Failed to get observation info: ${error.message}`, { duration: Infinity });
       } else {
-        toast.error('Error fetching observation info');
+        toast.error('Error fetching observation info', { duration: Infinity });
       }
     }
   };
@@ -380,9 +382,9 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     } catch (error) {
       console.error('Error deleting observation:', error);
       if (ApiError.isApiError(error)) {
-        toast.error(`Failed to delete observation: ${error.message}`);
+        toast.error(`Failed to delete observation: ${error.message}`, { duration: Infinity });
       } else {
-        toast.error('Error deleting observation');
+        toast.error('Error deleting observation', { duration: Infinity });
       }
     } finally {
       setIsDeleting(false);
@@ -404,9 +406,9 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     } catch (error) {
       console.error('Error fetching delete level preview:', error);
       if (ApiError.isApiError(error)) {
-        toast.error(`Failed to get level info: ${error.message}`);
+        toast.error(`Failed to get level info: ${error.message}`, { duration: Infinity });
       } else {
-        toast.error('Error fetching level info');
+        toast.error('Error fetching level info', { duration: Infinity });
       }
     }
   };
@@ -425,9 +427,9 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     } catch (error) {
       console.error('Error deleting level:', error);
       if (ApiError.isApiError(error)) {
-        toast.error(`Failed to delete level: ${error.message}`);
+        toast.error(`Failed to delete level: ${error.message}`, { duration: Infinity });
       } else {
-        toast.error('Error deleting level');
+        toast.error('Error deleting level', { duration: Infinity });
       }
     } finally {
       setIsDeleting(false);
@@ -462,9 +464,9 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
     } catch (error) {
       console.error('Error archiving level:', error);
       if (ApiError.isApiError(error)) {
-        toast.error(`Failed to archive level: ${error.message}`);
+        toast.error(`Failed to archive level: ${error.message}`, { duration: Infinity });
       } else {
-        toast.error('Error archiving level');
+        toast.error('Error archiving level', { duration: Infinity });
       }
     } finally {
       setIsArchivingLevel(false);

--- a/frontend/jwst-frontend/src/components/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/MastSearch.tsx
@@ -232,7 +232,7 @@ const MastSearch: React.FC<MastSearchProps> = ({ onImportComplete, importedObsId
       setResumableJobs((prev) => prev.filter((j) => j.jobId !== jobId));
     } catch (err) {
       console.error('Failed to dismiss download:', err);
-      toast.error('Failed to dismiss download');
+      toast.error('Failed to dismiss download', { duration: Infinity });
     }
   };
 

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.css
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.css
@@ -267,11 +267,9 @@
   background: var(--color-warning-subtle);
 }
 
-/* Archiving animation */
+/* Archiving state — keep card fully visible, disable interaction */
 .data-card.archiving {
-  opacity: 0.6;
   pointer-events: none;
-  transition: opacity var(--transition-base);
 }
 
 .card-actions .archive-btn:disabled {

--- a/frontend/jwst-frontend/src/components/dashboard/UploadModal.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/UploadModal.tsx
@@ -18,7 +18,7 @@ const UploadModal: React.FC<UploadModalProps> = ({ onUpload, onClose }) => {
     const tagsInput = form.querySelectorAll('input[type="text"]')[0] as HTMLInputElement;
 
     if (!fileInput.files || fileInput.files.length === 0) {
-      toast.error('Please select a file');
+      toast.error('Please select a file', { duration: Infinity });
       return;
     }
 


### PR DESCRIPTION
## Summary

Improve user feedback for archive actions and standardize toast dismissal behavior: errors persist until dismissed, success/info auto-dismiss after 4 seconds.

Closes #679

## Why

Users couldn't tell if archive requests were received (#679 — opacity pulse was barely visible). Additionally, error toasts disappeared too quickly for users to read the message, while success toasts lingered unnecessarily.

## Changes Made

- **Toast duration**: Set global default to 4s auto-dismiss; all `toast.error()` calls now use `duration: Infinity` to persist until manually dismissed
- **Archive success feedback**: Added `toast.success('File archived')` / `toast.success('File unarchived')` — previously silent
- **Archive loading state**: Removed the barely-visible opacity fade (0.6) on archiving cards; the button text change ("Archiving...") + disabled state provides clearer feedback
- Files touched: `App.tsx`, `JwstDataDashboard.tsx`, `MastSearch.tsx`, `UploadModal.tsx`, `DataCard.css`

## Test Plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npx tsc --noEmit` — no type errors
- [x] 868 frontend unit tests pass
- [x] E2E selectors checked — `.archive-btn` unchanged, no E2E updates needed

## Documentation Checklist

- [x] No documentation updates needed (behavioral change, no new endpoints/files)

## Tech Debt Impact

- [x] No impact on tech debt

## Risk & Rollback

Risk: Low — CSS and toast option changes only. No logic changes to archive/unarchive API calls.
Rollback: Revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)