### PR TITLE
fix: update E2E test for edge feather default change

### DIFF
--- a/frontend/jwst-frontend/e2e/guided-create.spec.ts
+++ b/frontend/jwst-frontend/e2e/guided-create.spec.ts
@@ -580,11 +580,11 @@ test.describe('Guided create — result step (step 3)', () => {
     await expect(labels.nth(2)).toContainText('Saturation');
     await expect(labels.nth(3)).toContainText('Edge Feather');
 
-    // Brightness, Contrast, Saturation default to 50; Edge Feather defaults to 15
+    // Brightness, Contrast, Saturation default to 50; Edge Feather defaults to 0
     for (let i = 0; i < 3; i++) {
       await expect(labels.nth(i).locator('input[type="range"]')).toHaveValue('50');
     }
-    await expect(labels.nth(3).locator('input[type="range"]')).toHaveValue('15');
+    await expect(labels.nth(3).locator('input[type="range"]')).toHaveValue('0');
   });
 
   test('shows export framing panel with preset buttons and export', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Fixes the flaky `shows quick adjustment sliders` E2E test that was failing on both main and feature branches
- Root cause: commit a01676b changed the Edge Feather slider default from 15 to 0 but did not update the E2E assertion

No linked issue — test-only fix.

## Changes Made
- **`frontend/jwst-frontend/e2e/guided-create.spec.ts`** — Updated Edge Feather slider assertion from `'15'` to `'0'` to match the intentional default change

## Test Plan
- [x] Assertion matches `ResultStep.tsx` line 69: `useState(0)`
- [ ] E2E test passes in CI

## Documentation Checklist
- [x] No doc updates needed (test-only)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — test-only change correcting a stale assertion.
Rollback: Revert commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)