### PR TITLE
fix: use line content as React key instead of array index

### DIFF
--- a/frontend/jwst-frontend/src/components/CompositeWizard.tsx
+++ b/frontend/jwst-frontend/src/components/CompositeWizard.tsx
@@ -174,11 +174,11 @@ export const CompositeWizard: React.FC<CompositeWizardProps> = ({
               <div className="overlap-warning-text">
                 {overlapWarning.split('\n').map((line, i) =>
                   i === 0 ? (
-                    <p key={i} className="overlap-warning-summary">
+                    <p key={line} className="overlap-warning-summary">
                       {line}
                     </p>
                   ) : (
-                    <p key={i} className="overlap-warning-group">
+                    <p key={line} className="overlap-warning-group">
                       {line}
                     </p>
                   )

--- a/frontend/jwst-frontend/src/pages/CompositePage.tsx
+++ b/frontend/jwst-frontend/src/pages/CompositePage.tsx
@@ -232,11 +232,11 @@ export function CompositePage() {
               <div className="overlap-warning-text">
                 {overlapWarning.split('\n').map((line, i) =>
                   i === 0 ? (
-                    <p key={i} className="overlap-warning-summary">
+                    <p key={line} className="overlap-warning-summary">
                       {line}
                     </p>
                   ) : (
-                    <p key={i} className="overlap-warning-group">
+                    <p key={line} className="overlap-warning-group">
                       {line}
                     </p>
                   )


### PR DESCRIPTION
## Summary
Fix pre-existing ESLint `no-array-index-key` warnings in overlap warning banners.

## Why
CI was reporting these warnings on every PR. Line content is unique per warning message, making it a stable React key.

## Changes Made
- `CompositeWizard.tsx`: Use `line` content as key instead of array index `i`
- `CompositePage.tsx`: Same fix

## Test Plan
- [x] ESLint: warnings eliminated (only unrelated `initialFeatherStrength` dep warning remains)
- [x] 883 frontend tests pass
- [x] TypeScript compiles clean

## Documentation Checklist
- [x] N/A — lint fix only

## Tech Debt Impact
- [x] Reduces warnings — 2 fewer ESLint warnings in CI output

## Risk & Rollback
Risk: None — key change only affects React reconciliation for static warning text.
Rollback: Revert.

No linked issue
