### PR TITLE
chore: Integrate plan review and retro skills into workflow

### DIFF
--- a/.claude/skills/interface-design/SKILL.md
+++ b/.claude/skills/interface-design/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: interface-design
+description: This skill is for interface design — dashboards, admin panels, apps, tools, and interactive products. NOT for marketing design (landing pages, marketing sites, campaigns).
+---
+
+# Interface Design
+
+Build interface design with craft and consistency.
+
+## Scope
+
+**Use for:** Dashboards, admin panels, SaaS apps, tools, settings pages, data interfaces.
+
+**Not for:** Landing pages, marketing sites, campaigns. Redirect those to `/frontend-design`.
+
+---
+
+# The Problem
+
+You will generate generic output. Your training has seen thousands of dashboards. The patterns are strong.
+
+You can follow the entire process below — explore the domain, name a signature, state your intent — and still produce a template. Warm colors on cold structures. Friendly fonts on generic layouts. "Kitchen feel" that looks like every other app.
+
+This happens because intent lives in prose, but code generation pulls from patterns. The gap between them is where defaults win.
+
+The process below helps. But process alone doesn't guarantee craft. You have to catch yourself.
+
+---
+
+# Where Defaults Hide
+
+Defaults don't announce themselves. They disguise themselves as infrastructure — the parts that feel like they just need to work, not be designed.
+
+**Typography feels like a container.** Pick something readable, move on. But typography isn't holding your design — it IS your design. The weight of a headline, the personality of a label, the texture of a paragraph. These shape how the product feels before anyone reads a word. A bakery management tool and a trading terminal might both need "clean, readable type" — but the type that's warm and handmade is not the type that's cold and precise. If you're reaching for your usual font, you're not designing.
+
+**Navigation feels like scaffolding.** Build the sidebar, add the links, get to the real work. But navigation isn't around your product — it IS your product. Where you are, where you can go, what matters most. A page floating in space is a component demo, not software. The navigation teaches people how to think about the space they're in.
+
+**Data feels like presentation.** You have numbers, show numbers. But a number on screen is not design. The question is: what does this number mean to the person looking at it? What will they do with it? A progress ring and a stacked label both show "3 of 10" — one tells a story, one fills space. If you're reaching for number-on-label, you're not designing.
+
+**Token names feel like implementation detail.** But your CSS variables are design decisions. `--ink` and `--parchment` evoke a world. `--gray-700` and `--surface-2` evoke a template. Someone reading only your tokens should be able to guess what product this is.
+
+The trap is thinking some decisions are creative and others are structural. There are no structural decisions. Everything is design. The moment you stop asking "why this?" is the moment defaults take over.
+
+---
+
+# Intent First
+
+Before touching code, answer these. Not in your head — out loud, to yourself or the user.
+
+**Who is this human?**
+Not "users." The actual person. Where are they when they open this? What's on their mind? What did they do 5 minutes ago, what will they do 5 minutes after? A teacher at 7am with coffee is not a developer debugging at midnight is not a founder between investor meetings. Their world shapes the interface.
+
+**What must they accomplish?**
+Not "use the dashboard." The verb. Grade these submissions. Find the broken deployment. Approve the payment. The answer determines what leads, what follows, what hides.
+
+**What should this feel like?**
+Say it in words that mean something. "Clean and modern" means nothing — every AI says that. Warm like a notebook? Cold like a terminal? Dense like a trading floor? Calm like a reading app? The answer shapes color, type, spacing, density — everything.
+
+If you cannot answer these with specifics, stop. Ask the user. Do not guess. Do not default.
+
+## Every Choice Must Be A Choice
+
+For every decision, you must be able to explain WHY.
+
+- Why this layout and not another?
+- Why this color temperature?
+- Why this typeface?
+- Why this spacing scale?
+- Why this information hierarchy?
+
+If your answer is "it's common" or "it's clean" or "it works" — you haven't chosen. You've defaulted. Defaults are invisible. Invisible choices compound into generic output.
+
+**The test:** If you swapped your choices for the most common alternatives and the design didn't feel meaningfully different, you never made real choices.
+
+## Sameness Is Failure
+
+If another AI, given a similar prompt, would produce substantially the same output — you have failed.
+
+This is not about being different for its own sake. It's about the interface emerging from the specific problem, the specific user, the specific context. When you design from intent, sameness becomes impossible because no two intents are identical.
+
+When you design from defaults, everything looks the same because defaults are shared.
+
+## Intent Must Be Systemic
+
+Saying "warm" and using cold colors is not following through. Intent is not a label — it's a constraint that shapes every decision.
+
+If the intent is warm: surfaces, text, borders, accents, semantic colors, typography — all warm. If the intent is dense: spacing, type size, information architecture — all dense. If the intent is calm: motion, contrast, color saturation — all calm.
+
+Check your output against your stated intent. Does every token reinforce it? Or did you state an intent and then default anyway?
+
+---
+
+# Product Domain Exploration
+
+This is where defaults get caught — or don't.
+
+Generic output: Task type → Visual template → Theme
+Crafted output: Task type → Product domain → Signature → Structure + Expression
+
+The difference: time in the product's world before any visual or structural thinking.
+
+## Required Outputs
+
+**Do not propose any direction until you produce all four:**
+
+**Domain:** Concepts, metaphors, vocabulary from this product's world. Not features — territory. Minimum 5.
+
+**Color world:** What colors exist naturally in this product's domain? Not "warm" or "cool" — go to the actual world. If this product were a physical space, what would you see? What colors belong there that don't belong elsewhere? List 5+.
+
+**Signature:** One element — visual, structural, or interaction — that could only exist for THIS product. If you can't name one, keep exploring.
+
+**Defaults:** 3 obvious choices for this interface type — visual AND structural. You can't avoid patterns you haven't named.
+
+## Proposal Requirements
+
+Your direction must explicitly reference:
+- Domain concepts you explored
+- Colors from your color world exploration
+- Your signature element
+- What replaces each default
+
+**The test:** Read your proposal. Remove the product name. Could someone identify what this is for? If not, it's generic. Explore deeper.
+
+---
+
+# The Mandate
+
+**Before showing the user, look at what you made.**
+
+Ask yourself: "If they said this lacks craft, what would they mean?"
+
+That thing you just thought of — fix it first.
+
+Your first output is probably generic. That's normal. The work is catching it before the user has to.
+
+## The Checks
+
+Run these against your output before presenting:
+
+- **The swap test:** If you swapped the typeface for your usual one, would anyone notice? If you swapped the layout for a standard dashboard template, would it feel different? The places where swapping wouldn't matter are the places you defaulted.
+
+- **The squint test:** Blur your eyes. Can you still perceive hierarchy? Is anything jumping out harshly? Craft whispers.
+
+- **The signature test:** Can you point to five specific elements where your signature appears? Not "the overall feel" — actual components. A signature you can't locate doesn't exist.
+
+- **The token test:** Read your CSS variables out loud. Do they sound like they belong to this product's world, or could they belong to any project?
+
+If any check fails, iterate before showing.
+
+---
+
+# Craft Foundations
+
+## Subtle Layering
+
+This is the backbone of craft. Regardless of direction, product type, or visual style — this principle applies to everything. You should barely notice the system working. When you look at Vercel's dashboard, you don't think "nice borders." You just understand the structure. The craft is invisible — that's how you know it's working.
+
+### Surface Elevation
+
+Surfaces stack. A dropdown sits above a card which sits above the page. Build a numbered system — base, then increasing elevation levels. In dark mode, higher elevation = slightly lighter. In light mode, higher elevation = slightly lighter or uses shadow.
+
+Each jump should be only a few percentage points of lightness. You can barely see the difference in isolation. But when surfaces stack, the hierarchy emerges. Whisper-quiet shifts that you feel rather than see.
+
+**Key decisions:**
+- **Sidebars:** Same background as canvas, not different. Different colors fragment the visual space into "sidebar world" and "content world." A subtle border is enough separation.
+- **Dropdowns:** One level above their parent surface. If both share the same level, the dropdown blends into the card and layering is lost.
+- **Inputs:** Slightly darker than their surroundings, not lighter. Inputs are "inset" — they receive content. A darker background signals "type here" without heavy borders.
+
+### Borders
+
+Borders should disappear when you're not looking for them, but be findable when you need structure. Low opacity rgba blends with the background — it defines edges without demanding attention. Solid hex borders look harsh in comparison.
+
+Build a progression — not all borders are equal. Standard borders, softer separation, emphasis borders, maximum emphasis for focus rings. Match intensity to the importance of the boundary.
+
+**The squint test:** Blur your eyes at the interface. You should still perceive hierarchy — what's above what, where sections divide. But nothing should jump out. No harsh lines. No jarring color shifts. Just quiet structure.
+
+This separates professional interfaces from amateur ones. Get this wrong and nothing else matters.
+
+## Infinite Expression
+
+Every pattern has infinite expressions. **No interface should look the same.**
+
+A metric display could be a hero number, inline stat, sparkline, gauge, progress bar, comparison delta, trend badge, or something new. A dashboard could emphasize density, whitespace, hierarchy, or flow in completely different ways. Even sidebar + cards has infinite variations in proportion, spacing, and emphasis.
+
+**Before building, ask:**
+- What's the ONE thing users do most here?
+- What products solve similar problems brilliantly? Study them.
+- Why would this interface feel designed for its purpose, not templated?
+
+**NEVER produce identical output.** Same sidebar width, same card grid, same metric boxes with icon-left-number-big-label-small every time — this signals AI-generated immediately. It's forgettable.
+
+The architecture and components should emerge from the task and data, executed in a way that feels fresh. Linear's cards don't look like Notion's. Vercel's metrics don't look like Stripe's. Same concepts, infinite expressions.
+
+## Color Lives Somewhere
+
+Every product exists in a world. That world has colors.
+
+Before you reach for a palette, spend time in the product's world. What would you see if you walked into the physical version of this space? What materials? What light? What objects?
+
+Your palette should feel like it came FROM somewhere — not like it was applied TO something.
+
+**Beyond Warm and Cold:** Temperature is one axis. Is this quiet or loud? Dense or spacious? Serious or playful? Geometric or organic? A trading terminal and a meditation app are both "focused" — completely different kinds of focus. Find the specific quality, not the generic label.
+
+**Color Carries Meaning:** Gray builds structure. Color communicates — status, action, emphasis, identity. Unmotivated color is noise. One accent color, used with intention, beats five colors used without thought.
+
+---
+
+# Before Writing Each Component
+
+**Every time** you write UI code — even small additions — state:
+
+```
+Intent: [who is this human, what must they do, how should it feel]
+Palette: [colors from your exploration — and WHY they fit this product's world]
+Depth: [borders / shadows / layered — and WHY this fits the intent]
+Surfaces: [your elevation scale — and WHY this color temperature]
+Typography: [your typeface — and WHY it fits the intent]
+Spacing: [your base unit]
+```
+
+This checkpoint is mandatory. It forces you to connect every technical choice back to intent.
+
+If you can't explain WHY for each choice, you're defaulting. Stop and think.
+
+---
+
+# Design Principles
+
+## Token Architecture
+
+Every color in your interface should trace back to a small set of primitives: foreground (text hierarchy), background (surface elevation), border (separation hierarchy), brand, and semantic (destructive, warning, success). No random hex values — everything maps to primitives.
+
+### Text Hierarchy
+
+Don't just have "text" and "gray text." Build four levels — primary, secondary, tertiary, muted. Each serves a different role: default text, supporting text, metadata, and disabled/placeholder. Use all four consistently. If you're only using two, your hierarchy is too flat.
+
+### Border Progression
+
+Borders aren't binary. Build a scale that matches intensity to importance — standard separation, softer separation, emphasis, maximum emphasis. Not every boundary deserves the same weight.
+
+### Control Tokens
+
+Form controls have specific needs. Don't reuse surface tokens — create dedicated ones for control backgrounds, control borders, and focus states. This lets you tune interactive elements independently from layout surfaces.
+
+## Spacing
+
+Pick a base unit and stick to multiples. Build a scale for different contexts — micro spacing for icon gaps, component spacing within buttons and cards, section spacing between groups, major separation between distinct areas. Random values signal no system.
+
+## Padding
+
+Keep it symmetrical. If one side has a value, others should match unless content naturally requires asymmetry.
+
+## Depth
+
+Choose ONE approach and commit:
+- **Borders-only** — Clean, technical. For dense tools.
+- **Subtle shadows** — Soft lift. For approachable products.
+- **Layered shadows** — Premium, dimensional. For cards that need presence.
+- **Surface color shifts** — Background tints establish hierarchy without shadows.
+
+Don't mix approaches.
+
+## Border Radius
+
+Sharper feels technical. Rounder feels friendly. Build a scale — small for inputs and buttons, medium for cards, large for modals. Don't mix sharp and soft randomly.
+
+## Typography
+
+Build distinct levels distinguishable at a glance. Headlines need weight and tight tracking for presence. Body needs comfortable weight for readability. Labels need medium weight that works at smaller sizes. Data needs monospace with tabular number spacing for alignment. Don't rely on size alone — combine size, weight, and letter-spacing.
+
+## Card Layouts
+
+A metric card doesn't have to look like a plan card doesn't have to look like a settings card. Design each card's internal structure for its specific content — but keep the surface treatment consistent: same border weight, shadow depth, corner radius, padding scale.
+
+## Controls
+
+Native `<select>` and `<input type="date">` render OS-native elements that cannot be styled. Build custom components — trigger buttons with positioned dropdowns, calendar popovers, styled state management.
+
+## Iconography
+
+Icons clarify, not decorate — if removing an icon loses no meaning, remove it. Choose one icon set and stick with it. Give standalone icons presence with subtle background containers.
+
+## Animation
+
+Fast micro-interactions, smooth easing. Larger transitions can be slightly longer. Use deceleration easing. Avoid spring/bounce in professional interfaces.
+
+## States
+
+Every interactive element needs states: default, hover, active, focus, disabled. Data needs states too: loading, empty, error. Missing states feel broken.
+
+## Navigation Context
+
+Screens need grounding. A data table floating in space feels like a component demo, not a product. Include navigation showing where you are in the app, location indicators, and user context. When building sidebars, consider same background as main content with border separation rather than different colors.
+
+## Dark Mode
+
+Dark interfaces have different needs. Shadows are less visible on dark backgrounds — lean on borders for definition. Semantic colors (success, warning, error) often need slight desaturation. The hierarchy system still applies, just with inverted values.
+
+---
+
+# Avoid
+
+- **Harsh borders** — if borders are the first thing you see, they're too strong
+- **Dramatic surface jumps** — elevation changes should be whisper-quiet
+- **Inconsistent spacing** — the clearest sign of no system
+- **Mixed depth strategies** — pick one approach and commit
+- **Missing interaction states** — hover, focus, disabled, loading, error
+- **Dramatic drop shadows** — shadows should be subtle, not attention-grabbing
+- **Large radius on small elements**
+- **Pure white cards on colored backgrounds**
+- **Thick decorative borders**
+- **Gradients and color for decoration** — color should mean something
+- **Multiple accent colors** — dilutes focus
+- **Different hues for different surfaces** — keep the same hue, shift only lightness
+
+---
+
+# Workflow
+
+## Communication
+Be invisible. Don't announce modes or narrate process.
+
+**Never say:** "I'm in ESTABLISH MODE", "Let me check system.md..."
+
+**Instead:** Jump into work. State suggestions with reasoning.
+
+## Suggest + Ask
+Lead with your exploration and recommendation, then confirm:
+```
+"Domain: [5+ concepts from the product's world]
+Color world: [5+ colors that exist in this domain]
+Signature: [one element unique to this product]
+Rejecting: [default 1] → [alternative], [default 2] → [alternative], [default 3] → [alternative]
+
+Direction: [approach that connects to the above]"
+
+[Ask: "Does that direction feel right?"]
+```
+
+## If Project Has system.md
+Read `.interface-design/system.md` and apply. Decisions are made.
+
+## If No system.md
+1. Explore domain — Produce all four required outputs
+2. Propose — Direction must reference all four
+3. Confirm — Get user buy-in
+4. Build — Apply principles
+5. **Evaluate** — Run the mandate checks before showing
+6. Offer to save
+
+---
+
+# After Completing a Task
+
+When you finish building something, **always offer to save**:
+
+```
+"Want me to save these patterns for future sessions?"
+```
+
+If yes, write to `.interface-design/system.md`:
+- Direction and feel
+- Depth strategy (borders/shadows/layered)
+- Spacing base unit
+- Key component patterns
+
+### What to Save
+
+Add patterns when a component is used 2+ times, is reusable across the project, or has specific measurements worth remembering. Don't save one-off components, temporary experiments, or variations better handled with props.
+
+### Consistency Checks
+
+If system.md defines values, check against them: spacing on the defined grid, depth using the declared strategy throughout, colors from the defined palette, documented patterns reused instead of reinvented.
+
+This compounds — each save makes future work faster and more consistent.
+
+---
+
+# Deep Dives
+
+For more detail on specific topics:
+- `references/principles.md` — Code examples, specific values, dark mode
+- `references/validation.md` — Memory management, when to update system.md
+- `references/critique.md` — Post-build craft critique protocol
+
+# Commands
+
+- `/interface-design:status` — Current system state
+- `/interface-design:audit` — Check code against system
+- `/interface-design:extract` — Extract patterns from code
+- `/interface-design:critique` — Critique your build for craft, then rebuild what defaulted

--- a/.claude/skills/interface-design/references/critique.md
+++ b/.claude/skills/interface-design/references/critique.md
@@ -1,0 +1,67 @@
+# Critique
+
+Your first build shipped the structure. Now look at it the way a design lead reviews a junior's work — not asking "does this work?" but "would I put my name on this?"
+
+---
+
+## The Gap
+
+There's a distance between correct and crafted. Correct means the layout holds, the grid aligns, the colors don't clash. Crafted means someone cared about every decision down to the last pixel. You can feel the difference immediately — the way you tell a hand-thrown mug from an injection-molded one. Both hold coffee. One has presence.
+
+Your first output lives in correct. This command pulls it toward crafted.
+
+---
+
+## See the Composition
+
+Step back. Look at the whole thing.
+
+Does the layout have rhythm? Great interfaces breathe unevenly — dense tooling areas give way to open content, heavy elements balance against light ones, the eye travels through the page with purpose. Default layouts are monotone: same card size, same gaps, same density everywhere. Flatness is the sound of no one deciding.
+
+Are proportions doing work? A 280px sidebar next to full-width content says "navigation serves content." A 360px sidebar says "these are peers." The specific number declares what matters. If you can't articulate what your proportions are saying, they're not saying anything.
+
+Is there a clear focal point? Every screen has one thing the user came here to do. That thing should dominate — through size, position, contrast, or the space around it. When everything competes equally, nothing wins and the interface feels like a parking lot.
+
+---
+
+## See the Craft
+
+Move close. Pixel-close.
+
+The spacing grid is non-negotiable — every value a multiple of 4, no exceptions — but correctness alone isn't craft. Craft is knowing that a tool panel at 16px padding feels workbench-tight while the same card at 24px feels like a brochure. The same number can be right in one context and lazy in another. Density is a design decision, not a constant.
+
+Typography should be legible even squinted. If size is the only thing separating your headline from your body from your label, the hierarchy is too weak. Weight, tracking, and opacity create layers that size alone can't.
+
+Surfaces should whisper hierarchy. Not thick borders, not dramatic shadows — quiet tonal shifts where you feel the depth without seeing it. Remove every border from your CSS mentally. Can you still perceive the structure through surface color alone? If not, your surfaces aren't working hard enough.
+
+Interactive elements need life. Every button, link, and clickable region should respond to hover and press. Not dramatically — a subtle shift in background, a gentle darkening. Missing states make an interface feel like a photograph of software instead of software.
+
+---
+
+## See the Content
+
+Read every visible string as a user would. Not checking for typos — checking for truth.
+
+Does this screen tell one coherent story? Could a real person at a real company be looking at exactly this data right now? Or does the page title belong to one product, the article body to another, and the sidebar metrics to a third?
+
+Content incoherence breaks the illusion faster than any visual flaw. A beautifully designed interface with nonsensical content is a movie set with no script.
+
+---
+
+## See the Structure
+
+Open the CSS and find the lies — the places that look right but are held together with tape.
+
+Negative margins undoing a parent's padding. Calc() values that exist only as workarounds. Absolute positioning to escape layout flow. Each is a shortcut where a clean solution exists. Cards with full-width dividers use flex column and section-level padding. Centered content uses max-width with auto margins. The correct answer is always simpler than the hack.
+
+---
+
+## Again
+
+Look at your output one final time.
+
+Ask: "If they said this lacks craft, what would they point to?"
+
+That thing you just thought of — fix it. Then ask again.
+
+The first build was the draft. The critique is the design.

--- a/.claude/skills/interface-design/references/example.md
+++ b/.claude/skills/interface-design/references/example.md
@@ -1,0 +1,86 @@
+# Craft in Action
+
+This shows how the subtle layering principle translates to real decisions. Learn the thinking, not the code. Your values will differ — the approach won't.
+
+---
+
+## The Subtle Layering Mindset
+
+Before looking at any example, internalize this: **you should barely notice the system working.**
+
+When you look at Vercel's dashboard, you don't think "nice borders." You just understand the structure. When you look at Supabase, you don't think "good surface elevation." You just know what's above what. The craft is invisible — that's how you know it's working.
+
+---
+
+## Example: Dashboard with Sidebar and Dropdown
+
+### The Surface Decisions
+
+**Why so subtle?** Each elevation jump should be only a few percentage points of lightness. You can barely see the difference in isolation. But when surfaces stack, the hierarchy emerges. This is the Vercel/Supabase way — whisper-quiet shifts that you feel rather than see.
+
+**What NOT to do:** Don't make dramatic jumps between elevations. That's jarring. Don't use different hues for different levels. Keep the same hue, shift only lightness.
+
+### The Border Decisions
+
+**Why rgba, not solid colors?** Low opacity borders blend with their background. A low-opacity white border on a dark surface is barely there — it defines the edge without demanding attention. Solid hex borders look harsh in comparison.
+
+**The test:** Look at your interface from arm's length. If borders are the first thing you notice, reduce opacity. If you can't find where regions end, increase slightly.
+
+### The Sidebar Decision
+
+**Why same background as canvas, not different?**
+
+Many dashboards make the sidebar a different color. This fragments the visual space — now you have "sidebar world" and "content world."
+
+Better: Same background, subtle border separation. The sidebar is part of the app, not a separate region. Vercel does this. Supabase does this. The border is enough.
+
+### The Dropdown Decision
+
+**Why surface-200, not surface-100?**
+
+The dropdown floats above the card it emerged from. If both were surface-100, the dropdown would blend into the card — you'd lose the sense of layering. Surface-200 is just light enough to feel "above" without being dramatically different.
+
+**Why border-overlay instead of border-default?**
+
+Overlays (dropdowns, popovers) often need slightly more definition because they're floating in space. A touch more border opacity helps them feel contained without being harsh.
+
+---
+
+## Example: Form Controls
+
+### Input Background Decision
+
+**Why darker, not lighter?**
+
+Inputs are "inset" — they receive content, they don't project it. A slightly darker background signals "type here" without needing heavy borders. This is the alternative-background principle.
+
+### Focus State Decision
+
+**Why subtle focus states?**
+
+Focus needs to be visible, but you don't need a glowing ring or dramatic color. A noticeable increase in border opacity is enough for a clear state change. Subtle-but-noticeable — the same principle as surfaces.
+
+---
+
+## Adapt to Context
+
+Your product might need:
+- Warmer hues (slight yellow/orange tint)
+- Cooler hues (blue-gray base)
+- Different lightness progression
+- Light mode (principles invert — higher elevation = shadow, not lightness)
+
+**The principle is constant:** barely different, still distinguishable. The values adapt to context.
+
+---
+
+## The Craft Check
+
+Apply the squint test to your work:
+
+1. Blur your eyes or step back
+2. Can you still perceive hierarchy?
+3. Is anything jumping out at you?
+4. Can you tell where regions begin and end?
+
+If hierarchy is visible and nothing is harsh — the subtle layering is working.

--- a/.claude/skills/interface-design/references/principles.md
+++ b/.claude/skills/interface-design/references/principles.md
@@ -1,0 +1,235 @@
+# Core Craft Principles
+
+These apply regardless of design direction. This is the quality floor.
+
+---
+
+## Surface & Token Architecture
+
+Professional interfaces don't pick colors randomly — they build systems. Understanding this architecture is the difference between "looks okay" and "feels like a real product."
+
+### The Primitive Foundation
+
+Every color in your interface should trace back to a small set of primitives:
+
+- **Foreground** — text colors (primary, secondary, muted)
+- **Background** — surface colors (base, elevated, overlay)
+- **Border** — edge colors (default, subtle, strong)
+- **Brand** — your primary accent
+- **Semantic** — functional colors (destructive, warning, success)
+
+Don't invent new colors. Map everything to these primitives.
+
+### Surface Elevation Hierarchy
+
+Surfaces stack. A dropdown sits above a card which sits above the page. Build a numbered system:
+
+```
+Level 0: Base background (the app canvas)
+Level 1: Cards, panels (same visual plane as base)
+Level 2: Dropdowns, popovers (floating above)
+Level 3: Nested dropdowns, stacked overlays
+Level 4: Highest elevation (rare)
+```
+
+In dark mode, higher elevation = slightly lighter. In light mode, higher elevation = slightly lighter or uses shadow. The principle: **elevated surfaces need visual distinction from what's beneath them.**
+
+### The Subtlety Principle
+
+This is where most interfaces fail. Study Vercel, Supabase, Linear — their surfaces are **barely different** but still distinguishable. Their borders are **light but not invisible**.
+
+**For surfaces:** The difference between elevation levels should be subtle — a few percentage points of lightness, not dramatic jumps. In dark mode, surface-100 might be 7% lighter than base, surface-200 might be 9%, surface-300 might be 12%. You can barely see it, but you feel it.
+
+**For borders:** Borders should define regions without demanding attention. Use low opacity (0.05-0.12 alpha for dark mode, slightly higher for light). The border should disappear when you're not looking for it, but be findable when you need to understand the structure.
+
+**The test:** Squint at your interface. You should still perceive the hierarchy — what's above what, where regions begin and end. But no single border or surface should jump out at you. If borders are the first thing you notice, they're too strong. If you can't find where one region ends and another begins, they're too subtle.
+
+**Common AI mistakes to avoid:**
+- Borders that are too visible (1px solid gray instead of subtle rgba)
+- Surface jumps that are too dramatic (going from dark to light instead of dark to slightly-less-dark)
+- Using different hues for different surfaces (gray card on blue background)
+- Harsh dividers where subtle borders would do
+
+### Text Hierarchy via Tokens
+
+Don't just have "text" and "gray text." Build four levels:
+
+- **Primary** — default text, highest contrast
+- **Secondary** — supporting text, slightly muted
+- **Tertiary** — metadata, timestamps, less important
+- **Muted** — disabled, placeholder, lowest contrast
+
+Use all four consistently. If you're only using two, your hierarchy is too flat.
+
+### Border Progression
+
+Borders aren't binary. Build a scale:
+
+- **Default** — standard borders
+- **Subtle/Muted** — softer separation
+- **Strong** — emphasis, hover states
+- **Stronger** — maximum emphasis, focus rings
+
+Match border intensity to the importance of the boundary.
+
+### Dedicated Control Tokens
+
+Form controls (inputs, checkboxes, selects) have specific needs. Don't just reuse surface tokens — create dedicated ones:
+
+- **Control background** — often different from surface backgrounds
+- **Control border** — needs to feel interactive
+- **Control focus** — clear focus indication
+
+This separation lets you tune controls independently from layout surfaces.
+
+### Context-Aware Bases
+
+Different areas of your app might need different base surfaces:
+
+- **Marketing pages** — might use darker/richer backgrounds
+- **Dashboard/app** — might use neutral working backgrounds
+- **Sidebar** — might differ from main canvas
+
+The surface hierarchy works the same way — it just starts from a different base.
+
+### Alternative Backgrounds for Depth
+
+Beyond shadows, use contrasting backgrounds to create depth. An "alternative" or "inset" background makes content feel recessed. Useful for:
+
+- Empty states in data grids
+- Code blocks
+- Inset panels
+- Visual grouping without borders
+
+---
+
+## Spacing System
+
+Pick a base unit (4px and 8px are common) and use multiples throughout. The specific number matters less than consistency — every spacing value should be explainable as "X times the base unit."
+
+Build a scale for different contexts:
+- Micro spacing (icon gaps, tight element pairs)
+- Component spacing (within buttons, inputs, cards)
+- Section spacing (between related groups)
+- Major separation (between distinct sections)
+
+## Symmetrical Padding
+
+TLBR must match. If top padding is 16px, left/bottom/right must also be 16px. Exception: when content naturally creates visual balance.
+
+```css
+/* Good */
+padding: 16px;
+padding: 12px 16px; /* Only when horizontal needs more room */
+
+/* Bad */
+padding: 24px 16px 12px 16px;
+```
+
+## Border Radius Consistency
+
+Sharper corners feel technical, rounder corners feel friendly. Pick a scale that fits your product's personality and use it consistently.
+
+The key is having a system: small radius for inputs and buttons, medium for cards, large for modals or containers. Don't mix sharp and soft randomly — inconsistent radius is as jarring as inconsistent spacing.
+
+## Depth & Elevation Strategy
+
+Match your depth approach to your design direction. Choose ONE and commit:
+
+**Borders-only (flat)** — Clean, technical, dense. Works for utility-focused tools where information density matters more than visual lift. Linear, Raycast, and many developer tools use almost no shadows — just subtle borders to define regions.
+
+**Subtle single shadows** — Soft lift without complexity. A simple `0 1px 3px rgba(0,0,0,0.08)` can be enough. Works for approachable products that want gentle depth.
+
+**Layered shadows** — Rich, premium, dimensional. Multiple shadow layers create realistic depth. Stripe and Mercury use this approach. Best for cards that need to feel like physical objects.
+
+**Surface color shifts** — Background tints establish hierarchy without any shadows. A card at `#fff` on a `#f8fafc` background already feels elevated.
+
+```css
+/* Borders-only approach */
+--border: rgba(0, 0, 0, 0.08);
+--border-subtle: rgba(0, 0, 0, 0.05);
+border: 0.5px solid var(--border);
+
+/* Single shadow approach */
+--shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+
+/* Layered shadow approach */
+--shadow-layered:
+  0 0 0 0.5px rgba(0, 0, 0, 0.05),
+  0 1px 2px rgba(0, 0, 0, 0.04),
+  0 2px 4px rgba(0, 0, 0, 0.03),
+  0 4px 8px rgba(0, 0, 0, 0.02);
+```
+
+## Card Layouts
+
+Monotonous card layouts are lazy design. A metric card doesn't have to look like a plan card doesn't have to look like a settings card.
+
+Design each card's internal structure for its specific content — but keep the surface treatment consistent: same border weight, shadow depth, corner radius, padding scale, typography.
+
+## Isolated Controls
+
+UI controls deserve container treatment. Date pickers, filters, dropdowns — these should feel like crafted objects.
+
+**Never use native form elements for styled UI.** Native `<select>`, `<input type="date">`, and similar elements render OS-native dropdowns that cannot be styled. Build custom components instead:
+
+- Custom select: trigger button + positioned dropdown menu
+- Custom date picker: input + calendar popover
+- Custom checkbox/radio: styled div with state management
+
+Custom select triggers must use `display: inline-flex` with `white-space: nowrap` to keep text and chevron icons on the same row.
+
+## Typography Hierarchy
+
+Build distinct levels that are visually distinguishable at a glance:
+
+- **Headlines** — heavier weight, tighter letter-spacing for presence
+- **Body** — comfortable weight for readability
+- **Labels/UI** — medium weight, works at smaller sizes
+- **Data** — often monospace, needs `tabular-nums` for alignment
+
+Don't rely on size alone. Combine size, weight, and letter-spacing to create clear hierarchy. If you squint and can't tell headline from body, the hierarchy is too weak.
+
+## Monospace for Data
+
+Numbers, IDs, codes, timestamps belong in monospace. Use `tabular-nums` for columnar alignment. Mono signals "this is data."
+
+## Iconography
+
+Icons clarify, not decorate — if removing an icon loses no meaning, remove it. Choose a consistent icon set and stick with it throughout the product.
+
+Give standalone icons presence with subtle background containers. Icons next to text should align optically, not mathematically.
+
+## Animation
+
+Keep it fast and functional. Micro-interactions (hover, focus) should feel instant — around 150ms. Larger transitions (modals, panels) can be slightly longer — 200-250ms.
+
+Use smooth deceleration easing (ease-out variants). Avoid spring/bounce effects in professional interfaces — they feel playful, not serious.
+
+## Contrast Hierarchy
+
+Build a four-level system: foreground (primary) → secondary → muted → faint. Use all four consistently.
+
+## Color Carries Meaning
+
+Gray builds structure. Color communicates — status, action, emphasis, identity. Unmotivated color is noise. Color that reinforces the product's world is character.
+
+## Navigation Context
+
+Screens need grounding. A data table floating in space feels like a component demo, not a product. Consider including:
+
+- **Navigation** — sidebar or top nav showing where you are in the app
+- **Location indicator** — breadcrumbs, page title, or active nav state
+- **User context** — who's logged in, what workspace/org
+
+When building sidebars, consider using the same background as the main content area. Rely on a subtle border for separation rather than different background colors.
+
+## Dark Mode
+
+Dark interfaces have different needs:
+
+**Borders over shadows** — Shadows are less visible on dark backgrounds. Lean more on borders for definition.
+
+**Adjust semantic colors** — Status colors (success, warning, error) often need to be slightly desaturated for dark backgrounds.
+
+**Same structure, different values** — The hierarchy system still applies, just with inverted values.

--- a/.claude/skills/interface-design/references/validation.md
+++ b/.claude/skills/interface-design/references/validation.md
@@ -1,0 +1,48 @@
+# Memory Management
+
+When and how to update `.interface-design/system.md`.
+
+## When to Add Patterns
+
+Add to system.md when:
+- Component used 2+ times
+- Pattern is reusable across the project
+- Has specific measurements worth remembering
+
+## Pattern Format
+
+```markdown
+### Button Primary
+- Height: 36px
+- Padding: 12px 16px
+- Radius: 6px
+- Font: 14px, 500 weight
+```
+
+## Don't Document
+
+- One-off components
+- Temporary experiments
+- Variations better handled with props
+
+## Pattern Reuse
+
+Before creating a component, check system.md:
+- Pattern exists? Use it.
+- Need variation? Extend, don't create new.
+
+Memory compounds: each pattern saved makes future work faster and more consistent.
+
+---
+
+# Validation Checks
+
+If system.md defines specific values, check consistency:
+
+**Spacing** — All values multiples of the defined base?
+
+**Depth** — Using the declared strategy throughout? (borders-only means no shadows)
+
+**Colors** — Using defined palette, not random hex codes?
+
+**Patterns** — Reusing documented patterns instead of creating new?

--- a/.claude/skills/plan-ceo-review/SKILL.md
+++ b/.claude/skills/plan-ceo-review/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: plan-ceo-review
+description: CEO/founder-mode plan review before implementing. Rethinks the problem, challenges premises, expands or reduces scope, and ensures you're solving the RIGHT thing before writing a line of code. Use when starting any feature, bug fix, or refactor — especially before entering plan mode. Triggers on "ceo review", "rethink this", "challenge this plan", "is this the right approach", "/plan-ceo-review".
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - AskUserQuestion
+  - EnterPlanMode
+---
+
+# Plan: CEO Review Mode
+
+You are not here to rubber-stamp this plan. You are here to make it extraordinary, catch every landmine before it explodes, and ensure that when this ships, it ships right.
+
+**First: detect the base branch.**
+```bash
+git -C /Users/shanon/Source/Astronomy symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"
+```
+
+## Step 0: Orient
+
+Read the plan, feature request, or problem statement the user just described. If it references files, read them. If it references open GitHub issues, note the issue numbers.
+
+Identify:
+- What problem is actually being solved?
+- Who benefits and how?
+- What constraints exist (auth-adjacent? data model? storage? API contract)?
+- Does this already exist? (`grep -r` the codebase for related functionality before assuming it doesn't)
+
+## Step 1: Choose a Mode
+
+Ask the user which mode they want — present this as a single AskUserQuestion:
+
+> "Before I review this plan, which lens should I use?
+>
+> **A — SCOPE EXPANSION**: Dream big. What would make this 10x better for 2x the effort? I'll push scope up and ask you to opt in/out of each expansion.
+>
+> **B — SELECTIVE EXPANSION**: Hold current scope as the baseline — make it bulletproof — but also surface cherry-pick opportunities. You decide each one.
+>
+> **C — HOLD SCOPE**: The plan's scope is accepted. Your job is to make it bulletproof — catch every failure mode, test every edge case. No silent additions or reductions.
+>
+> **D — SCOPE REDUCTION**: Surgeon mode. Find the minimum viable version. Cut everything else. Be ruthless."
+
+Once the user selects, COMMIT to that mode. Do not silently drift.
+
+## Step 2: Problem Challenge
+
+Regardless of mode, ask these questions internally before proceeding (do not skip):
+
+1. **Is this the right problem?** Could the symptom being fixed have a different root cause?
+2. **Is there a simpler solution?** Could a 10-line fix replace a 200-line feature?
+3. **Does this already exist?** Grep for related code. Check `docs/feature-ideas.md` and open GitHub issues.
+4. **What's the reversal cost?** Apply the gate:
+   - "Can I rip this out in an hour?" → 80% confidence, go
+   - Load-bearing for 6+ months (auth, data model, storage, API contracts) → flag it, sketch 2-3 approaches before committing → trigger `EnterPlanMode`
+
+## Step 3: Mode Execution
+
+### Mode A — Scope Expansion
+- Identify 3-5 scope expansions that would make this significantly better
+- For EACH expansion, use AskUserQuestion: state what it adds, estimated effort (S/M/L), risk level
+- Never batch expansions into one question
+- Accepted expansions become part of the scope; rejected ones go to "NOT in scope" list
+
+### Mode B — Selective Expansion
+- First: make the current scope bulletproof (same as Mode C)
+- Then: surface expansion opportunities one at a time via AskUserQuestion
+- Neutral posture — present the option, state effort + risk, let the user decide
+
+### Mode C — Hold Scope
+- Accept the scope. Focus entirely on making it unbreakable:
+  - What are the failure modes?
+  - What edge cases aren't handled?
+  - What's the error path for each external call?
+  - What observability exists? (logging, metrics, SignalR progress events)
+  - What happens if MongoDB is unavailable mid-operation?
+  - What happens if the processing engine times out?
+
+### Mode D — Scope Reduction
+- What is the absolute core outcome?
+- Strip everything that isn't the core
+- List what was cut and why
+- Confirm the stripped version still solves the user's actual need
+
+## Step 4: Stack-Specific Landmine Check
+
+For any plan touching the JWST stack, check:
+
+**Frontend (React/TypeScript)**
+- Are new components needed or can existing ones be extended?
+- Does this add props to shared components? Check downstream consumers.
+- Are E2E tests affected? (`grep -r` in `e2e/` for related selectors)
+
+**Backend (.NET)**
+- Does this touch auth? → Full review required, flag to user
+- Does this add/change an API endpoint? → Requires docs update (key-files.md, standards)
+- Does this change a DTO shape? → Check frontend consumers
+
+**Processing Engine (Python)**
+- Does this change the job tracker interface? → Check SignalR events
+- Does this affect reproject/combine? → Verify `combine_function` is one of: mean, sum, first, last, min, max (NOT median)
+
+**Data Model (MongoDB)**
+- Does this add/change a collection schema? → Load-bearing, requires EnterPlanMode
+- Does this add indexes? → Check existing index definitions first
+
+## Step 5: Required Outputs
+
+Produce:
+
+1. **Assessment** — 2-3 sentences on whether this is the right approach
+2. **Risks identified** — bulleted list with severity (HIGH/MED/LOW)
+3. **NOT in scope** — explicit list of related things that were considered and excluded
+4. **What already exists** — any related code found during grep
+5. **Recommendation** — proceed as-is / proceed with changes / needs EnterPlanMode before starting
+
+If the plan requires EnterPlanMode (load-bearing change), say so explicitly and trigger it.
+
+## Formatting Rules
+
+- Use AskUserQuestion for every scope opt-in/opt-out — never make scope decisions silently
+- One issue per AskUserQuestion — never batch unrelated decisions
+- Label questions: "EXPANSION-1", "RISK-1", "DECISION-1" etc. for reference
+- Be direct. No rubber-stamping. If the plan has a flaw, say so.

--- a/.claude/skills/plan-eng-review/SKILL.md
+++ b/.claude/skills/plan-eng-review/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: plan-eng-review
+description: Staff-engineer-mode plan review. Challenges architecture, catches complexity traps, produces a test plan artifact, and ensures implementation is clean before a single line is written. Use before any medium+ complexity implementation. Triggers on "eng review", "architecture review", "review this plan", "/plan-eng-review".
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - AskUserQuestion
+  - EnterPlanMode
+---
+
+# Plan: Engineering Review
+
+Engineering preferences that guide this review:
+- **DRY** — don't repeat logic; extract shared behavior
+- **Well-tested** — new behavior gets tests; edge cases are covered
+- **Explicit > clever** — readable code beats clever code
+- **Minimal diff** — solve the problem, don't refactor the neighborhood
+
+**Detect base branch:**
+```bash
+git -C /Users/shanon/Source/Astronomy symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"
+```
+
+---
+
+## Step 0: Scope Challenge
+
+Before reviewing the plan itself, challenge its scope:
+
+**Complexity gate**: If the plan touches more than 8 files OR introduces more than 2 new classes/services, it's a large change. Flag this immediately and verify the user wants to proceed at this scope vs. a smaller slice.
+
+**Completeness check**: Is the plan complete enough to implement without mid-implementation decisions? List any under-specified areas.
+
+**Existing work check**: Grep the codebase for existing implementations that overlap:
+```bash
+# Adapt these to the specific feature being reviewed
+grep -r "relevant-term" /Users/shanon/Source/Astronomy/backend/src --include="*.cs" -l
+grep -r "relevant-term" /Users/shanon/Source/Astronomy/frontend/jwst-frontend/src --include="*.tsx" -l
+```
+
+**TODOS cross-reference**: Check if related items exist in `docs/development-plan.md` or `docs/tech-debt.md`.
+
+---
+
+## Step 1: Architecture Review
+
+Evaluate the proposed architecture:
+
+### Structure
+- Is the layer separation clean? (Controller → Service → Repository, no business logic in controllers)
+- Are DTOs used at the API boundary? (snake_case backend, camelCase frontend — verify no leakage)
+- Is the dependency injection pattern followed?
+- Does this introduce any circular dependencies?
+
+### Data Flow
+- Trace the data flow end-to-end: HTTP request → controller → service → repository → MongoDB → response
+- For async operations: how does job progress get reported? (Must use IJobTracker + SignalR)
+- For Python processing: how does the .NET backend communicate? (HTTP to processing engine)
+
+### JWST Stack Specifics
+- **New API endpoint?** → Needs route, controller action, service method, DTO, docs update
+- **New MongoDB collection/index?** → Requires schema design review (load-bearing — trigger EnterPlanMode)
+- **New React component?** → Follows collapsible panel pattern? Fits existing component hierarchy?
+- **New Python processing step?** → Fits pipeline stage model? Uses correct combine_function values?
+
+### Failure Modes
+List every external call or I/O operation and answer: "What happens if this fails?"
+- MongoDB unavailable
+- Processing engine timeout / OOM
+- MAST API rate limit or downtime
+- File system full during FITS processing
+- SignalR disconnect mid-job
+
+---
+
+## Step 2: Code Quality Preview
+
+Without seeing the code yet, predict quality risks based on the plan:
+
+- **Over-engineering risk**: Is the proposed solution more complex than the problem warrants?
+- **Under-engineering risk**: Is it taking a shortcut that creates tech debt?
+- **Test surface**: What's hard to test in this design? Can the design be tweaked to make it more testable?
+- **Naming clarity**: Are the proposed names (endpoints, services, components) unambiguous?
+
+---
+
+## Step 3: Test Plan Artifact
+
+Produce a concrete test plan as a structured artifact:
+
+```
+TEST PLAN — [Feature Name]
+
+Unit Tests:
+- [ ] [service/component]: [what behavior is tested]
+- [ ] [service/component]: [edge case]
+
+Integration Tests:
+- [ ] [endpoint or flow]: [happy path]
+- [ ] [endpoint or flow]: [error path]
+
+E2E Tests (if UI change):
+- [ ] [user action]: [expected result]
+- [ ] [user action]: [expected result with error state]
+
+Manual Verification:
+- [ ] [specific thing to click/observe in the running app]
+- [ ] [Docker rebuild required? yes/no]
+```
+
+---
+
+## Step 4: Performance Considerations
+
+- Does this add any N+1 query patterns? (loading related docs in a loop)
+- Does this block the request thread during heavy processing? (should be async + job queue)
+- Does this load unbounded data? (large FITS files, full collection scans)
+- Does this affect any hot paths? (observation list loading, composite generation)
+
+---
+
+## Step 5: AskUserQuestion Loop
+
+For each significant architectural decision or risk found, ask one question at a time:
+
+- Label: "ARCH-1", "RISK-1", "DECISION-1"
+- State the issue, the options, and your recommendation
+- Never batch unrelated decisions into one question
+- If a decision is load-bearing (auth, data model, storage, API contract) — recommend EnterPlanMode before proceeding
+
+---
+
+## Step 6: Required Outputs
+
+1. **Complexity assessment** — simple / medium / large + whether scope reduction is warranted
+2. **Architecture verdict** — sound / needs changes / blocked (with specific blockers)
+3. **Unresolved decisions** — list of open questions that must be answered before implementing
+4. **NOT in scope** — explicit list of related things excluded from this plan
+5. **Test plan artifact** — as structured above
+6. **Docs update checklist** — which docs need updating when this ships:
+   - `docs/key-files.md`
+   - `docs/standards/backend-development.md` or `frontend-development.md`
+   - `docs/architecture/`
+   - `docs/quick-reference.md`
+   - `docs/development-plan.md`
+
+If EnterPlanMode is warranted, say so explicitly and trigger it.

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: retro
+description: Git velocity retrospective. Analyzes commit history to surface velocity metrics, session patterns, hotspots, and what's slowing you down. Produces a tweetable summary. Use at end of a work session or weekly review. Triggers on "retro", "retrospective", "velocity check", "how productive was I", "/retro". Accepts optional time window argument (default 7d): /retro 24h, /retro 14d, /retro 30d.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+---
+
+# Retrospective — Velocity Analysis
+
+Parse the argument for a time window. Default: `7d`.
+- `/retro` → 7d
+- `/retro 24h` → 1 day
+- `/retro 14d` → 14 days
+- `/retro 30d` → 30 days
+- `/retro compare` → compare current 7d vs prior 7d
+
+**Repo root:** `/Users/shanon/Source/Astronomy`
+
+---
+
+## Step 1: Gather Raw Data (run all in parallel)
+
+```bash
+# Commits in window (author = Shanon or Co-Authored-By Claude)
+git -C /Users/shanon/Source/Astronomy log --oneline --since="TIME_WINDOW" --format="%H %ad %s" --date=short
+
+# Files changed per commit
+git -C /Users/shanon/Source/Astronomy log --since="TIME_WINDOW" --name-only --format="COMMIT:%H %s"
+
+# LOC stats
+git -C /Users/shanon/Source/Astronomy log --since="TIME_WINDOW" --shortstat --format="COMMIT:%H %s"
+
+# PRs merged (approximated by merge commits)
+git -C /Users/shanon/Source/Astronomy log --since="TIME_WINDOW" --merges --oneline
+
+# All branches touched
+git -C /Users/shanon/Source/Astronomy log --since="TIME_WINDOW" --format="%D" | grep -oE '(feature|fix|docs|refactor|test|chore|codex)/[^ ,]+' | sort | uniq
+
+# Commit timestamps for session detection
+git -C /Users/shanon/Source/Astronomy log --since="TIME_WINDOW" --format="%ad" --date=format:'%Y-%m-%d %H:%M'
+```
+
+---
+
+## Step 2: Core Metrics Table
+
+Compute and display:
+
+```
+VELOCITY METRICS — [start date] to [end date]
+════════════════════════════════════════════
+Total commits          [N]
+Merge commits          [N]  (= PRs shipped)
+Lines added            [N]
+Lines deleted          [N]
+Net LOC delta          [+/-N]
+Files changed          [N unique files]
+Active days            [N / N calendar days]
+Avg commits/day        [N]
+Avg LOC/day            [N]
+```
+
+---
+
+## Step 3: Session Detection
+
+Group commits into "sessions" — a session is a sequence of commits where no gap exceeds 90 minutes.
+
+Display:
+```
+WORK SESSIONS
+═════════════
+[Date]  [start time] – [end time]  ([duration])  [N commits]
+...
+
+Longest session:  [date]  [duration]
+Most productive:  [date]  [N commits, N LOC]
+```
+
+---
+
+## Step 4: Commit Type Breakdown
+
+Parse commit prefixes (feat/fix/docs/refactor/test/chore):
+
+```
+COMMIT TYPES
+════════════
+feat:      [N] commits  [████████░░]  [N%]
+fix:       [N] commits  [████░░░░░░]  [N%]
+refactor:  [N] commits  [███░░░░░░░]  [N%]
+docs:      [N] commits  [██░░░░░░░░]  [N%]
+test:      [N] commits  [█░░░░░░░░░]  [N%]
+chore:     [N] commits  [░░░░░░░░░░]  [N%]
+other:     [N] commits
+```
+
+Flag if `fix:` > 40% — may indicate reactive work or insufficient pre-implementation review.
+Flag if `test:` < 10% — test coverage may be falling behind.
+
+---
+
+## Step 5: File Hotspot Analysis
+
+Top 10 most-touched files in the window:
+
+```
+HOTSPOTS
+════════
+[N changes]  frontend/jwst-frontend/src/...
+[N changes]  backend/src/...
+[N changes]  ...
+```
+
+Flag hotspots that appear in >50% of commits — these are churn candidates worth extracting or stabilizing.
+
+---
+
+## Step 6: Branch Health
+
+```
+BRANCHES IN WINDOW
+══════════════════
+[branch name]  [status: merged/open/stale]  [age]  [commits]
+```
+
+Flag any branches open >7 days — these may be blocking forward progress.
+
+---
+
+## Step 7: What Slowed You Down
+
+Infer friction from the data:
+- Commits with message "fix:" within 2 hours of a "feat:" on the same files → regression pattern
+- Large gaps between sessions (>2 days) → blocked or context-switching
+- High churn on same files → unclear spec or complex refactor
+- Many small commits on same feature → may indicate iterative struggle
+
+Surface as:
+```
+FRICTION SIGNALS
+════════════════
+[signal type]: [evidence from git log]
+```
+
+---
+
+## Step 8: Ship of the Week
+
+Identify the single most impactful merged PR (by LOC, file breadth, or commit description). Write one sentence about it.
+
+---
+
+## Step 9: Tweetable Summary
+
+Write a 1-3 sentence summary that a developer would find satisfying to read. Include:
+- Key wins
+- One honest friction point
+- One pattern to repeat or avoid
+
+Format:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[Tweetable summary here]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## Step 10: Save Snapshot (optional)
+
+If the user says "save" or the window is 7d+, write a snapshot:
+
+```bash
+mkdir -p /Users/shanon/Source/Astronomy/.claude/retros
+# Write JSON snapshot to .claude/retros/YYYY-MM-DD.json
+```
+
+Fields: date, window, commits, locs_added, locs_deleted, active_days, sessions, top_files, friction_signals, summary.

--- a/.claude/skills/ux-designer/ACCESSIBILITY.md
+++ b/.claude/skills/ux-designer/ACCESSIBILITY.md
@@ -1,0 +1,828 @@
+# Accessibility Reference
+
+Comprehensive guide for implementing accessible interfaces following WCAG 2.1 AA standards.
+
+## Core Principles (POUR)
+
+### Perceivable
+Information and UI components must be presentable to users in ways they can perceive.
+
+### Operable
+UI components and navigation must be operable by all users.
+
+### Understandable
+Information and the operation of UI must be understandable.
+
+### Robust
+Content must be robust enough to be interpreted by a wide variety of user agents, including assistive technologies.
+
+## Semantic HTML
+
+### Use Appropriate Elements
+
+**Good:**
+```tsx
+<header>
+  <nav>
+    <ul>
+      <li><a href="/">Home</a></li>
+      <li><a href="/about">About</a></li>
+    </ul>
+  </nav>
+</header>
+
+<main>
+  <article>
+    <h1>Article Title</h1>
+    <p>Article content...</p>
+  </article>
+</main>
+
+<footer>
+  <p>&copy; 2025 Company Name</p>
+</footer>
+```
+
+**Bad:**
+```tsx
+<div class="header">
+  <div class="nav">
+    <div class="link">Home</div>
+    <div class="link">About</div>
+  </div>
+</div>
+```
+
+### Heading Hierarchy
+
+**Correct hierarchy:**
+```tsx
+<h1>Page Title</h1>
+  <h2>Section 1</h2>
+    <h3>Subsection 1.1</h3>
+    <h3>Subsection 1.2</h3>
+  <h2>Section 2</h2>
+    <h3>Subsection 2.1</h3>
+```
+
+**Incorrect (skips levels):**
+```tsx
+<h1>Page Title</h1>
+  <h4>Section 1</h4>  // ❌ Skips h2 and h3
+```
+
+## Keyboard Navigation
+
+### Focus Management
+
+```tsx
+// Ensure all interactive elements are keyboard accessible
+<button
+  className="
+    px-4 py-2
+    focus:outline-none
+    focus:ring-4 focus:ring-blue-500
+    focus:ring-offset-2
+    rounded-lg
+  "
+  tabIndex={0}
+>
+  Accessible Button
+</button>
+
+// Custom interactive elements need tabindex
+<div
+  role="button"
+  tabIndex={0}
+  onClick={handleClick}
+  onKeyDown={(e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      handleClick();
+    }
+  }}
+  className="cursor-pointer focus:ring-4 focus:ring-blue-500"
+>
+  Custom Button
+</div>
+```
+
+### Tab Order
+
+```tsx
+// Use tabIndex to control focus order
+<form>
+  <input tabIndex={1} aria-label="First name" />
+  <input tabIndex={2} aria-label="Last name" />
+  <input tabIndex={3} aria-label="Email" />
+  <button tabIndex={4}>Submit</button>
+</form>
+
+// Use tabIndex={-1} to remove from tab order but allow programmatic focus
+<div tabIndex={-1} id="error-message">
+  Error details...
+</div>
+```
+
+### Skip Links
+
+```tsx
+// Allow keyboard users to skip to main content
+<a
+  href="#main-content"
+  className="
+    sr-only
+    focus:not-sr-only
+    focus:absolute
+    focus:top-4 focus:left-4
+    focus:z-50
+    focus:px-4 focus:py-2
+    focus:bg-blue-600 focus:text-white
+    focus:rounded-lg
+  "
+>
+  Skip to main content
+</a>
+
+<main id="main-content">
+  {/* Main content */}
+</main>
+```
+
+## ARIA Attributes
+
+### Common ARIA Roles
+
+```tsx
+// Navigation landmark
+<nav role="navigation" aria-label="Main navigation">
+  {/* Navigation items */}
+</nav>
+
+// Banner (header)
+<header role="banner">
+  {/* Header content */}
+</header>
+
+// Main content
+<main role="main">
+  {/* Main content */}
+</main>
+
+// Complementary (sidebar)
+<aside role="complementary" aria-label="Related articles">
+  {/* Sidebar content */}
+</aside>
+
+// Content info (footer)
+<footer role="contentinfo">
+  {/* Footer content */}
+</footer>
+
+// Search
+<form role="search" aria-label="Site search">
+  <input type="search" aria-label="Search query" />
+  <button type="submit">Search</button>
+</form>
+```
+
+### ARIA Labels
+
+```tsx
+// aria-label for elements without visible text
+<button aria-label="Close dialog">
+  <X size={24} />
+</button>
+
+// aria-labelledby to reference another element
+<div role="dialog" aria-labelledby="dialog-title">
+  <h2 id="dialog-title">Confirm Action</h2>
+  <p>Are you sure you want to continue?</p>
+</div>
+
+// aria-describedby for additional description
+<input
+  type="password"
+  aria-describedby="password-requirements"
+/>
+<p id="password-requirements">
+  Password must be at least 8 characters
+</p>
+```
+
+### ARIA States
+
+```tsx
+// aria-expanded for expandable elements
+<button
+  aria-expanded={isOpen}
+  aria-controls="dropdown-menu"
+  onClick={() => setIsOpen(!isOpen)}
+>
+  Menu {isOpen ? <ChevronUp /> : <ChevronDown />}
+</button>
+<div id="dropdown-menu" hidden={!isOpen}>
+  {/* Dropdown content */}
+</div>
+
+// aria-pressed for toggle buttons
+<button
+  aria-pressed={isPressed}
+  onClick={() => setIsPressed(!isPressed)}
+>
+  {isPressed ? 'Pressed' : 'Not Pressed'}
+</button>
+
+// aria-selected for selectable items
+<div role="tab" aria-selected={isActive}>
+  Tab 1
+</div>
+
+// aria-checked for checkboxes/radio buttons
+<div
+  role="checkbox"
+  aria-checked={isChecked}
+  tabIndex={0}
+  onClick={() => setIsChecked(!isChecked)}
+>
+  Custom Checkbox
+</div>
+```
+
+### ARIA Live Regions
+
+```tsx
+// Announce changes to screen readers
+<div
+  role="status"
+  aria-live="polite"
+  aria-atomic="true"
+>
+  {statusMessage}
+</div>
+
+// For urgent announcements
+<div
+  role="alert"
+  aria-live="assertive"
+  aria-atomic="true"
+>
+  {errorMessage}
+</div>
+
+// For form validation
+<input
+  type="email"
+  aria-invalid={hasError}
+  aria-describedby={hasError ? 'email-error' : undefined}
+/>
+{hasError && (
+  <p id="email-error" role="alert">
+    Please enter a valid email address
+  </p>
+)}
+```
+
+## Color Contrast
+
+### Minimum Contrast Ratios (WCAG AA)
+
+- **Normal text:** 4.5:1
+- **Large text (18pt+ or 14pt+ bold):** 3:1
+- **UI components and graphics:** 3:1
+
+### Good Contrast Examples
+
+```tsx
+// High contrast text
+<p className="text-slate-900 bg-white">
+  Great contrast (21:1)
+</p>
+
+<p className="text-slate-700 bg-white">
+  Good contrast (8:1)
+</p>
+
+// Button with good contrast
+<button className="
+  bg-blue-600 text-white
+  hover:bg-blue-700
+">
+  High Contrast Button (4.5:1)
+</button>
+```
+
+### Poor Contrast Examples (Avoid)
+
+```tsx
+// ❌ Insufficient contrast
+<p className="text-gray-400 bg-white">
+  Poor contrast (2.8:1) - fails WCAG AA
+</p>
+
+// ❌ Don't rely on color alone
+<button className="bg-red-500 text-white">
+  Error Button (color alone indicates state)
+</button>
+
+// ✅ Better: Use icons + color
+<button className="bg-red-500 text-white flex items-center gap-2">
+  <AlertCircle size={20} />
+  Error: Fix Issues
+</button>
+```
+
+### Tools for Checking Contrast
+
+- Chrome DevTools: Inspect element → Accessibility tab
+- Online: WebAIM Contrast Checker
+- Figma: Stark plugin
+
+## Alternative Text
+
+### Images
+
+```tsx
+// Informative images
+<img
+  src="chart.png"
+  alt="Bar chart showing sales increased 40% in Q4 2025"
+/>
+
+// Decorative images
+<img
+  src="decoration.png"
+  alt=""
+  role="presentation"
+/>
+
+// Functional images (buttons)
+<button aria-label="Search">
+  <img src="search-icon.png" alt="" />
+</button>
+
+// Complex images
+<figure>
+  <img
+    src="complex-diagram.png"
+    alt="System architecture diagram"
+    aria-describedby="diagram-description"
+  />
+  <figcaption id="diagram-description">
+    Detailed description of the system architecture showing
+    three main components: frontend, API layer, and database.
+    The frontend communicates with the API via REST...
+  </figcaption>
+</figure>
+```
+
+### Icons
+
+```tsx
+import { MagnifyingGlass, Bell, User } from '@phosphor-icons/react';
+
+// Decorative icons (with adjacent text)
+<button className="flex items-center gap-2">
+  <MagnifyingGlass aria-hidden="true" />
+  Search
+</button>
+
+// Functional icons (no adjacent text)
+<button aria-label="Search">
+  <MagnifyingGlass />
+</button>
+
+// Icons with state
+<button aria-label="Notifications (3 unread)">
+  <Bell />
+  <span className="sr-only">3 unread notifications</span>
+  <span aria-hidden="true" className="badge">3</span>
+</button>
+```
+
+## Forms
+
+### Labels and Instructions
+
+```tsx
+// Always associate labels with inputs
+<div>
+  <label htmlFor="email" className="block mb-1 font-medium">
+    Email Address
+  </label>
+  <input
+    id="email"
+    type="email"
+    required
+    aria-required="true"
+    className="w-full px-4 py-2 border rounded-lg"
+  />
+</div>
+
+// Group related inputs
+<fieldset>
+  <legend className="font-medium mb-2">Contact Preferences</legend>
+  <div className="space-y-2">
+    <label className="flex items-center gap-2">
+      <input type="checkbox" name="email" />
+      Email
+    </label>
+    <label className="flex items-center gap-2">
+      <input type="checkbox" name="sms" />
+      SMS
+    </label>
+  </div>
+</fieldset>
+```
+
+### Error Handling
+
+```tsx
+<div>
+  <label htmlFor="password" className="block mb-1 font-medium">
+    Password
+  </label>
+  <input
+    id="password"
+    type="password"
+    aria-invalid={hasError}
+    aria-describedby="password-requirements password-error"
+    className={`
+      w-full px-4 py-2 border rounded-lg
+      ${hasError ? 'border-red-500' : 'border-slate-300'}
+    `}
+  />
+  <p id="password-requirements" className="text-sm text-slate-600 mt-1">
+    Must be at least 8 characters
+  </p>
+  {hasError && (
+    <p id="password-error" role="alert" className="text-sm text-red-600 mt-1">
+      <AlertCircle className="inline" size={16} />
+      Password is too short
+    </p>
+  )}
+</div>
+```
+
+### Required Fields
+
+```tsx
+// Indicate required fields clearly
+<label htmlFor="name" className="block mb-1 font-medium">
+  Full Name
+  <span className="text-red-600" aria-label="required">*</span>
+</label>
+<input
+  id="name"
+  type="text"
+  required
+  aria-required="true"
+  className="w-full px-4 py-2 border rounded-lg"
+/>
+
+// Or use text
+<label htmlFor="email" className="block mb-1 font-medium">
+  Email
+  <span className="text-sm font-normal text-slate-600">(required)</span>
+</label>
+```
+
+## Screen Reader-Only Content
+
+### sr-only Class
+
+```css
+/* Add to your CSS */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.focus\:not-sr-only:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: inherit;
+  margin: inherit;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+```
+
+### Usage Examples
+
+```tsx
+// Add context for screen readers
+<button>
+  <Heart />
+  <span className="sr-only">Add to favorites</span>
+</button>
+
+// Provide additional context
+<div>
+  <h2>Products</h2>
+  <span className="sr-only">Showing 24 of 100 results</span>
+</div>
+
+// Skip link
+<a href="#main" className="sr-only focus:not-sr-only">
+  Skip to main content
+</a>
+```
+
+## Focus Indicators
+
+### Visible Focus States
+
+```tsx
+// Default focus with ring
+<button className="
+  px-4 py-2 rounded-lg
+  bg-blue-600 text-white
+  focus:outline-none
+  focus:ring-4 focus:ring-blue-500
+  focus:ring-offset-2
+">
+  Click Me
+</button>
+
+// Custom focus style
+<a
+  href="/page"
+  className="
+    underline
+    focus:outline-none
+    focus:ring-2 focus:ring-blue-500
+    focus:rounded
+  "
+>
+  Link Text
+</a>
+
+// Focus within containers
+<div className="
+  p-4 border border-slate-300 rounded-lg
+  focus-within:ring-4 focus-within:ring-blue-500
+  focus-within:border-blue-500
+">
+  <input type="text" className="w-full focus:outline-none" />
+</div>
+```
+
+### Focus Management in Modals
+
+```tsx
+import { useEffect, useRef } from 'react';
+
+function Modal({ isOpen, onClose, children }) {
+  const modalRef = useRef(null);
+  const previousFocus = useRef(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Store current focus
+      previousFocus.current = document.activeElement;
+
+      // Focus modal
+      modalRef.current?.focus();
+
+      // Trap focus within modal
+      const handleTab = (e) => {
+        if (e.key === 'Tab') {
+          const focusableElements = modalRef.current.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          );
+          const firstElement = focusableElements[0];
+          const lastElement = focusableElements[focusableElements.length - 1];
+
+          if (e.shiftKey && document.activeElement === firstElement) {
+            e.preventDefault();
+            lastElement.focus();
+          } else if (!e.shiftKey && document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement.focus();
+          }
+        }
+      };
+
+      document.addEventListener('keydown', handleTab);
+      return () => document.removeEventListener('keydown', handleTab);
+    } else {
+      // Restore focus
+      previousFocus.current?.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        className="bg-white rounded-lg p-6 max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+        <button
+          onClick={onClose}
+          className="mt-4 px-4 py-2 bg-slate-200 rounded-lg"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+## Testing Checklist
+
+### Automated Testing
+
+```bash
+# Install axe-core for accessibility testing
+npm install --save-dev @axe-core/react
+
+# Use in tests
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+test('should have no accessibility violations', async () => {
+  const { container } = render(<MyComponent />);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});
+```
+
+### Manual Testing
+
+**Keyboard Navigation:**
+- [ ] Can navigate entire site using Tab key
+- [ ] Can activate all interactive elements with Enter/Space
+- [ ] Focus indicators are clearly visible
+- [ ] No keyboard traps
+- [ ] Logical tab order
+
+**Screen Reader Testing:**
+- [ ] Test with NVDA (Windows) or VoiceOver (Mac)
+- [ ] All images have appropriate alt text
+- [ ] Headings create logical structure
+- [ ] Forms have proper labels
+- [ ] Dynamic content is announced
+
+**Visual Testing:**
+- [ ] Text has sufficient contrast (4.5:1 minimum)
+- [ ] UI works at 200% zoom
+- [ ] Content reflows properly on mobile
+- [ ] No information conveyed by color alone
+- [ ] Focus indicators are visible
+
+**Tools to Use:**
+- Chrome DevTools Lighthouse
+- WAVE browser extension
+- axe DevTools browser extension
+- Color contrast analyzer
+- Screen reader (NVDA/VoiceOver)
+
+## Common Patterns
+
+### Accessible Modal
+
+```tsx
+<div
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="modal-title"
+  aria-describedby="modal-description"
+  className="fixed inset-0 z-50 flex items-center justify-center"
+>
+  <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+  <div className="relative bg-white rounded-lg p-6 max-w-md">
+    <h2 id="modal-title" className="text-xl font-bold mb-2">
+      Confirm Action
+    </h2>
+    <p id="modal-description" className="text-slate-600 mb-4">
+      Are you sure you want to proceed?
+    </p>
+    <div className="flex gap-4">
+      <button
+        onClick={onConfirm}
+        className="px-4 py-2 bg-blue-600 text-white rounded-lg"
+      >
+        Confirm
+      </button>
+      <button
+        onClick={onClose}
+        className="px-4 py-2 border border-slate-300 rounded-lg"
+      >
+        Cancel
+      </button>
+    </div>
+  </div>
+</div>
+```
+
+### Accessible Tabs
+
+```tsx
+function Tabs({ tabs }) {
+  const [activeTab, setActiveTab] = useState(0);
+
+  return (
+    <div>
+      <div role="tablist" aria-label="Content sections">
+        {tabs.map((tab, index) => (
+          <button
+            key={index}
+            role="tab"
+            aria-selected={activeTab === index}
+            aria-controls={`panel-${index}`}
+            id={`tab-${index}`}
+            tabIndex={activeTab === index ? 0 : -1}
+            onClick={() => setActiveTab(index)}
+            className={`
+              px-4 py-2 border-b-2
+              ${activeTab === index
+                ? 'border-blue-600 font-medium'
+                : 'border-transparent'
+              }
+            `}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {tabs.map((tab, index) => (
+        <div
+          key={index}
+          role="tabpanel"
+          id={`panel-${index}`}
+          aria-labelledby={`tab-${index}`}
+          hidden={activeTab !== index}
+          className="p-4"
+        >
+          {tab.content}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+### Accessible Tooltip
+
+```tsx
+function Tooltip({ text, children }) {
+  const [isVisible, setIsVisible] = useState(false);
+  const tooltipId = useId();
+
+  return (
+    <div className="relative inline-block">
+      <button
+        aria-describedby={isVisible ? tooltipId : undefined}
+        onMouseEnter={() => setIsVisible(true)}
+        onMouseLeave={() => setIsVisible(false)}
+        onFocus={() => setIsVisible(true)}
+        onBlur={() => setIsVisible(false)}
+      >
+        {children}
+      </button>
+      {isVisible && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className="
+            absolute z-10 px-3 py-2
+            bg-slate-900 text-white text-sm
+            rounded-lg
+            bottom-full left-1/2 -translate-x-1/2 mb-2
+          "
+        >
+          {text}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+## Resources
+
+- [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
+- [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/)
+- [axe DevTools](https://www.deque.com/axe/devtools/)
+- [WAVE Browser Extension](https://wave.webaim.org/extension/)

--- a/.claude/skills/ux-designer/DESIGN-SYSTEM-TEMPLATE.md
+++ b/.claude/skills/ux-designer/DESIGN-SYSTEM-TEMPLATE.md
@@ -1,0 +1,577 @@
+# Design System Template
+
+Meta-framework for understanding what's fixed, project-specific, and adaptable in your design system.
+
+## Purpose
+
+This template helps you distinguish between:
+- **Fixed Elements**: Universal rules that never change
+- **Project-Specific Elements**: Filled in for each project based on brand
+- **Adaptable Elements**: Context-dependent implementations
+
+---
+
+## I. FIXED ELEMENTS
+
+These foundations remain consistent across all projects, regardless of brand or context.
+
+### 1. Spacing Scale
+
+**Fixed System:**
+```
+4px, 8px, 12px, 16px, 24px, 32px, 48px, 64px, 96px
+```
+
+**Usage:**
+- Margins, padding, gaps between elements
+- Mathematical relationships ensure visual harmony
+- Use multipliers of base unit (4px)
+
+**Why Fixed:**
+Consistent spacing creates visual rhythm regardless of brand personality.
+
+### 2. Grid System
+
+**Fixed Structure:**
+- **12-column grid** for most layouts (divisible by 2, 3, 4, 6)
+- **16-column grid** for data-heavy interfaces
+- **Gutters**: 16px (mobile), 24px (tablet), 32px (desktop)
+
+**Why Fixed:**
+Grid provides structural order. Brand personality shows through color, typography, content—not grid structure.
+
+### 3. Accessibility Standards
+
+**Fixed Requirements:**
+- **WCAG 2.1 AA** compliance minimum
+- **Contrast**: 4.5:1 for normal text, 3:1 for large text
+- **Touch targets**: Minimum 44×44px
+- **Keyboard navigation**: All interactive elements accessible
+- **Screen reader**: Semantic HTML, ARIA labels where needed
+
+**Why Fixed:**
+Accessibility is not negotiable. It's a baseline requirement for ethical, legal, and usable products.
+
+### 4. Typography Hierarchy Logic
+
+**Fixed Structure:**
+- **Mathematical scaling**: 1.25x (major third) or 1.333x (perfect fourth)
+- **Hierarchy levels**: Display → H1 → H2 → H3 → Body → Small → Caption
+- **Line height**: 1.5x for body text, 1.2-1.3x for headlines
+- **Line length**: 45-75 characters optimal
+
+**Why Fixed:**
+Mathematical relationships create predictable, harmonious hierarchy. Specific fonts change, but the logic doesn't.
+
+### 5. Component Architecture
+
+**Fixed Patterns:**
+- **Button states**: Default, Hover, Active, Focus, Disabled
+- **Form structure**: Label above input, error below, helper text optional
+- **Modal pattern**: Overlay + centered content + close mechanism
+- **Card structure**: Container → Header → Body → Footer (optional)
+
+**Why Fixed:**
+Users expect consistent component behavior. Architecture is fixed; appearance is project-specific.
+
+### 6. Animation Timing Framework
+
+**Fixed Physics Profiles:**
+- **Lightweight** (icons, chips): 150ms
+- **Standard** (cards, panels): 300ms
+- **Weighty** (modals, pages): 500ms
+
+**Fixed Easing:**
+- **Ease-out**: Entrances (fast start, slow end)
+- **Ease-in**: Exits (slow start, fast end)
+- **Ease-in-out**: Transitions (smooth both ends)
+
+**Why Fixed:**
+Natural physics feel consistent across brands. Duration and easing create that feeling.
+
+---
+
+## II. PROJECT-SPECIFIC ELEMENTS
+
+Fill in these for each project based on brand personality and purpose.
+
+### 1. Brand Color System
+
+**Template Structure:**
+
+```
+NEUTRALS (4-5 colors):
+- Background lightest: _______ (e.g., slate-50 or warm-white)
+- Surface: _______ (e.g., slate-100)
+- Border/divider: _______ (e.g., slate-300)
+- Text secondary: _______ (e.g., slate-600)
+- Text primary: _______ (e.g., slate-900)
+
+ACCENTS (1-3 colors):
+- Primary (main CTA): _______ (e.g., teal-500)
+- Secondary (alternative action): _______ (optional)
+- Status colors:
+  - Success: _______ (green-ish)
+  - Warning: _______ (amber-ish)
+  - Error: _______ (red-ish)
+  - Info: _______ (blue-ish)
+```
+
+**Questions to Answer:**
+- What emotion should the brand evoke? (Trust, excitement, calm, urgency)
+- Warm or cool neutrals?
+- Conservative or bold accents?
+
+**Examples:**
+
+**Project A: Fintech App**
+```
+Neutrals: Cool greys (slate-50 → slate-900)
+Primary: Deep blue (#0A2463) – trust, professionalism
+Success: Muted green (#10B981)
+Why: Financial products need trust, not playfulness
+```
+
+**Project B: Creative Community**
+```
+Neutrals: Warm greys with beige undertones
+Primary: Coral (#FF6B6B) – energy, creativity
+Success: Teal (#06D6A0) – fresh, unexpected
+Why: Creative spaces should feel inviting, not corporate
+```
+
+**Project C: Healthcare Platform**
+```
+Neutrals: Pure greys (minimal color temperature)
+Primary: Soft blue (#4A90E2) – calm, clinical
+Success: Medical green (#38A169)
+Why: Healthcare needs clarity and calm, not distraction
+```
+
+### 2. Typography Pairing
+
+**Template:**
+
+```
+HEADLINE FONT: _______
+- Weight: _______ (e.g., Bold 700)
+- Use case: H1, H2, display text
+- Personality: _______ (geometric/humanist/serif/etc.)
+
+BODY FONT: _______
+- Weight: _______ (e.g., Regular 400, Medium 500)
+- Use case: Paragraphs, UI text
+- Personality: _______ (neutral/readable/efficient)
+
+OPTIONAL ACCENT FONT: _______
+- Weight: _______
+- Use case: _______ (special headlines, callouts)
+```
+
+**Pairing Logic:**
+- Serif + Sans-serif (classic, editorial)
+- Geometric + Humanist (modern + warm)
+- Display + System (distinctive + efficient)
+
+**Examples:**
+
+**Project A: Editorial Platform**
+```
+Headline: Playfair Display (Serif, Bold 700)
+Body: Inter (Sans-serif, Regular 400)
+Why: Serif headlines = trustworthy, editorial feel
+```
+
+**Project B: Tech Startup**
+```
+Headline: DM Sans (Sans-serif, Bold 700)
+Body: DM Sans (Regular 400, Medium 500)
+Why: Single-font system = modern, efficient, cohesive
+```
+
+**Project C: Luxury Brand**
+```
+Headline: Cormorant Garamond (Serif, Light 300)
+Body: Lato (Sans-serif, Regular 400)
+Why: Elegant serif + readable sans = sophisticated
+```
+
+### 3. Tone of Voice
+
+**Template:**
+
+```
+BRAND PERSONALITY:
+- Formal ↔ Casual: _______ (1-10 scale)
+- Professional ↔ Friendly: _______ (1-10 scale)
+- Serious ↔ Playful: _______ (1-10 scale)
+- Authoritative ↔ Conversational: _______ (1-10 scale)
+
+MICROCOPY EXAMPLES:
+- Button label (submit form): _______
+- Error message (invalid email): _______
+- Success message (saved): _______
+- Empty state: _______
+
+ANIMATION PERSONALITY:
+- Speed: _______ (quick/moderate/slow)
+- Feel: _______ (precise/smooth/bouncy)
+```
+
+**Examples:**
+
+**Project A: Banking App**
+```
+Personality: Formal (8), Professional (9), Serious (8)
+Button: "Submit Application"
+Error: "Email address format is invalid"
+Success: "Application submitted successfully"
+Animation: Quick (precise, efficient, no-nonsense)
+```
+
+**Project B: Social App**
+```
+Personality: Casual (8), Friendly (9), Playful (7)
+Button: "Let's go!"
+Error: "Hmm, that email doesn't look right"
+Success: "Nice! You're all set 🎉"
+Animation: Moderate (smooth, friendly bounce)
+```
+
+### 4. Animation Speed & Feel
+
+**Template:**
+
+```
+SPEED PREFERENCE:
+- UI interactions: _______ (100-150ms / 150-200ms / 200-300ms)
+- State changes: _______ (200ms / 300ms / 400ms)
+- Page transitions: _______ (300ms / 500ms / 700ms)
+
+ANIMATION STYLE:
+- Easing preference: _______ (sharp / standard / bouncy)
+- Movement type: _______ (minimal / smooth / expressive)
+```
+
+**Examples:**
+
+**Project A: Trading Platform**
+```
+Speed: Fast (100ms UI, 200ms states, 300ms pages)
+Style: Sharp easing, minimal movement
+Why: Traders need speed, not distraction
+```
+
+**Project B: Wellness App**
+```
+Speed: Slow (200ms UI, 400ms states, 500ms pages)
+Style: Smooth easing, gentle movement
+Why: Calm, relaxing experience matches brand
+```
+
+---
+
+## III. ADAPTABLE ELEMENTS
+
+Context-dependent implementations that vary based on use case.
+
+### 1. Component Variations
+
+**Button Variants:**
+- **Primary**: Full background color (high emphasis)
+- **Secondary**: Outline only (medium emphasis)
+- **Tertiary**: Text only (low emphasis)
+- **Destructive**: Red-ish (danger actions)
+- **Ghost**: Minimal (navigation, toolbars)
+
+**Adaptation Rules:**
+- Primary: Main CTA, one per screen section
+- Secondary: Alternative actions
+- Tertiary: Less important actions, multiple allowed
+- Use brand colors, but hierarchy logic is fixed
+
+### 2. Responsive Breakpoints
+
+**Fixed Ranges:**
+- XS: 0-479px (small phones)
+- SM: 480-767px (large phones)
+- MD: 768-1023px (tablets)
+- LG: 1024-1439px (laptops)
+- XL: 1440px+ (desktop)
+
+**Adaptable Implementations:**
+
+**Simple Content Site:**
+```
+XS-SM: Single column
+MD: 2 columns
+LG-XL: 3 columns max
+Why: Content-focused, don't overwhelm
+```
+
+**Dashboard/Data App:**
+```
+XS: Collapsed, cards stack
+SM: Simplified sidebar
+MD: Full sidebar + main content
+LG-XL: Sidebar + main + right panel
+Why: Data apps need more screen real estate
+```
+
+### 3. Dark Mode Palette
+
+**Adaptation Strategy:**
+
+Not a simple inversion. Dark mode needs adjusted contrast:
+
+**Light Mode:**
+```
+Background: #FFFFFF (white)
+Text: #0F172A (slate-900) → 21:1 contrast
+```
+
+**Dark Mode (Adapted):**
+```
+Background: #0F172A (slate-900)
+Text: #E2E8F0 (slate-200) → 15.8:1 contrast (still AA, but softer)
+```
+
+**Why Adapt:**
+Pure white on pure black is too harsh. Dark mode needs slightly lower contrast for eye comfort.
+
+### 4. Loading States
+
+**Context-Dependent:**
+
+**Fast operations (<500ms):**
+- No loading indicator (feels instant)
+
+**Medium operations (500ms-2s):**
+- Spinner or skeleton screen
+
+**Long operations (>2s):**
+- Progress bar with percentage
+- Or: Skeleton + estimated time
+
+**Interactive Operations:**
+- Button shows spinner inside (don't disable, show state)
+
+### 5. Error Handling Strategy
+
+**Context-Dependent:**
+
+**Form Errors:**
+```
+Validate: On blur (after user leaves field)
+Display: Inline below field
+Recovery: Clear error on fix
+```
+
+**API Errors:**
+```
+Transient (network): Show retry button
+Permanent (404): Show helpful message + next steps
+Critical (500): Contact support option
+```
+
+**Data Errors:**
+```
+Missing: Show empty state with action
+Corrupt: Show error boundary with reload
+Invalid: Highlight + explain what's wrong
+```
+
+---
+
+## DECISION TREE
+
+When implementing a feature, ask:
+
+### Is this...
+
+**FIXED?**
+- Does it affect structure, accessibility, or universal UX?
+- Examples: Spacing scale, grid, contrast ratios, component architecture
+- **Action**: Use the fixed system, no variation
+
+**PROJECT-SPECIFIC?**
+- Does it express brand personality or purpose?
+- Examples: Colors, typography, tone of voice, animation feel
+- **Action**: Fill in the template for this project
+
+**ADAPTABLE?**
+- Does it depend on context, content, or use case?
+- Examples: Component variants, responsive behavior, error handling
+- **Action**: Choose appropriate variation based on context
+
+---
+
+## EXAMPLE: Implementing a "Submit" Button
+
+### Fixed Elements (Always the same):
+- Touch target: 44px minimum height
+- Padding: 16px horizontal (from spacing scale)
+- States: Default, Hover, Active, Focus, Disabled
+- Animation: 150ms ease-out (lightweight profile)
+
+### Project-Specific (Filled per project):
+- **Project A (Bank)**: Dark blue background, white text, "Submit Application"
+- **Project B (Social)**: Coral background, white text, "Let's Go!"
+- **Project C (Healthcare)**: Soft blue background, white text, "Continue"
+
+### Adaptable (Context-dependent):
+- **Form context**: Primary button (full color)
+- **Toolbar context**: Ghost button (text only)
+- **Danger context**: Destructive variant (red-ish)
+
+---
+
+## VALIDATION CHECKLIST
+
+Before finalizing a design, check:
+
+### Fixed Elements
+- [ ] Uses spacing scale (4/8/12/16/24/32/48/64/96px)
+- [ ] Follows grid system (12 or 16 columns)
+- [ ] Meets WCAG AA contrast (4.5:1 normal, 3:1 large)
+- [ ] Touch targets ≥ 44px
+- [ ] Typography follows mathematical scale
+- [ ] Components follow standard architecture
+
+### Project-Specific Elements
+- [ ] Brand colors filled in and intentional
+- [ ] Typography pairing chosen and justified
+- [ ] Tone of voice defined and consistent
+- [ ] Animation speed matches brand personality
+
+### Adaptable Elements
+- [ ] Component variants appropriate for context
+- [ ] Responsive behavior fits content type
+- [ ] Loading states match operation duration
+- [ ] Error handling fits error type
+
+---
+
+## PROJECT KICKOFF TEMPLATE
+
+Use this to start a new project:
+
+```
+PROJECT NAME: _______________________
+PURPOSE: ____________________________
+
+BRAND PERSONALITY:
+- Primary emotion: _______
+- Warm or cool: _______
+- Formal or casual: _______
+- Conservative or bold: _______
+
+COLORS (fill the template):
+- Neutral base: _______
+- Primary accent: _______
+- Status colors: _______ / _______ / _______
+
+TYPOGRAPHY (fill the template):
+- Headline font: _______
+- Body font: _______
+- Pairing rationale: _______
+
+TONE:
+- Button labels style: _______
+- Error message style: _______
+- Success message style: _______
+
+ANIMATION:
+- Speed preference: _______ (fast/moderate/slow)
+- Feel preference: _______ (sharp/smooth/bouncy)
+
+TARGET DEVICES:
+- Primary: _______ (mobile/desktop/both)
+- Secondary: _______
+```
+
+---
+
+## MAINTAINING CONSISTENCY
+
+### Documentation
+- Keep this template updated as system evolves
+- Document WHY choices were made, not just WHAT
+
+### Communication
+- Share with designers: "Here's what varies vs. what's fixed"
+- Share with developers: "Here are the design tokens"
+
+### Tooling
+- Use CSS variables for project-specific values
+- Use Tailwind config for spacing scale
+- Use design tokens in Figma/Storybook
+
+### Reviews
+- Audit: Does new work follow fixed elements?
+- Validate: Are project-specific elements intentional?
+- Question: Are adaptations justified by context?
+
+---
+
+## EXAMPLES OF COMPLETE SYSTEMS
+
+### System A: B2B SaaS (Conservative)
+
+**Fixed**: Standard spacing, 12-col grid, WCAG AA, major third type scale
+**Project-Specific**:
+- Colors: Cool greys + corporate blue
+- Typography: DM Sans (headlines + body)
+- Tone: Professional, formal
+- Animation: Quick, precise (150ms)
+**Adaptable**:
+- Dashboard gets multi-panel layout
+- Forms are extensive (use progressive disclosure)
+- Errors show detailed technical info
+
+### System B: Consumer Social App (Playful)
+
+**Fixed**: Same spacing/grid/accessibility/type logic
+**Project-Specific**:
+- Colors: Warm greys + vibrant coral
+- Typography: Poppins (headlines) + Inter (body)
+- Tone: Casual, friendly, playful
+- Animation: Moderate, bouncy (200ms)
+**Adaptable**:
+- Mobile-first (most users on phones)
+- Forms are minimal (progressive profiling)
+- Errors are friendly, not technical
+
+### System C: Healthcare Platform (Clinical)
+
+**Fixed**: Same foundational structure
+**Project-Specific**:
+- Colors: Pure greys + medical blue
+- Typography: System fonts (SF Pro / Segoe)
+- Tone: Clear, authoritative, calm
+- Animation: Slow, smooth (300ms)
+**Adaptable**:
+- Desktop-first (clinical use at workstations)
+- Forms are complex (HIPAA compliance)
+- Errors are precise with next steps
+
+---
+
+## KEY TAKEAWAY
+
+**The system flexibility framework lets you:**
+- Maintain consistency (fixed elements)
+- Express brand personality (project-specific)
+- Adapt to context (adaptable elements)
+
+**Without this framework:**
+- Designers reinvent spacing every project
+- Components feel inconsistent across products
+- Brand personality overrides accessibility
+- Context-blind implementations feel wrong
+
+**With this framework:**
+- Speed: Start from proven foundations
+- Consistency: Fixed elements guarantee it
+- Flexibility: Express unique brand identity
+- Context: Adapt without breaking system

--- a/.claude/skills/ux-designer/MOTION-SPEC.md
+++ b/.claude/skills/ux-designer/MOTION-SPEC.md
@@ -1,0 +1,544 @@
+# Motion Specification Template
+
+Detailed animation specifications for consistent motion design across projects.
+
+## Easing Curves
+
+### Standard Easings
+
+**Ease-out (Entrances)**
+```css
+cubic-bezier(0.0, 0.0, 0.2, 1)
+```
+Use for: Elements entering view, expanding, appearing
+
+**Ease-in (Exits)**
+```css
+cubic-bezier(0.4, 0.0, 1, 1)
+```
+Use for: Elements leaving view, collapsing, disappearing
+
+**Ease-in-out (Transitions)**
+```css
+cubic-bezier(0.4, 0.0, 0.2, 1)
+```
+Use for: State changes, transformations, element swaps
+
+**Linear (Continuous)**
+```css
+linear
+```
+Use for: Loading spinners, continuous animations, marquee scrolls
+
+### Custom Easings
+
+**Spring (Bouncy)**
+```css
+cubic-bezier(0.68, -0.55, 0.265, 1.55)
+```
+Use for: Playful interactions, game-like UIs, attention-grabbing
+
+**Sharp (Quick snap)**
+```css
+cubic-bezier(0.4, 0.0, 0.6, 1)
+```
+Use for: Mechanical interactions, precise movements
+
+## Duration Tables
+
+### By Interaction Type
+
+| Interaction | Duration | Easing | Example |
+|-------------|----------|--------|---------|
+| Button press | 100ms | ease-out | Background color change |
+| Hover state | 150ms | ease-out | Underline appearing |
+| Checkbox toggle | 150ms | ease-out | Checkmark animation |
+| Tooltip appear | 200ms | ease-out | Tooltip fade in |
+| Tab switch | 250ms | ease-in-out | Content swap |
+| Accordion expand | 300ms | ease-out | Height animation |
+| Modal open | 300ms | ease-out | Fade + scale up |
+| Modal close | 250ms | ease-in | Fade + scale down |
+| Page transition | 400ms | ease-in-out | Route change |
+| Sheet slide-in | 300ms | ease-out | Bottom sheet |
+| Toast notification | 300ms | ease-out | Slide in from top |
+
+### By Element Weight
+
+| Element Weight | Duration | Example |
+|----------------|----------|---------|
+| Lightweight (< 100px) | 150ms | Icons, badges, chips |
+| Standard (100-500px) | 300ms | Cards, panels, list items |
+| Weighty (> 500px) | 500ms | Modals, full-page transitions |
+
+## State-Specific Animations
+
+### Hover States
+
+**Button Hover:**
+```tsx
+// Tailwind
+<button className="
+  bg-blue-600 hover:bg-blue-700
+  transition-colors duration-150 ease-out
+">
+  Hover Me
+</button>
+
+// Framer Motion
+<motion.button
+  whileHover={{ scale: 1.02 }}
+  transition={{ duration: 0.15, ease: "easeOut" }}
+>
+  Hover Me
+</motion.button>
+```
+
+**Link Hover:**
+```tsx
+<a className="
+  underline-offset-4
+  hover:underline
+  transition-all duration-200 ease-out
+">
+  Link Text
+</a>
+```
+
+**Card Hover:**
+```tsx
+<div className="
+  transition-all duration-200 ease-out
+  hover:shadow-lg
+  hover:scale-[1.02]
+">
+  Card Content
+</div>
+```
+
+### Focus States
+
+**Keyboard Focus:**
+```tsx
+<button className="
+  focus:outline-none
+  focus:ring-4 focus:ring-blue-500
+  focus:ring-offset-2
+  transition-all duration-200 ease-out
+">
+  Focus Me
+</button>
+```
+
+**Input Focus:**
+```tsx
+<input className="
+  border-2 border-slate-300
+  focus:border-blue-500
+  focus:ring-4 focus:ring-blue-200
+  transition-all duration-200 ease-out
+" />
+```
+
+### Active/Pressed States
+
+**Button Press:**
+```tsx
+<motion.button
+  whileTap={{ scale: 0.98 }}
+  transition={{ duration: 0.1, ease: "easeIn" }}
+>
+  Press Me
+</motion.button>
+
+// CSS alternative
+<button className="
+  active:scale-98
+  transition-transform duration-100 ease-in
+">
+  Press Me
+</button>
+```
+
+### Disabled States
+
+**Disabled Button:**
+```tsx
+<button
+  disabled
+  className="
+    bg-slate-400 text-slate-600
+    opacity-50 cursor-not-allowed
+    pointer-events-none
+  "
+>
+  Disabled
+</button>
+```
+
+### Loading States
+
+**Loading Spinner:**
+```tsx
+<div className="
+  w-8 h-8 border-4 border-slate-300
+  border-t-blue-600 rounded-full
+  animate-spin
+">
+</div>
+
+// CSS
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+```
+
+**Skeleton Loader:**
+```tsx
+<div className="animate-pulse space-y-4">
+  <div className="h-4 bg-slate-200 rounded w-3/4"></div>
+  <div className="h-4 bg-slate-200 rounded w-1/2"></div>
+</div>
+
+// CSS
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.animate-pulse {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+```
+
+### Success Feedback
+
+**Checkmark Animation:**
+```tsx
+<motion.div
+  initial={{ opacity: 0, scale: 0.5 }}
+  animate={{ opacity: 1, scale: 1 }}
+  transition={{ duration: 0.3, ease: "easeOut" }}
+>
+  <CheckCircle className="text-green-600" size={48} />
+</motion.div>
+```
+
+**Toast Notification:**
+```tsx
+<motion.div
+  initial={{ y: -100, opacity: 0 }}
+  animate={{ y: 0, opacity: 1 }}
+  exit={{ y: -100, opacity: 0 }}
+  transition={{ duration: 0.3, ease: "easeOut" }}
+  className="bg-green-600 text-white p-4 rounded-lg"
+>
+  Success! Changes saved.
+</motion.div>
+```
+
+### Error Feedback
+
+**Shake Animation:**
+```tsx
+<motion.div
+  animate={{ x: [0, -4, 4, -4, 4, 0] }}
+  transition={{ duration: 0.3, ease: "easeInOut" }}
+  className="border-2 border-red-500"
+>
+  <input type="text" />
+</motion.div>
+
+// CSS alternative
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-4px); }
+  40%, 80% { transform: translateX(4px); }
+}
+
+.shake {
+  animation: shake 0.3s ease-in-out;
+}
+```
+
+**Error Message Slide-in:**
+```tsx
+<motion.div
+  initial={{ height: 0, opacity: 0 }}
+  animate={{ height: "auto", opacity: 1 }}
+  exit={{ height: 0, opacity: 0 }}
+  transition={{ duration: 0.2, ease: "easeOut" }}
+  className="text-red-600 text-sm"
+>
+  Please enter a valid email address
+</motion.div>
+```
+
+### Warning Feedback
+
+**Pulse Animation:**
+```tsx
+<motion.div
+  animate={{ scale: [1, 1.05, 1] }}
+  transition={{
+    duration: 0.6,
+    ease: "easeInOut",
+    repeat: Infinity
+  }}
+  className="border-2 border-amber-500"
+>
+  Warning Content
+</motion.div>
+```
+
+### Form Validation
+
+**Field Validation (On Blur):**
+```tsx
+// Validate on blur, not during typing
+<input
+  onBlur={(e) => {
+    const isValid = validateEmail(e.target.value);
+    setError(!isValid);
+  }}
+  className={`
+    border-2 transition-all duration-200 ease-out
+    ${error
+      ? 'border-red-500 focus:ring-red-200'
+      : 'border-slate-300 focus:ring-blue-200'
+    }
+  `}
+/>
+
+{error && (
+  <motion.p
+    initial={{ opacity: 0, y: -10 }}
+    animate={{ opacity: 1, y: 0 }}
+    className="text-red-600 text-sm mt-1"
+  >
+    Please enter a valid email
+  </motion.p>
+)}
+```
+
+## Common Animation Patterns
+
+### Fade In
+```tsx
+// Framer Motion
+<motion.div
+  initial={{ opacity: 0 }}
+  animate={{ opacity: 1 }}
+  transition={{ duration: 0.3, ease: "easeOut" }}
+>
+  Content
+</motion.div>
+
+// CSS
+.fade-in {
+  animation: fadeIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+```
+
+### Slide Up
+```tsx
+// Framer Motion
+<motion.div
+  initial={{ opacity: 0, y: 20 }}
+  animate={{ opacity: 1, y: 0 }}
+  transition={{ duration: 0.3, ease: "easeOut" }}
+>
+  Content
+</motion.div>
+
+// CSS
+.slide-up {
+  animation: slideUp 0.3s ease-out;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+```
+
+### Scale + Fade (Modal)
+```tsx
+// Framer Motion
+<motion.div
+  initial={{ opacity: 0, scale: 0.95 }}
+  animate={{ opacity: 1, scale: 1 }}
+  exit={{ opacity: 0, scale: 0.95 }}
+  transition={{ duration: 0.3, ease: "easeOut" }}
+>
+  Modal content
+</motion.div>
+```
+
+### Stagger Children
+```tsx
+// Framer Motion
+<motion.ul
+  initial="hidden"
+  animate="visible"
+  variants={{
+    visible: {
+      transition: {
+        staggerChildren: 0.1
+      }
+    }
+  }}
+>
+  {items.map(item => (
+    <motion.li
+      key={item.id}
+      variants={{
+        hidden: { opacity: 0, x: -20 },
+        visible: { opacity: 1, x: 0 }
+      }}
+    >
+      {item.name}
+    </motion.li>
+  ))}
+</motion.ul>
+```
+
+## Performance Checklist
+
+- [ ] Only animate `transform` and `opacity`
+- [ ] Avoid animating `width`, `height`, `top`, `left`, `margin`, `padding`
+- [ ] Test on mobile devices (target 60fps)
+- [ ] Use `will-change` only for complex animations
+- [ ] Implement `prefers-reduced-motion` media query
+- [ ] Keep animation duration under 500ms for UI interactions
+- [ ] Use CSS animations for simple transitions (better performance)
+- [ ] Use JS animation libraries for complex, choreographed sequences
+
+## Accessibility
+
+```css
+/* Disable or reduce animations for users who prefer less motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+**Implementation in React:**
+```tsx
+import { useReducedMotion } from 'framer-motion';
+
+function MyComponent() {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{
+        duration: shouldReduceMotion ? 0.01 : 0.3,
+        ease: "easeOut"
+      }}
+    >
+      Content
+    </motion.div>
+  );
+}
+```
+
+## Testing Animations
+
+1. **Test at 60fps** on target devices
+2. **Test with slow network** (does page still feel responsive?)
+3. **Test with reduced motion** preferences enabled
+4. **Verify animations don't block** critical user actions
+5. **Check that animations add value** (remove if purely decorative)
+6. **Test on low-end devices** (not just your development machine)
+7. **Measure performance** with Chrome DevTools Performance tab
+8. **Check for layout thrashing** (avoid reading and writing to DOM in same frame)
+
+## Animation & Gestalt Principles
+
+### Proximity
+Animated elements that are near each other should move together to reinforce grouping:
+```tsx
+// Animate card and its children together
+<motion.div
+  initial={{ opacity: 0, y: 20 }}
+  animate={{ opacity: 1, y: 0 }}
+>
+  <h3>Title</h3>
+  <p>Content</p>
+  <button>Action</button>
+</motion.div>
+```
+
+### Similarity
+Similar elements should have similar animation characteristics:
+```tsx
+// All buttons use same hover animation
+const buttonAnimation = {
+  whileHover: { scale: 1.02 },
+  transition: { duration: 0.15, ease: "easeOut" }
+};
+
+<motion.button {...buttonAnimation}>Button 1</motion.button>
+<motion.button {...buttonAnimation}>Button 2</motion.button>
+```
+
+### Continuity
+Movement should follow natural, smooth paths:
+```tsx
+// Smooth curve, not jumpy angles
+<motion.div
+  animate={{ x: [0, 50, 100], y: [0, -25, 0] }}
+  transition={{ duration: 1, ease: "easeInOut" }}
+/>
+```
+
+### Figure-Ground
+Important elements animate while backgrounds stay stable:
+```tsx
+// Background fades out, modal animates in
+<>
+  <motion.div
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 0.5 }}
+    className="fixed inset-0 bg-black"
+  />
+  <motion.div
+    initial={{ opacity: 0, scale: 0.95 }}
+    animate={{ opacity: 1, scale: 1 }}
+    className="fixed inset-0 flex items-center justify-center"
+  >
+    Modal Content
+  </motion.div>
+</>
+```
+
+## Resources
+
+- [Framer Motion Documentation](https://www.framer.com/motion/)
+- [CSS Easing Functions](https://easings.net/)
+- [Material Design Motion](https://m2.material.io/design/motion/)
+- [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)

--- a/.claude/skills/ux-designer/RESPONSIVE-DESIGN.md
+++ b/.claude/skills/ux-designer/RESPONSIVE-DESIGN.md
@@ -1,0 +1,604 @@
+# Responsive Design Reference
+
+Detailed reference for implementing responsive, mobile-first designs.
+
+## Mobile-First Approach
+
+Always start with mobile design, then progressively enhance for larger screens.
+
+**Why Mobile-First:**
+- Forces focus on essential content
+- Easier to scale up than scale down
+- Better performance on mobile devices
+- Aligns with usage patterns (mobile-first web)
+
+## Breakpoint Strategy
+
+### Standard Breakpoints
+
+```css
+/* Mobile First Approach */
+/* Base styles: 0-640px (mobile) */
+
+/* Small tablets and large phones */
+@media (min-width: 640px) { }
+
+/* Tablets */
+@media (min-width: 768px) { }
+
+/* Small laptops */
+@media (min-width: 1024px) { }
+
+/* Desktops */
+@media (min-width: 1280px) { }
+
+/* Large desktops */
+@media (min-width: 1536px) { }
+```
+
+### Specific Breakpoint Ranges
+
+| Range | Pixels | Target Devices | Layout Strategy |
+|-------|--------|----------------|-----------------|
+| **XS** | 0-479px | Small phones (iPhone SE, older Android) | Single column, stacked navigation, large touch targets (min 44px) |
+| **SM** | 480-767px | Large phones (iPhone 14, most modern phones) | Single column, simplified UI, bottom navigation, reduced complexity |
+| **MD** | 768-1023px | Tablets (iPad, Android tablets) | 2 columns possible, sidebar navigation, some desktop features |
+| **LG** | 1024-1439px | Small laptops, landscape tablets | Multi-column layouts, full navigation, desktop UI patterns |
+| **XL** | 1440px+ | Desktop monitors, large screens | Max-width containers, multi-panel layouts, advanced features visible |
+
+**Mobile Simplification Examples:**
+
+- **Navigation**: Hamburger menu (mobile) → Full nav bar (desktop)
+- **Forms**: Stacked fields (mobile) → Side-by-side fields (desktop)
+- **Content**: Single column (mobile) → Multi-column grid (desktop)
+- **Actions**: Fixed bottom bar (mobile) → Inline buttons (desktop)
+- **Tables**: Collapsed cards (mobile) → Full data table (desktop)
+- **Sidebars**: Hidden/collapsible (mobile) → Always visible (desktop)
+- **Filters**: Modal/drawer (mobile) → Sidebar panel (desktop)
+
+### Tailwind Responsive Classes
+
+```tsx
+<div className="
+  w-full          // mobile: full width
+  sm:w-1/2        // small: half width
+  md:w-1/3        // medium: third width
+  lg:w-1/4        // large: quarter width
+">
+  Responsive width
+</div>
+```
+
+## Responsive Images
+
+### Using srcset for Responsive Images
+
+```tsx
+<img
+  src="image-800w.jpg"
+  srcSet="
+    image-400w.jpg 400w,
+    image-800w.jpg 800w,
+    image-1200w.jpg 1200w
+  "
+  sizes="
+    (max-width: 640px) 100vw,
+    (max-width: 1024px) 50vw,
+    33vw
+  "
+  alt="Descriptive alt text"
+  loading="lazy"
+/>
+```
+
+### Next.js Image Component
+
+```tsx
+import Image from 'next/image';
+
+<Image
+  src="/hero-image.jpg"
+  alt="Descriptive alt text"
+  width={1200}
+  height={600}
+  priority // for above-the-fold images
+  className="w-full h-auto"
+/>
+```
+
+## Responsive Typography
+
+### Fluid Typography with Tailwind
+
+```tsx
+<h1 className="
+  text-3xl      // mobile: 30px
+  sm:text-4xl   // small: 36px
+  md:text-5xl   // medium: 48px
+  lg:text-6xl   // large: 60px
+">
+  Responsive Headline
+</h1>
+```
+
+### Fluid Typography with CSS Clamp
+
+```css
+h1 {
+  /* min: 2rem (32px), preferred: 5vw, max: 4rem (64px) */
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1.2;
+}
+
+p {
+  /* min: 1rem (16px), preferred: 2.5vw, max: 1.25rem (20px) */
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  line-height: 1.6;
+}
+```
+
+## Responsive Layouts
+
+### CSS Grid Responsive Pattern
+
+```tsx
+<div className="
+  grid
+  grid-cols-1        // mobile: 1 column
+  sm:grid-cols-2     // small: 2 columns
+  md:grid-cols-3     // medium: 3 columns
+  lg:grid-cols-4     // large: 4 columns
+  gap-4              // consistent gap
+">
+  {items.map(item => (
+    <Card key={item.id}>{item.content}</Card>
+  ))}
+</div>
+```
+
+### Flexbox Responsive Pattern
+
+```tsx
+<div className="
+  flex
+  flex-col           // mobile: stack vertically
+  md:flex-row        // medium+: horizontal layout
+  gap-6
+  items-center
+">
+  <div className="w-full md:w-1/2">Content Left</div>
+  <div className="w-full md:w-1/2">Content Right</div>
+</div>
+```
+
+## Touch-Friendly Interfaces
+
+### Touch Target Sizing
+
+```tsx
+// Minimum 44x44px touch targets
+<button className="
+  min-w-[44px]
+  min-h-[44px]
+  px-4 py-2
+  rounded-lg
+  touch-manipulation // prevents 300ms tap delay
+">
+  Tap Me
+</button>
+```
+
+### Touch Gestures
+
+```tsx
+// Consider common mobile gestures
+<div className="
+  overflow-x-auto    // horizontal scroll
+  snap-x             // snap scrolling
+  snap-mandatory
+  overscroll-contain // prevent bounce on mobile
+">
+  {/* Scrollable content */}
+</div>
+```
+
+## Navigation Patterns
+
+### Mobile Menu Pattern
+
+```tsx
+import { useState } from 'react';
+import { List, X } from '@phosphor-icons/react';
+
+export function MobileNav() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      {/* Mobile menu button */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="md:hidden p-2"
+        aria-label="Toggle menu"
+      >
+        {isOpen ? <X size={24} /> : <List size={24} />}
+      </button>
+
+      {/* Mobile menu overlay */}
+      {isOpen && (
+        <div className="
+          fixed inset-0 z-50 bg-white
+          md:hidden
+        ">
+          <nav className="p-6 space-y-4">
+            {/* Navigation items */}
+          </nav>
+        </div>
+      )}
+
+      {/* Desktop navigation */}
+      <nav className="hidden md:flex gap-6">
+        {/* Navigation items */}
+      </nav>
+    </>
+  );
+}
+```
+
+### Sticky Navigation
+
+```tsx
+<header className="
+  sticky top-0 z-40
+  bg-white/80
+  backdrop-blur-md
+  border-b border-slate-200
+">
+  <nav className="container mx-auto px-4 py-4">
+    {/* Navigation content */}
+  </nav>
+</header>
+```
+
+## Responsive Forms
+
+### Form Layout Pattern
+
+```tsx
+<form className="space-y-6">
+  {/* Full width on mobile, side-by-side on desktop */}
+  <div className="
+    grid
+    grid-cols-1
+    md:grid-cols-2
+    gap-4
+  ">
+    <div>
+      <label htmlFor="firstName" className="block text-sm font-medium mb-1">
+        First Name
+      </label>
+      <input
+        id="firstName"
+        type="text"
+        className="
+          w-full px-4 py-2
+          border border-slate-300
+          rounded-lg
+          focus:ring-2 focus:ring-blue-500
+          touch-manipulation
+        "
+      />
+    </div>
+
+    <div>
+      <label htmlFor="lastName" className="block text-sm font-medium mb-1">
+        Last Name
+      </label>
+      <input
+        id="lastName"
+        type="text"
+        className="
+          w-full px-4 py-2
+          border border-slate-300
+          rounded-lg
+          focus:ring-2 focus:ring-blue-500
+          touch-manipulation
+        "
+      />
+    </div>
+  </div>
+
+  {/* Full width textarea */}
+  <div>
+    <label htmlFor="message" className="block text-sm font-medium mb-1">
+      Message
+    </label>
+    <textarea
+      id="message"
+      rows={4}
+      className="
+        w-full px-4 py-2
+        border border-slate-300
+        rounded-lg
+        focus:ring-2 focus:ring-blue-500
+        touch-manipulation
+      "
+    />
+  </div>
+
+  <button
+    type="submit"
+    className="
+      w-full md:w-auto
+      px-8 py-3
+      bg-blue-600 text-white
+      rounded-lg
+      hover:bg-blue-700
+      transition-colors
+      touch-manipulation
+    "
+  >
+    Submit
+  </button>
+</form>
+```
+
+## Responsive Content Hiding
+
+### Show/Hide Based on Screen Size
+
+```tsx
+<div>
+  {/* Show only on mobile */}
+  <div className="block md:hidden">
+    Mobile content
+  </div>
+
+  {/* Show only on tablet and up */}
+  <div className="hidden md:block">
+    Desktop content
+  </div>
+
+  {/* Show only on desktop */}
+  <div className="hidden lg:block">
+    Large screen content
+  </div>
+</div>
+```
+
+## Performance Optimization
+
+### Lazy Loading Images
+
+```tsx
+<img
+  src="image.jpg"
+  alt="Description"
+  loading="lazy"
+  className="w-full h-auto"
+/>
+```
+
+### Responsive Video
+
+```tsx
+<div className="relative aspect-video">
+  <video
+    className="absolute inset-0 w-full h-full object-cover"
+    poster="thumbnail.jpg"
+    controls
+    preload="metadata"
+  >
+    <source src="video-mobile.mp4" media="(max-width: 640px)" />
+    <source src="video-desktop.mp4" />
+  </video>
+</div>
+```
+
+## Testing Responsive Designs
+
+### Browser DevTools
+
+1. Open Chrome/Firefox DevTools (F12)
+2. Toggle device toolbar (Ctrl+Shift+M)
+3. Test common breakpoints:
+   - iPhone SE (375px)
+   - iPhone 12 Pro (390px)
+   - iPad (768px)
+   - iPad Pro (1024px)
+   - Desktop (1280px+)
+
+### Real Device Testing
+
+**Essential devices to test:**
+- Small phone (iPhone SE, Android small)
+- Large phone (iPhone Pro Max, Android large)
+- Tablet (iPad, Android tablet)
+- Desktop (various resolutions)
+
+### Playwright Testing
+
+```typescript
+// Use playwright MCP to test responsive breakpoints
+await page.setViewportSize({ width: 375, height: 667 }); // iPhone SE
+await page.screenshot({ path: 'mobile.png' });
+
+await page.setViewportSize({ width: 768, height: 1024 }); // iPad
+await page.screenshot({ path: 'tablet.png' });
+
+await page.setViewportSize({ width: 1920, height: 1080 }); // Desktop
+await page.screenshot({ path: 'desktop.png' });
+```
+
+## Common Responsive Patterns
+
+### Card Grid
+
+```tsx
+<div className="
+  grid
+  grid-cols-1
+  sm:grid-cols-2
+  lg:grid-cols-3
+  xl:grid-cols-4
+  gap-6
+  p-4
+">
+  {items.map(item => (
+    <article
+      key={item.id}
+      className="
+        bg-white
+        rounded-lg
+        border border-slate-200
+        overflow-hidden
+        hover:shadow-lg
+        transition-shadow
+      "
+    >
+      <img
+        src={item.image}
+        alt={item.title}
+        className="w-full h-48 object-cover"
+        loading="lazy"
+      />
+      <div className="p-4">
+        <h3 className="text-lg font-semibold mb-2">{item.title}</h3>
+        <p className="text-slate-600">{item.description}</p>
+      </div>
+    </article>
+  ))}
+</div>
+```
+
+### Hero Section
+
+```tsx
+<section className="
+  relative
+  min-h-screen
+  flex items-center
+  px-4 sm:px-6 lg:px-8
+">
+  <div className="
+    max-w-7xl mx-auto w-full
+    grid grid-cols-1 lg:grid-cols-2
+    gap-12
+    items-center
+  ">
+    <div className="space-y-6">
+      <h1 className="
+        text-4xl sm:text-5xl lg:text-6xl
+        font-bold
+        tracking-tight
+      ">
+        Your Headline Here
+      </h1>
+      <p className="
+        text-lg sm:text-xl
+        text-slate-600
+        max-w-2xl
+      ">
+        Supporting description that works across all screen sizes.
+      </p>
+      <div className="
+        flex flex-col sm:flex-row
+        gap-4
+      ">
+        <button className="
+          px-8 py-3
+          bg-blue-600 text-white
+          rounded-lg
+          hover:bg-blue-700
+          transition-colors
+        ">
+          Primary Action
+        </button>
+        <button className="
+          px-8 py-3
+          border-2 border-slate-300
+          rounded-lg
+          hover:border-slate-400
+          transition-colors
+        ">
+          Secondary Action
+        </button>
+      </div>
+    </div>
+    <div className="
+      relative
+      aspect-square
+      rounded-2xl
+      overflow-hidden
+    ">
+      <img
+        src="hero-image.jpg"
+        alt="Hero"
+        className="w-full h-full object-cover"
+      />
+    </div>
+  </div>
+</section>
+```
+
+## Accessibility Considerations
+
+### Focus Management on Mobile
+
+```tsx
+<button
+  className="
+    focus:outline-none
+    focus:ring-4 focus:ring-blue-500
+    focus:ring-offset-2
+    rounded-lg
+  "
+  aria-label="Descriptive label"
+>
+  Action
+</button>
+```
+
+### Skip Links
+
+```tsx
+<a
+  href="#main-content"
+  className="
+    sr-only
+    focus:not-sr-only
+    focus:absolute
+    focus:top-4 focus:left-4
+    focus:z-50
+    focus:px-4 focus:py-2
+    focus:bg-blue-600 focus:text-white
+    focus:rounded-lg
+  "
+>
+  Skip to main content
+</a>
+```
+
+## Best Practices Summary
+
+✅ **Do:**
+- Start with mobile design first
+- Use relative units (rem, em, %) for flexibility
+- Test on real devices, not just emulators
+- Ensure touch targets are at least 44x44px
+- Use semantic HTML for better accessibility
+- Implement lazy loading for images and videos
+- Optimize assets for mobile networks
+- Use CSS Grid and Flexbox for flexible layouts
+- Provide adequate spacing between interactive elements
+
+❌ **Don't:**
+- Design for desktop first and scale down
+- Use fixed pixel widths for layout containers
+- Rely solely on browser DevTools for testing
+- Make touch targets too small
+- Forget keyboard navigation
+- Load all images eagerly
+- Use large unoptimized images on mobile
+- Use complex nested tables for layout
+- Place important actions in hard-to-reach areas

--- a/.claude/skills/ux-designer/SKILL.md
+++ b/.claude/skills/ux-designer/SKILL.md
@@ -1,0 +1,738 @@
+---
+name: bencium-controlled-ux-designer
+description: Expert UI/UX design guidance for unique, accessible interfaces. Use for visual decisions, colors, typography, layouts. Always ask before making design decisions. Use this skill when the user asks to build web components, pages, or applications.
+metadata:
+  version: 1.0.0
+---
+
+# UX Designer
+
+Expert UI/UX design skill that helps create unique, accessible, and thoughtfully designed interfaces. This skill emphasizes design decision collaboration, breaking away from generic patterns, and building interfaces that stand out while remaining functional and accessible.
+
+## Core Philosophy
+
+**CRITICAL: Design Decision Protocol**
+- **ALWAYS ASK** before making any design decisions (colors, fonts, sizes, layouts)
+- Never implement design changes until explicitly instructed
+- The guidelines below are practical guidance for when design decisions are approved
+- Present alternatives and trade-offs, not single "correct" solutions
+
+## Foundational Design Principles
+
+### Stand Out From Generic Patterns
+
+**Avoid Generic Training Dataset Patterns:**
+- Don't default to "Claude style" designs (excessive bauhaus, liquid glass, apple-like)
+- Don't use generic SaaS aesthetics that look machine-generated
+- Don't rely only on solid colors - suggest photography, patterns, textures
+- Think beyond typical patterns - you can step off the written path
+
+**Draw Inspiration From:**
+- Modern landing pages (Perplexity, Comet Browser, Dia Browser)
+- Framer templates and their innovative approaches
+- Leading brand design studios
+- Historical design movements (Bauhaus, Otl Aicher, Braun) - but as inspiration, not imitation
+- Beautiful background animations (CSS, SVG) - slow, looping, subtle
+
+**Visual Interest Strategies:**
+- Unique color pairs that aren't typical
+- Animation effects that feel fresh
+- Background patterns that add depth without distraction
+- Typography combinations that create contrast
+- Visual assets that tell a story
+
+### Core Design Philosophy
+
+1. **Simplicity Through Reduction**
+   - Identify the essential purpose and eliminate distractions
+   - Begin with complexity, then deliberately remove until reaching the simplest effective solution
+   - Every element must justify its existence
+
+2. **Material Honesty**
+   - Digital materials have unique properties - embrace them
+   - Buttons should communicate affordance through color, spacing, and typography (not shadows)
+   - Cards use borders and background differentiation (not depth effects)
+   - Animations follow real-world physics principles adapted to digital responsiveness
+
+   **Examples:**
+   - Clickable: Use distinct colors, hover state changes, cursor feedback
+   - Containers: Use subtle borders (1px), background color shifts, or generous padding
+   - Hierarchy: Use scale, weight, and spacing rather than elevation
+
+3. **Functional Layering (Not Visual Depth)**
+   - Create hierarchy through typography scale, color contrast, and spatial relationships
+   - Layer information conceptually (primary → secondary → tertiary)
+   - Reject skeuomorphic shadows/gradients that imitate physical depth
+   - Embrace functional depth: modals over content, dropdowns over UI
+
+4. **Obsessive Detail**
+   - Consider every pixel, interaction, and transition
+   - Excellence emerges from hundreds of small, intentional decisions
+   - Balance: Details should serve simplicity, not complexity
+   - When detail conflicts with clarity, clarity wins
+
+5. **Coherent Design Language**
+   - Every element should visually communicate its function
+   - Elements should feel part of a unified system
+   - Nothing should feel arbitrary
+
+6. **Invisibility of Technology**
+   - The best technology disappears
+   - Users should focus on content and goals, not on understanding the interface
+
+### What This Means in Practice
+
+**Color Usage:**
+- Base palette: 4-5 neutral shades (backgrounds, borders, text)
+- Accent palette: 1-3 bold colors (CTAs, status, emphasis)
+- Neutrals are slightly desaturated, warm or cool based on brand intent
+- Accents are saturated enough to create clear contrast
+
+**Typography:**
+- Headlines: Emotional, attention-grabbing (personality over pure legibility)
+- Body/UI: Functional, highly legible (clarity over expression)
+- 2-3 typefaces maximum
+- Clear mathematical scale (e.g., 1.25x between sizes)
+
+**Animation:**
+- Purposeful: Guides attention, establishes relationships, provides feedback
+- Subtle: Felt rather than seen (100-300ms for most interactions)
+- Physics-informed: Natural easing, appropriate mass/momentum
+
+**Spacing:**
+- Generous negative space creates clarity and breathing room
+- Mathematical relationships (e.g., 4px base, 8/16/24/32/48px scale)
+- Consistent application creates visual rhythm
+
+### Design Decision Checklist
+
+Before presenting any design, verify:
+
+1. **Purpose**: Does every element serve a clear function?
+2. **Hierarchy**: Is visual importance aligned with content importance?
+3. **Consistency**: Do similar elements look and behave similarly?
+4. **Accessibility**: Does it meet WCAG AA standards? (contrast, touch targets, keyboard nav)
+5. **Responsiveness**: Does it work on mobile, tablet, desktop?
+6. **Uniqueness**: Does this break from generic SaaS patterns?
+7. **Approval**: Have I asked before implementing colors, fonts, sizes, layouts?
+
+**Design System Framework:**
+
+For understanding what's fixed (universal rules), project-specific (brand personality), and adaptable (context-dependent) in your design system, see DESIGN-SYSTEM-TEMPLATE.md (meta-framework, project templates, decision trees).
+
+## Visual Design Standards
+
+### Color & Contrast
+
+**Color System Architecture:**
+
+Every interface needs two color roles:
+
+1. **Base/Neutral Palette (4-5 colors):**
+   - Backgrounds (lightest)
+   - Surface colors (cards, inputs)
+   - Borders and dividers
+   - Text (darkest)
+   - Use slightly desaturated, warm or cool greys based on brand
+
+2. **Accent Palette (1-3 colors):**
+   - Primary action (CTA buttons)
+   - Status indicators (success, warning, error, info)
+   - Focus/hover states
+   - Use saturated colors for clear contrast against neutrals
+
+**Palette Structure Example:**
+```
+Neutrals: slate-50, slate-100, slate-300, slate-700, slate-900
+Accents: teal-500 (primary), amber-500 (warning), red-500 (error)
+```
+
+**Color Application Rules:**
+
+- **Backgrounds**: Lightest neutral (slate-50 or white)
+- **Text**: Darkest neutral for primary text (slate-900), mid-tone for secondary (slate-600)
+- **Buttons (primary)**: Accent color with white text
+- **Buttons (secondary)**: Neutral with border and dark text
+- **Status indicators**: Specific accent (green=success, red=error, amber=warning, blue=info)
+- **Interactive states**:
+  - Hover: Darken by 10-15% or shift hue slightly
+  - Focus: Use ring/outline in accent color
+  - Disabled: Reduce opacity to 40-50% and remove hover effects
+
+**Color Relationships:**
+
+Choose warm or cool intentionally based on brand:
+- **Warm greys** (beige/brown undertones): Organic, approachable, trustworthy
+- **Cool greys** (blue undertones): Modern, tech-forward, professional
+
+Accent colors should have clear contrast with both:
+- Light backgrounds (for buttons on white)
+- Dark text (if used as backgrounds for white text)
+
+**Intentional Color Usage:**
+- Every color must serve a purpose (hierarchy, function, status, or action)
+- Avoid decorative colors that don't communicate meaning
+- Maintain consistency: same color = same meaning throughout
+
+**Accessibility:**
+- Ensure sufficient contrast for color-blind users
+- Follow WCAG 2.1 AA: minimum 4.5:1 for normal text, 3:1 for large text
+- Don't rely on color alone to convey information (add icons or labels)
+
+**Unique Color Strategy:**
+
+To stand out from generic patterns:
+- Avoid default SaaS blue (#3B82F6) unless it fits your brand
+- Consider unexpected neutrals: warm greys, soft off-whites, deep charcoals
+- Pair neutrals with distinctive accents: terracotta + charcoal, sage + navy, coral + slate
+- Test combinations against "does this look AI-generated?" filter
+
+### Typography Excellence
+
+**Typography Philosophy:**
+
+Typography is a primary design element that conveys personality and hierarchy.
+
+**Functional vs Emotional Typography:**
+- **Headlines/Display**: Prioritize emotion, personality, attention (legibility secondary)
+- **Body Text**: Prioritize legibility, reading comfort, accessibility
+- **UI/Labels**: Prioritize clarity, scannability, consistency
+
+**Font Selection:**
+- Use 2-3 typefaces maximum
+- Limit to 3 weights per typeface (e.g., Regular 400, Medium 500, Bold 700)
+- Prefer variable fonts for fine-tuned control and performance
+
+**Font Version Usage:**
+- **Display version**: Headlines and hero text only
+- **Text version**: Paragraphs and long-form content
+- **Caption/Micro**: Small UI labels (1-2 lines, non-critical info)
+
+**Recommended Sources:**
+- Google Fonts for web (free, well-optimized, reliable)
+- System fonts for performance-critical apps (-apple-system, BlinkMacSystemFont, Segoe UI)
+- Choose fonts that serve your brand's purpose (not "trending" lists)
+
+**Typographic Scale:**
+
+Use mathematical relationships for size hierarchy:
+- **Ratio**: Major third (1.25x) for moderate contrast, Perfect fourth (1.333x) for dramatic
+- **Base size**: 16px (1rem) for body text
+- **Example scale (1.25x)**:
+  ```
+  xs:   0.64rem (10px)
+  sm:   0.8rem  (13px)
+  base: 1rem    (16px)
+  lg:   1.25rem (20px)
+  xl:   1.563rem (25px)
+  2xl:  1.953rem (31px)
+  3xl:  2.441rem (39px)
+  4xl:  3.052rem (49px)
+  5xl:  3.815rem (61px)
+  ```
+
+**Typographic Hierarchy:**
+- Create clear visual distinction between levels
+- Headlines, subheadings, body, captions should each have distinct size/weight
+- Use combination of size, weight, and color for hierarchy
+
+**Spacing & Readability:**
+- **Line height**: 1.5x font size for body text (e.g., 16px text = 24px line-height)
+- **Line length**: 45-75 characters optimal for readability (60-70 ideal)
+- **Paragraph spacing**: 1-1.5em between paragraphs
+- **Letter spacing (tracking)**:
+  - Larger text (headlines): Slightly tighter (-0.02em to -0.05em)
+  - Normal text (body): Default (0)
+  - Small text (captions): Slightly looser (+0.01em to +0.03em)
+  - General rule: As size increases, reduce tracking; as size decreases, increase tracking
+
+**Font Pairing Logic:**
+
+When using multiple typefaces, create contrast through:
+- **Category contrast**: Serif + Sans-serif (classic, clear distinction)
+- **Weight contrast**: Light + Bold (dynamic, energetic)
+- **Personality contrast**: Geometric + Humanist (modern + warm)
+
+Examples:
+- Serif headlines + Sans body (editorial, trustworthy)
+- Display headlines + System body (distinctive + efficient)
+- Bold sans headlines + Light sans body (modern, clean)
+
+**UI Typography:**
+
+Specific guidance for interface elements:
+- **Button text**: Semi-Bold (600), 14-16px, consistent casing (all-caps OR title case)
+- **Form labels**: Regular (400), 14px, positioned above input
+- **Form input text**: Regular (400), 16px minimum (prevents iOS zoom on focus)
+- **Placeholder text**: Light (300) or desaturated color, same size as input
+- **Error messages**: Regular (400), 12-14px, color-coded (red-ish)
+
+**Responsive Typography:**
+
+Scale type sizes across breakpoints:
+```tsx
+// Example with Tailwind
+<h1 className="text-3xl md:text-4xl lg:text-5xl">
+  Responsive Headline
+</h1>
+
+// Or with CSS clamp (fluid)
+h1 {
+  font-size: clamp(2rem, 5vw, 4rem);
+}
+```
+
+Reduce sizes on mobile (20-30% smaller than desktop)
+Reduce hierarchy levels on small screens (fewer distinct sizes)
+
+### Layout & Spatial Design
+
+**Compositional Balance:**
+- Every screen should feel balanced
+- Pay attention to visual weight and negative space
+- Use generous negative space to focus attention
+- Add sufficient margins and paddings for professional, spacious look
+
+**Grid Discipline:**
+- Maintain consistent underlying grid system
+- Create sense of order while allowing meaningful exceptions
+- Use grid/flex wrappers with `gap` for spacing
+- Prioritize wrappers over direct margins/padding on children
+
+**Spatial Relationships:**
+- Group related elements through proximity, alignment, and shared attributes
+- Use size, color, and spacing to highlight important elements
+- Guide user focus through visual hierarchy
+
+**Attention Guidance:**
+- Design interfaces that guide user attention effectively
+- Avoid cluttered interfaces where elements compete
+- Create clear paths through the content
+
+## Interaction Design
+
+### Motion & Animation
+
+**Purposeful Animation:**
+
+Every animation must serve a functional purpose:
+- **Orient users**: Smooth transitions during navigation changes
+- **Establish relationships**: Show how elements connect (expand from source, slide between states)
+- **Provide feedback**: Confirm interactions (button press, form submission)
+- **Guide attention**: Direct focus to important changes (new messages, errors)
+
+**Animation & Gestalt Principles:**
+
+Motion should reinforce visual relationships:
+- **Proximity**: Elements near each other move together (grouped cards animating)
+- **Similarity**: Similar elements animate similarly (all buttons have same hover timing)
+- **Continuity**: Movement follows natural paths (smooth curves, not jumpy angles)
+- **Figure-ground**: Important elements animate while backgrounds stay stable
+
+**Natural Physics:**
+
+Animations should feel organic, not mechanical:
+- **Easing**: Use ease-out for entrances (fast start, slow end)
+- **Easing**: Use ease-in for exits (slow start, fast end)
+- **Easing**: Use ease-in-out for transitions (smooth both ends)
+- Avoid linear easing (feels robotic) except for continuous loops
+- Apply appropriate mass/momentum (lightweight UI vs weighty modals)
+
+**Subtle Restraint:**
+- Animations should be felt rather than seen
+- Don't delay user actions unnecessarily (keep under 300ms for interactive feedback)
+- Never block critical actions with decorative animations
+- Respect `prefers-reduced-motion` media query
+
+**Timing Guidelines:**
+
+- **Micro-interactions** (button press, checkbox toggle): 100-150ms
+- **State changes** (expanding accordion, tab switch): 200-300ms
+- **Page transitions** (route changes, modal open/close): 300-500ms
+- **Attention-directing** (notification appearance, error highlight): 200-400ms
+
+**Physics Profiles:**
+
+Define consistent durations for element types:
+- **Lightweight** (icons, small UI): 150ms
+- **Standard** (cards, panels): 300ms
+- **Weighty** (modals, page transitions): 500ms
+
+**Performance Optimization:**
+
+- Animate `transform` and `opacity` only (GPU-accelerated, smooth 60fps)
+- Avoid animating `width`, `height`, `top`, `left`, `margin` (causes reflow/repaint)
+- Use `will-change` sparingly for complex animations (pre-allocates GPU resources)
+- Test on low-end devices (60fps on powerful hardware ≠ 60fps on mobile)
+
+**Implementation:**
+- Use `framer-motion` sparingly and purposefully
+- Prefer CSS animations over JavaScript when possible (better performance)
+- Use CSS transitions for simple hover/focus states
+- Implement `@media (prefers-reduced-motion: reduce)` to disable/reduce animations
+
+**Example:**
+```tsx
+// Simple hover transition
+<button className="
+  transition-colors duration-200 ease-out
+  bg-blue-600 hover:bg-blue-700
+">
+  Click me
+</button>
+
+// Framer Motion for complex interaction
+<motion.div
+  initial={{ opacity: 0, y: 20 }}
+  animate={{ opacity: 1, y: 0 }}
+  exit={{ opacity: 0, y: -20 }}
+  transition={{ duration: 0.3, ease: "easeOut" }}
+>
+  Content
+</motion.div>
+```
+
+**Motion Specification:**
+
+For detailed motion specs, see MOTION-SPEC.md (easing curves, duration tables, state-specific animations, implementation patterns).
+
+### User Experience Patterns
+
+**Core UX Principles:**
+
+1. **Direct Manipulation**
+   - Users interact directly with content, not through abstract controls
+   - Examples:
+     - Drag & drop to reorder items (not up/down buttons)
+     - Inline editing (click to edit, not separate form)
+     - Sliders for ranges (not numeric input with +/-)
+     - Pinch/zoom gestures on mobile (not +/- buttons)
+
+2. **Immediate Feedback**
+   - Every interaction provides instantaneous visual feedback (within 100ms)
+   - Types of feedback:
+     - **Visual**: Button pressed state, hover effects, color changes
+     - **Haptic**: Vibration on mobile (submit, error, success)
+     - **Audio**: Subtle sounds for critical actions (optional, user-controlled)
+     - **Loading**: Skeleton screens, spinners for >300ms operations
+     - **Success**: Checkmarks, green highlights, toast notifications
+     - **Error**: Red highlights, inline error messages, shake animations
+
+3. **Consistent Behavior**
+   - Similar-looking elements behave similarly
+   - Examples:
+     - **Visual consistency**: All primary buttons have same colors, sizes, hover states
+     - **Behavioral consistency**: All modals close via X button, ESC key, and outside click
+     - **Interaction consistency**: All drag targets have same hover state and drop feedback
+     - **Pattern consistency**: All forms validate on blur and submit
+
+4. **Forgiveness**
+   - Make errors difficult, but recovery easy
+   - **Prevention strategies**:
+     - Disable invalid actions (grey out unavailable buttons)
+     - Validate inputs inline (before submission)
+     - Confirm destructive actions (delete, overwrite)
+     - Auto-save in background (drafts, progress)
+   - **Recovery strategies**:
+     - Undo/redo for all state changes
+     - Soft deletes (trash/archive before permanent delete)
+     - Clear error messages with actionable fixes
+     - Preserve user input on errors (don't clear forms)
+
+5. **Progressive Disclosure**
+   - Reveal details as needed rather than overwhelming users
+   - Levels of disclosure:
+     - **Summary**: Show essential info by default (card title, price, rating)
+     - **Details**: Expand to show more info (description, specs, reviews)
+     - **Advanced**: Hide complex options behind "Advanced settings" toggle
+   - Examples:
+     - Accordion: Start collapsed, expand on click
+     - Search filters: Show 3-5 common filters, hide rest behind "More filters"
+     - Settings: Basic settings visible, advanced behind "Show advanced"
+
+**Modern UX Patterns:**
+
+1. **Conversational Interfaces**
+
+   Prioritize natural language interaction where appropriate:
+
+   **Four types:**
+   - **Pure chat**: Full conversation (AI assistants, support bots)
+   - **Command palette**: Text-based shortcuts (Cmd+K, search everywhere)
+   - **Smart search**: Natural language queries (search "meetings next week" vs filtering)
+   - **Form alternatives**: Conversational data collection ("What's your name?" vs form fields)
+
+   **When to use:**
+   - Complex searches with multiple variables
+   - Task guidance (wizards, onboarding)
+   - Contextual help
+   - Quick actions (command palette)
+
+   **When NOT to use:**
+   - Simple forms (just use inputs)
+   - Precise control interfaces (design tools, dashboards)
+   - High-frequency repetitive tasks
+
+2. **Adaptive Layouts**
+
+   Respond to user context automatically:
+   - **Time-based**: Dark mode at night, light during day
+   - **Device-based**: Simplified UI on mobile, full features on desktop
+   - **Connection-based**: Reduce images/video on slow connections
+   - **Usage-based**: Prioritize frequent actions, hide rarely-used features
+
+   Examples:
+   - Auto dark/light mode based on time or system preference
+   - Simplified mobile navigation (hamburger menu) vs full desktop nav
+   - Collapsed sidebar on small screens, expanded on large
+
+3. **Minimal, Flat Design**
+
+   Current aesthetic preference:
+   - No drop shadows (except subtle ones for modals/dropdowns)
+   - No gradients for depth (use for accents/backgrounds if desired)
+   - No glass morphism effects
+   - Focus on typography, color, and spacing to create hierarchy
+   - Functional depth: Layers of content (modals, sheets) use positioning, not visual depth
+
+**Navigation:**
+- Clear structure with intuitive navigation menus
+- Implement breadcrumbs for deep hierarchies (more than 2 levels)
+- Use standard UI patterns to reduce learning curve (hamburger menu, tab bars)
+- Ensure predictable behavior (back button works, links look clickable)
+- Maintain navigation context (highlight current page, preserve scroll position)
+
+## Styling Implementation
+
+### Component Library & Tools
+
+**Component Library:**
+- Strongly prefer shadcn components (v4, pre-installed in `@/components/ui`)
+- Import individually: `import { Button } from "@/components/ui/button";`
+- Use over plain HTML elements (`<Button>` over `<button>`)
+- Avoid creating custom components with names that clash with shadcn
+
+**Styling Engine:**
+- Use Tailwind utility classes exclusively
+- Adhere to theme variables in `index.css` via CSS custom properties
+- Map variables in `@theme` (see `tailwind.config.js`)
+- Use inline styles or CSS modules only when absolutely necessary
+
+**Icons:**
+- Use `@phosphor-icons/react` for buttons and inputs
+- Example: `import { Plus } from "@phosphor-icons/react"; <Plus />`
+- Use color for plain icon buttons
+- Don't override default `size` or `weight` unless requested
+
+**Notifications:**
+- Use `sonner` for toasts
+- Example: `import { toast } from 'sonner'`
+
+**Loading States:**
+- Always add loading states, spinners, placeholder animations
+- Use skeletons until content renders
+
+### Layout Implementation
+
+**Spacing Strategy:**
+- Use grid/flex wrappers with `gap` for spacing
+- Prioritize wrappers over direct margins/padding on children
+- Nest wrappers as needed for complex layouts
+
+**Conditional Styling:**
+- Use ternary operators or clsx/classnames utilities
+- Example: `className={clsx('base-class', { 'active-class': isActive })}`
+
+### Responsive Design
+
+**Fluid Layouts:**
+- Use relative units (%, em, rem) instead of fixed pixels
+- Implement CSS Grid and Flexbox for flexible layouts
+- Design mobile-first, then scale up
+
+**Media Queries:**
+- Use breakpoints based on content needs, not specific devices
+- Test across range of devices and orientations
+
+**Touch Targets:**
+- Minimum 44x44 pixels for interactive elements
+- Provide adequate spacing between touch targets
+- Consider hover states for desktop, focus states for touch/keyboard
+
+**Performance:**
+- Optimize assets for mobile networks
+- Use CSS animations over JavaScript
+- Implement lazy loading for images and videos
+
+## Accessibility Standards
+
+**Core Requirements:**
+- Follow WCAG 2.1 AA guidelines
+- Ensure keyboard navigability for all interactive elements
+- Minimum touch target size: 44×44px
+- Use semantic HTML for screen reader compatibility
+- Provide alternative text for images and non-text content
+
+**Implementation Details:**
+- Use descriptive variable and function names
+- Event functions: prefix with "handle" (handleClick, handleKeyDown)
+- Add accessibility attributes:
+  - `tabindex="0"` for custom interactive elements
+  - `aria-label` for buttons without text
+  - `role` attributes when semantic HTML isn't sufficient
+- Ensure logical tab order
+- Provide visible focus states
+
+## Design Process & Testing
+
+### Design Workflow
+
+1. **Understand Context:**
+   - What problem are we solving?
+   - Who are the users and when will they use this?
+   - What are the success criteria?
+
+2. **Explore Options:**
+   - Present 2-3 alternative approaches
+   - Explain trade-offs of each option
+   - Ask which direction resonates
+
+3. **Implement Iteratively:**
+   - Start with structure and hierarchy
+   - Add visual polish progressively
+   - Test at each stage
+
+4. **Validate:**
+   - Use playwright MCP to test visual changes
+   - Check across different screen sizes
+   - Verify accessibility
+
+### Testing Checklist
+
+**Visual Testing:**
+- Use playwright MCP when available for automated testing
+- Check responsive behavior at common breakpoints
+- Verify touch targets on mobile
+- Test with different content lengths (short, long, edge cases)
+
+**Accessibility Testing:**
+- Test keyboard navigation
+- Verify screen reader compatibility
+- Check color contrast ratios
+- Ensure focus states are visible
+
+**Cross-Device Testing:**
+- Test on actual devices, not just emulators
+- Check different browsers (Chrome, Firefox, Safari)
+- Verify touch interactions on mobile
+- Test landscape and portrait orientations
+
+## Examples
+
+### Example 1: Designing a Button
+
+**Initial Question to Ask:**
+```
+Before I implement this button, I have a few design questions:
+1. What's the primary action you want to emphasize?
+2. Do you have brand colors in mind, or should I suggest options?
+3. What emotion should this button convey? (urgent, calm, playful, professional)
+```
+
+**After Getting Approval, Implementation:**
+```tsx
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "@phosphor-icons/react";
+
+<Button
+  className="bg-slate-800 hover:bg-slate-700 text-white px-6 py-3 rounded-lg transition-colors duration-200"
+>
+  Get Started
+  <ArrowRight className="ml-2" />
+</Button>
+```
+
+### Example 2: Typography Hierarchy
+
+**Question First:**
+```
+For this content hierarchy, I'm thinking:
+- Headline: Large, bold, attention-grabbing
+- Subheading: Medium, regular weight
+- Body: Smaller, optimized for reading
+
+Should we go bold and contemporary, or subtle and refined?
+```
+
+**Implementation After Approval:**
+```tsx
+<div className="space-y-4">
+  <h1 className="text-5xl font-bold tracking-tight text-slate-900">
+    Headline Here
+  </h1>
+  <h2 className="text-2xl text-slate-600">
+    Supporting subheading
+  </h2>
+  <p className="text-base leading-relaxed text-slate-700">
+    Body text optimized for readability with proper line height.
+  </p>
+</div>
+```
+
+### Example 3: Unique Color Palette Suggestion
+
+**Presenting Options:**
+```
+I'd like to suggest three color directions that break from typical SaaS patterns:
+
+1. **Warm Earth Tones**
+   - Base: Warm grey (#E8E2DC)
+   - Accent: Terracotta (#C86E4B)
+   - For: Organic, trustworthy feel
+
+2. **Cool Midnight**
+   - Base: Deep navy (#1A2332)
+   - Accent: Cyan (#4ECDC4)
+   - For: Modern, tech-forward feel
+
+3. **Soft Pastels**
+   - Base: Soft pink (#FFE5E5)
+   - Accent: Sage green (#9DB5A4)
+   - For: Calm, approachable feel
+
+Which direction feels right for your brand?
+```
+
+## Common Patterns to Avoid
+
+❌ **Don't:**
+- Use generic SaaS blue (#3B82F6) without considering alternatives
+- Default to shadows and gradients for depth
+- Copy Apple's design language
+- Use glass morphism effects
+- Make design decisions without asking
+- Implement typography without considering the font version
+- Use animations that delay user actions
+- Create cluttered interfaces with competing elements
+
+✅ **Do:**
+- Ask before making design decisions
+- Suggest unique, contextually appropriate color pairs
+- Use flat, minimal design
+- Consider unconventional typography choices
+- Provide immediate feedback for interactions
+- Create generous white space
+- Test with real devices
+- Validate accessibility
+
+## Version History
+
+- v1.0.0 (2025-10-18): Initial release with comprehensive UI/UX design guidance
+
+## References
+
+For additional context, see:
+- WCAG 2.1 Guidelines: https://www.w3.org/WAI/WCAG21/quickref/
+- Google Fonts: https://fonts.google.com/
+- Tailwind CSS Docs: https://tailwindcss.com/docs
+- Shadcn UI Components: https://ui.shadcn.com/

--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,9 @@ data/mast/
 data/
 data-agent*/
 
-# Claude Code local settings
-.claude/
+# Claude Code local settings (skills are committed, everything else is local)
+.claude/*
+!.claude/skills/
 CLAUDE.md
 
 # Environment files (prevent accidental commit of secrets)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,15 @@ pytest
 - Follow the **tiered merge policy**: docs/test/config PRs can auto-merge when CI passes; low-risk features get a skim review; medium+ risk changes require explicit maintainer approval.
 - Keep commits **focused and atomic**.
 
+### Plan Review Before Implementation
+
+Before writing code for any feature, bug fix, or refactor:
+
+1. **Run `/plan-ceo-review`** — rethinks the problem, challenges premises, ensures you're solving the right thing. Especially important before entering plan mode.
+2. **Run `/plan-eng-review`** for medium+ complexity work — challenges architecture, catches complexity traps, produces a test plan artifact.
+
+Both reviews should complete before the first line of implementation code is written.
+
 ### Branch-First Rule
 
 Before making any file edits:
@@ -188,6 +197,10 @@ Before creating a PR, verify:
 3. **Docker verification** — for integration/backend changes, rebuild and test in Docker (`docker compose up -d --build`).
 4. **Documentation updated** — update relevant docs if the change affects APIs, features, models, or milestones (see [Documentation Expectations](#documentation-expectations)).
 5. **Test plan executed** — run all items in the PR's test plan using the Docker environment. Document results (pass/fail). If a test item cannot be executed (e.g. requires manual UI interaction), note that clearly.
+
+## Session Wrap-up
+
+At the end of every session, run `/retro` to generate a velocity retrospective. This surfaces commit metrics, session patterns, file hotspots, and friction signals. Running this consistently builds data to tune work cadence over time.
 
 ## Agent Coordination
 


### PR DESCRIPTION
## Summary
Commits project-specific Claude Code skills to the repo and integrates plan review + retrospective into the documented agent workflow.

## Why
Skills in `.claude/skills/` were gitignored, making them unavailable to worktree agents. New plan-review and retro skills needed workflow integration points in AGENTS.md.

## Changes Made
- `.gitignore`: Changed `.claude/` to `.claude/*` + `!.claude/skills/` so skills are committed while settings/commands remain local
- `AGENTS.md`: Added "Plan Review Before Implementation" section — run `/plan-ceo-review` before features and `/plan-eng-review` before medium+ complexity work
- `AGENTS.md`: Added "Session Wrap-up" section — run `/retro` at end of every session
- Committed 5 project skills: `plan-ceo-review`, `plan-eng-review`, `retro`, `interface-design`, `ux-designer`

## Test Plan
- [x] Verify skills are no longer gitignored: `git check-ignore .claude/skills/retro/SKILL.md` returns nothing
- [x] Verify other `.claude/` contents still ignored: `git check-ignore .claude/settings.json` returns match
- [x] Verify all 5 skill directories committed with SKILL.md files
- [x] Verify AGENTS.md sections render correctly in markdown preview

## Documentation Checklist
- [x] AGENTS.md updated with new workflow sections

## Tech Debt Impact
- [x] None — no new tech debt introduced

## Risk & Rollback
Risk: Low — config/docs only, no code changes
Rollback: Revert the commit

No linked issue