### PR TITLE
fix: coverage-aware filter selection in recipe engine

### DIFF
--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -690,11 +690,21 @@ def _compute_filter_coverage(
         dec_vals = [p[1] for p in positions]
         fov_vals = [p[2] for p in positions]
 
-        mean_ra = sum(ra_vals) / len(ra_vals)
+        # Circular mean for RA to handle 0/360 wraparound
+        ra_rads = [math.radians(ra) for ra in ra_vals]
+        mean_ra = (
+            math.degrees(
+                math.atan2(
+                    sum(math.sin(r) for r in ra_rads),
+                    sum(math.cos(r) for r in ra_rads),
+                )
+            )
+            % 360
+        )
         mean_dec_rad = math.radians(sum(dec_vals) / len(dec_vals))
         cos_dec = max(math.cos(mean_dec_rad), 0.01)  # avoid division by zero near poles
 
-        # RA offsets in arcmin with wraparound handling
+        # RA offsets in arcmin from circular centroid
         ra_offsets = [((ra - mean_ra + 180) % 360 - 180) * cos_dec * 60 for ra in ra_vals]
 
         # Bounding box edges in arcmin, accounting for FOV radius at each position

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -1474,13 +1474,13 @@ class TestComputeFilterCoverage:
 
     def test_many_observations_larger_coverage(self):
         """A filter with many spread-out observations has larger coverage."""
-        # F1130W: 50 tiles spanning a wide area
+        # F1130W: 50 tiles spanning a wide area (0.02 deg spacing for realistic disparity)
         obs_many = [
             ObservationInput(
-                filter="F1130W", instrument="MIRI", s_ra=83.63 + i * 0.01, s_dec=22.01 + j * 0.01
+                filter="F1130W", instrument="MIRI", s_ra=83.5 + i * 0.02, s_dec=21.9 + j * 0.02
             )
-            for i in range(5)
-            for j in range(10)
+            for i in range(10)
+            for j in range(5)
         ]
         # F560W: 2 tiles at a single pointing
         obs_few = [
@@ -1576,8 +1576,8 @@ class TestPartitionByCoverage:
         well, low = _partition_by_coverage(coverage)
         assert set(well) == {"F1130W", "F560W"}
         assert low == []
-        # Higher threshold: 20.0 < 30.0 → F560W is low
-        well, low = _partition_by_coverage(coverage, threshold_fraction=0.3)
+        # Higher threshold: median=60, 0.5*60=30, 20.0 < 30.0 → F560W is low
+        well, low = _partition_by_coverage(coverage, threshold_fraction=0.5)
         assert well == ["F1130W"]
         assert low == ["F560W"]
 
@@ -1588,26 +1588,27 @@ class TestCoverageAwareClassic3Color:
     def _make_crab_obs(self):
         """Create Crab Nebula-like observations: F1130W/F1800W full mosaic, F560W/F2100W sparse."""
         obs = []
-        # F1130W: 50 tiles spanning a wide area (full mosaic)
-        for i in range(5):
-            for j in range(10):
+        # F1130W: 50 tiles spanning a wide area (full 12-pointing mosaic)
+        # Use 0.02 degree spacing (~72 arcsec) to create realistic coverage disparity
+        for i in range(10):
+            for j in range(5):
                 obs.append(
                     ObservationInput(
                         filter="F1130W",
                         instrument="MIRI",
-                        s_ra=83.63 + i * 0.01,
-                        s_dec=22.01 + j * 0.01,
+                        s_ra=83.5 + i * 0.02,
+                        s_dec=21.9 + j * 0.02,
                     )
                 )
-        # F1800W: 50 tiles spanning a wide area (full mosaic)
-        for i in range(5):
-            for j in range(10):
+        # F1800W: 50 tiles spanning a wide area (full 12-pointing mosaic)
+        for i in range(10):
+            for j in range(5):
                 obs.append(
                     ObservationInput(
                         filter="F1800W",
                         instrument="MIRI",
-                        s_ra=83.63 + i * 0.01,
-                        s_dec=22.01 + j * 0.01,
+                        s_ra=83.5 + i * 0.02,
+                        s_dec=21.9 + j * 0.02,
                     )
                 )
         # F560W: 2 files at a single pointing (sparse)
@@ -1643,14 +1644,14 @@ class TestCoverageAwareClassic3Color:
     def test_uniform_coverage_keeps_classic_3_color(self):
         """When all filters have similar coverage, Classic 3-color is unchanged."""
         obs = []
-        # All 4 filters with similar coverage (10 tiles each)
+        # All 4 filters with similar coverage (10 tiles each, same spread)
         for filt in ["F560W", "F1130W", "F1800W", "F2100W"]:
             for i in range(10):
                 obs.append(
                     ObservationInput(
                         filter=filt,
                         instrument="MIRI",
-                        s_ra=83.63 + i * 0.01,
+                        s_ra=83.5 + i * 0.02,
                         s_dec=22.01,
                     )
                 )
@@ -1662,7 +1663,7 @@ class TestCoverageAwareClassic3Color:
     def test_three_well_covered_out_of_four(self):
         """3 well-covered + 1 low-coverage: Classic uses only the 3 well-covered."""
         obs = []
-        # F560W, F1130W, F1800W: 20 tiles each (well-covered)
+        # F560W, F1130W, F1800W: 20 tiles each spanning a wide area (well-covered)
         for filt in ["F560W", "F1130W", "F1800W"]:
             for i in range(4):
                 for j in range(5):
@@ -1670,8 +1671,8 @@ class TestCoverageAwareClassic3Color:
                         ObservationInput(
                             filter=filt,
                             instrument="MIRI",
-                            s_ra=83.63 + i * 0.01,
-                            s_dec=22.01 + j * 0.01,
+                            s_ra=83.5 + i * 0.02,
+                            s_dec=21.9 + j * 0.02,
                         )
                     )
         # F2100W: 1 tile (low-coverage)
@@ -1707,7 +1708,7 @@ class TestCoverageAwareClassic3Color:
                     ObservationInput(
                         filter=filt,
                         instrument="MIRI",
-                        s_ra=83.63 + i * 0.01,
+                        s_ra=83.5 + i * 0.02,
                         s_dec=22.01,
                     )
                 )


### PR DESCRIPTION
## Summary

- Recipe engine now considers spatial coverage when selecting filters, avoiding composites where some channels cover ~5% of the field while others cover 100%
- Fixes the Crab Nebula case where Classic 3-color picked F560W + F1800W + F2100W (2 of 3 channels at ~5% coverage) instead of the well-covered F1130W + F1800W pair

Closes #871

## Why

The recipe engine selected filters purely by wavelength spread and bandpass priority, ignoring observation count/spatial extent. Programs like jw01714 (Crab Nebula) use F1130W/F1800W for full 12-pointing mosaics (50 tiles each) but only F560W/F2100W for single-pointing supplementary observations (2 files). The old logic would pick the sparse filters for maximum wavelength spread, creating patchwork composites with large gaps.

## Changes Made

- Added `_compute_filter_coverage()` — estimates per-filter spatial coverage area from observation coordinates using bounding-box approach with circular-mean RA centroid (handles RA=0/360 wraparound)
- Added `_partition_by_coverage()` — splits filters into well-covered vs low-coverage relative to median (threshold: 10% of median area via `LOW_COVERAGE_FRACTION` constant)
- Modified Classic 3-color recipe to pick from well-covered filters only; falls back to 2-filter recipe when only 2 have good coverage; skips entirely when < 2 well-covered
- Modified `select_best_n_filters()` to use coverage as tiebreaker when choosing between candidate filters in the same wavelength bin
- Added `overlap_warning` to "all filters" recipes when any included filter has low coverage
- Cross-instrument `select_best_n_filters()` calls also pass coverage data
- Curated NASA-style recipes are completely unaffected

## Test Plan

- [x] All 139 recipe engine tests pass (`docker exec jwst-processing python -m pytest tests/test_recipe_engine.py -v`) after Docker rebuild
- [x] Ruff lint + format clean
- [x] New tests cover:
  - [x] Coverage computation (single obs, many obs, no spatial data, mixed)
  - [x] RA wraparound near 0/360 boundary (circular mean)
  - [x] Partition logic (uniform, mixed, single, empty, zero area, 2-filter disparity, custom threshold)
  - [x] Crab Nebula scenario: Classic avoids low-coverage, produces 2-filter instead
  - [x] Coverage warning on "all" recipe
  - [x] 3 well-covered out of 4 filters: Classic picks only the 3 well-covered
  - [x] Uniform coverage: Classic 3-color unchanged
  - [x] No spatial data: falls back to original wavelength-only logic
  - [x] Coverage-weighted bin selection in select_best_n_filters
  - [x] No coverage data: identical to original behavior

## Documentation Checklist

- [x] No new endpoints, models, or frontend features — no doc updates needed

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — recipe generation only, no impact on compositing pipeline or data model. Worst case: a recipe that previously used 3 filters now uses 2, which produces a valid but less colorful composite.

Rollback: Revert these two commits. No data migration, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)