### PR TITLE
fix: Update E2E test for composite button (always enabled after #844)

### DIFF
--- a/frontend/jwst-frontend/e2e/dashboard.spec.ts
+++ b/frontend/jwst-frontend/e2e/dashboard.spec.ts
@@ -75,10 +75,12 @@ test.describe('Dashboard controls and panels', () => {
     await expect(page.locator('.form-actions button[type="submit"]')).toHaveText('Upload');
   });
 
-  test('Composite button exists and is disabled without selection', async ({ page }) => {
+  test('Composite button navigates to /composite', async ({ page }) => {
     const compositeBtn = page.getByRole('button', { name: /Composite/i }).first();
     await expect(compositeBtn).toBeVisible();
-    await expect(compositeBtn).toBeDisabled();
+    await expect(compositeBtn).toBeEnabled();
+    await compositeBtn.click();
+    await expect(page).toHaveURL(/\/composite/);
   });
 
   test('WCS Mosaic button navigates to /mosaic', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Updates E2E test that expected composite button to be disabled without file selection

No linked issue

## Why
PR #844 removed the composite button selection gate — the wizard now has its own file picker, so the button is always enabled. The E2E test was not updated.

## Changes Made
- `e2e/dashboard.spec.ts` — changed test from asserting `toBeDisabled()` to asserting `toBeEnabled()` + click navigates to `/composite`

## Test Plan
- [x] 872 unit tests pass
- [x] E2E test updated to match current behavior

## Documentation Checklist
- [x] No doc updates needed — test-only change

## Tech Debt Impact
- [x] No impact

## Risk & Rollback
Risk: Trivial — test-only change.
Rollback: Revert commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)