### PR TITLE
chore: process improvements — trim AGENTS.md, add skills, docs audit

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: debug
+description: Full-stack debugging approach for the JWST application — traces issues through frontend, backend API, processing engine, and MongoDB. Use this skill when investigating errors (401s, 500s, download failures, rendering issues), debugging unexpected behavior, or when the user reports something broken. Also triggers on "debug this", "why is this failing", "trace this error", "investigate this bug".
+---
+
+# Full-Stack Debugging
+
+The JWST app has four layers. Errors often manifest in one layer but originate in another. Trace through the full stack — don't stop at the first layer.
+
+## Architecture
+
+```
+Frontend (:3000) → Backend API (:5001) → MongoDB (:27017)
+                                       → Processing Engine (:8000) → MAST Portal (STScI)
+```
+
+## Debugging Protocol
+
+### 1. Check Server Logs First
+
+Before suggesting the user troubleshoot manually, check logs and existing code:
+
+```bash
+docker compose -f docker/docker-compose.yml logs --tail=50 backend    # .NET API
+docker compose -f docker/docker-compose.yml logs --tail=50 processing # Python FastAPI
+docker compose -f docker/docker-compose.yml logs --tail=50 frontend   # Vite dev server
+```
+
+### 2. Trace the Request Path
+
+| Symptom | Start here | Then check |
+|---------|-----------|------------|
+| 401/403 errors | Backend auth middleware → AuthController | Frontend AuthContext, token refresh |
+| Download failures | Processing engine MAST client | Backend proxy endpoints, CORS |
+| Rendering issues | Frontend component → browser console | Backend API response shape |
+| Slow responses | Processing engine logs (timing) | Backend async operations |
+| Data missing | MongoDB queries in MongoDBService | Backend DTO mapping (snake_case ↔ camelCase) |
+
+### 3. Common Gotchas
+
+- **JSON casing mismatch**: Backend uses snake_case, frontend uses camelCase. Check DTO mapping for new endpoints.
+- **Auth flow is fragile** — be extra careful when touching it.
+- **Processing engine** fetches from backend API, not directly from MongoDB.
+- **SignalR connections** can silently fail — check hub connection state in frontend.
+
+### 4. Testing the Fix
+
+Run relevant tests via Docker:
+```bash
+docker exec jwst-processing python -m pytest     # Python tests
+docker exec jwst-backend dotnet test              # .NET tests (if available)
+```
+
+For frontend, the pre-commit hook catches type errors and test failures automatically.
+
+## Bug Filing
+
+If a bug is found during other work and is outside current scope:
+- File a [GitHub Issue](https://github.com/Snoww3d/jwst-data-analysis/issues) with `bug` label
+- Don't fix it in the current PR — separate branch/PR
+- But don't dismiss it as "pre-existing" either — track it immediately

--- a/.claude/skills/doc-update/SKILL.md
+++ b/.claude/skills/doc-update/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: doc-update
+description: Documentation update guide for the JWST project — which docs to update for each type of change. Use this skill when finishing a feature, adding endpoints, changing models, updating frontend components, or when the doc drift hook fires a warning. Also triggers on "update docs", "which docs need updating", "documentation checklist".
+---
+
+# Documentation Update Guide
+
+When source code changes affect behavior, update the corresponding documentation in the same PR.
+
+## Update Matrix
+
+| Change Type            | Files to Update                                                              |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| New API endpoint       | `docs/quick-reference.md`, `docs/standards/backend-development.md`           |
+| New data model field   | `docs/standards/database-models.md`, `docs/standards/backend-development.md` |
+| New frontend feature   | `docs/standards/frontend-development.md`                                     |
+| Phase completion       | `docs/development-plan.md`                                                   |
+| New TypeScript type    | `docs/standards/frontend-development.md`                                     |
+| Tech debt / bugs       | File as [GitHub Issue](https://github.com/Snoww3d/jwst-data-analysis/issues) with `tech-debt` or `bug` label |
+| **Any feature change** | `docs/plans/exploration/desktop-requirements.md` (keep desktop spec in sync)  |
+
+## Desktop Requirements Sync
+
+`docs/plans/exploration/desktop-requirements.md` captures all features as platform-agnostic requirements for a future desktop version. When adding or modifying features, update the corresponding functional requirements (FR-*) to keep the spec aligned.
+
+## Verification
+
+Before pushing, run: `grep -rn '<changed-name>' docs/` to confirm documentation references are consistent.
+
+## When Controller/Service/Endpoint Changes
+
+If a PR adds or renames a controller, service, or endpoint, update in the same PR:
+- `docs/key-files.md`
+- `docs/standards/backend-development.md`
+- `docs/architecture/`
+- `docs/quick-reference.md`
+
+Also triggered by: new API params, new frontend components, workflow changes, removed endpoints/files.
+
+## Before Marking Dev-Plan Tasks Complete
+
+Before checking off a broad task in `docs/development-plan.md`, grep for other places the task applies. Break into sub-items if others remain.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: git-workflow
+description: Git workflow for the JWST project — branch creation, commit flow, PR creation, and merge process. Use this skill whenever creating branches, committing code, creating PRs, or merging. Also triggers on "commit this", "push this", "create a PR", "merge", "git flow", or any git operation beyond simple status/log/diff checks.
+---
+
+# Git Workflow
+
+This skill covers the full branch → commit → PR → merge lifecycle for this project.
+
+## Branch-First Rule
+
+Before making any file edits:
+
+1. `git rev-parse --abbrev-ref HEAD` — confirm you're not on main.
+2. If on main: `git checkout -b <type>/<short-description>`.
+3. Only then begin changes.
+
+The pre-commit hook blocks commits to main as a safety net, but don't rely on it — create the branch first.
+
+### Branch Naming
+
+`{type}/{short-description}` — valid prefixes: `feature/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`, `perf/`, `ci/`, `dependabot/`, `codex/`.
+
+The PreToolUse hook validates branch prefixes on `gh pr create` and will block invalid names.
+
+## Commit Flow
+
+- Use **conventional commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
+- Keep commits **focused and atomic**.
+- `git add <specific-files>` — never `git add .` (picks up unintended files).
+- Pre-commit hook runs automatically: ESLint, Prettier, tsc, vitest, dotnet build+test, ruff. Don't duplicate these manually.
+
+## PR Creation
+
+1 Task = 1 PR. Each task gets its own branch and PR.
+
+```bash
+git push -u origin <branch>
+gh pr create --title "<type>: Summary" --body "$(cat <<'EOF'
+## Summary
+...
+## Changes Made
+- ...
+## Test Plan
+- [x] ...
+## Documentation Checklist
+- [x] ...
+## Tech Debt Impact
+- [x] ...
+## Risk & Rollback
+Risk: ...
+Rollback: ...
+
+Closes #N
+EOF
+)"
+```
+
+The PreToolUse hook validates that all required sections are present before `gh pr create` runs. It will block if any section is missing.
+
+### PR Title Format
+
+`{type}: Description` or `{type}: Description (Task #N)`
+
+### Tiered Merge Policy
+
+- **Auto-merge** (no review needed): docs-only, test-only, config/linting, dependency bumps, style fixes
+- **Skim review**: Low-risk feature/bug PRs — ping user, merge unless they want to look closer
+- **Full review required**: Medium+ risk, auth changes, data model changes, storage/security changes — always wait for explicit approval
+
+## No Dangling Changes
+
+After completing a PR, `git status` and resolve uncommitted changes immediately:
+
+- Related to completed work → follow-up PR
+- Separate concern → separate PR
+- Not needed → `git restore` / `git clean`
+
+## Before Pushing to Existing Branches
+
+Check if the branch's PR was already merged: `gh pr list --head <branch> --state merged`. The PreToolUse hook (`block-push-merged-branch.sh`) also enforces this — if a PR was merged, create a new branch from main.
+
+## Plan Review Before Implementation
+
+Before writing code for any feature, bug fix, or refactor:
+
+1. **`/plan-ceo-review`** — rethinks the problem, challenges premises
+2. **`/plan-eng-review`** for medium+ complexity — challenges architecture, catches complexity traps
+
+Both reviews should complete before the first line of implementation code is written.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,12 @@
 # AGENTS.md
 
-> **AI-Assisted Development**: This project is built with multiple AI coding agents
-> (Claude Code, Codex) working in parallel from isolated git worktrees.
-> This file defines the shared rules they follow. It is intentionally committed
-> to the public repository as part of the project's development methodology.
-
-Primary guidance for all coding agents working in this repository.
-
-## Scope and Precedence
-
-- This file defines shared workflow, process, and project expectations for every agent.
-- Tool-specific config files (gitignored) may add tips specific to individual tool capabilities.
-- If a tool-specific file conflicts with this file on shared process rules, **this file wins**.
-
-## Default Collaboration Style (All Agents)
-
-- Default to constructive challenge, not agreement-first responses.
-- Before endorsing an idea, surface the strongest practical reasons it could fail (risk, cost, maintenance, security, or complexity).
-- Offer at least one lower-cost alternative when the proposed approach is heavy or premature.
-- State clear go/no-go criteria when giving recommendations so decisions are testable.
-- If evidence is weak, say so directly and recommend validation steps instead of optimistic assumptions.
+Primary guidance for all agents working in this repository.
 
 ## Project Overview
 
-JWST Data Analysis Application — a microservices-based platform for analyzing James Webb Space Telescope data with advanced scientific computing capabilities.
+JWST Data Analysis Application — a microservices-based platform for analyzing James Webb Space Telescope data.
 
 **Architecture**: Frontend (React TypeScript) → Backend (.NET 10 API) → MongoDB + Processing Engine (Python FastAPI) → MAST Portal (STScI)
-
-**Service URLs** (local Docker):
 
 | Service           | URL    | Tech                      |
 | ----------------- | ------ | ------------------------- |
@@ -37,327 +16,98 @@ JWST Data Analysis Application — a microservices-based platform for analyzing 
 | MongoDB           | :27017 | Document database         |
 | Documentation     | :8001  | MkDocs                    |
 
-## Architecture Notes
-
-See [`docs/architecture/`](docs/architecture/index.md) for detailed diagrams.
-
-Key facts for development:
+## Architecture Constraints
 
 - All DB operations go through `MongoDBService.cs` (repository pattern) — never direct MongoDB calls in controllers.
 - All services have interfaces for testability (e.g. `IMongoDBService`, `IMastService`, `ICompositeService`).
-- Frontend state: local React hooks (useState/useEffect) + AuthContext for authentication.
+- Frontend state: local React hooks + AuthContext for authentication.
 - Processing engine fetches data from backend API (not directly from MongoDB).
-- Frontend uses SVG overlays for interactive drawing (annotations, regions, WCS grid) and canvas for high-performance rendering (histogram, curves editor).
-- Collapsible panel pattern: `collapsed` + `onToggleCollapse()` props on HistogramPanel, CurvesEditor, RegionStatisticsPanel, StretchControls, CubeNavigator.
-- Composite and mosaic wizards are **page routes** (`/composite`, `/mosaic`) with 2-step navigation (channel assignment → preview).
-- Guided create flow: `/create?target=...&recipe=...` — public discovery → auth gate → download → composite → result.
-- Async job queue: composite/mosaic/import jobs use a unified `IJobTracker` with SignalR push for real-time progress. Backend background services process queued items.
+- Async job queue: composite/mosaic/import jobs use `IJobTracker` with SignalR push.
+- JSON casing: backend uses **snake_case**, frontend uses **camelCase** — verify DTO mapping for new endpoints.
+- Auth flow is currently fragile — be extra careful when touching it.
 
-## Current Development Phase
+## Current Phase
 
-**Phases 1–4 complete.** Currently working across **Phase 5** (Scientific Processing & Infrastructure), **Phase 6** (Integration & Advanced Features), and **Phase 7** (Testing & Deployment).
+**Phases 1–4 complete.** Working across Phases 5–7. See [`docs/development-plan.md`](docs/development-plan.md) for details.
 
-**Recent focus**: Public discovery experience, guided composite creation, NASA color palette, SignalR real-time progress, layout/UX improvements.
-
-See [`docs/development-plan.md`](docs/development-plan.md) for the full 7-phase roadmap, completed items, and remaining work.
-
-## Quick Start (Docker — Recommended)
+## Quick Start
 
 ```bash
-cd docker && cp .env.example .env       # First time: copy env template
+cd docker && cp .env.example .env       # First time
 docker compose up -d                     # Start all services
-docker compose logs -f                   # View logs
-docker compose down                      # Stop services
-docker compose up -d --build             # Rebuild after code changes
+docker compose up -d --build             # Rebuild after changes
 ```
 
-`.env` is gitignored. Default values work for local dev. See [`docs/setup-guide.md`](docs/setup-guide.md) for full setup including default credentials.
+For full setup: [`docs/setup-guide.md`](docs/setup-guide.md). For service-specific dev commands: same file.
 
-### Git Hooks (Recommended)
+## Core Rules
 
-```bash
-./scripts/setup-hooks.sh   # Installs pre-push hook that blocks direct pushes to main
-```
+- **Never push directly to `main`** — hooks enforce this at commit and push time.
+- Every change goes through a **feature branch + PR** (see `/git-workflow` skill).
+- **Conventional commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
+- **1 Task = 1 PR** — atomic, reviewable changes.
+- **Plan review before implementation**: `/plan-ceo-review` always, `/plan-eng-review` for medium+ complexity.
 
-### Service-Specific Development
+## Testing Philosophy
 
-**Backend (.NET 10)**:
+- **Never delete or weaken tests** — if tests fail due to architecture, fix the architecture.
+- Create interfaces for dependencies to enable proper mocking.
+- Use Moq for .NET unit tests; `NullLogger<T>` only for the class under test.
+- Python tests run via Docker: `docker exec jwst-processing python -m pytest`.
 
-```bash
-cd backend
-dotnet restore JwstDataAnalysis.sln
-dotnet build JwstDataAnalysis.sln
-dotnet test JwstDataAnalysis.API.Tests --verbosity normal
-cd JwstDataAnalysis.API && dotnet run
-```
+## Hook Enforcement
 
-**Frontend (React + Vite)**:
+Quality is enforced structurally, not by memory:
 
-```bash
-cd frontend/jwst-frontend
-npm install
-npm run dev         # Dev server on :3000
-npm run build       # Production build
-```
+| Hook | When | What |
+|------|------|------|
+| Pre-commit (git) | At commit | Blocks main, runs ESLint, Prettier, tsc, vitest, dotnet build+test, ruff |
+| Pre-push (git) | At push | Blocks pushes to main |
+| validate-before-pr-create | Before `gh pr create` | Validates PR body sections and branch prefix |
+| block-pr-merge | Before `gh pr merge` | Warns — get user approval |
+| block-push-merged-branch | Before `git push` | Blocks pushes to branches with merged PRs |
+| post-edit-typecheck | After Edit/Write | Per-file tsc on .ts/.tsx files |
+| post-edit-lint | After Edit/Write | Anti-pattern scan (inline styles, `any`, unexplained suppressions, debug logging) |
+| post-edit-doc-drift | After Edit/Write | Scores changes, warns when docs may need updating |
 
-**Processing Engine (Python)**:
+Don't manually run checks the hooks already enforce.
 
-```bash
-cd processing-engine
-python3 -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-uvicorn main:app --reload    # Server on :8000
-pytest
-```
+## Security
 
-## Core Workflow Rules
+- Credentials via environment variables in `docker/.env` (gitignored, copy from `.env.example`).
+- Processing engine has DoS limits: `MAX_FITS_FILE_SIZE_MB` (2GB), `MAX_FITS_ARRAY_ELEMENTS` (100M), `MAX_MOSAIC_OUTPUT_PIXELS` (64M).
+- Before production: strong passwords, review CORS/auth config, remove seed accounts.
 
-- **Never push directly to `main`** — not even for "quick fixes" or docs-only changes. Server-side branch protection enforces this (required status checks, no force pushes, no deletions).
-- Every change goes through a **feature branch + PR**.
-- Use **conventional commit prefixes**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
-- Follow the **tiered merge policy**: docs/test/config PRs can auto-merge when CI passes; low-risk features get a skim review; medium+ risk changes require explicit maintainer approval.
-- Keep commits **focused and atomic**.
+## Bug & Tech Debt
 
-### Plan Review Before Implementation
-
-Before writing code for any feature, bug fix, or refactor:
-
-1. **Run `/plan-ceo-review`** — rethinks the problem, challenges premises, ensures you're solving the right thing. Especially important before entering plan mode.
-2. **Run `/plan-eng-review`** for medium+ complexity work — challenges architecture, catches complexity traps, produces a test plan artifact.
-
-Both reviews should complete before the first line of implementation code is written.
-
-### Branch-First Rule
-
-Before making any file edits:
-
-1. Run `git status` to confirm current branch and state.
-2. Create the feature branch: `git checkout -b <type>/<short-description>`.
-3. Only then begin making changes.
-
-This prevents accidental work on `main`.
-
-### No Dangling Changes
-
-After completing a PR, run `git status` and resolve any uncommitted changes immediately:
-
-- Related to completed work → follow-up PR.
-- Separate concern → separate PR or flag for maintainer decision.
-- Not needed → discard with `git restore` / `git clean`.
-
-Never proceed to new tasks with uncommitted changes lingering.
-
-## Standard Git Flow
-
-```bash
-git status                                          # Confirm clean state
-git checkout -b <type>/<short-description>          # Create branch
-
-# Make changes and commit
-git add <specific-files>
-git commit -m "<type>: <summary>"
-
-# Push and create PR
-git push -u origin <branch>
-gh pr create --title "<type>: Summary" --body "..."
-
-# Wait for CI, then request review
-gh pr checks <pr-number>
-# STOP — report PR URL, CI status, wait for maintainer approval
-
-# After approval
-gh pr merge <pr-number> --merge --delete-branch
-```
-
-### Branch Naming
-
-`{type}/{short-description}` or `{type}/task-{N}-{short-description}`
-
-Examples:
-
-- `feature/spectral-line-tool`
-- `fix/task-3-auth-refresh-loop`
-- `refactor/task-6-mast-import`
-- `docs/expand-agents-md`
-
-### PR Title Format
-
-`{type}: Description` or `{type}: Description (Task #N)`
-
-### 1 Task = 1 PR
-
-Each task gets its own feature branch and PR. This ensures atomic, reviewable changes, clear commit history, and easy rollback.
-
-## Pre-PR Checklist
-
-Before creating a PR, verify:
-
-1. **Linting passes** — run relevant quality tools (see [Code Quality Tools](#code-quality-tools)).
-2. **Tests pass** — `dotnet test`, `npm run test`, `pytest` as applicable.
-3. **Docker verification** — for integration/backend changes, rebuild and test in Docker (`docker compose up -d --build`).
-4. **Documentation updated** — update relevant docs if the change affects APIs, features, models, or milestones (see [Documentation Expectations](#documentation-expectations)).
-5. **Test plan executed** — run all items in the PR's test plan using the Docker environment. Document results (pass/fail). If a test item cannot be executed (e.g. requires manual UI interaction), note that clearly.
-
-## Session Wrap-up
-
-At the end of every session, run `/retro` to generate a velocity retrospective. This surfaces commit metrics, session patterns, file hotspots, and friction signals. Running this consistently builds data to tune work cadence over time.
+- Tracked in [GitHub Issues](https://github.com/Snoww3d/jwst-data-analysis/issues) (`tech-debt`, `bug` labels).
+- `docs/tech-debt.md` and `docs/bugs.md` are historical references only.
 
 ## Agent Coordination
 
 > **Status**: Multi-agent parallel development was attempted but didn't work well in practice. The infrastructure (`scripts/agent-docker.sh`, isolated Docker stacks) still exists if revisited later, but is not actively used.
 
-Current workflow: **single agent, sequential tasks**. All work goes through the standard branch → PR → merge flow.
+Current workflow: **single agent, sequential tasks**.
 
-If parallel agents are revisited, key infrastructure:
-- `scripts/agent-docker.sh` — manages per-agent Docker stacks on separate ports
-- Worktrees would be siblings of the primary clone (e.g. `Astronomy-agent-1`)
+## Skills
 
-## Coding Standards
+Procedural knowledge lives in skills (loaded on demand, zero tokens when inactive):
 
-### Backend (.NET)
+| Skill | When |
+|-------|------|
+| `/git-workflow` | Branch, commit, PR, merge operations |
+| `/doc-update` | Finishing features, the doc drift hook fires |
+| `/debug` | Investigating errors or unexpected behavior |
+| `/plan-ceo-review` | Before any implementation |
+| `/plan-eng-review` | Medium+ complexity work |
+| `/retro` | End of session |
+| `/compliance-check` | Before merge |
 
-- Async/await for all database operations
-- Dependency injection for services
-- MongoDB.Driver for database access (never direct queries)
-- Nullable reference types enabled
-- PascalCase for public members
-- Structured logging with ILogger
-- DTOs for request/response validation
-- JSON casing: backend uses **snake_case** — verify DTO mapping when connecting new endpoints
+## Session Wrap-up
 
-### Frontend (React)
+Run `/retro` at the end of every session.
 
-- TypeScript interfaces mirror backend models (keep in sync)
-- Functional components with hooks
-- Semantic HTML with ARIA attributes
-- CSS classes (no inline styles)
-- Error boundaries with try-catch
-- Loading states for async operations
-- JSON casing: frontend uses **camelCase**
-
-### Processing Engine (Python)
-
-- Type hints with Pydantic models
-- Async routes in FastAPI
-- Astropy for FITS file handling
-- NumPy for numerical operations
-- pytest for testing
-- Uses **Python 3.10+ syntax** — do not use 3.9 patterns
-- **Always run `ruff check . && ruff format .` before committing** (CI will fail otherwise)
-
-## Testing Standards
-
-### Never Delete or Weaken Tests
-
-- If tests fail due to architectural limitations (e.g. can't mock a concrete class), **fix the architecture**, not the tests.
-- Create interfaces for dependencies to enable proper mocking.
-- Removing or simplifying tests to make them pass is never acceptable.
-
-### Test Architecture
-
-- All services should have interfaces for testability (e.g. `IMongoDBService`, `IMastService`).
-- Use Moq for mocking interfaces in .NET unit tests.
-- Use `NullLogger<T>` only for the class under test, not for its dependencies.
-- Controller tests should mock all service dependencies.
-
-### When Tests Fail
-
-1. Identify the root cause (missing interface, tight coupling, etc.).
-2. Fix the architectural issue first.
-3. Keep the original test logic intact.
-4. Add the fix as a separate commit with clear explanation.
-
-### Gotchas
-
-- **JSON casing mismatch**: backend snake_case vs frontend camelCase. Verify DTO mapping for new endpoints.
-- **Python processing engine** uses 3.10+ syntax — do not use 3.9 patterns.
-- Always run the **full test suite** before committing.
-
-## Code Quality Tools
-
-### Frontend (ESLint + Prettier)
-
-```bash
-cd frontend/jwst-frontend
-npm run lint          # Check for linting issues
-npm run lint:fix      # Auto-fix linting issues
-npm run format        # Format code with Prettier
-npm run format:check  # Check formatting without changes
-```
-
-### Backend (.NET Analyzers)
-
-```bash
-cd backend/JwstDataAnalysis.API
-dotnet build          # Analyzers run automatically during build
-dotnet format         # Format code according to .editorconfig
-```
-
-### Processing Engine (Ruff)
-
-```bash
-cd processing-engine
-ruff check .          # Lint Python code
-ruff check --fix .    # Auto-fix lint issues
-ruff format .         # Format Python code
-```
-
-CI runs all linting checks on every PR.
-
-## Security Notes
-
-### Environment Configuration
-
-- All credentials are configured via environment variables in `docker/.env`.
-- `.env` is gitignored and should never be committed. Copy from `.env.example`.
-- Default values in docker-compose.yml are for local development only.
-
-### Processing Engine Resource Limits (DoS Protection)
-
-| Variable                   | Default     | Description                           |
-| -------------------------- | ----------- | ------------------------------------- |
-| `MAX_FITS_FILE_SIZE_MB`    | 2048 (2 GB) | Maximum FITS file size                |
-| `MAX_FITS_ARRAY_ELEMENTS`  | 100,000,000 | Maximum array elements before loading |
-| `MAX_MOSAIC_OUTPUT_PIXELS` | 64,000,000  | Maximum mosaic output grid size       |
-
-Files/arrays exceeding limits return HTTP 413 Payload Too Large.
-
-### Before Production
-
-- Set a strong, unique `MONGO_ROOT_PASSWORD` in `.env`.
-- Review authentication configuration for production requirements.
-- Review CORS configuration for production.
-- Remove or change passwords for any seed accounts (`admin`/`demo`).
-- Review all environment variables for production values.
-
-## Bug & Tech Debt Workflow
-
-- Active bug and tech debt tracking lives in [GitHub Issues](https://github.com/Snoww3d/jwst-data-analysis/issues). `docs/tech-debt.md` and `docs/bugs.md` are historical references only.
-- When asked about "the next bug" or "next tech debt item", check GitHub Issues first (`gh issue list --label tech-debt` or `gh issue list --label bug`).
-- Auth flow is currently fragile — be extra careful when touching it.
-
-### Debugging Approach
-
-- When errors are reported (e.g. 401, download failures), check server logs and existing code **first** before suggesting the user troubleshoot manually.
-- Trace issues through the full stack (frontend → API → backend → processing engine) rather than stopping at the first layer.
-
-## Documentation Expectations
-
-Update docs when behavior changes:
-
-| Change Type            | Files to Update                                                              |
-| ---------------------- | ---------------------------------------------------------------------------- |
-| New API endpoint       | `docs/quick-reference.md`, `docs/standards/backend-development.md`           |
-| New data model field   | `docs/standards/database-models.md`, `docs/standards/backend-development.md` |
-| New frontend feature   | `docs/standards/frontend-development.md`                                     |
-| Phase completion       | `docs/development-plan.md`                                                   |
-| New TypeScript type    | `docs/standards/frontend-development.md`                                     |
-| Tech debt / bugs       | File as [GitHub Issue](https://github.com/Snoww3d/jwst-data-analysis/issues) with `tech-debt` or `bug` label |
-| **Any feature change** | `docs/plans/exploration/desktop-requirements.md` (keep desktop spec in sync)  |
-
-> **Desktop Requirements Sync**: `docs/plans/exploration/desktop-requirements.md` captures all features as platform-agnostic requirements for a future desktop version. When adding or modifying features, update the corresponding functional requirements (FR-*) to keep the spec aligned.
-
-## Authoritative Project References
+## References
 
 | Resource                | Location                                                                 |
 | ----------------------- | ------------------------------------------------------------------------ |
@@ -366,23 +116,13 @@ Update docs when behavior changes:
 | Key file map            | [`docs/key-files.md`](docs/key-files.md)                                 |
 | Quick reference & API   | [`docs/quick-reference.md`](docs/quick-reference.md)                     |
 | Technical standards     | `docs/standards/`                                                        |
-| Backlog tracking        | [GitHub Issues](https://github.com/Snoww3d/jwst-data-analysis/issues) (`tech-debt`, `bug` labels) |
+| Backlog tracking        | [GitHub Issues](https://github.com/Snoww3d/jwst-data-analysis/issues)   |
 | Development roadmap     | [`docs/development-plan.md`](docs/development-plan.md)                   |
 | Desktop requirements    | [`docs/plans/exploration/desktop-requirements.md`](docs/plans/exploration/desktop-requirements.md) |
 | Feature ideas           | [`docs/feature-ideas.md`](docs/feature-ideas.md)                         |
 | Swagger UI              | <http://localhost:5001/swagger>                                          |
 
-## Tooling Notes
+## Tooling
 
-- Prefer repository scripts and standard CLI commands over tool-specific slash commands.
-- Keep instructions repository-relative and portable; avoid machine-specific absolute paths in shared docs.
-- Run processing engine tests via Docker (local macOS Python may be too old): `docker exec jwst-processing python -m pytest`.
-
-### Browser Automation (playwright-cli)
-
-- **playwright-cli** is used for agent-driven browser automation and screenshot capture. Config: `playwright-cli.json`.
-- **@playwright/test** (in `frontend/jwst-frontend/`) remains the CI test runner for e2e tests. These are separate tools.
-- Capture documentation screenshots: `./scripts/capture-screenshots.sh` (requires Docker stack running).
-- The screenshot script handles auth injection (registers a temp user, sets localStorage tokens).
-- Use `--headed` flag for visible browser debugging.
-- playwright-cli is installed globally (`npm install -g @playwright/cli@latest`) to avoid version conflicts with @playwright/test v1.49.
+- Run processing engine tests via Docker: `docker exec jwst-processing python -m pytest`.
+- **playwright-cli** for browser automation; **@playwright/test** for CI e2e tests. These are separate tools.

--- a/docs/audits/2026-03-19-docs-audit.md
+++ b/docs/audits/2026-03-19-docs-audit.md
@@ -1,0 +1,481 @@
+# Documentation Audit Report
+**Date**: 2026-03-19
+**Project**: JWST Data Analysis Application
+**Scope**: Complete documentation review against codebase and AGENTS.md specification
+
+---
+
+## Executive Summary
+
+The JWST Data Analysis project maintains comprehensive documentation across **115+ markdown files** with strong coverage of architecture, development standards, and API references. Overall documentation quality is **good**, with well-organized hierarchies and clear structure. However, several gaps and inconsistencies were identified:
+
+**Key Findings**:
+- ✅ **Strong coverage**: Architecture flows, backend/frontend standards, API quick reference, setup guide
+- ⚠️ **Gaps identified**: Processing engine analysis module, semantic search, frontend utilities, edge cases in deployment
+- ⚠️ **Inconsistencies**: AGENTS.md mentions some undocumented features (semantic routes, diagnostics module)
+- ⚠️ **Outdated references**: Development plan roadmap needs updating for current Phase 5b focus
+- ✅ **Well-maintained**: Tech debt and bug tracking properly migrated to GitHub Issues
+
+---
+
+## 1. Documentation Inventory
+
+### 1.1 Documentation Structure
+
+```
+docs/
+├── architecture/         [14 files] — System design and data flows ✅
+├── standards/           [8 files]  — Development rules and patterns ✅
+├── plans/               [8 files]  — Design, exploration, feature specs ✅
+├── blog/                [67 files] — Development journal (posts + MILESTONES)
+├── audits/              [3 files]  — Historical code reviews
+├── index.md             — Landing page
+├── quick-reference.md   — API endpoints and patterns ✅
+├── setup-guide.md       — Docker and local setup ✅
+├── development-plan.md  — Roadmap and current phase ✅
+├── tech-debt.md         — Historical debt (superseded by GitHub Issues)
+├── key-files.md         — File location reference ✅
+├── bugs.md              — Bug tracking (superseded by GitHub Issues)
+├── mast-usage.md        — MAST search examples
+└── Other files: deployment.md, feature-ideas.md, completed-phases.md, etc.
+```
+
+### 1.2 Root-Level Documentation
+
+| File | Status | Notes |
+|------|--------|-------|
+| `README.md` | ✅ Current | Feature list, tech stack, quick start, links to key docs |
+| `AGENTS.md` / `CLAUDE.md` | ✅ Current | Comprehensive AI development rules, architecture overview, phase status |
+| `CONTRIBUTING.md` | ✅ Current | PR workflow, coding standards, issue reporting |
+| `CODE_OF_CONDUCT.md` | ✅ Current | Contributor covenant |
+| `SECURITY.md` | ✅ Current | Security reporting guidelines |
+
+---
+
+## 2. What Documentation Exists & Coverage
+
+### 2.1 Architecture Documentation (14 files)
+
+| Document | Coverage | Status |
+|----------|----------|--------|
+| `system-overview.md` | High-level microservices diagram | ✅ Complete |
+| `frontend-architecture.md` | Routes, component hierarchy, state management | ✅ Complete |
+| `backend-service-layer.md` | Repository pattern, service interfaces | ✅ Complete |
+| `storage-layer.md` | Storage abstraction, S3/local providers | ✅ Complete |
+| `mongodb-document.md` | Document schema and flexible fields | ✅ Complete |
+| `processing-engine.md` | MAST proxy vs. processing engine split, module breakdown | ⚠️ Partial |
+| `data-lineage.md` | JWST processing levels, observation grouping | ✅ Complete |
+| `job-queue-signalr.md` | Async job pattern, real-time progress | ✅ Complete |
+| `authentication-flow.md` | JWT, access/refresh tokens, refresh retry logic | ✅ Complete |
+| `security-model.md` | Roles, authorization matrix, access patterns | ✅ Complete |
+| `mast-import-flow.md` | Search, chunked download, state persistence | ✅ Complete |
+| `local-upload-flow.md` | File upload, validation, storage routing | ✅ Complete |
+| `guidedcreate-flow.md` | 3-step creation: download → process → result | ✅ Complete |
+| `discovery-recipe-flow.md` | Featured targets, recipe suggestions, search | ✅ Complete |
+| `docker-compose.md` | Service orchestration, networking | ✅ Complete |
+
+**Processing Engine Gap**: `processing-engine.md` covers MAST proxy and high-level module names but lacks detailed documentation for:
+- `app/analysis/` module (region statistics, source detection)
+- `app/semantic/` module (embedding service, FAISS vector store)
+- `app/diagnostics.py` (memory monitoring utilities)
+- `app/processing/` directory structure
+
+### 2.2 Development Standards (8 files)
+
+| Document | Coverage | Status |
+|----------|----------|--------|
+| `README.md` (standards/) | Index of all standards | ✅ Complete |
+| `project-overview.md` | Architecture, tech stack, service URLs | ✅ Complete |
+| `backend-development.md` | Architecture, key files, controllers, services, DB patterns | ✅ Complete |
+| `frontend-development.md` | TBD — Not fully reviewed |
+| `processing-engine.md` | Python standards, type hints, async FastAPI | ✅ Complete |
+| `database-models.md` | MongoDB schema, nullable types, indexing | ✅ Complete |
+| `development-workflow.md` | Git, testing, documentation expectations | ✅ Complete |
+| `docker-deployment.md` | Containerization, multi-service orchestration | ✅ Complete |
+
+### 2.3 Planning & Feature Documents
+
+Well-organized under `docs/plans/`:
+- **design/** — Color mapping, guided discovery UX, job queue, 2x UX specs
+- **exploration/** — Cloud storage, processing engine scaling, desktop requirements, Claude Code agents
+- **features/** — Auto-stretch detection, smart recipe ranking, observation mosaic, coverage-aware blending
+
+**Status**: ✅ Complete but not all feature specs have corresponding implementation docs.
+
+### 2.4 Quick Reference & API Documentation
+
+| Document | Coverage | Gaps |
+|----------|----------|------|
+| `quick-reference.md` | 47 endpoints documented (health, auth, CRUD, MAST, composite, mosaic, analysis, discovery, search) | ⚠️ Analysis and discovery endpoints mentioned but lacking details (see section 3.2) |
+| `key-files.md` | 232 file entries across backend, frontend, processing engine | ✅ Comprehensive |
+| `setup-guide.md` | Docker quick start, service URLs, default credentials, env variables | ✅ Complete |
+| `mast-usage.md` | MAST search syntax, filter examples | ✅ Complete |
+
+---
+
+## 3. Identified Gaps & Inconsistencies
+
+### 3.1 Processing Engine Documentation Gaps
+
+**Missing detailed documentation for**:
+
+1. **Analysis Module** (`app/analysis/routes.py`, `models.py`)
+   - Quick reference mentions endpoints but not their inputs/outputs
+   - No documentation of region selection algorithm, ellipse/rectangle mask generation
+   - Source detection parameters not documented
+
+2. **Semantic Search Module** (`app/semantic/routes.py`, `embedding_service.py`, `text_builder.py`)
+   - Mentioned in `processing-engine.md` module diagram but no detailed docs
+   - No explanation of ONNX embedding model, FAISS index operations
+   - Text builder (metadata → natural language) not documented
+   - Embedding job queue lifecycle unclear
+
+3. **Diagnostics Module** (`app/diagnostics.py`)
+   - AGENTS.md references memory monitoring but not in architecture docs
+   - OOM debugging patterns not documented
+
+**Impact**: Medium. These are advanced features. Basic integration is documented in `quick-reference.md`, but developers need to read source code for details.
+
+### 3.2 API Endpoint Coverage Inconsistencies
+
+**Analysis endpoints in `quick-reference.md`**:
+- `POST /analysis/region-stats` — Mentioned but no parameter details
+- `GET /analysis/source-detection` — Mentioned but no output schema
+
+**Discovery endpoints**:
+- `POST /discovery/featured` — Not in quick reference at all
+- `POST /discovery/suggest-recipes` — Mentioned but missing color/wavelength mapping details
+
+**Search endpoints**:
+- `POST /search/embed` — Mentioned as admin-only but access control details missing
+- `POST /search/search` — Fuzzy vs. semantic search behavior not explained
+
+### 3.3 Frontend Documentation Gaps
+
+**`key-files.md` lists 50+ frontend files** ✅, but:
+- Frontend development standards document is incomplete (need to verify)
+- Component interaction patterns for discovery flow not documented in detail
+- Signal R real-time updates client-side implementation not fully explained
+- Error boundary strategy and error recovery patterns not documented
+
+### 3.4 Deployment & Infrastructure Gaps
+
+**Missing documentation**:
+- Staging deployment specifics (`docker-compose.staging.yml` exists but not documented)
+- AWS S3 configuration and presigned URL setup
+- Production secrets management (MONGO_ROOT_PASSWORD, JWT_SECRET handling)
+- Scaling considerations (resource limits, rate limiting tuning)
+- Health check endpoint details (what each component reports)
+
+**`deployment.md` exists** but not reviewed in detail. Need to verify it covers:
+- Multi-service health monitoring
+- Database migration strategies
+- Backup/restore procedures
+- Environment-specific configuration
+
+### 3.5 Development Plan Roadmap Outdated
+
+**Current state**: Development plan shows Phases 1–5 complete, but current work is across **Phase 5b** (UI/UX Polish), **Phase 6** (Integration), and **Phase 7** (Testing & Deployment).
+
+**What's missing from current plan**:
+- Phase 5b details (accessibility, compositing quality, security hardening)
+- Phase 6 integration timeline
+- Phase 7 deployment strategy
+- Critical blockers or risks
+
+**Note**: GitHub Issues now carry detailed tracking. The `.md` file is a high-level reference that should be updated to reflect current phase focus.
+
+---
+
+## 4. Outdated or Inaccurate Content
+
+### 4.1 AGENTS.md References
+
+AGENTS.md mentions several features that don't have corresponding detailed documentation:
+
+| Feature | Mentioned in | Documented Where | Gap |
+|---------|--------------|------------------|-----|
+| Semantic routes | "Semantic search FastAPI routes" | Quick reference only | Needs architecture doc |
+| Diagnostics module | "Memory monitoring utilities" | Not documented | Needs integration guide |
+| Collapsible panel pattern | Key architecture note | Scattered across component docs | Could be consolidated |
+| Observation mosaic generation | Feature list | Partially in mosaic.md | Auto-generation settings unclear |
+
+### 4.2 Tech Debt & Bug Tracking
+
+**Status**: ✅ Properly migrated to GitHub Issues
+
+- `tech-debt.md` — Marked as historical, points to GitHub Issues
+- `bugs.md` — Marked as historical, points to GitHub Issues
+- **53 tech debt items resolved**, **38 migrated to GitHub Issues** with proper labels
+
+**No inconsistencies found** — tracking system is clear.
+
+### 4.3 Default Credentials & Security
+
+**Documented in `setup-guide.md`**:
+- Default users (`admin` / `Admin123!`, `demo` / `Demo1234!`)
+- Note about disabling seeded users in production
+
+**Concern**: AGENTS.md mentions "Disable Seed Users in Production" but this is not prominently featured in setup guide. Should be highlighted in deployment section.
+
+---
+
+## 5. Inconsistencies Between Documentation & Code
+
+### 5.1 Controllers vs. Documentation
+
+| Controller | Documented | Notes |
+|-----------|-----------|-------|
+| JwstDataController | ✅ Yes | 2375 LOC, fully documented |
+| DataManagementController | ✅ Yes | 603 LOC, fully documented |
+| MastController | ✅ Yes | 2002 LOC, fully documented |
+| CompositeController | ✅ Yes | 227 LOC, fully documented |
+| MosaicController | ✅ Yes | Mentioned in key-files.md |
+| AnalysisController | ⚠️ Partial | Listed in backend-development.md but endpoint details sparse |
+| AuthController | ✅ Yes | 181 LOC, fully documented |
+| DiscoveryController | ⚠️ Partial | Listed but endpoints need detail |
+| SearchController | ⚠️ Partial | Listed but semantic search behavior unclear |
+| JobsController | ✅ Yes | 151 LOC, fully documented |
+
+### 5.2 Processing Engine Modules vs. Documentation
+
+**Actual modules in `app/`**:
+```
+app/
+├── analysis/          ← Architecture mentions, quick-ref mentions, but no detailed docs
+├── composite/         ✅ Documented
+├── diagnostics.py     ← Not in architecture docs
+├── discovery/         ✅ Documented
+├── instruments.py     ← Not documented
+├── mast/             ✅ Documented
+├── mosaic/           ✅ Documented
+├── processing/       ← Marked "in progress" in key-files but no docs
+├── semantic/         ← Partial: mentioned in architecture but no detailed docs
+└── storage/          ✅ Documented
+```
+
+**Instruments module**: Not documented anywhere but exists in source. Appears to contain filter/instrument metadata.
+
+### 5.3 Frontend Routes vs. Documentation
+
+**App.tsx defines routes**:
+- `/` → DiscoveryHome
+- `/login` → LoginPage
+- `/register` → RegisterPage
+- `/library` → MyLibrary (protected)
+- `/create` → GuidedCreate (protected)
+- `/composite` → CompositePage (protected)
+- `/mosaic` → MosaicPage (protected)
+- `/search` → SearchPage (semantic search)
+- `/target/:targetName` → TargetDetail
+
+**Documentation**: ✅ All routes listed in architecture or component docs.
+
+---
+
+## 6. Missing Documentation Categories
+
+### 6.1 Testing Strategy
+
+- **Exists**: `development-workflow.md` mentions testing requirements
+- **Missing**: No dedicated testing guide or test coverage metrics
+- **Impact**: Medium — developers must infer testing approach from existing tests
+
+### 6.2 Performance & Optimization
+
+- **Exists**: Processing engine resource limits documented in AGENTS.md
+- **Missing**: Frontend performance budgets, lazy loading strategy details, image optimization guide
+- **Impact**: Medium — documented via code comments but not in dedicated guide
+
+### 6.3 Error Handling & Logging
+
+- **Exists**: Structured logging mentioned in backend standards
+- **Missing**: Error code reference, debug logging patterns, troubleshooting guide for common errors
+- **Impact**: Medium — developers rely on Swagger/code for error responses
+
+### 6.4 Localization & Internationalization
+
+- **Status**: Not documented (likely not implemented)
+- **Impact**: Low (not a stated feature)
+
+### 6.5 Browser Support & Accessibility Roadmap
+
+- **Exists**: Accessibility issues tracked in development plan (#665–#678)
+- **Missing**: Detailed WCAG compliance guide, accessibility testing procedures
+- **Impact**: Medium — critical for Phase 5b work
+
+---
+
+## 7. Cross-Check Against AGENTS.md Requirements
+
+AGENTS.md defines documentation expectations:
+
+### Required Documentation Updates (from AGENTS.md):
+
+| Change Type | File to Update | Status |
+|-------------|----------------|--------|
+| New API endpoint | `docs/quick-reference.md` | ✅ Current |
+| New data model field | `docs/standards/database-models.md` | ✅ Current |
+| New frontend feature | `docs/standards/frontend-development.md` | ⚠️ Need to verify completeness |
+| Phase completion | `docs/development-plan.md` | ⚠️ Needs Phase 5b update |
+| New TypeScript type | `docs/standards/frontend-development.md` | ⚠️ Need to verify |
+| Tech debt / bugs | GitHub Issues (with labels) | ✅ Current |
+| Feature change | `docs/plans/exploration/desktop-requirements.md` | ⚠️ Need to verify sync |
+
+### Documentation References in AGENTS.md:
+
+All major references point to existing files:
+- ✅ `docs/architecture/` — documented
+- ✅ `docs/development-plan.md` — exists but needs update
+- ✅ `docs/quick-reference.md` — current
+- ✅ `docs/key-files.md` — current
+- ✅ `docs/setup-guide.md` — current
+
+---
+
+## 8. Documentation Quality Assessment
+
+### Strengths
+
+1. **Well-organized hierarchy** — docs/ structure is logical and easy to navigate
+2. **Comprehensive architecture docs** — 14 detailed flow diagrams cover major features
+3. **Complete API reference** — quick-reference.md covers 47 endpoints with parameters
+4. **Strong standards documentation** — backend, frontend, processing engine all have coding guidelines
+5. **File location reference** — key-files.md is exceptionally detailed (232 entries)
+6. **Development journal** — 67 blog posts provide historical context and decision rationale
+7. **Git-first workflow** — AGENTS.md + CONTRIBUTING.md clearly define branch/PR/commit standards
+
+### Weaknesses
+
+1. **Processing engine gaps** — Analysis, semantic, and diagnostics modules lack detailed docs
+2. **Incomplete API docs** — Some endpoints (analysis, discovery, search) need parameter details
+3. **Frontend development guide incomplete** — standards/frontend-development.md needs verification
+4. **Deployment guide sparse** — Multi-service health monitoring and scaling not documented
+5. **Testing strategy unclear** — No dedicated testing guide or coverage report
+6. **Roadmap outdated** — Development plan needs Phase 5b/6/7 details
+7. **No troubleshooting guide** — Common errors and debug procedures not documented
+
+---
+
+## 9. Prioritized Recommendations
+
+### Priority 1: Critical (Week 1)
+
+1. **Update `docs/development-plan.md`** to reflect current Phase 5b focus
+   - Add Phase 5b accessibility/security/quality details
+   - Update Phase 6/7 timeline and deliverables
+   - Link to relevant GitHub Issues for tracking
+
+2. **Complete `docs/standards/frontend-development.md`**
+   - Verify component patterns are documented
+   - Add error boundary strategy
+   - Document SignalR client-side integration
+   - Add accessibility testing procedures
+
+3. **Create `docs/architecture/analysis-and-search.md`**
+   - Document analysis module (region selection, source detection)
+   - Document semantic search (embedding, FAISS, text transformation)
+   - Include endpoint parameters and response schemas
+
+### Priority 2: High (Week 2-3)
+
+4. **Expand `docs/quick-reference.md`**
+   - Add detailed parameters for `/analysis/*` endpoints
+   - Add detailed parameters for `/discovery/*` endpoints
+   - Add detailed parameters for `/search/*` endpoints
+   - Include example request/response payloads
+
+5. **Create `docs/deployment.md` revisions** (if file is incomplete)
+   - Multi-service health monitoring strategy
+   - Database migration procedures
+   - Backup/restore procedures
+   - S3 configuration for production
+   - Scaling and resource limits
+
+6. **Create `docs/standards/testing-guide.md`**
+   - Unit test patterns (backend/frontend/python)
+   - Integration test approach
+   - E2E test coverage strategy
+   - Coverage metrics and goals
+
+### Priority 3: Medium (Week 4+)
+
+7. **Create `docs/troubleshooting-guide.md`**
+   - Common errors and solutions
+   - Debug procedures (logs, network inspection)
+   - Performance profiling guides
+
+8. **Create `docs/standards/accessibility-guide.md`**
+   - WCAG 2.1 AA compliance checklist
+   - Component accessibility testing procedures
+   - Screen reader testing procedures
+
+9. **Update `docs/plans/exploration/desktop-requirements.md`** to sync with current features
+   - Add any missing functional requirements
+   - Remove deprecated features
+   - Update acceptance criteria
+
+10. **Create `docs/standards/performance-guide.md`**
+    - Frontend performance budgets
+    - Image optimization strategies
+    - Processing engine resource limits
+    - Caching strategies
+
+### Priority 4: Nice-to-Have
+
+11. Create architecture decision records (ADRs) for major design choices
+12. Add visual component library / design system reference
+13. Create video tutorials for common workflows
+14. Document browser support matrix
+
+---
+
+## 10. Consistency Matrix
+
+| Area | Consistency | Notes |
+|------|-------------|-------|
+| API endpoints | ✅ Good | 47/50 endpoints documented; 3 need detail |
+| File references | ✅ Excellent | key-files.md is comprehensive and accurate |
+| Architecture diagrams | ✅ Good | Clear mermaid diagrams; some modules lack detail |
+| Coding standards | ✅ Good | Backend/frontend/Python standards all present |
+| Development workflow | ✅ Excellent | AGENTS.md and CONTRIBUTING.md aligned |
+| Phase status | ⚠️ Needs update | Currently at Phase 5b/6/7, roadmap shows older phases |
+| Controller/service naming | ✅ Good | Matches actual codebase structure |
+| Frontend routes | ✅ Good | All routes documented and accounted for |
+
+---
+
+## 11. Summary Statistics
+
+| Metric | Count | Status |
+|--------|-------|--------|
+| **Total .md files** | 115+ | Well-organized |
+| **Architecture docs** | 14 | ✅ Complete |
+| **Standards docs** | 8 | ⚠️ 1 incomplete |
+| **Feature/plan docs** | 16 | ✅ Complete |
+| **API endpoints documented** | 47 | ⚠️ 3 need detail |
+| **Controllers** | 9 | ✅ 8 fully, 1 partial |
+| **Processing modules** | 8 | ⚠️ 3 partial |
+| **Frontend components referenced** | 50+ | ✅ Complete |
+| **Key files cataloged** | 232 | ✅ Comprehensive |
+| **Outstanding GitHub Issues** | 38 tech-debt, ~20+ bugs | ✅ Tracked properly |
+
+---
+
+## 12. Conclusion
+
+The JWST Data Analysis project maintains **strong, well-organized documentation** that reflects a mature development process. Coverage is comprehensive across architecture, standards, and API references. Key gaps exist in:
+
+1. Processing engine advanced modules (analysis, semantic search)
+2. Frontend development standards completeness
+3. Deployment and infrastructure details
+4. Testing and troubleshooting guides
+5. Phase roadmap needs refresh for current work
+
+**Overall Assessment**: **7.5/10**
+- Documentation quality and organization: **8.5/10**
+- Coverage of features: **7/10** (gaps in advanced modules)
+- Consistency with code: **7.5/10** (mostly aligned, some drift in processing engine)
+- Accessibility and discoverability: **8/10** (well-organized, could use more cross-linking)
+
+**Recommended Action**: Address Priority 1 items within 1 week to ensure roadmap and API docs accurately reflect current development state. Priority 2 items should be resolved before Phase 5b completion.

--- a/frontend/jwst-frontend/.gitignore
+++ b/frontend/jwst-frontend/.gitignore
@@ -14,6 +14,7 @@
 
 # TypeScript build info
 *.tsbuildinfo
+tsconfig.check.json
 
 # misc
 .DS_Store


### PR DESCRIPTION
## Summary
Process improvements from a parallel session — AGENTS.md trim, new skill definitions, docs audit, and gitignore update.

## Why
AGENTS.md had verbose sections duplicated in CLAUDE.md. New skills needed to be committed. Docs audit identifies gaps for future work.

## Changes Made
- **AGENTS.md**: Trimmed to essentials — removed verbose sections that duplicated CLAUDE.md content (collaboration style, scope/precedence boilerplate)
- **Skills**: Added `debug`, `doc-update`, and `git-workflow` skill definitions (`.claude/skills/`)
- **Docs audit**: Added `docs/audits/2026-03-19-docs-audit.md` — comprehensive documentation review
- **Gitignore**: Added `tsconfig.check.json` to frontend `.gitignore`

## Test Plan
- [x] Pre-commit hooks pass (ESLint, tsc, vitest, Prettier)
- [x] No code changes — docs/config only

## Documentation Checklist
- [x] This IS the documentation update

## Tech Debt Impact
- [x] No impact — docs and config only

## Risk & Rollback
Risk: None — no code changes.
Rollback: Revert.

No linked issue
