### PR TITLE
fix: color-contribution feathering for multi-instrument composites

### DIFF
--- a/processing-engine/app/composite/color_mapping.py
+++ b/processing-engine/app/composite/color_mapping.py
@@ -414,16 +414,21 @@ def blend_instrument_groups(
     ch_names: list[str],
     feather_fraction: float,
 ) -> NDArray:
-    """Blend channels grouped by instrument for smooth multi-instrument composites.
+    """Blend multi-instrument composites via color-contribution feathering.
 
-    Instead of feathering individual channels (which fails when all channels
-    from one instrument share the same FOV footprint), this function:
+    Instead of fading each instrument's **signal** at FOV boundaries (which
+    destroys structural detail), this function feathers between **palette
+    interpretations**:
 
-    1. Groups channels by instrument identity
-    2. Produces an independent RGB image per instrument group
-    3. Computes a single instrument-level coverage mask per group
-    4. Blends group RGBs with equal weight per instrument, using feathered
-       masks for smooth transitions at instrument FOV boundaries
+    1. ``full_rgb`` — all channels combined (the full color palette)
+    2. ``base_rgb`` — only the majority-instrument channels (the palette
+       outside the minority instrument's FOV)
+    3. Lerp between them using the minority instrument's feathered coverage
+       mask: ``result = base_rgb × (1 - mask) + full_rgb × mask``
+
+    Structural detail from the majority instrument is present in **both**
+    RGB images, so nothing is lost in the transition — only the color
+    interpretation changes.
 
     For single-instrument composites (or when all instruments are unknown),
     this is a no-op: it delegates directly to :func:`combine_channels_to_rgb`.
@@ -450,7 +455,7 @@ def blend_instrument_groups(
             f"and ch_names ({len(ch_names)}) must all have the same length"
         )
 
-    # Build instrument groups: map instrument key → list of (index, channel)
+    # Build instrument groups: map instrument key → list of indices
     groups: dict[str, list[int]] = {}
     for i, inst in enumerate(instruments):
         key = (inst or "_unknown_").upper()
@@ -463,48 +468,41 @@ def blend_instrument_groups(
     ref_shape = channels[0][0].shape
     h, w = ref_shape
 
-    # Produce per-group RGB and coverage mask.
-    # Iteration order doesn't matter — weighted average blend is commutative.
-    group_rgbs: list[NDArray] = []
-    group_masks: list[NDArray] = []
+    # Full palette: all channels combined
+    full_rgb = combine_channels_to_rgb(channels)
 
-    for _inst_key, indices in groups.items():
-        # Extract this group's channels
-        group_channels = [channels[i] for i in indices]
-        group_ch_names = [ch_names[i] for i in indices]
+    # Find the majority instrument (most channels = widest FOV typically)
+    majority_key = max(groups, key=lambda k: len(groups[k]))
+    minority_keys = [k for k in groups if k != majority_key]
 
-        # Combine this group's channels to RGB (independently normalized)
-        group_rgb = combine_channels_to_rgb(group_channels)
+    # Start with the full palette, then lerp toward the base palette
+    # at each minority instrument's FOV boundary.
+    result = full_rgb.copy()
 
-        # Compute instrument-level coverage: union of all channels in group
+    for minor_key in minority_keys:
+        minor_indices = set(groups[minor_key])
+
+        # Base palette: all channels EXCEPT this minority instrument
+        base_channels = [ch for i, ch in enumerate(channels) if i not in minor_indices]
+
+        if not base_channels:
+            continue
+
+        base_rgb = combine_channels_to_rgb(base_channels)
+
+        # Compute minority instrument's coverage mask (union of its channels)
+        minor_ch_names = [ch_names[i] for i in groups[minor_key]]
         union_coverage = np.zeros((h, w), dtype=np.float64)
-        for name in group_ch_names:
+        for name in minor_ch_names:
             union_coverage = np.maximum(union_coverage, (reprojected[name] != 0).astype(np.float64))
 
-        # Compute feathered mask from the union coverage
-        mask = compute_feather_weights(
-            union_coverage,
-            fraction=feather_fraction,
-        )
+        mask = compute_feather_weights(union_coverage, fraction=feather_fraction)
         if mask is None:
-            # Full coverage — use ones
-            mask = np.ones((h, w), dtype=np.float64)
+            # Full coverage — minority instrument covers everything, no transition needed
+            continue
 
-        group_rgbs.append(group_rgb)
-        group_masks.append(mask)
-
-    # Blend group RGBs: weighted average with equal weight per instrument.
-    # result = sum(rgb_i * mask_i) / sum(mask_i)
-    blended = np.zeros((h, w, 3), dtype=np.float64)
-    weight_sum = np.zeros((h, w), dtype=np.float64)
-
-    for rgb, mask in zip(group_rgbs, group_masks, strict=True):
+        # Lerp: base_rgb where mask=0, full_rgb where mask=1
         mask_3d = mask[:, :, np.newaxis]
-        blended += rgb * mask_3d
-        weight_sum += mask
+        result = base_rgb * (1.0 - mask_3d) + full_rgb * mask_3d
 
-    # Avoid division by zero where no instrument has coverage
-    safe_weight = np.maximum(weight_sum, 1e-10)
-    blended /= safe_weight[:, :, np.newaxis]
-
-    return np.clip(blended, 0.0, 1.0)
+    return np.clip(result, 0.0, 1.0)

--- a/processing-engine/tests/test_color_mapping.py
+++ b/processing-engine/tests/test_color_mapping.py
@@ -834,14 +834,13 @@ class TestBlendInstrumentGroups:
         assert result.min() >= 0.0
         assert result.max() <= 1.0
 
-    def test_equal_weight_blending(self):
-        """In the overlap region, both instruments contribute equally regardless of input intensity."""
+    def test_full_coverage_overlap_matches_combine(self):
+        """When minority instrument has full coverage, result matches combine_channels_to_rgb."""
         h, w = 100, 100
 
-        # Different intensities — per-group normalization should equalize,
-        # then equal blending means both groups contribute the same.
+        # Both instruments cover the full image
         ch1 = np.ones((h, w)) * 0.8
-        ch2 = np.ones((h, w)) * 0.4  # half the intensity
+        ch2 = np.ones((h, w)) * 0.4
 
         channels = [
             (ch1, (1.0, 0.0, 0.0)),  # red
@@ -852,8 +851,34 @@ class TestBlendInstrumentGroups:
         ch_names = ["ch0", "ch1"]
 
         result = blend_instrument_groups(channels, instruments, reprojected, ch_names, 0.15)
+        expected = combine_channels_to_rgb(channels)
 
-        # Each group normalizes independently to [0,1], then equal-weight blend.
-        # Despite different input intensities, red and blue should be equal.
-        center = result[50, 50]
-        assert center[0] == pytest.approx(center[2], abs=0.05)
+        # Full coverage on both → MIRI mask is None → no lerp → full palette everywhere
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_detail_preserved_in_transition_zone(self):
+        """Structural detail from the majority instrument survives in the transition zone."""
+        h, w = 100, 100
+
+        # NIRCAM has structure (varying intensity) across the full image
+        rng = np.random.RandomState(99)
+        nircam_data = rng.rand(h, w) * 0.8 + 0.1  # structured, full coverage
+
+        # MIRI covers center only
+        miri_data = np.zeros((h, w))
+        miri_data[30:70, 30:70] = 0.6
+
+        channels = [
+            (nircam_data, (0.0, 0.0, 1.0)),  # blue
+            (miri_data, (1.0, 0.0, 0.0)),  # red
+        ]
+        instruments = ["NIRCAM", "MIRI"]
+        reprojected = {"ch0": nircam_data, "ch1": miri_data}
+        ch_names = ["ch0", "ch1"]
+
+        result = blend_instrument_groups(channels, instruments, reprojected, ch_names, 0.15)
+
+        # In the transition zone (row 31), NIRCAM detail should still be visible:
+        # adjacent pixels should have different blue values (not washed out)
+        transition_blue = result[31, 40:50, 2]
+        assert np.std(transition_blue) > 0.01  # structure preserved, not flat


### PR DESCRIPTION
## Summary
- Replaces signal-fading instrument blending with palette-lerp approach that preserves structural detail in the transition zone
- Instead of fading MIRI's signal to zero at boundaries, lerps between the full 6-channel palette and the NIRCAM-only palette

Closes #889

## Why
The previous instrument-level blending (#888) faded each instrument's **entire contribution** (structure + color) at FOV boundaries. Increasing feather width softened the boundary but also washed out structural detail — a fundamental tradeoff. Color-contribution feathering eliminates this tradeoff by keeping all structural detail and only transitioning which color palette interpretation wins.

## Changes Made
- **`color_mapping.py`**: Rewrote `blend_instrument_groups` internals — computes `full_rgb` (all channels) and `base_rgb` (majority-instrument only), lerps between them using minority instrument's feathered coverage mask
- **`test_color_mapping.py`**: Replaced `test_equal_weight_blending` with `test_full_coverage_overlap_matches_combine` and added `test_detail_preserved_in_transition_zone` verifying structural detail survives in the feather zone

## Test Plan
- [x] Single group matches combine_channels_to_rgb (regression)
- [x] All-None instruments → single group no-op
- [x] Non-overlapping FOV — each region shows correct colors
- [x] Overlapping FOV — smooth palette transition at boundary
- [x] Three instrument groups handled
- [x] Full coverage overlap → matches combine (no lerp needed)
- [x] Detail preserved in transition zone — structural variation not washed out
- [x] Full test suite: 1081 passed
- [ ] Manual: M16 6-filter MIRI+NIRCAM — verify detail preservation at MIRI boundary

## Documentation Checklist
- [x] No API changes — internal algorithm only

## Tech Debt Impact
- [x] No new tech debt — simplifies the blending approach (fewer intermediate arrays)

## Risk & Rollback
Risk: Low — same function signature, same call site, processing engine only.
Rollback: Revert commit. Previous signal-fading approach is in git history.