### PR TITLE
feat: walkthrough uses async export queue, bump backend proxy timeouts

### DIFF
--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -122,6 +122,8 @@ builder.Services.AddHttpClient<IMastService, MastService>(client => client.Timeo
 // Configure HttpClient for CompositeService — resilience handler owns all timeouts.
 // Retry transient failures (connection refused, 502/503/504) with exponential backoff — handles processing engine restarts.
 // HttpClient.Timeout disabled so it doesn't race with the resilience pipeline's TotalRequestTimeout.
+// Generous timeouts: background job queue means no user blocking on HTTP; large multi-channel
+// composites (4ch × 49 tiles) can take 30+ minutes on modest hardware.
 builder.Services.AddHttpClient<ICompositeService, CompositeService>(client => client.Timeout = Timeout.InfiniteTimeSpan)
     .AddStandardResilienceHandler(options =>
     {
@@ -133,9 +135,9 @@ builder.Services.AddHttpClient<ICompositeService, CompositeService>(client => cl
             args.Outcome.Exception is HttpRequestException or TimeoutRejectedException
             || (args.Outcome.Result?.StatusCode is >= (System.Net.HttpStatusCode)500
                 and not System.Net.HttpStatusCode.InternalServerError));
-        options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(5);
-        options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(10);
-        options.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(10);
+        options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(30);
+        options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(60);
+        options.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(61);
     });
 
 // Configure HttpClient for MosaicService — same resilience config as CompositeService.
@@ -148,9 +150,9 @@ builder.Services.AddHttpClient<IMosaicService, MosaicService>(client => client.T
             args.Outcome.Exception is HttpRequestException or TimeoutRejectedException
             || (args.Outcome.Result?.StatusCode is >= (System.Net.HttpStatusCode)500
                 and not System.Net.HttpStatusCode.InternalServerError));
-        options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(5);
-        options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(10);
-        options.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(10);
+        options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(30);
+        options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(60);
+        options.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(61);
     });
 
 // Configure HttpClient for AnalysisService with 2-minute timeout for region statistics

--- a/scripts/recipe-walkthrough.py
+++ b/scripts/recipe-walkthrough.py
@@ -329,11 +329,17 @@ def hex_to_hue(hex_color: str) -> float | None:
 
 def generate_composite(
     channels: list[dict],
+    token: str,
     preset_name: str = "nasa_press",
     width: int = 2000,
     height: int = 2000,
+    poll_interval: int = 5,
 ) -> bytes:
-    """Call generate-nchannel composite API and return PNG bytes."""
+    """Queue a composite via the async export API and poll until complete.
+
+    Uses the export-nchannel endpoint which queues work via the background
+    service, avoiding HTTP timeout issues for large multi-channel composites.
+    """
     preset = PRESETS.get(preset_name, PRESETS["nasa_press"])
     miri_preset = MIRI_OVERRIDES.get(preset_name)
     is_auto = preset.get("auto_stretch", False)
@@ -356,9 +362,7 @@ def generate_composite(
         if is_auto:
             ch["autoStretch"] = True
 
-    # Large output grids can take 3-5 min even with few files; use 300s baseline,
-    # 600s for multi-tile mosaics that need streaming reproject.
-    timeout = 600 if any(len(ch.get("dataIds", [])) > 5 for ch in channels) else 300
+    headers = {"Authorization": f"Bearer {token}"}
     payload = {
         "channels": channels,
         "width": width,
@@ -368,24 +372,51 @@ def generate_composite(
         "featherStrength": 0.0,
         "backgroundNeutralization": True,
     }
+
+    # Submit to async export queue
     resp = requests.post(
-        f"{BASE_URL}/api/composite/generate-nchannel",
+        f"{BASE_URL}/api/composite/export-nchannel",
         json=payload,
-        timeout=timeout,
+        headers=headers,
+        timeout=30,
     )
-    if resp.status_code == 503:
-        print("503 — waiting for recovery...", end=" ", flush=True)
-        if wait_for_healthy():
-            print("OK, retrying...", end=" ", flush=True)
-            resp = requests.post(
-                f"{BASE_URL}/api/composite/generate-nchannel",
-                json=payload,
-                timeout=timeout,
-            )
-        else:
-            print("TIMEOUT")
     resp.raise_for_status()
-    return resp.content
+    job_id = resp.json()["jobId"]
+
+    # Poll job status until terminal state
+    last_stage = ""
+    while True:
+        time.sleep(poll_interval)
+        status_resp = requests.get(
+            f"{BASE_URL}/api/jobs/{job_id}",
+            headers=headers,
+            timeout=30,
+        )
+        status_resp.raise_for_status()
+        job = status_resp.json()
+        state = job.get("state", "unknown")
+
+        # Print progress updates inline
+        stage = job.get("stage", "")
+        pct = job.get("progressPercent", 0)
+        if stage and stage != last_stage:
+            print(f"{stage} {pct}%...", end=" ", flush=True)
+            last_stage = stage
+
+        if state == "completed":
+            break
+        if state in ("failed", "cancelled"):
+            error = job.get("errorMessage", state)
+            raise RuntimeError(f"Job {job_id} {state}: {error}")
+
+    # Download result blob
+    result_resp = requests.get(
+        f"{BASE_URL}/api/jobs/{job_id}/result",
+        headers=headers,
+        timeout=60,
+    )
+    result_resp.raise_for_status()
+    return result_resp.content
 
 
 def run(
@@ -530,7 +561,7 @@ def run(
             print(f"    {recipe_name} ({len(channels)} ch)...", end=" ", flush=True)
             t0 = time.time()
             try:
-                png_data = generate_composite(channels, preset_name)
+                png_data = generate_composite(channels, token, preset_name)
                 output_path.write_bytes(png_data)
                 elapsed = time.time() - t0
                 size_kb = len(png_data) / 1024


### PR DESCRIPTION
## Summary
- Switch recipe walkthrough from sync `generate-nchannel` to async `export-nchannel` job queue
- Bump backend-to-processing-engine proxy timeouts for background job resilience

**Why:** Large multi-channel composites (4ch × 49 tiles = 11+ min) exceed the 10-minute `TotalRequestTimeout` on the backend's HttpClient. The async export queue eliminates HTTP timeout issues entirely — the walkthrough polls job status instead of blocking.

## Changes Made
- `scripts/recipe-walkthrough.py`: Rewrite `generate_composite()` to use `POST /api/composite/export-nchannel` (202 + job queue), poll `GET /api/jobs/{jobId}` for status, download `GET /api/jobs/{jobId}/result` on completion
- `backend/.../Program.cs`: Bump CompositeService and MosaicService resilience timeouts (AttemptTimeout: 5→30 min, TotalRequestTimeout: 10→60 min, CircuitBreaker sampling: 10→61 min) since background jobs have no user blocking on the HTTP response

## Test Plan
- [x] Backend builds, 1019 tests pass
- [x] Pre-commit hooks pass
- [x] CRAB-NEBULA 4-filter MIRI (4ch × 49 tiles): completed in 667s — previously timed out at 600s
- [x] CRAB-NEBULA Classic 3-color MIRI (3ch): completed in 311s
- [x] CRAB-NEBULA-BKG 7-filter MIRI (7ch): completed in 20s
- [x] CRAB-NEBULA-BKG Classic 3-color (3ch): completed in 15s
- [x] Container: 0 restarts, no OOM during all runs

## Documentation Checklist
- [x] No new endpoints or API changes
- [x] No model changes

## Tech Debt Impact
- [x] Reduces tech debt (removes fragile sync HTTP path from walkthrough)

## Risk & Rollback
Risk: Low — walkthrough script change only affects batch generation tooling. Timeout bumps are generous but safe since they only apply to background job processing.
Rollback: Revert commit.

No linked issue — follow-up from #874 / #875 OOM fix validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)