### PR TITLE
fix: walkthrough multi-file channels + pre-commit improvements

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -118,6 +118,15 @@ if has_staged_files_in "frontend/jwst-frontend/"; then
             echo -e "${GREEN}  ✓ Prettier skipped (no staged frontend source files)${NC}"
         fi
 
+        # TypeScript type check
+        echo "  → Running TypeScript type check..."
+        if ! npx tsc --noEmit 2>/dev/null; then
+            echo -e "${RED}  ❌ TypeScript type check failed${NC}"
+            FAILED=1
+        else
+            echo -e "${GREEN}  ✓ TypeScript type check passed${NC}"
+        fi
+
         # Unit Tests
         echo "  → Running unit tests..."
         if ! npm test --silent 2>/dev/null; then
@@ -141,7 +150,7 @@ if has_staged_files_in "backend/"; then
     # Check if dotnet is available
     if command -v dotnet &> /dev/null; then
         echo "  → Building backend..."
-        if ! dotnet build "$REPO_ROOT/backend/JwstDataAnalysis.sln" --verbosity quiet 2>/dev/null; then
+        if ! dotnet build "$REPO_ROOT/backend/JwstDataAnalysis.sln" --verbosity quiet --warnaserror 2>/dev/null; then
             echo -e "${RED}  ❌ Backend build failed${NC}"
             FAILED=1
         else

--- a/scripts/recipe-walkthrough.py
+++ b/scripts/recipe-walkthrough.py
@@ -347,6 +347,7 @@ def run(
     username: str = "snoww3d",
     password: str = "",
     run_id: str | None = None,
+    max_files: int | None = None,
 ):
     """Main entry point."""
     if not password:
@@ -354,7 +355,7 @@ def run(
         sys.exit(1)
 
     if not run_id:
-        run_id = datetime.now().strftime("%Y%m%d")
+        run_id = datetime.now().strftime("%Y%m%d-%H%M")
 
     print("=== Recipe Walkthrough Generator ===")
     print(f"  Run ID: v{run_id}\n")
@@ -455,9 +456,10 @@ def run(
                     missing.append(filt)
                     continue
                 hue = hex_to_hue(color_mapping.get(filt, "#ffffff"))
+                ch_ids = ids if max_files is None else ids[:max_files]
                 channels.append(
                     {
-                        "dataIds": ids[:1],  # Limit to 1 file per channel to avoid OOM
+                        "dataIds": ch_ids,
                         "color": {"hue": hue},
                         "label": filt,
                         "wavelengthUm": FILTER_WAVELENGTHS.get(filt),
@@ -555,7 +557,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--run-id",
         default=None,
-        help="Version tag for output files (default: YYYYMMDD)",
+        help="Version tag for output files (default: YYYYMMDD-HHMM)",
+    )
+    parser.add_argument(
+        "--max-files-per-channel",
+        type=int,
+        default=None,
+        help="Max FITS files per channel (default: unlimited — use all files, mosaic if needed)",
     )
     args = parser.parse_args()
 
@@ -568,5 +576,6 @@ if __name__ == "__main__":
             username=args.username,
             password=password or "",
             run_id=args.run_id,
+            max_files=args.max_files_per_channel,
         )
     )


### PR DESCRIPTION
## Summary
- Walkthrough script now uses all available files per channel instead of picking just the first one — multi-tile targets like NGC-3324 get mosaicked into full-field composites
- Pre-commit hook gains TypeScript type checking and --warnaserror for .NET builds

Closes #851

## Why
NGC-3324 composites scored 1/5 because the walkthrough hardcoded `ids[:1]`, picking a single NIRCAM detector tile (~1/5th of the Carina Nebula). The composite backend already supports multi-file mosaicking via `generate_mosaic()` — it just wasn't being used. With the memmap fix (#858), loading 158 tiles won't OOM.

## Changes Made
- **`scripts/recipe-walkthrough.py`** — Removed `ids[:1]` limit (uses all files), added `--max-files-per-channel` CLI arg (default: unlimited), changed default run_id to `YYYYMMDD-HHMM`
- **`.githooks/pre-commit`** — Added `npx tsc --noEmit` for frontend type checking, `--warnaserror` for backend builds

## Test Plan
- [x] `ruff check` — walkthrough lint clean
- [ ] Run walkthrough for NGC-3324: `python3 scripts/recipe-walkthrough.py --target NGC-3324 --preset auto`
- [ ] Verify NGC-3324 composite shows full Carina Nebula (not a single tile)
- [ ] Verify no OOM with 158-file channel

## Documentation Checklist
- [x] No doc updates needed (script + hook only)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — script-only change. If multi-file mosaicking OOMs, use `--max-files-per-channel 1` for old behavior.

Rollback: Revert commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)