### PR TITLE
fix: walkthrough multi-file channels + grader UX improvements

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -118,6 +118,15 @@ if has_staged_files_in "frontend/jwst-frontend/"; then
             echo -e "${GREEN}  ✓ Prettier skipped (no staged frontend source files)${NC}"
         fi
 
+        # TypeScript type check
+        echo "  → Running TypeScript type check..."
+        if ! npx tsc --noEmit 2>/dev/null; then
+            echo -e "${RED}  ❌ TypeScript type check failed${NC}"
+            FAILED=1
+        else
+            echo -e "${GREEN}  ✓ TypeScript type check passed${NC}"
+        fi
+
         # Unit Tests
         echo "  → Running unit tests..."
         if ! npm test --silent 2>/dev/null; then
@@ -141,7 +150,7 @@ if has_staged_files_in "backend/"; then
     # Check if dotnet is available
     if command -v dotnet &> /dev/null; then
         echo "  → Building backend..."
-        if ! dotnet build "$REPO_ROOT/backend/JwstDataAnalysis.sln" --verbosity quiet 2>/dev/null; then
+        if ! dotnet build "$REPO_ROOT/backend/JwstDataAnalysis.sln" --verbosity quiet --warnaserror 2>/dev/null; then
             echo -e "${RED}  ❌ Backend build failed${NC}"
             FAILED=1
         else

--- a/scripts/recipe-grader.py
+++ b/scripts/recipe-grader.py
@@ -27,6 +27,7 @@ DEFAULT_PORT = 8888
 
 # Known preset suffixes to strip from recipe display names
 KNOWN_PRESETS = [
+    "auto",
     "nasa_press",
     "natural",
     "high_contrast",
@@ -524,7 +525,12 @@ let versionGroups = {};  // "target/baseName" → [{version, filename, ...}, ...
 
 function formatVersion(v) {
   if (!v) return 'Baseline';
-  return v.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3');
+  // Strip sort key (the .0 or .1 between date and preset)
+  return v
+    .replace(/\.[01]\./, '.')
+    .replace(/^00000000\./, 'baseline ')
+    .replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3')
+    .replace(/[._]/g, ' ');
 }
 
 function getVersionGroupKey(img) {
@@ -542,12 +548,12 @@ function buildVersionGroups() {
     if (!versionGroups[key]) versionGroups[key] = [];
     versionGroups[key].push(img);
   }
-  // Sort each group: baseline first, then by version ascending
+  // Sort each group: newest version first, baseline last (left-to-right = new-to-old)
   for (const key of Object.keys(versionGroups)) {
     versionGroups[key].sort((a, b) => {
-      if (!a.version) return -1;
-      if (!b.version) return 1;
-      return a.version.localeCompare(b.version);
+      if (!a.version) return 1;
+      if (!b.version) return -1;
+      return b.version.localeCompare(a.version);
     });
   }
 }
@@ -729,8 +735,12 @@ function renderViewer() {
 
   if (compareMode) {
     const versions = getVersionsForImage(img);
-    const baseline = versions.find(v => !v.version) || versions[0];
     const current = img;
+    // Compare against oldest version; if current IS the oldest, use second-newest
+    let baseline = versions[versions.length - 1];
+    if (getImageKey(baseline) === getImageKey(current) && versions.length > 1) {
+      baseline = versions[versions.length - 2];
+    }
     const baseGrade = getGrade(baseline).grade;
     const curGrade = getGrade(current).grade;
     const baseMeta = getMetaForImage(baseline);
@@ -744,17 +754,17 @@ function renderViewer() {
         '<span style="color:#666; margin-left:8px">' + (currentIndex + 1) + ' / ' + filteredImages.length + '</span>' +
       '</div>' +
       '<div class="compare-pane">' +
-        '<img src="/images/' + baseline.target + '/' + baseline.filename + '" alt="Baseline">' +
-        '<div class="compare-label">' + formatVersion(baseline.version) +
-          (baseGrade ? ' — ' + baseGrade + '/5' : '') +
-          (baseMeta.time_s ? ' — ' + formatTime(baseMeta.time_s) : '') + '</div>' +
-      '</div>' +
-      '<div class="compare-divider"></div>' +
-      '<div class="compare-pane">' +
         '<img src="/images/' + current.target + '/' + current.filename + '" alt="Current">' +
         '<div class="compare-label">' + formatVersion(current.version) +
           (curGrade ? ' — ' + curGrade + '/5' : '') +
           (curMeta.time_s ? ' — ' + formatTime(curMeta.time_s) : '') + '</div>' +
+      '</div>' +
+      '<div class="compare-divider"></div>' +
+      '<div class="compare-pane">' +
+        '<img src="/images/' + baseline.target + '/' + baseline.filename + '" alt="Baseline">' +
+        '<div class="compare-label">' + formatVersion(baseline.version) +
+          (baseGrade ? ' — ' + baseGrade + '/5' : '') +
+          (baseMeta.time_s ? ' — ' + formatTime(baseMeta.time_s) : '') + '</div>' +
       '</div>';
   } else {
     viewer.className = 'viewer';
@@ -1027,17 +1037,29 @@ class GraderHandler(SimpleHTTPRequestHandler):
                 target = target_dir.name
                 for img_file in sorted(target_dir.glob("*.png")):
                     recipe, preset, version = parse_image_stem(img_file.stem)
-                    # baseName = stem without version suffix (for grouping)
-                    base = img_file.stem
-                    if version:
-                        base = base[: -(len(version) + 2)]  # strip .vYYYYMMDD
+                    # baseName = recipe display name (preset-stripped) for grouping.
+                    # This groups all presets + versions of the same recipe together
+                    # so auto vs nasa_press appear as versions, not separate recipes.
+                    base = recipe.replace(" ", "_")
+                    # Composite version label for sorting and display.
+                    # Format: "run_id.sort_key.preset" where sort_key ensures
+                    # auto sorts first (newest-left) in descending order.
+                    sort_key = "1" if preset == "auto" else "0"
+                    if version and preset:
+                        vlabel = f"{version}.{sort_key}.{preset}"
+                    elif version:
+                        vlabel = version
+                    elif preset:
+                        vlabel = f"00000000.{sort_key}.{preset}"  # baseline sorts last
+                    else:
+                        vlabel = None
                     result.append(
                         {
                             "target": target,
                             "recipe": recipe,
                             "filename": img_file.name,
                             "baseName": base,
-                            "version": version,
+                            "version": vlabel,
                             "preset": preset,
                         }
                     )

--- a/scripts/recipe-walkthrough.py
+++ b/scripts/recipe-walkthrough.py
@@ -347,6 +347,7 @@ def run(
     username: str = "snoww3d",
     password: str = "",
     run_id: str | None = None,
+    max_files: int | None = None,
 ):
     """Main entry point."""
     if not password:
@@ -354,7 +355,7 @@ def run(
         sys.exit(1)
 
     if not run_id:
-        run_id = datetime.now().strftime("%Y%m%d")
+        run_id = datetime.now().strftime("%Y%m%d-%H%M")
 
     print("=== Recipe Walkthrough Generator ===")
     print(f"  Run ID: v{run_id}\n")
@@ -455,9 +456,10 @@ def run(
                     missing.append(filt)
                     continue
                 hue = hex_to_hue(color_mapping.get(filt, "#ffffff"))
+                ch_ids = ids if max_files is None else ids[:max_files]
                 channels.append(
                     {
-                        "dataIds": ids[:1],  # Limit to 1 file per channel to avoid OOM
+                        "dataIds": ch_ids,
                         "color": {"hue": hue},
                         "label": filt,
                         "wavelengthUm": FILTER_WAVELENGTHS.get(filt),
@@ -555,7 +557,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--run-id",
         default=None,
-        help="Version tag for output files (default: YYYYMMDD)",
+        help="Version tag for output files (default: YYYYMMDD-HHMM)",
+    )
+    parser.add_argument(
+        "--max-files-per-channel",
+        type=int,
+        default=None,
+        help="Max FITS files per channel (default: unlimited — use all files, mosaic if needed)",
     )
     args = parser.parse_args()
 
@@ -568,5 +576,6 @@ if __name__ == "__main__":
             username=args.username,
             password=password or "",
             run_id=args.run_id,
+            max_files=args.max_files_per_channel,
         )
     )


### PR DESCRIPTION
## Summary
- Walkthrough script now uses all available files per channel instead of picking just the first one — multi-tile targets like NGC-3324 (158 NIRCAM tiles) get mosaicked into full-field composites
- Grader UX: groups presets as versions of the same recipe, newest-left ordering, fixed compare-with-self bug
- Pre-commit hook: added tsc type checking and --warnaserror for dotnet build

Closes #851

## Why
NGC-3324 composites scored 1/5 because the walkthrough hardcoded `ids[:1]`, picking a single NIRCAM detector tile (~1/5th of the Carina Nebula). The composite backend already supports multi-file mosaicking — it just wasn't being used. The grader also needed fixes to properly compare auto vs nasa_press presets.

## Changes Made
- **`scripts/recipe-walkthrough.py`** — Removed `ids[:1]` limit, added `--max-files-per-channel` CLI arg (default: unlimited), changed default run_id to `YYYYMMDD-HHMM` for multiple runs per day
- **`scripts/recipe-grader.py`** — Added `auto` to `KNOWN_PRESETS`, group versions by preset-stripped recipe name, newest-left sort order, fixed compare mode showing same image on both sides
- **`.githooks/pre-commit`** — Added `npx tsc --noEmit` type check for frontend, `--warnaserror` for backend build

## Test Plan
- [x] `ruff check` — walkthrough and grader lint clean
- [x] Grader serves correctly with updated grouping (manual verification)
- [ ] Run walkthrough for NGC-3324 with all files: `python3 scripts/recipe-walkthrough.py --target NGC-3324 --preset auto`
- [ ] Verify NGC-3324 composite shows full Carina Nebula field (not a single tile)
- [ ] Verify no OOM with 158-file channel (memmap + per-file budget should handle it)

## Documentation Checklist
- [x] No doc updates needed (script + hook changes only)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — script-only changes. The composite API, backend, and frontend are untouched. If multi-file mosaicking OOMs for extreme cases, `--max-files-per-channel` provides an escape hatch.

Rollback: Revert commit, or use `--max-files-per-channel 1` for old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)