### PR TITLE
fix: exclude background/calibration targets from recipe generation

### DIFF
--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -98,10 +98,10 @@ def _is_o_prefix(obs_id: str) -> bool:
     return bool(_O_PREFIX_PATTERN.search(obs_id))
 
 
-# Suffixes that identify background/calibration field observations in MAST.
+# Patterns that identify background/calibration field observations in MAST.
 # These targets are used for background subtraction or calibration and should
 # not generate composite recipes (they produce random star fields, not science).
-_BACKGROUND_TARGET_SUFFIXES = ("-BKG", "_BKG", "-CAL", "_CAL")
+_BACKGROUND_TARGET_SUFFIXES = ("-BKG", "_BKG", "-BG", "_BG", "-CAL", "_CAL")
 
 
 def is_background_target(target_name: str | None) -> bool:
@@ -109,11 +109,14 @@ def is_background_target(target_name: str | None) -> bool:
 
     MAST uses suffixes like -BKG (background subtraction field) and -CAL
     (calibration field) to distinguish non-science pointings from the
-    actual science target.
+    actual science target. Also catches names containing "BACKGROUND"
+    (e.g. SQ-MRS-SKY-BACKGROUND, BACKGROUND-J0937+5628).
     """
     if not target_name:
         return False
     upper = target_name.upper()
+    if "BACKGROUND" in upper:
+        return True
     return upper.endswith(_BACKGROUND_TARGET_SUFFIXES)
 
 

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -1780,6 +1780,21 @@ class TestIsBackgroundTarget:
     def test_ngc_target_returns_false(self):
         assert is_background_target("NGC-3324") is False
 
+    def test_bg_suffix_hyphen(self):
+        assert is_background_target("SN-2013EJ-BG") is True
+
+    def test_bg_suffix_underscore(self):
+        assert is_background_target("SN_2013EJ_BG") is True
+
+    def test_background_in_name(self):
+        assert is_background_target("SQ-MRS-SKY-BACKGROUND") is True
+
+    def test_background_prefix(self):
+        assert is_background_target("BACKGROUND-J0937+5628") is True
+
+    def test_background_case_insensitive(self):
+        assert is_background_target("sky-background-field") is True
+
     def test_bkg_mid_word_not_matched(self):
         """BKG in the middle of a name is not a suffix match."""
         assert is_background_target("BKGND-FIELD") is False

--- a/scripts/recipe-walkthrough.py
+++ b/scripts/recipe-walkthrough.py
@@ -193,16 +193,19 @@ def get_all_data(token: str) -> list[dict]:
     return data.get("items", data.get("data", []))
 
 
-# Suffixes that identify background/calibration field observations in MAST.
+# Patterns that identify background/calibration field observations in MAST.
 # Duplicated from recipe_engine.py — script is standalone, doesn't import engine.
-_BACKGROUND_TARGET_SUFFIXES = ("-BKG", "_BKG", "-CAL", "_CAL")
+_BACKGROUND_TARGET_SUFFIXES = ("-BKG", "_BKG", "-BG", "_BG", "-CAL", "_CAL")
 
 
 def _is_background_target(target_name: str | None) -> bool:
     """Check if a target name indicates a background or calibration field."""
     if not target_name:
         return False
-    return target_name.upper().endswith(_BACKGROUND_TARGET_SUFFIXES)
+    upper = target_name.upper()
+    if "BACKGROUND" in upper:
+        return True
+    return upper.endswith(_BACKGROUND_TARGET_SUFFIXES)
 
 
 def group_by_target(records: list[dict]) -> dict[str, list[dict]]:


### PR DESCRIPTION
## Summary
Background field observations (e.g. `CRAB-NEBULA-BKG`, `SQ-MRS-SKY-BACKGROUND`) generate composite recipes that produce random star fields instead of science data. This adds target name filtering to exclude them.

## Why
Issue #868 — the recipe walkthrough generates recipes for background/calibration targets that exist in MAST for calibration purposes, not actual science imaging.

## Changes Made
- Added `is_background_target()` to recipe engine — filters targets by:
  - Suffix: `-BKG`, `_BKG`, `-BG`, `_BG`, `-CAL`, `_CAL` (case-insensitive)
  - Keyword: `BACKGROUND` anywhere in name
- Added early return in `generate_recipes()` to skip background targets before any processing
- Added `_is_background_target()` to walkthrough script's `group_by_target()` as pre-filter
- Added 19 unit tests covering positive cases, negative cases, edge cases, and integration through `generate_recipes()`

## Targets Excluded (from current database)
| Target | Observations | Effect |
|--------|-------------|--------|
| `CRAB-NEBULA-BKG` | 7 obs, 7 filters | ~4 junk recipes removed |
| `NGC628-MIRI-BKG` | 1 obs, 1 filter | Already skipped (needs ≥2) |
| `SN-2013EJ-BG` | 1 obs, 1 filter | Already skipped (needs ≥2) |
| `SQ-MRS-SKY-BACKGROUND` | 2 obs, 2 filters | ~1 junk recipe removed |
| `BACKGROUND-J0937+5628` | 10 obs, CH1 filters | Already skipped (IFU data) |

## Test Plan
- [x] Syntax check passes on all 3 changed files
- [x] Pre-commit hooks pass (ruff lint + format)
- [x] 19/19 new tests pass in Docker (`TestIsBackgroundTarget` + `TestGenerateRecipesBackgroundTarget`)
- [x] Full recipe engine suite: 158 passed, 0 regressions
- [ ] Manual: `python3 scripts/recipe-walkthrough.py --target CRAB` — only `CRAB-NEBULA` appears

## Documentation Checklist
- [x] No new endpoints, API changes, or model changes — no docs update needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — suffix and keyword filtering on target names, no API/model changes. False positive risk mitigated by requiring separator before suffix (not substring for BKG/CAL/BG).
Rollback: Revert these two commits.

Closes #868
