### PR TITLE
fix: Default edge feather to 0 for composites + recipe walkthrough script

### DIFF
--- a/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
@@ -161,7 +161,7 @@ namespace JwstDataAnalysis.API.Models
         /// Gets or sets edge feathering strength for multi-instrument FOV blending (0=off, 1=max).
         /// </summary>
         [Range(0.0, 1.0)]
-        public double FeatherStrength { get; set; } = 0.15;
+        public double FeatherStrength { get; set; } = 0.0;
 
         /// <summary>
         /// Gets or sets rotation angle in degrees (-180 to 180, positive = clockwise).
@@ -301,7 +301,7 @@ namespace JwstDataAnalysis.API.Models
         public bool BackgroundNeutralization { get; set; } = true;
 
         [JsonPropertyName("feather_strength")]
-        public double FeatherStrength { get; set; } = 0.15;
+        public double FeatherStrength { get; set; } = 0.0;
 
         [JsonPropertyName("rotation_degrees")]
         public double RotationDegrees { get; set; } = 0.0;

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -66,7 +66,7 @@ export function ResultStep({
   const [brightness, setBrightness] = useState(50);
   const [contrast, setContrast] = useState(50);
   const [saturation, setSaturation] = useState(50);
-  const [featherStrength, setFeatherStrength] = useState(15);
+  const [featherStrength, setFeatherStrength] = useState(0);
   const [rotation, setRotation] = useState(0);
 
   // Local channel state for immediate UI feedback before debounced regeneration
@@ -83,7 +83,7 @@ export function ResultStep({
       setBrightness(50);
       setContrast(50);
       setSaturation(50);
-      setFeatherStrength(15);
+      setFeatherStrength(0);
       setLocalChannels(null);
       /* eslint-enable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
     }

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -736,7 +736,7 @@ export function GuidedCreate() {
 
     setChannelPayloads(updatedChannels);
     // Reset quick adjustments by using the preset's overall directly
-    // Note: featherStrength resets to default (15%) via ResultStep's preset reset
+    // Note: featherStrength resets to default (0%) via ResultStep's preset reset
     featherStrengthRef.current = undefined;
     regenerateComposite(updatedChannels, preset.overall);
   }

--- a/processing-engine/app/composite/models.py
+++ b/processing-engine/app/composite/models.py
@@ -113,7 +113,7 @@ class NChannelCompositeRequest(BaseModel):
         description="Subtract per-channel sky background to neutralize color casts",
     )
     feather_strength: float = Field(
-        default=0.15,
+        default=0.0,
         ge=0.0,
         le=1.0,
         description="Edge feathering strength for multi-instrument FOV blending (0=off, 1=max)",

--- a/scripts/recipe-walkthrough.py
+++ b/scripts/recipe-walkthrough.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""
+Recipe Walkthrough Generator
+
+Generates composite images for every recipe across all available targets.
+Queries the database for downloaded MAST data, generates recipes via the
+discovery API, and renders composites via the composite API.
+
+Output: data/recipe-review/{target}/{recipe_name}.png
+
+Usage:
+    python3 scripts/recipe-walkthrough.py [--target NGC-3324] [--preset nasa_press]
+
+Requires: requests (pip install requests)
+Docker stack must be running.
+"""
+
+import argparse
+import json
+import re
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    print("Missing 'requests' library. Install: pip install requests")
+    sys.exit(1)
+
+import os
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", "data/recipe-review"))
+
+# Filter wavelengths (micrometers) — matches processing engine's recipe_engine.py
+FILTER_WAVELENGTHS = {
+    "F070W": 0.704, "F090W": 0.901, "F115W": 1.154, "F140M": 1.405,
+    "F150W": 1.501, "F162M": 1.627, "F182M": 1.845, "F187N": 1.874,
+    "F200W": 1.989, "F210M": 2.093, "F212N": 2.120, "F250M": 2.503,
+    "F277W": 2.762, "F300M": 2.989, "F322W2": 3.232, "F335M": 3.365,
+    "F356W": 3.568, "F360M": 3.621, "F410M": 4.082, "F430M": 4.280,
+    "F444W": 4.421, "F460M": 4.624, "F480M": 4.834,
+    "F560W": 5.6, "F770W": 7.7, "F1000W": 10.0, "F1065C": 10.65,
+    "F1130W": 11.3, "F1140C": 11.4, "F1280W": 12.8, "F1500W": 15.0,
+    "F1550C": 15.5, "F1800W": 18.0, "F2100W": 21.0, "F2300C": 23.0,
+    "F2550W": 25.5,
+}
+
+# Composite presets matching frontend's GuidedCreate.tsx
+PRESETS = {
+    "natural": {
+        "stretch": "asinh", "black_point": 0.02, "white_point": 0.98,
+        "gamma": 1.0, "asinh_a": 0.1, "curve": "linear",
+    },
+    "nasa_press": {
+        "stretch": "asinh", "black_point": 0.05, "white_point": 0.995,
+        "gamma": 0.85, "asinh_a": 0.02, "curve": "s_curve",
+    },
+    "high_contrast": {
+        "stretch": "asinh", "black_point": 0.1, "white_point": 0.99,
+        "gamma": 0.7, "asinh_a": 0.01, "curve": "s_curve",
+    },
+}
+
+
+def login(username: str, password: str) -> str:
+    """Authenticate and return access token."""
+    resp = requests.post(
+        f"{BASE_URL}/api/auth/login",
+        json={"username": username, "password": password},
+    )
+    resp.raise_for_status()
+    return resp.json()["accessToken"]
+
+
+def get_all_data(token: str) -> list[dict]:
+    """Fetch all data records from the backend API."""
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = requests.get(
+        f"{BASE_URL}/api/jwstdata",
+        headers=headers,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    # API may return a list directly or a paginated wrapper
+    if isinstance(data, list):
+        return data
+    return data.get("items", data.get("data", []))
+
+
+def group_by_target(records: list[dict]) -> dict[str, list[dict]]:
+    """Group records by target name, filtering to imaging data with known filters."""
+    targets: dict[str, list[dict]] = defaultdict(list)
+
+    # Skip IFU, spectral, and unknown data
+    skip_instruments = {"MIRI/IFU", "NIRSPEC/IFU", "NIRISS/WFSS"}
+    skip_filter_patterns = re.compile(r"^(CH\d|GR|CLEAR;PRISM|F290LP)")
+
+    for r in records:
+        info = r.get("imageInfo") or r.get("ImageInfo") or {}
+        filt = info.get("filter") or info.get("Filter")
+        instrument = info.get("instrument") or info.get("Instrument")
+        target = info.get("targetName") or info.get("TargetName")
+
+        if not filt or not target:
+            continue
+        if instrument in skip_instruments:
+            continue
+        if skip_filter_patterns.match(filt):
+            continue
+        # Skip compound filters like "F444W;F470N" — keep base filter only
+        if ";" in filt:
+            continue
+
+        targets[target].append(r)
+
+    return targets
+
+
+def get_unique_filters(records: list[dict]) -> dict[str, list[str]]:
+    """Map filter name → list of dataIds for a target's records."""
+    filter_to_ids: dict[str, list[str]] = defaultdict(list)
+    for r in records:
+        info = r.get("imageInfo") or r.get("ImageInfo") or {}
+        filt = info.get("filter") or info.get("Filter")
+        data_id = r.get("id") or str(r.get("_id"))
+        if filt and data_id:
+            filter_to_ids[filt].append(data_id)
+    return dict(filter_to_ids)
+
+
+def build_observations(records: list[dict]) -> list[dict]:
+    """Build observation list for suggest-recipes API."""
+    seen = set()
+    observations = []
+    for r in records:
+        info = r.get("imageInfo") or r.get("ImageInfo") or {}
+        filt = info.get("filter") or info.get("Filter")
+        instrument = info.get("instrument") or info.get("Instrument") or ""
+        obs_id = r.get("observationBaseId") or r.get("ObservationBaseId") or ""
+
+        if not filt:
+            continue
+        # Deduplicate by filter
+        if filt in seen:
+            continue
+        seen.add(filt)
+
+        # Normalize instrument name (NIRCAM/IMAGE → NIRCAM)
+        inst_short = instrument.split("/")[0]
+
+        observations.append({
+            "filter": filt,
+            "instrument": inst_short,
+            "wavelengthUm": FILTER_WAVELENGTHS.get(filt, 0),
+            "observationId": obs_id,
+            "dataProductType": "image",
+        })
+    return observations
+
+
+def suggest_recipes(target_name: str, observations: list[dict]) -> list[dict]:
+    """Call suggest-recipes API and return recipe list."""
+    resp = requests.post(
+        f"{BASE_URL}/api/discovery/suggest-recipes",
+        json={"targetName": target_name, "observations": observations},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("recipes", [])
+
+
+def hex_to_hue(hex_color: str) -> float | None:
+    """Convert hex color to hue angle (0-360). Returns None for grays."""
+    hex_color = hex_color.lstrip("#")
+    r, g, b = (int(hex_color[i:i+2], 16) / 255.0 for i in (0, 2, 4))
+    max_c = max(r, g, b)
+    min_c = min(r, g, b)
+    diff = max_c - min_c
+    if diff < 0.001:
+        return 0.0  # Gray → red (fallback)
+    if max_c == r:
+        hue = 60 * (((g - b) / diff) % 6)
+    elif max_c == g:
+        hue = 60 * (((b - r) / diff) + 2)
+    else:
+        hue = 60 * (((r - g) / diff) + 4)
+    return hue % 360
+
+
+def generate_composite(
+    channels: list[dict],
+    preset_name: str = "nasa_press",
+    width: int = 2000,
+    height: int = 2000,
+) -> bytes:
+    """Call generate-nchannel composite API and return PNG bytes."""
+    preset = PRESETS.get(preset_name, PRESETS["nasa_press"])
+
+    # Apply preset to each channel
+    for ch in channels:
+        ch.update({
+            "stretch": preset["stretch"],
+            "blackPoint": preset["black_point"],
+            "whitePoint": preset["white_point"],
+            "gamma": preset["gamma"],
+            "asinhA": preset["asinh_a"],
+            "curve": preset["curve"],
+            "weight": 1.0,
+        })
+
+    resp = requests.post(
+        f"{BASE_URL}/api/composite/generate-nchannel",
+        json={
+            "channels": channels,
+            "width": width,
+            "height": height,
+            "outputFormat": "png",
+            "quality": 95,
+            "featherStrength": 0.0,
+            "backgroundNeutralization": True,
+        },
+        timeout=120,
+    )
+    resp.raise_for_status()
+    return resp.content
+
+
+def run(
+    target_filter: str | None = None,
+    preset_name: str = "nasa_press",
+    username: str = "snoww3d",
+    password: str = "admin123",
+):
+    """Main entry point."""
+    print("=== Recipe Walkthrough Generator ===\n")
+
+    # Step 1: Login
+    print("Logging in...", end=" ", flush=True)
+    try:
+        token = login(username, password)
+    except Exception as e:
+        print(f"FAILED: {e}")
+        print("Check credentials and that Docker stack is running.")
+        sys.exit(1)
+    print("OK")
+
+    # Step 2: Fetch all data
+    print("Fetching data records...", end=" ", flush=True)
+    records = get_all_data(token)
+    print(f"{len(records)} records")
+
+    # Step 3: Group by target
+    targets = group_by_target(records)
+    print(f"Found {len(targets)} targets with imaging data\n")
+
+    if target_filter:
+        matched = {k: v for k, v in targets.items() if target_filter.lower() in k.lower()}
+        if not matched:
+            print(f"No target matching '{target_filter}'. Available:")
+            for t in sorted(targets.keys()):
+                print(f"  {t}")
+            sys.exit(1)
+        targets = matched
+
+    # Step 4: Process each target
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    summary = []
+
+    for target_name, target_records in sorted(targets.items()):
+        filter_to_ids = get_unique_filters(target_records)
+
+        # Need at least 2 filters for a composite
+        if len(filter_to_ids) < 2:
+            print(f"  SKIP {target_name} — only {len(filter_to_ids)} filter(s)")
+            continue
+
+        print(f"\n{'='*60}")
+        print(f"  {target_name}")
+        print(f"  Filters: {', '.join(sorted(filter_to_ids.keys()))}")
+        print(f"{'='*60}")
+
+        # Get recipes
+        observations = build_observations(target_records)
+        try:
+            recipes = suggest_recipes(target_name, observations)
+        except Exception as e:
+            print(f"  SKIP — suggest-recipes failed: {e}")
+            continue
+
+        if not recipes:
+            print("  SKIP — no recipes generated")
+            continue
+
+        print(f"  {len(recipes)} recipe(s) generated")
+
+        # Create target output directory
+        safe_target = re.sub(r'[^\w\-]', '_', target_name)
+        target_dir = OUTPUT_DIR / safe_target
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        for recipe in recipes:
+            recipe_name = recipe.get("name", "unnamed")
+            recipe_filters = recipe.get("filters", [])
+            color_mapping = recipe.get("colorMapping", {})
+            safe_recipe = re.sub(r'[^\w\-]', '_', recipe_name)
+
+            output_path = target_dir / f"{safe_recipe}_{preset_name}.png"
+            if output_path.exists():
+                print(f"    SKIP {recipe_name} — already exists")
+                summary.append((target_name, recipe_name, "skipped"))
+                continue
+
+            # Build channels: map recipe filters to dataIds
+            channels = []
+            missing = []
+            for filt in recipe_filters:
+                ids = filter_to_ids.get(filt)
+                if not ids:
+                    missing.append(filt)
+                    continue
+                hue = hex_to_hue(color_mapping.get(filt, "#ffffff"))
+                channels.append({
+                    "dataIds": ids[:3],  # Limit to 3 files per channel to keep it fast
+                    "color": {"hue": hue},
+                    "label": filt,
+                    "wavelengthUm": FILTER_WAVELENGTHS.get(filt),
+                })
+
+            if missing:
+                print(f"    SKIP {recipe_name} — missing filters: {', '.join(missing)}")
+                summary.append((target_name, recipe_name, f"missing: {', '.join(missing)}"))
+                continue
+
+            if len(channels) < 2:
+                print(f"    SKIP {recipe_name} — only {len(channels)} channel(s)")
+                summary.append((target_name, recipe_name, "too few channels"))
+                continue
+
+            # Generate composite
+            print(f"    {recipe_name} ({len(channels)} ch)...", end=" ", flush=True)
+            t0 = time.time()
+            try:
+                png_data = generate_composite(channels, preset_name)
+                output_path.write_bytes(png_data)
+                elapsed = time.time() - t0
+                size_kb = len(png_data) / 1024
+                print(f"OK ({elapsed:.1f}s, {size_kb:.0f} KB)")
+                summary.append((target_name, recipe_name, f"ok ({elapsed:.1f}s)"))
+            except requests.HTTPError as e:
+                elapsed = time.time() - t0
+                print(f"FAILED ({elapsed:.1f}s): {e}")
+                # Try to get error details
+                try:
+                    err = e.response.json() if e.response else {}
+                    print(f"      {err.get('message', err.get('detail', ''))}")
+                except Exception:
+                    pass
+                summary.append((target_name, recipe_name, f"failed: {e}"))
+            except Exception as e:
+                print(f"FAILED: {e}")
+                summary.append((target_name, recipe_name, f"error: {e}"))
+
+    # Print summary
+    print(f"\n{'='*60}")
+    print("SUMMARY")
+    print(f"{'='*60}")
+    ok = sum(1 for _, _, s in summary if s.startswith("ok"))
+    failed = sum(1 for _, _, s in summary if "failed" in s or "error" in s)
+    skipped = len(summary) - ok - failed
+    print(f"  Generated: {ok}  Skipped: {skipped}  Failed: {failed}")
+    print(f"  Output: {OUTPUT_DIR.resolve()}")
+
+    if failed:
+        print("\nFailed recipes:")
+        for target, recipe, status in summary:
+            if "failed" in status or "error" in status:
+                print(f"  {target} / {recipe}: {status}")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate composite images for every recipe")
+    parser.add_argument("--target", help="Filter to a specific target (substring match)")
+    parser.add_argument("--preset", default="nasa_press", choices=PRESETS.keys(),
+                        help="Stretch preset (default: nasa_press)")
+    parser.add_argument("--username", default="snoww3d", help="Login username")
+    parser.add_argument("--password", default=None,
+                        help="Login password (or set WALKTHROUGH_PASSWORD env var)")
+    args = parser.parse_args()
+
+    password = args.password or os.environ.get("WALKTHROUGH_PASSWORD")
+    if not password:
+        print("Password required: --password or WALKTHROUGH_PASSWORD env var")
+        sys.exit(1)
+
+    sys.exit(run(
+        target_filter=args.target,
+        preset_name=args.preset,
+        username=args.username,
+        password=password,
+    ))


### PR DESCRIPTION
## Summary
- Default edge feathering from 0.15 to 0.0 across all layers (frontend, backend, processing engine)
- Add `scripts/recipe-walkthrough.py` for bulk composite generation across all recipes

No linked issue

## Why
Edge feathering is for mosaics (tile seam blending). Composites stack channels from the same pointing — edges already align, so the default feather was adding unnecessary softening to every composite.

## Changes Made
- `frontend/.../guided/ResultStep.tsx` — `useState(15)` → `useState(0)`, reset value 15→0
- `frontend/.../pages/GuidedCreate.tsx` — updated comment referencing old default
- `backend/.../Models/CompositeModels.cs` — `FeatherStrength` default 0.15→0.0 (both DTOs)
- `processing-engine/.../composite/models.py` — `feather_strength` default 0.15→0.0
- `scripts/recipe-walkthrough.py` — new script: queries DB for targets, generates recipes via discovery API, renders composites via composite API, saves to `data/recipe-review/`

## Test Plan
- [x] 872 frontend tests pass
- [x] 1019 backend tests pass
- [x] Script tested: 5 composites generated for NGC-346 targets, 0 failures
- [x] Resumable: re-running skips existing files

## Documentation Checklist
- [x] No doc updates needed — default value change + internal tooling script

## Tech Debt Impact
- [x] No impact

## Risk & Rollback
Risk: Low — default value change, slider still available for manual adjustment.
Rollback: Revert commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)