### PR TITLE
fix: instrument-level blending for multi-instrument composites

### DIFF
--- a/.claude/skills/plan-ceo-review/SKILL.md
+++ b/.claude/skills/plan-ceo-review/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools:
   - Bash
   - AskUserQuestion
   - EnterPlanMode
+  - Skill
+  - Agent
 ---
 
 # Plan: CEO Review Mode
@@ -117,6 +119,13 @@ Produce:
 5. **Recommendation** — proceed as-is / proceed with changes / needs EnterPlanMode before starting
 
 If the plan requires EnterPlanMode (load-bearing change), say so explicitly and trigger it.
+
+## Step 6: Auto-Progression to Engineering Review
+
+When the recommendation is **"proceed as-is"** or **"proceed with changes"**:
+- Automatically invoke `/plan-eng-review` by calling the Skill tool with `skill: "plan-eng-review"` and passing the same arguments/context forward.
+- Do NOT ask the user whether to proceed — the eng review is the defined next step in the implementation sequence and should flow automatically.
+- If the recommendation is **"needs EnterPlanMode"** or **"blocked"**, do NOT auto-progress — stop and wait for user input.
 
 ## Formatting Rules
 

--- a/processing-engine/app/composite/color_mapping.py
+++ b/processing-engine/app/composite/color_mapping.py
@@ -405,3 +405,106 @@ def combine_channels_to_rgb(
             component /= c_max
 
     return rgb
+
+
+def blend_instrument_groups(
+    channels: list[tuple[NDArray, tuple[float, float, float]]],
+    instruments: list[str | None],
+    reprojected: dict[str, NDArray],
+    ch_names: list[str],
+    feather_fraction: float,
+) -> NDArray:
+    """Blend channels grouped by instrument for smooth multi-instrument composites.
+
+    Instead of feathering individual channels (which fails when all channels
+    from one instrument share the same FOV footprint), this function:
+
+    1. Groups channels by instrument identity
+    2. Produces an independent RGB image per instrument group
+    3. Computes a single instrument-level coverage mask per group
+    4. Blends group RGBs with equal weight per instrument, using feathered
+       masks for smooth transitions at instrument FOV boundaries
+
+    For single-instrument composites (or when all instruments are unknown),
+    this is a no-op: it delegates directly to :func:`combine_channels_to_rgb`.
+
+    Args:
+        channels: List of (data, rgb_weights) tuples — same format as
+            :func:`combine_channels_to_rgb`.
+        instruments: Per-channel instrument name (e.g. ``"NIRCAM"``,
+            ``"MIRI"``) or ``None`` if unknown.  Must be same length as
+            *channels*.
+        reprojected: Dict mapping channel name → raw reprojected 2D array
+            (pre-stretch).  Used to compute instrument-level coverage masks.
+        ch_names: Channel names corresponding to *channels*, used as keys
+            into *reprojected*.
+        feather_fraction: Fraction of image dimension for the feather radius,
+            passed to :func:`compute_feather_weights`.
+
+    Returns:
+        3D numpy array [H, W, 3] with values in [0, 1], dtype float64.
+    """
+    if len(instruments) != len(channels) or len(ch_names) != len(channels):
+        raise ValueError(
+            f"instruments ({len(instruments)}), channels ({len(channels)}), "
+            f"and ch_names ({len(ch_names)}) must all have the same length"
+        )
+
+    # Build instrument groups: map instrument key → list of (index, channel)
+    groups: dict[str, list[int]] = {}
+    for i, inst in enumerate(instruments):
+        key = (inst or "_unknown_").upper()
+        groups.setdefault(key, []).append(i)
+
+    # Single group → no instrument blending needed
+    if len(groups) <= 1:
+        return combine_channels_to_rgb(channels)
+
+    ref_shape = channels[0][0].shape
+    h, w = ref_shape
+
+    # Produce per-group RGB and coverage mask.
+    # Iteration order doesn't matter — weighted average blend is commutative.
+    group_rgbs: list[NDArray] = []
+    group_masks: list[NDArray] = []
+
+    for _inst_key, indices in groups.items():
+        # Extract this group's channels
+        group_channels = [channels[i] for i in indices]
+        group_ch_names = [ch_names[i] for i in indices]
+
+        # Combine this group's channels to RGB (independently normalized)
+        group_rgb = combine_channels_to_rgb(group_channels)
+
+        # Compute instrument-level coverage: union of all channels in group
+        union_coverage = np.zeros((h, w), dtype=np.float64)
+        for name in group_ch_names:
+            union_coverage = np.maximum(union_coverage, (reprojected[name] != 0).astype(np.float64))
+
+        # Compute feathered mask from the union coverage
+        mask = compute_feather_weights(
+            union_coverage,
+            fraction=feather_fraction,
+        )
+        if mask is None:
+            # Full coverage — use ones
+            mask = np.ones((h, w), dtype=np.float64)
+
+        group_rgbs.append(group_rgb)
+        group_masks.append(mask)
+
+    # Blend group RGBs: weighted average with equal weight per instrument.
+    # result = sum(rgb_i * mask_i) / sum(mask_i)
+    blended = np.zeros((h, w, 3), dtype=np.float64)
+    weight_sum = np.zeros((h, w), dtype=np.float64)
+
+    for rgb, mask in zip(group_rgbs, group_masks, strict=True):
+        mask_3d = mask[:, :, np.newaxis]
+        blended += rgb * mask_3d
+        weight_sum += mask
+
+    # Avoid division by zero where no instrument has coverage
+    safe_weight = np.maximum(weight_sum, 1e-10)
+    blended /= safe_weight[:, :, np.newaxis]
+
+    return np.clip(blended, 0.0, 1.0)

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -41,6 +41,7 @@ from app.storage.helpers import resolve_fits_path
 from .auto_stretch import auto_stretch_params
 from .cache import CompositeCache
 from .color_mapping import (
+    blend_instrument_groups,
     blend_luminance,
     combine_channels_to_rgb,
     compute_feather_weights,
@@ -696,6 +697,7 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
         logger.info("Applying stretch and color mapping")
         color_mapped: list[tuple[np.ndarray, tuple[float, float, float]]] = []
         color_ch_names: list[str] = []
+        color_ch_instruments: list[str | None] = []
         lum_data: np.ndarray | None = None
         lum_weight: float = 1.0
         ch_names = list(stretch_input.keys())
@@ -735,6 +737,9 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
                     stretched = np.clip(stretched * ch_config.weight, 0, 1)
                 color_mapped.append((stretched, rgb_weights))
                 color_ch_names.append(ch_name)
+                color_ch_instruments.append(
+                    channel_instruments[idx] if idx < len(channel_instruments) else None
+                )
 
         # Combine color channels into RGB
         if not color_mapped:
@@ -743,15 +748,29 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
                 detail="At least one color channel (hue or rgb) is required",
             )
 
-        # Per-channel feathering: each channel gets its own coverage-based
-        # feather mask.  compute_feather_weights returns None for channels
-        # with ≥95% coverage, so full-FOV channels pass through untouched.
-        # EXP-4: coverage-scaled radius — low-coverage channels get wider feather.
+        # Instrument-level blending for multi-instrument composites.
+        # Groups channels by instrument, produces per-group RGB, then blends
+        # with feathered instrument-level coverage masks.  This prevents the
+        # color palette shift at instrument FOV boundaries that per-channel
+        # feathering cannot fix (all channels from one instrument share the
+        # same footprint and fade identically).
+        #
+        # For single-instrument composites this is a no-op — delegates
+        # directly to combine_channels_to_rgb.
+        unique_color_instruments = {i for i in color_ch_instruments if i is not None}
+        use_instrument_blending = (
+            is_multi_instrument
+            and len(unique_color_instruments) > 1
+            and effective_feather > 0
+            and len(color_mapped) > 1
+        )
+
+        # Per-channel feathering (legacy path): used for single-instrument
+        # composites or when instrument blending is not applicable.
         per_channel_masks: list[np.ndarray | None] = []
-        if effective_feather > 0 and len(color_mapped) > 1:
+        if not use_instrument_blending and effective_feather > 0 and len(color_mapped) > 1:
             for ch_name in color_ch_names:
                 ch_data = reprojected_channels[ch_name]
-                # Per-channel coverage ratio for adaptive feather radius
                 coverage = (ch_data != 0).sum() / ch_data.size
                 mask = compute_feather_weights(
                     ch_data,
@@ -766,20 +785,38 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
         # the composite image.  Each channel becomes a grayscale panel showing
         # white=covered, black=no coverage, gray gradient=feather zone.
         if request.debug_masks:
-            return _render_debug_masks(
+            response = _render_debug_masks(
                 color_ch_names, reprojected_channels, per_channel_masks, request
             )
+            if use_instrument_blending:
+                response.headers["X-Debug-Warning"] = (
+                    "instrument-blending-active: per-channel masks shown but "
+                    "actual compositing uses instrument-level blended masks"
+                )
+            return response
 
-        # Build effective masks list for combine — replace None with ones
-        effective_masks: list[np.ndarray] | None = None
-        if any(m is not None for m in per_channel_masks):
-            ref_shape = color_mapped[0][0].shape
-            effective_masks = [
-                m if m is not None else np.ones(ref_shape, dtype=np.float64)
-                for m in per_channel_masks
-            ]
-
-        rgb_array = combine_channels_to_rgb(color_mapped, coverage_masks=effective_masks)
+        if use_instrument_blending:
+            logger.info(
+                f"Using instrument-level blending for {len(unique_color_instruments)} "
+                f"instrument groups ({', '.join(sorted(unique_color_instruments))})"
+            )
+            rgb_array = blend_instrument_groups(
+                channels=color_mapped,
+                instruments=color_ch_instruments,
+                reprojected=reprojected_channels,
+                ch_names=color_ch_names,
+                feather_fraction=effective_feather,
+            )
+        else:
+            # Single-instrument or no feathering: use per-channel masks
+            effective_masks: list[np.ndarray] | None = None
+            if any(m is not None for m in per_channel_masks):
+                ref_shape = color_mapped[0][0].shape
+                effective_masks = [
+                    m if m is not None else np.ones(ref_shape, dtype=np.float64)
+                    for m in per_channel_masks
+                ]
+            rgb_array = combine_channels_to_rgb(color_mapped, coverage_masks=effective_masks)
         log_memory("after-combine-rgb")
 
         # Blend luminance if present

--- a/processing-engine/tests/test_color_mapping.py
+++ b/processing-engine/tests/test_color_mapping.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from app.composite.color_mapping import (
+    blend_instrument_groups,
     chromatic_order_hues,
     combine_channels_to_rgb,
     compute_feather_weights,
@@ -676,3 +677,183 @@ class TestChannelColorModel:
         assert color.rgb == (0.0, 0.0, 0.0)
         color = ChannelColor(rgb=(1.0, 1.0, 1.0))
         assert color.rgb == (1.0, 1.0, 1.0)
+
+
+class TestBlendInstrumentGroups:
+    """Tests for instrument-level blending in multi-instrument composites."""
+
+    def test_single_group_matches_combine(self):
+        """Single instrument group → identical to combine_channels_to_rgb."""
+        h, w = 50, 50
+        rng = np.random.RandomState(42)
+        ch1 = rng.rand(h, w) * 0.8 + 0.1
+        ch2 = rng.rand(h, w) * 0.6 + 0.1
+
+        channels = [
+            (ch1, (1.0, 0.0, 0.0)),
+            (ch2, (0.0, 1.0, 0.0)),
+        ]
+        instruments = ["NIRCAM", "NIRCAM"]
+        reprojected = {"ch0": ch1, "ch1": ch2}
+        ch_names = ["ch0", "ch1"]
+
+        result = blend_instrument_groups(channels, instruments, reprojected, ch_names, 0.15)
+        expected = combine_channels_to_rgb(channels)
+
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_all_none_instruments_matches_combine(self):
+        """All-None instruments → single group, identical to combine."""
+        h, w = 50, 50
+        rng = np.random.RandomState(42)
+        ch1 = rng.rand(h, w) * 0.5
+        ch2 = rng.rand(h, w) * 0.5
+
+        channels = [
+            (ch1, (1.0, 0.0, 0.0)),
+            (ch2, (0.0, 0.0, 1.0)),
+        ]
+        instruments = [None, None]
+        reprojected = {"ch0": ch1, "ch1": ch2}
+        ch_names = ["ch0", "ch1"]
+
+        result = blend_instrument_groups(channels, instruments, reprojected, ch_names, 0.15)
+        expected = combine_channels_to_rgb(channels)
+
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_two_groups_non_overlapping_fov(self):
+        """Two instrument groups with non-overlapping FOV — each region shows only its group."""
+        h, w = 100, 200
+
+        # NIRCAM covers left half, MIRI covers right half
+        nircam_data = np.zeros((h, w))
+        nircam_data[:, :100] = 0.7
+        miri_data = np.zeros((h, w))
+        miri_data[:, 100:] = 0.6
+
+        channels = [
+            (nircam_data, (0.0, 0.0, 1.0)),  # blue
+            (miri_data, (1.0, 0.0, 0.0)),  # red
+        ]
+        instruments = ["NIRCAM", "MIRI"]
+        reprojected = {"nircam_f200w": nircam_data, "miri_f770w": miri_data}
+        ch_names = ["nircam_f200w", "miri_f770w"]
+
+        result = blend_instrument_groups(channels, instruments, reprojected, ch_names, 0.05)
+
+        # Far left: pure NIRCAM (blue)
+        assert result[50, 10, 2] > 0.5  # blue channel
+        assert result[50, 10, 0] == pytest.approx(0.0, abs=0.01)  # no red
+
+        # Far right: pure MIRI (red)
+        assert result[50, 190, 0] > 0.5  # red channel
+        assert result[50, 190, 2] == pytest.approx(0.0, abs=0.01)  # no blue
+
+    def test_two_groups_overlapping_smooth_transition(self):
+        """Two groups with overlapping FOV — smooth color transition at boundary."""
+        h, w = 100, 100
+
+        # NIRCAM covers full image, MIRI covers center 40x40
+        nircam_data = np.ones((h, w)) * 0.5
+        miri_data = np.zeros((h, w))
+        miri_data[30:70, 30:70] = 0.6
+
+        channels = [
+            (nircam_data, (0.0, 0.0, 1.0)),  # blue
+            (miri_data, (1.0, 0.0, 0.0)),  # red
+        ]
+        instruments = ["NIRCAM", "MIRI"]
+        reprojected = {"nircam_f200w": nircam_data, "miri_f770w": miri_data}
+        ch_names = ["nircam_f200w", "miri_f770w"]
+
+        result = blend_instrument_groups(channels, instruments, reprojected, ch_names, 0.15)
+
+        # Corner (NIRCAM only): should be blue, no red
+        assert result[5, 5, 2] > 0.5
+        assert result[5, 5, 0] == pytest.approx(0.0, abs=0.01)
+
+        # Center (overlap): both colors present
+        assert result[50, 50, 0] > 0.1  # red from MIRI
+        assert result[50, 50, 2] > 0.1  # blue from NIRCAM
+
+        # Transition zone (just inside MIRI boundary): intermediate values
+        # Should not be a hard edge — values between pure NIRCAM and full blend
+        edge_red = result[31, 50, 0]
+        center_red = result[50, 50, 0]
+        assert 0.0 < edge_red < center_red  # gradual increase toward center
+
+    def test_three_instrument_groups(self):
+        """Three instrument groups — handles N > 2."""
+        h, w = 100, 300
+
+        # Three non-overlapping strips
+        ch1 = np.zeros((h, w))
+        ch1[:, :100] = 0.6
+        ch2 = np.zeros((h, w))
+        ch2[:, 100:200] = 0.7
+        ch3 = np.zeros((h, w))
+        ch3[:, 200:] = 0.5
+
+        channels = [
+            (ch1, (1.0, 0.0, 0.0)),  # red
+            (ch2, (0.0, 1.0, 0.0)),  # green
+            (ch3, (0.0, 0.0, 1.0)),  # blue
+        ]
+        instruments = ["NIRCAM", "MIRI", "NIRISS"]
+        reprojected = {"ch0": ch1, "ch1": ch2, "ch2": ch3}
+        ch_names = ["ch0", "ch1", "ch2"]
+
+        result = blend_instrument_groups(channels, instruments, reprojected, ch_names, 0.05)
+
+        # Each strip should show its respective color
+        assert result[50, 10, 0] > 0.5  # red in left strip
+        assert result[50, 150, 1] > 0.5  # green in middle strip
+        assert result[50, 290, 2] > 0.5  # blue in right strip
+
+    def test_one_channel_per_group(self):
+        """Single channel per instrument group — monochromatic group RGB works."""
+        h, w = 80, 80
+
+        nircam_data = np.ones((h, w)) * 0.6
+        miri_data = np.zeros((h, w))
+        miri_data[20:60, 20:60] = 0.5
+
+        channels = [
+            (nircam_data, (0.0, 0.0, 1.0)),
+            (miri_data, (1.0, 0.0, 0.0)),
+        ]
+        instruments = ["NIRCAM", "MIRI"]
+        reprojected = {"ch0": nircam_data, "ch1": miri_data}
+        ch_names = ["ch0", "ch1"]
+
+        result = blend_instrument_groups(channels, instruments, reprojected, ch_names, 0.15)
+
+        # Should produce valid output without errors
+        assert result.shape == (h, w, 3)
+        assert result.min() >= 0.0
+        assert result.max() <= 1.0
+
+    def test_equal_weight_blending(self):
+        """In the overlap region, both instruments contribute equally regardless of input intensity."""
+        h, w = 100, 100
+
+        # Different intensities — per-group normalization should equalize,
+        # then equal blending means both groups contribute the same.
+        ch1 = np.ones((h, w)) * 0.8
+        ch2 = np.ones((h, w)) * 0.4  # half the intensity
+
+        channels = [
+            (ch1, (1.0, 0.0, 0.0)),  # red
+            (ch2, (0.0, 0.0, 1.0)),  # blue
+        ]
+        instruments = ["NIRCAM", "MIRI"]
+        reprojected = {"ch0": ch1, "ch1": ch2}
+        ch_names = ["ch0", "ch1"]
+
+        result = blend_instrument_groups(channels, instruments, reprojected, ch_names, 0.15)
+
+        # Each group normalizes independently to [0,1], then equal-weight blend.
+        # Despite different input intensities, red and blue should be equal.
+        center = result[50, 50]
+        assert center[0] == pytest.approx(center[2], abs=0.05)


### PR DESCRIPTION
## Summary
- Replaces per-channel feathering with instrument-level blending for multi-instrument composites
- Eliminates the visible color palette shift at MIRI FOV boundaries that per-channel feathering cannot fix
- Activates automatically when mixed instruments are detected — no user action needed

Closes #885

## Why
All MIRI channels share the same FOV footprint, so per-channel feathering produces identical masks and all channels fade in lockstep. The result is an abrupt 6→4 channel color palette shift at the MIRI boundary regardless of feather strength. The fix requires blending at the instrument level, not the channel level.

## Changes Made
- **`color_mapping.py`**: Added `blend_instrument_groups()` — groups channels by instrument, produces independent RGB per group via `combine_channels_to_rgb`, computes instrument-level coverage masks, blends with equal weight per instrument using feathered transitions
- **`routes.py`**: Added `color_ch_instruments` tracking for color channels; when multi-instrument with feathering enabled, calls `blend_instrument_groups` instead of per-channel feather path; added `X-Debug-Warning` header when debug_masks is used with instrument blending active
- **`test_color_mapping.py`**: 7 new tests covering single group, all-None instruments, non-overlapping FOV, overlapping with smooth transition, 3+ instruments, single channel per group, and equal-weight blending verification
- **`plan-ceo-review/SKILL.md`**: Added auto-progression to eng review when verdict is "proceed"

## Test Plan
- [x] `blend_instrument_groups` single group matches `combine_channels_to_rgb` (regression gate)
- [x] All-None instruments treated as single group (no-op)
- [x] Two groups with non-overlapping FOV — each region shows only its group's colors
- [x] Two groups with overlapping FOV — smooth color transition at boundary (no hard edge)
- [x] Three instrument groups handled correctly
- [x] Equal-weight blending verified with different input intensities
- [x] Full processing engine test suite: 1080 passed
- [ ] Manual: M16 6-filter MIRI+NIRCAM composite — verify palette shift eliminated
- [ ] Manual: Single-instrument composite — verify no visual change

## Documentation Checklist
- [x] No API changes — internal algorithm only
- [x] No new endpoints, collections, or components

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
Risk: Low — processing engine algorithm change only, no API/data model changes. Single-instrument composites use unchanged code path.
Rollback: Revert commit. Per-channel feathering path is preserved as fallback.
