### PR TITLE
fix: Simplify auth flow — eliminate refresh races and cascading 403s

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/AuthServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/AuthServiceTests.cs
@@ -22,7 +22,7 @@ public class AuthServiceTests
     private const string UserId = "user-123";
     private const string Username = "testuser";
     private const string Email = "test@example.com";
-    private const int GraceWindowSeconds = 30;
+    private const int GraceWindowSeconds = 60;
 
     private readonly Mock<IMongoDBService> mockMongoDb = new();
     private readonly Mock<IJwtTokenService> mockJwtService = new();

--- a/backend/JwstDataAnalysis.API/Configuration/JwtSettings.cs
+++ b/backend/JwstDataAnalysis.API/Configuration/JwtSettings.cs
@@ -44,7 +44,9 @@ namespace JwstDataAnalysis.API.Configuration
         /// Gets or sets the grace window in seconds during which a previous refresh token
         /// remains valid after token rotation. Prevents race conditions when concurrent
         /// requests use the old token during rotation.
+        /// 60s accommodates the simplified 2-attempt client retry (try + 1s delay + retry)
+        /// plus network latency margin.
         /// </summary>
-        public int RefreshTokenGraceWindowSeconds { get; set; } = 30;
+        public int RefreshTokenGraceWindowSeconds { get; set; } = 60;
     }
 }

--- a/frontend/jwst-frontend/e2e/session-persistence.spec.ts
+++ b/frontend/jwst-frontend/e2e/session-persistence.spec.ts
@@ -48,8 +48,7 @@ test.describe('Session persistence and token handling', () => {
     );
 
     // Navigate to library — app should detect expired token and refresh.
-    // The refresh path involves retryRefreshToken which can take up to ~5s on
-    // retries (1s + 3s delays), so we give generous timeouts.
+    // The refresh path retries once after 1s, so we give generous timeouts.
     await page.goto('/library');
 
     // Should still end up on dashboard (refresh succeeded)

--- a/frontend/jwst-frontend/src/context/AuthContext.test.tsx
+++ b/frontend/jwst-frontend/src/context/AuthContext.test.tsx
@@ -337,7 +337,7 @@ describe('AuthContext', () => {
   });
 
   describe('token refresh retry', () => {
-    it('should retry on transient failure then succeed', async () => {
+    it('should retry once on transient failure then succeed', async () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
 
       // Pre-populate localStorage so AuthProvider starts authenticated
@@ -390,12 +390,13 @@ describe('AuthContext', () => {
 
       const result = await refreshPromise;
       expect(result).toBe(true);
+      // Now only 2 attempts: initial + 1 retry (was 3 with old retry logic)
       expect(authService.refreshToken).toHaveBeenCalledTimes(2);
 
       vi.useRealTimers();
     });
 
-    it('should log out after all retries exhausted', async () => {
+    it('should deauth immediately after all retries exhausted (no delay)', async () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
 
       // Pre-populate localStorage so AuthProvider starts authenticated
@@ -433,27 +434,134 @@ describe('AuthContext', () => {
         expect(capturedRefresher).not.toBeNull();
       });
 
-      // Invoke the captured refresher and advance through all delays
+      // Invoke the captured refresher and advance through the 1s retry delay
       if (!capturedRefresher) throw new Error('refresher not captured');
       const doRefresh: () => Promise<boolean> = capturedRefresher;
       let refreshPromise: Promise<boolean> | undefined;
       await act(async () => {
         refreshPromise = doRefresh();
-        // Advance past retry delays: 1s + 3s
+        // Advance past the 1s retry delay only — no 1.5s logout delay anymore
         await vi.advanceTimersByTimeAsync(1100);
-        await vi.advanceTimersByTimeAsync(3100);
-        // Advance past the 1.5s logout delay
-        await vi.advanceTimersByTimeAsync(1600);
       });
 
       const result = await refreshPromise;
       expect(result).toBe(false);
-      expect(authService.refreshToken).toHaveBeenCalledTimes(3);
+      // Now only 2 attempts: initial + 1 retry (was 3)
+      expect(authService.refreshToken).toHaveBeenCalledTimes(2);
 
-      // Auth should be cleared
+      // Auth should be cleared immediately (no 1.5s delay)
       await waitFor(() => {
         expect(localStorage.getItem('jwst_auth_token')).toBeNull();
       });
+
+      vi.useRealTimers();
+    });
+
+    it('should stay logged out when logout happens during in-flight refresh', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      vi.mocked(authService.login).mockResolvedValue(mockTokenResponse);
+      vi.mocked(authService.logout).mockResolvedValue(undefined);
+
+      // refreshToken returns a promise we control
+      let resolveRefresh: ((value: typeof mockTokenResponse) => void) | null = null;
+      vi.mocked(authService.refreshToken).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+
+      let capturedRefresher: (() => Promise<boolean>) | null = null;
+      vi.mocked(setTokenRefresher).mockImplementation((fn) => {
+        capturedRefresher = fn;
+      });
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      // Login first
+      await user.click(screen.getByText('Login'));
+      await waitFor(() => {
+        expect(screen.getByTestId('authenticated')).toHaveTextContent('authenticated');
+      });
+
+      // Start a refresh (simulating 401 retry)
+      if (!capturedRefresher) throw new Error('refresher not captured');
+      const doRefresh: () => Promise<boolean> = capturedRefresher;
+      let refreshPromise: Promise<boolean> | undefined;
+      await act(async () => {
+        refreshPromise = doRefresh();
+      });
+
+      // While refresh is in-flight, logout
+      await user.click(screen.getByText('Logout'));
+      await waitFor(() => {
+        expect(screen.getByTestId('authenticated')).toHaveTextContent('not-authenticated');
+      });
+
+      // Now resolve the in-flight refresh with success
+      await act(async () => {
+        resolveRefresh?.(mockTokenResponse);
+      });
+
+      // Should STILL be logged out — sessionIdRef prevents stale update
+      expect(screen.getByTestId('authenticated')).toHaveTextContent('not-authenticated');
+
+      await refreshPromise;
+
+      vi.useRealTimers();
+    });
+
+    it('should not update state after unmount during init refresh', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      // Pre-populate localStorage with expired token to trigger init refresh
+      const pastExpiry = new Date(Date.now() - 3600000).toISOString();
+      localStorage.setItem('jwst_auth_token', 'expired-token');
+      localStorage.setItem('jwst_refresh_token', 'expired-refresh');
+      localStorage.setItem(
+        'jwst_user',
+        JSON.stringify({
+          id: '456',
+          username: 'storeduser',
+          email: 'stored@example.com',
+          role: 'User',
+          createdAt: '2026-02-03T00:00:00Z',
+        })
+      );
+      localStorage.setItem('jwst_expires_at', pastExpiry);
+
+      // refreshToken returns a slow promise we control
+      let resolveRefresh: ((value: typeof mockTokenResponse) => void) | null = null;
+      vi.mocked(authService.refreshToken).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+
+      const { unmount } = render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      // Unmount while init refresh is pending
+      unmount();
+
+      // Resolve the init refresh — should be guarded by sessionIdRef
+      await act(async () => {
+        resolveRefresh?.(mockTokenResponse);
+      });
+
+      // localStorage should NOT be updated with new tokens (init was aborted)
+      expect(localStorage.getItem('jwst_auth_token')).not.toBe('test-access-token');
 
       vi.useRealTimers();
     });
@@ -489,7 +597,10 @@ describe('AuthContext', () => {
       });
     });
 
-    it('should not restore expired auth state', async () => {
+    it('should not restore expired auth state when refresh fails', async () => {
+      // Explicitly fail the init refresh — don't rely on undefined mock default
+      vi.mocked(authService.refreshToken).mockRejectedValue(new Error('Token expired'));
+
       // Pre-populate localStorage with expired token
       const pastExpiry = new Date(Date.now() - 3600000).toISOString();
       localStorage.setItem('jwst_auth_token', 'expired-token');
@@ -515,6 +626,46 @@ describe('AuthContext', () => {
       await waitFor(() => {
         expect(screen.getByTestId('authenticated')).toHaveTextContent('not-authenticated');
       });
+    });
+
+    it('should restore expired auth via init refresh when server accepts refresh token', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const refreshedResponse = {
+        ...mockTokenResponse,
+        user: { ...mockTokenResponse.user, username: 'refresheduser' },
+      };
+      vi.mocked(authService.refreshToken).mockResolvedValue(refreshedResponse);
+
+      // Pre-populate localStorage with expired access token but valid refresh token
+      const pastExpiry = new Date(Date.now() - 3600000).toISOString();
+      localStorage.setItem('jwst_auth_token', 'expired-token');
+      localStorage.setItem('jwst_refresh_token', 'valid-refresh');
+      localStorage.setItem(
+        'jwst_user',
+        JSON.stringify({
+          id: '456',
+          username: 'olduser',
+          email: 'old@example.com',
+          role: 'User',
+          createdAt: '2026-02-03T00:00:00Z',
+        })
+      );
+      localStorage.setItem('jwst_expires_at', pastExpiry);
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      // Init refresh should succeed and restore the session
+      await waitFor(() => {
+        expect(screen.getByTestId('authenticated')).toHaveTextContent('authenticated');
+        expect(screen.getByTestId('username')).toHaveTextContent('refresheduser');
+      });
+
+      vi.useRealTimers();
     });
   });
 });

--- a/frontend/jwst-frontend/src/context/AuthContext.tsx
+++ b/frontend/jwst-frontend/src/context/AuthContext.tsx
@@ -14,7 +14,6 @@ import {
   clearTokenGetter,
   setTokenRefresher,
   clearTokenRefresher,
-  attemptTokenRefresh,
 } from '../services';
 import type {
   AuthContextType,
@@ -25,39 +24,6 @@ import type {
   UserInfo,
 } from '../types/AuthTypes';
 import { AuthToast, type AuthToastHandle } from '../components/AuthToast';
-
-/**
- * Retry delays in ms for token refresh attempts (initial call + 2 retries).
- */
-const RETRY_DELAYS = [1000, 3000];
-const LOGOUT_DELAY_MS = 1500;
-
-/**
- * Retry a token-refresh function up to 3 times with backoff.
- * Pure async — callers handle toasts and logout.
- */
-async function retryRefreshToken<T>(
-  refreshFn: () => Promise<T>,
-  onRetrying?: (attempt: number) => void
-): Promise<T> {
-  // Attempt 1 (initial)
-  try {
-    return await refreshFn();
-  } catch (firstErr) {
-    // Retry attempts
-    for (let i = 0; i < RETRY_DELAYS.length; i++) {
-      onRetrying?.(i + 2);
-      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAYS[i]));
-      try {
-        return await refreshFn();
-      } catch {
-        // continue to next retry
-      }
-    }
-    // All retries exhausted — rethrow original error
-    throw firstErr;
-  }
-}
 
 // localStorage keys
 const STORAGE_KEYS = {
@@ -78,7 +44,7 @@ const initialState: AuthState = {
 };
 
 // Create context with undefined default - exported for useAuth hook
-// eslint-disable-next-line react-refresh/only-export-components
+// eslint-disable-next-line react-refresh/only-export-components -- context must be exported for useAuth hook
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 /**
@@ -154,15 +120,18 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const [state, setState] = useState<AuthState>(initialState);
-  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const logoutDelayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const toastRef = useRef<AuthToastHandle>(null);
+  const sessionIdRef = useRef<number>(0);
 
   /**
    * Update state from token response
    */
   const updateStateFromResponse = useCallback((response: TokenResponse): void => {
     saveAuth(response);
+    // Re-register token getter — may have been cleared by clearState on session expiry.
+    // The mount useEffect only runs once, so this ensures re-login works within the same lifecycle.
+    setTokenGetter(() => localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN));
     setState({
       user: response.user,
       accessToken: response.accessToken,
@@ -174,15 +143,17 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   /**
-   * Clear state on logout
+   * Clear state on logout. Increments sessionId to invalidate in-flight
+   * async operations that capture it before calling setState.
    */
   const clearState = useCallback((): void => {
+    sessionIdRef.current++;
     clearStoredAuth();
     clearTokenGetter();
     clearTokenRefresher();
-    if (refreshTimerRef.current) {
-      clearTimeout(refreshTimerRef.current);
-      refreshTimerRef.current = null;
+    if (logoutDelayRef.current) {
+      clearTimeout(logoutDelayRef.current);
+      logoutDelayRef.current = null;
     }
     setState({
       user: null,
@@ -195,9 +166,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   /**
-   * Refresh the access token with retry logic.
+   * Refresh the access token.
    * Reads refresh token from localStorage to avoid stale closure issues.
-   * Shows a warning toast during retries and an error toast before logout.
+   * Retries once after 1s, then immediately deauths on failure.
    */
   const refreshAuth = useCallback(async (): Promise<boolean> => {
     const currentRefreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
@@ -206,51 +177,31 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return false;
     }
 
+    const sessionId = sessionIdRef.current;
+    const doRefresh = () => authService.refreshToken({ refreshToken: currentRefreshToken });
+
     try {
-      const response = await retryRefreshToken(
-        () => authService.refreshToken({ refreshToken: currentRefreshToken }),
-        (attempt) => {
-          toastRef.current?.show(`Connection lost — retrying (${attempt}/3)...`, 'warning');
-        }
-      );
-      toastRef.current?.hide();
+      let response: TokenResponse;
+      try {
+        response = await doRefresh();
+      } catch {
+        await new Promise((resolve) => {
+          logoutDelayRef.current = setTimeout(resolve, 1000);
+        });
+        logoutDelayRef.current = null;
+        if (sessionIdRef.current !== sessionId) return false;
+        response = await doRefresh();
+      }
+      if (sessionIdRef.current !== sessionId) return false;
       updateStateFromResponse(response);
       return true;
     } catch {
-      toastRef.current?.show('Session expired — please log in again.', 'error');
-      await new Promise((resolve) => setTimeout(resolve, LOGOUT_DELAY_MS));
+      if (sessionIdRef.current !== sessionId) return false;
       clearState();
+      toastRef.current?.show('Session expired — please log in again.', 'error');
       return false;
     }
   }, [updateStateFromResponse, clearState]);
-
-  /**
-   * Schedule token refresh before expiry.
-   * Routes through attemptTokenRefresh (apiClient's deduplication layer)
-   * to prevent concurrent refreshes from proactive and reactive paths.
-   */
-  const scheduleRefresh = useCallback((expiresAt: Date): void => {
-    // Clear existing timer
-    if (refreshTimerRef.current) {
-      clearTimeout(refreshTimerRef.current);
-      refreshTimerRef.current = null;
-    }
-
-    // Calculate time until refresh (60 seconds before expiry)
-    const now = Date.now();
-    const expiresAtMs = expiresAt.getTime();
-    const refreshBufferMs = 60 * 1000;
-    const timeUntilRefresh = expiresAtMs - now - refreshBufferMs;
-
-    if (timeUntilRefresh > 0) {
-      refreshTimerRef.current = setTimeout(() => {
-        attemptTokenRefresh();
-      }, timeUntilRefresh);
-    } else {
-      // Token already expired or about to, refresh now
-      attemptTokenRefresh();
-    }
-  }, []);
 
   /**
    * Login with username/password
@@ -305,17 +256,25 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     // If access token expired but refresh token exists, attempt refresh
     if (!stored.isAuthenticated && stored.refreshToken) {
-      console.warn('[AuthContext] Access token expired on load, attempting refresh...');
-      retryRefreshToken(
-        () => authService.refreshToken({ refreshToken: stored.refreshToken as string }),
-        (attempt) => {
-          console.warn(`[AuthContext] Init refresh retry ${attempt}/3`);
-          toastRef.current?.show(`Restoring session — retrying (${attempt}/3)...`, 'warning');
-        }
-      )
-        .then((response) => {
+      const sessionId = sessionIdRef.current;
+      const doRefresh = () =>
+        authService.refreshToken({ refreshToken: stored.refreshToken as string });
+
+      (async () => {
+        try {
+          let response: TokenResponse;
+          try {
+            response = await doRefresh();
+          } catch {
+            await new Promise((resolve) => {
+              logoutDelayRef.current = setTimeout(resolve, 1000);
+            });
+            logoutDelayRef.current = null;
+            if (sessionIdRef.current !== sessionId) return;
+            response = await doRefresh();
+          }
+          if (sessionIdRef.current !== sessionId) return;
           console.warn('[AuthContext] Init refresh succeeded');
-          toastRef.current?.hide();
           saveAuth(response);
           setState({
             user: response.user,
@@ -325,12 +284,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
             isAuthenticated: true,
             isLoading: false,
           });
-        })
-        .catch((err) => {
+        } catch (err) {
           console.warn(
             '[AuthContext] Init refresh failed:',
             err instanceof Error ? err.message : String(err)
           );
+          if (sessionIdRef.current !== sessionId) return;
           clearStoredAuth();
           setState({
             user: null,
@@ -340,7 +299,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
             isAuthenticated: false,
             isLoading: false,
           });
-        });
+        }
+      })();
     }
 
     // Set up token getter for API client (composite/mosaic services
@@ -353,7 +313,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // Set up token refresher for API client 401 handling.
     // This function is called by apiClient when a 401 is received.
     // It reads from localStorage to avoid stale closure issues.
-    // toastRef is a stable ref, safe to capture in this closure.
+    // toastRef and sessionIdRef are stable refs, safe to capture.
     setTokenRefresher(async () => {
       const refreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
       console.warn('[AuthContext] Refresh callback invoked, hasRefreshToken:', !!refreshToken);
@@ -362,19 +322,26 @@ export function AuthProvider({ children }: AuthProviderProps) {
         return false;
       }
 
+      const sessionId = sessionIdRef.current;
+      const doRefresh = () => {
+        console.warn('[AuthContext] Calling authService.refreshToken...');
+        return authService.refreshToken({ refreshToken });
+      };
+
       try {
-        const response = await retryRefreshToken(
-          () => {
-            console.warn('[AuthContext] Calling authService.refreshToken...');
-            return authService.refreshToken({ refreshToken });
-          },
-          (attempt) => {
-            console.warn(`[AuthContext] Retry attempt ${attempt}/3`);
-            toastRef.current?.show(`Connection lost — retrying (${attempt}/3)...`, 'warning');
-          }
-        );
+        let response: TokenResponse;
+        try {
+          response = await doRefresh();
+        } catch {
+          await new Promise((resolve) => {
+            logoutDelayRef.current = setTimeout(resolve, 1000);
+          });
+          logoutDelayRef.current = null;
+          if (sessionIdRef.current !== sessionId) return false;
+          response = await doRefresh();
+        }
+        if (sessionIdRef.current !== sessionId) return false;
         console.warn('[AuthContext] Refresh succeeded, saving new tokens');
-        toastRef.current?.hide();
         saveAuth(response);
         setState({
           user: response.user,
@@ -387,14 +354,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
         return true;
       } catch (err) {
         console.warn(
-          '[AuthContext] Refresh failed after retries:',
+          '[AuthContext] Refresh failed:',
           err instanceof Error ? err.message : String(err)
         );
-        toastRef.current?.show('Session expired — please log in again.', 'error');
-        await new Promise((resolve) => {
-          logoutDelayRef.current = setTimeout(resolve, LOGOUT_DELAY_MS);
-        });
-        logoutDelayRef.current = null;
+        if (sessionIdRef.current !== sessionId) return false;
+        // Clear stored tokens and state but keep getter/refresher registered —
+        // they read from localStorage and must survive for re-login within the same lifecycle.
+        // clearState (used by logout) handles full cleanup including getter/refresher.
         clearStoredAuth();
         setState({
           user: null,
@@ -404,47 +370,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
           isAuthenticated: false,
           isLoading: false,
         });
+        toastRef.current?.show('Session expired — please log in again.', 'error');
         return false;
       }
     });
 
     // Clean up on unmount
     return () => {
-      if (refreshTimerRef.current) {
-        clearTimeout(refreshTimerRef.current);
-      }
+      sessionIdRef.current++; // eslint-disable-line react-hooks/exhaustive-deps -- writing (not reading) ref to invalidate in-flight async; false positive
       if (logoutDelayRef.current) {
         clearTimeout(logoutDelayRef.current);
       }
       clearTokenRefresher();
     };
-  }, []);
-
-  // Schedule refresh when token changes
-  useEffect(() => {
-    if (state.isAuthenticated && state.expiresAt) {
-      scheduleRefresh(state.expiresAt);
-    }
-  }, [state.isAuthenticated, state.expiresAt, scheduleRefresh]);
-
-  // Refresh token when tab becomes visible again (covers browser throttling of setTimeout)
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== 'visible') return;
-
-      const expiresAtStr = localStorage.getItem(STORAGE_KEYS.EXPIRES_AT);
-      const refreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
-      if (!expiresAtStr || !refreshToken) return;
-
-      const expiresAt = new Date(expiresAtStr);
-      const bufferMs = 60 * 1000;
-      if (expiresAt.getTime() - bufferMs <= Date.now()) {
-        attemptTokenRefresh();
-      }
-    };
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
   }, []);
 
   const value: AuthContextType = {

--- a/frontend/jwst-frontend/src/services/apiClient.test.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.test.ts
@@ -390,6 +390,35 @@ describe('apiClient', () => {
     });
   });
 
+  describe('wasAuthenticated warning', () => {
+    it('should log warning when authenticated session has no token', async () => {
+      // setTokenGetter marks wasAuthenticated = true, but getter returns null
+      setTokenGetter(() => null);
+      mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+      await apiClient.get('/api/test');
+
+      expect(console.warn).toHaveBeenCalledWith(
+        '[Auth]',
+        'Token missing for previously authenticated session — possible silent auth downgrade',
+        ''
+      );
+    });
+
+    it('should not log warning for anonymous requests', async () => {
+      // No setTokenGetter called — wasAuthenticated stays false
+      mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+      await apiClient.get('/api/test');
+
+      expect(console.warn).not.toHaveBeenCalledWith(
+        '[Auth]',
+        expect.stringContaining('silent auth downgrade'),
+        expect.anything()
+      );
+    });
+  });
+
   describe('setTokenRefresher / clearTokenRefresher', () => {
     it('should enable 401 retry when refresher is set', async () => {
       const refresher = vi.fn().mockResolvedValue(true);

--- a/frontend/jwst-frontend/src/services/apiClient.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.ts
@@ -78,6 +78,10 @@ type RequestOptions = {
 // Token getter function - set by AuthContext
 let getAccessToken: (() => string | null) | null = null;
 
+// Tracks whether a session was ever authenticated in this page lifecycle.
+// Used to detect silent auth downgrades (token disappears without explicit logout).
+let wasAuthenticated = false;
+
 // Token refresh callback - set by AuthContext
 let refreshTokenCallback: (() => Promise<boolean>) | null = null;
 let refreshPromise: Promise<boolean> | null = null;
@@ -88,6 +92,7 @@ let refreshPromise: Promise<boolean> | null = null;
  */
 export function setTokenGetter(getter: () => string | null): void {
   getAccessToken = getter;
+  wasAuthenticated = true;
 }
 
 /**
@@ -95,6 +100,7 @@ export function setTokenGetter(getter: () => string | null): void {
  */
 export function clearTokenGetter(): void {
   getAccessToken = null;
+  wasAuthenticated = false;
 }
 
 /**
@@ -123,13 +129,10 @@ const STORAGE_KEYS = {
   EXPIRES_AT: 'jwst_expires_at',
 };
 
-/** Retry delays for fallback refresh (keeps apiClient decoupled from AuthContext) */
-const FALLBACK_RETRY_DELAYS = [1000, 3000];
-
 /**
  * Fallback token refresh that reads directly from localStorage.
  * Used when AuthContext hasn't registered its callback yet (timing issue).
- * Retries up to 3 times (initial + 2 retries) with backoff before clearing auth.
+ * Tries once, waits 1s, retries once, then clears auth on failure.
  */
 async function fallbackTokenRefresh(): Promise<boolean> {
   const refreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
@@ -152,29 +155,27 @@ async function fallbackTokenRefresh(): Promise<boolean> {
     return true;
   };
 
-  // Attempt 1 (initial)
+  // Attempt 1
   try {
     return await doRefresh();
   } catch {
-    authLog('Fallback refresh attempt 1 failed, will retry');
+    authLog('Fallback refresh attempt 1 failed, retrying in 1s');
   }
 
-  // Retry attempts
-  for (let i = 0; i < FALLBACK_RETRY_DELAYS.length; i++) {
-    authLog(`Fallback refresh: waiting ${FALLBACK_RETRY_DELAYS[i]}ms before retry ${i + 2}/3`);
-    await new Promise((resolve) => setTimeout(resolve, FALLBACK_RETRY_DELAYS[i]));
-    try {
-      return await doRefresh();
-    } catch (err) {
-      authLog(
-        `Fallback refresh attempt ${i + 2} failed:`,
-        err instanceof Error ? err.message : String(err)
-      );
-    }
+  // Wait 1s, retry once — re-check localStorage in case logout cleared tokens during the delay
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  if (!localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN)) {
+    authLog('Fallback refresh: refresh token cleared during retry delay, aborting');
+    return false;
+  }
+  try {
+    return await doRefresh();
+  } catch (err) {
+    authLog('Fallback refresh attempt 2 failed:', err instanceof Error ? err.message : String(err));
   }
 
-  // All retries exhausted — clear auth
-  authLog('Fallback refresh: all retries exhausted, clearing auth');
+  // Both attempts failed — clear auth
+  authLog('Fallback refresh: retries exhausted, clearing auth');
   localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
   localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
   localStorage.removeItem(STORAGE_KEYS.USER);
@@ -250,6 +251,10 @@ class ApiClient {
     const token = getAccessToken?.() || localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    } else if (wasAuthenticated) {
+      authLog(
+        'Token missing for previously authenticated session — possible silent auth downgrade'
+      );
     }
     return headers;
   }


### PR DESCRIPTION
## Summary
- Removes 2 of 5 refresh triggers (scheduled timer + visibility handler) that caused race conditions
- Simplifies retry logic: 1 retry after 1s then immediate deauth (was 3 retries + 1.5s logout delay)
- Adds `sessionIdRef` guard to prevent stale closures from updating state after logout or unmount
- Adds `wasAuthenticated` flag to detect silent auth downgrades
- Bumps backend refresh token grace window 30s → 60s

## Why
Auth causes daily friction — stale tokens trigger cascading 403 errors and confusing toasts. Root cause: refresh token rotation with a 30s grace window + 5 concurrent refresh triggers + race conditions = double refreshes invalidate the session. This PR simplifies the system rather than patching individual race conditions.

Closes #654, Closes #655, Closes #656, Closes #657

## Changes Made
- **Backend**: `JwtSettings.cs` — grace window 30→60s, updated test constant
- **Frontend AuthContext.tsx** — removed `scheduleRefresh()`, `refreshTimerRef`, visibility change handler, `retryRefreshToken()` utility, `RETRY_DELAYS`/`LOGOUT_DELAY_MS` constants; added `sessionIdRef` stale closure guard; simplified all 3 refresh failure paths to try→1s→retry→immediate deauth; re-register token getter on re-login via `updateStateFromResponse`; clear `logoutDelayRef` in `clearState()`
- **Frontend apiClient.ts** — added `wasAuthenticated` module-level flag (set in `setTokenGetter`, cleared in `clearTokenGetter`); logs warning when token missing for previously authenticated session; simplified `fallbackTokenRefresh` from 3 retries to 2; added stale-token re-check after retry delay
- **Frontend e2e** — updated retry timing comment in session-persistence spec

## Test Plan
- [x] 872 frontend unit tests pass (71 test files)
- [x] 1019 backend tests pass
- [x] ESLint clean (0 errors, 4 pre-existing warnings)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] Prettier clean
- [x] New: retry once on transient failure then succeed (2 attempts, not 3)
- [x] New: deauth immediately after retries exhausted (no 1.5s delay)
- [x] New: logout during in-flight refresh → stays logged-out (sessionIdRef)
- [x] New: unmount during init refresh → no stale state update (sessionIdRef)
- [x] New: init refresh success restores session from expired access token
- [x] New: warning logged when authenticated session has no token
- [x] New: no warning for anonymous requests
- [ ] Manual: Docker rebuild → login → wait >1h → API call → single silent refresh
- [ ] Manual: Kill backend → API call → one retry → immediate clean logout

## Documentation Checklist
- [x] No new endpoints or models — no doc updates needed

## Tech Debt Impact
- [x] Reduces tech debt (net ~60 lines removed from AuthContext, eliminates race condition surface area)

## Risk & Rollback
Risk: Low-Medium — removes timer + visibility handler (simplification), immediate deauth is biggest behavioral shift (components see `isAuthenticated` flip earlier). Grace window is backend config, backward compatible.
Rollback: Revert commit. No migrations, no data model changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)