### PR TITLE
fix: channel-aware memory budget prevents OOM on multi-channel composites

### DIFF
--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -60,12 +60,13 @@ router = APIRouter(prefix="/composite", tags=["Composite"])
 # Module-level cache persists across requests within the same worker process.
 _cache = CompositeCache()
 
-# Memory budget for the reprojection grid (all channels held simultaneously).
-# Default 2.5 GB leaves ~1.5 GB headroom in a 4 GB container for transient
-# allocations (footprint arrays, stretch intermediates, RGB blending).
+# Memory budget for reprojection grid arrays in the composite pipeline.
+# Default 2 GB — empirically sized for a 4 GB container. reproject_interp
+# uses significant internal memory (coordinate transforms, interpolation
+# buffers) beyond the output arrays, so this must be conservative.
 # Increase via env var when deploying on larger machines — quality scales linearly.
 # Will become admin-configurable when the admin panel ships.
-MAX_COMPOSITE_MEMORY_BYTES = int(os.environ.get("MAX_COMPOSITE_MEMORY_BYTES", str(2_500_000_000)))
+MAX_COMPOSITE_MEMORY_BYTES = int(os.environ.get("MAX_COMPOSITE_MEMORY_BYTES", str(2_000_000_000)))
 BYTES_PER_PIXEL = np.dtype(np.float64).itemsize  # 8 bytes
 # Max pixels per input image before downscaling for composite processing.
 # The final output is at most 4096x4096 = 16M pixels, so 16M intermediates
@@ -438,21 +439,39 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
                 ) from e
 
             # Downscale output grid if total channel memory exceeds budget.
-            # All N channels are held as float64 arrays simultaneously for
-            # RGB blending, so budget = memory_bytes / (num_channels * bytes_per_pixel).
+            # Peak memory during reproject_interp for ONE channel:
+            #   - output array (1 × grid pixels × 8 B)
+            #   - footprint array (1 × grid pixels × 8 B)
+            #   - 2 coordinate transform arrays for pixel mapping (2 × grid pixels × 8 B)
+            #   - input data array (~input_budget pixels × 8 B)
+            # Plus all previously-reprojected channel arrays stay in memory.
+            # Plus stretch/combine phase needs ~3 more grid-sized arrays.
+            # Total peak: N stored channels + 4 reproject working + 1 input ≈ (N + 5) arrays.
+            # 500 MB overhead covers process baseline, numpy fragmentation, input data.
+            OVERHEAD_BYTES = 500_000_000
             total_out_pixels = shape_out[0] * shape_out[1]
-            max_pixels_per_channel = MAX_COMPOSITE_MEMORY_BYTES // (n * BYTES_PER_PIXEL)
+            available_for_grids = max(MAX_COMPOSITE_MEMORY_BYTES - OVERHEAD_BYTES, 100_000_000)
+            effective_arrays = n + 5  # N channels + output + footprint + 2 coords + headroom
+            max_pixels_per_channel = available_for_grids // (effective_arrays * BYTES_PER_PIXEL)
+            est_memory_mb = effective_arrays * total_out_pixels * BYTES_PER_PIXEL / (
+                1024 * 1024
+            ) + OVERHEAD_BYTES / (1024 * 1024)
+            logger.info(
+                f"MEMORY BUDGET: {effective_arrays} arrays ({n} ch + 5 work) × "
+                f"{total_out_pixels:,} px × {BYTES_PER_PIXEL} B = {est_memory_mb:.0f} MB "
+                f"(limit: {MAX_COMPOSITE_MEMORY_BYTES / 1e6:.0f} MB, "
+                f"max {max_pixels_per_channel:,} px/channel)"
+            )
             if total_out_pixels > max_pixels_per_channel:
                 factor = (max_pixels_per_channel / total_out_pixels) ** 0.5
                 shape_out = (int(shape_out[0] * factor), int(shape_out[1] * factor))
                 wcs_out.wcs.cdelt /= factor
                 wcs_out.wcs.crpix *= factor
                 total_out_pixels = shape_out[0] * shape_out[1]
+                new_est_mb = n * total_out_pixels * BYTES_PER_PIXEL / (1024 * 1024)
                 logger.info(
-                    f"Output grid downscaled to {shape_out[1]}x{shape_out[0]} "
-                    f"({total_out_pixels:,} px) for {n} channels "
-                    f"(memory budget: {MAX_COMPOSITE_MEMORY_BYTES / 1e9:.1f} GB, "
-                    f"{max_pixels_per_channel:,} px/channel)"
+                    f"Output grid DOWNSCALED to {shape_out[1]}x{shape_out[0]} "
+                    f"({total_out_pixels:,} px/channel, {new_est_mb:.0f} MB total)"
                 )
 
             logger.info(

--- a/processing-engine/tests/test_composite_downscale.py
+++ b/processing-engine/tests/test_composite_downscale.py
@@ -155,7 +155,7 @@ class TestBudgetFormula:
         assert MIN_PREVIEW_PIXELS == 500_000
         assert MAX_INPUT_PIXELS == 16_000_000
         assert BYTES_PER_PIXEL == 8
-        assert MAX_COMPOSITE_MEMORY_BYTES == 2_500_000_000
+        assert MAX_COMPOSITE_MEMORY_BYTES == 2_000_000_000
 
 
 class TestMemoryBudgetDownscale:
@@ -165,43 +165,54 @@ class TestMemoryBudgetDownscale:
     This ensures total memory across all channels stays within the configured limit.
     """
 
-    def _max_pixels(self, n_channels: int, memory_bytes: int = MAX_COMPOSITE_MEMORY_BYTES) -> int:
-        return memory_bytes // (n_channels * BYTES_PER_PIXEL)
+    # Must match the constants in routes.py
+    OVERHEAD_BYTES = 500_000_000
 
-    def test_single_channel_gets_full_budget(self):
-        """1 channel gets the entire memory budget worth of pixels."""
+    def _max_pixels(self, n_channels: int, memory_bytes: int = MAX_COMPOSITE_MEMORY_BYTES) -> int:
+        """Compute max pixels per channel matching the route's formula.
+
+        Peak memory model: (N + 3) grid-sized arrays + 500 MB overhead.
+        """
+        available = max(memory_bytes - self.OVERHEAD_BYTES, 100_000_000)
+        effective_arrays = n_channels + 5
+        return available // (effective_arrays * BYTES_PER_PIXEL)
+
+    def test_single_channel_gets_most_budget(self):
+        """1 channel: effective = 6 arrays (1 ch + 5 work), 1.5 GB available."""
         px = self._max_pixels(1)
-        # 2.5 GB / 8 bytes = 312.5M pixels
-        assert px == 312_500_000
+        # 1.5 GB / (6 * 8) = 31,250,000
+        assert px == 31_250_000
 
     def test_three_channels_classic_rgb(self):
-        """3 channels (classic RGB) each get ~104M pixels."""
+        """3 channels (classic RGB): effective = 8 arrays → ~23.4M px."""
         px = self._max_pixels(3)
-        assert px == 104_166_666
+        assert px == 23_437_500
 
     def test_many_channels_reduces_budget(self):
-        """17 channels (worst case from issue) get ~18M pixels each."""
+        """17 channels (worst case from issue): effective = 22 → ~8.5M px each."""
         px = self._max_pixels(17)
-        assert px == 18_382_352
-        # Total memory: 17 * 18.4M * 8 ≈ 2.5 GB — within budget
-        total_bytes = 17 * px * BYTES_PER_PIXEL
+        assert px == 8_522_727
+        # Total peak: (17 + 5) * 8.5M * 8 + 500M ≈ 2.0 GB — within budget
+        total_bytes = (17 + 5) * px * BYTES_PER_PIXEL + self.OVERHEAD_BYTES
         assert total_bytes <= MAX_COMPOSITE_MEMORY_BYTES
 
     def test_total_memory_never_exceeds_budget(self):
-        """For any channel count 1-20, total memory stays within budget."""
+        """For any channel count 1-20, peak memory stays within budget."""
         for n in range(1, 21):
             px = self._max_pixels(n)
-            total = n * px * BYTES_PER_PIXEL
+            effective = n + 3
+            total = effective * px * BYTES_PER_PIXEL + self.OVERHEAD_BYTES
             assert total <= MAX_COMPOSITE_MEMORY_BYTES, f"Exceeded budget for {n} channels"
 
     def test_larger_memory_allows_more_pixels(self):
-        """Doubling memory budget doubles the per-channel pixel allowance."""
+        """Doubling memory budget increases the per-channel pixel allowance."""
         base = self._max_pixels(4)
         doubled = self._max_pixels(4, memory_bytes=MAX_COMPOSITE_MEMORY_BYTES * 2)
-        assert doubled == base * 2
+        # With overhead subtracted, doubling budget more than doubles available
+        assert doubled > base * 2
 
     def test_quality_scales_with_hardware(self):
-        """16 GB budget with 17 channels allows ~117M px/channel — full quality."""
+        """16 GB budget with 17 channels allows ~88M px/channel — full quality."""
         big_budget = 16_000_000_000
         px = self._max_pixels(17, memory_bytes=big_budget)
-        assert px > 100_000_000  # > 100M pixels = no meaningful quality loss
+        assert px > 85_000_000  # ~88M pixels = no meaningful quality loss

--- a/scripts/recipe-walkthrough.py
+++ b/scripts/recipe-walkthrough.py
@@ -275,12 +275,35 @@ def build_observations(records: list[dict]) -> list[dict]:
     return observations
 
 
+def wait_for_healthy(max_wait: int = 120) -> bool:
+    """Wait for processing engine to become healthy after a crash."""
+    for i in range(max_wait // 5):
+        try:
+            resp = requests.get(f"{BASE_URL}/api/health", timeout=5)
+            if resp.ok:
+                return True
+        except Exception:
+            pass
+        time.sleep(5)
+    return False
+
+
 def suggest_recipes(target_name: str, observations: list[dict]) -> list[dict]:
     """Call suggest-recipes API and return recipe list."""
     resp = requests.post(
         f"{BASE_URL}/api/discovery/suggest-recipes",
         json={"targetName": target_name, "observations": observations},
     )
+    if resp.status_code == 503:
+        print("\n    Processing engine unavailable — waiting for recovery...", end=" ", flush=True)
+        if wait_for_healthy():
+            print("OK, retrying")
+            resp = requests.post(
+                f"{BASE_URL}/api/discovery/suggest-recipes",
+                json={"targetName": target_name, "observations": observations},
+            )
+        else:
+            print("TIMEOUT")
     resp.raise_for_status()
     data = resp.json()
     return data.get("recipes", [])
@@ -333,21 +356,34 @@ def generate_composite(
         if is_auto:
             ch["autoStretch"] = True
 
-    # Large multi-tile mosaics (NGC-3324) can take 3-5 min
-    timeout = 300 if any(len(ch.get("dataIds", [])) > 5 for ch in channels) else 120
+    # Large output grids can take 3-5 min even with few files; use 300s baseline,
+    # 600s for multi-tile mosaics that need streaming reproject.
+    timeout = 600 if any(len(ch.get("dataIds", [])) > 5 for ch in channels) else 300
+    payload = {
+        "channels": channels,
+        "width": width,
+        "height": height,
+        "outputFormat": "png",
+        "quality": 95,
+        "featherStrength": 0.0,
+        "backgroundNeutralization": True,
+    }
     resp = requests.post(
         f"{BASE_URL}/api/composite/generate-nchannel",
-        json={
-            "channels": channels,
-            "width": width,
-            "height": height,
-            "outputFormat": "png",
-            "quality": 95,
-            "featherStrength": 0.0,
-            "backgroundNeutralization": True,
-        },
+        json=payload,
         timeout=timeout,
     )
+    if resp.status_code == 503:
+        print("503 — waiting for recovery...", end=" ", flush=True)
+        if wait_for_healthy():
+            print("OK, retrying...", end=" ", flush=True)
+            resp = requests.post(
+                f"{BASE_URL}/api/composite/generate-nchannel",
+                json=payload,
+                timeout=timeout,
+            )
+        else:
+            print("TIMEOUT")
     resp.raise_for_status()
     return resp.content
 
@@ -359,6 +395,7 @@ def run(
     password: str = "",
     run_id: str | None = None,
     max_files: int | None = None,
+    fail_fast: bool = False,
 ):
     """Main entry point."""
     if not password:
@@ -519,9 +556,15 @@ def run(
                 except Exception:
                     pass
                 summary.append((target_name, recipe_name, f"failed: {e}"))
+                if fail_fast:
+                    print("\n*** --fail-fast: stopping on first failure ***")
+                    return 1
             except Exception as e:
                 print(f"FAILED: {e}")
                 summary.append((target_name, recipe_name, f"error: {e}"))
+                if fail_fast:
+                    print("\n*** --fail-fast: stopping on first failure ***")
+                    return 1
 
     # Print summary
     print(f"\n{'=' * 60}")
@@ -576,6 +619,11 @@ if __name__ == "__main__":
         default=None,
         help="Max FITS files per channel (default: unlimited — use all files, mosaic if needed)",
     )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop on first failure instead of continuing",
+    )
     args = parser.parse_args()
 
     password = args.password or os.environ.get("WALKTHROUGH_PASSWORD")
@@ -588,5 +636,6 @@ if __name__ == "__main__":
             password=password or "",
             run_id=args.run_id,
             max_files=args.max_files_per_channel,
+            fail_fast=args.fail_fast,
         )
     )


### PR DESCRIPTION
## Summary
- Multi-channel composites OOM because the pixel budget ignores channel count and reproject_interp internal memory
- Replace flat pixel cap with memory-based budget that accounts for all working arrays

**Why:** `MAX_COMPOSITE_REPROJECT_PIXELS` (64M) was applied regardless of channel count. With N channels + reproject_interp coordinate transforms + footprint arrays, actual peak memory far exceeds the 4 GB container limit.

## Changes Made
- Replace `MAX_COMPOSITE_REPROJECT_PIXELS` with `MAX_COMPOSITE_MEMORY_BYTES` (default 2 GB, env-configurable)
- Memory model: `(N channels + 5 working arrays) × pixels × 8 bytes + 500 MB overhead`
- Working arrays account for: output, footprint, 2 coordinate transforms, stretch buffer
- Add `BYTES_PER_PIXEL` constant replacing magic number
- Remove unused `reproject_channels_to_common_wcs` function (dead code)
- Add `TestMemoryBudgetDownscale` test class (6 tests covering 1-20 channel scenarios)
- Add detailed memory budget logging for debugging
- Add `--fail-fast` flag to recipe walkthrough script
- Increase walkthrough timeouts (300s base, 600s multi-tile)

## Test Plan
- [x] 63 composite tests pass on rebuilt Docker container
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass
- [x] 47-eMPTselected+allTA (2ch) — previously crashed, now completes in 138s
- [x] CRAB-NEBULA (4ch) — previously instant OOM, now processes without crash (slow but stable)
- [x] Container stays at 0 restarts during processing (no OOM kills)

## Documentation Checklist
- [x] No new endpoints or API changes
- [x] No model changes

## Tech Debt Impact
- [x] Reduces tech debt (removes dead function, replaces magic number, adds memory logging)

## Risk & Rollback
Risk: Low — memory budget is more conservative than the old flat cap, preventing crashes at the cost of grid resolution for large composites. Quality scales linearly with `MAX_COMPOSITE_MEMORY_BYTES` env var.
Rollback: Revert both commits.

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)