### PR TITLE
docs: blog posts March 16-20 + enrich-blog skill

### DIFF
--- a/.claude/skills/enrich-blog/SKILL.md
+++ b/.claude/skills/enrich-blog/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: enrich-blog
+description: Write the Blog — find the gap since the last post, create posts for every working day, sort inbox images, enrich with Slack journal content, and wire images into posts. Triggers on "write the blog", "update blog", "blog posts", "enrich blog", "/enrich-blog".
+---
+
+# Write the Blog
+
+The complete blog workflow: find the gap since the last post, create posts for every working day in that gap, sort inbox images to the correct dates, enrich everything with Slack journal content, and wire images into posts.
+
+This is the single entry point for "write the blog." It replaces the old multi-step process of generate → enrich → wire.
+
+## Arguments
+
+- `--date YYYY-MM-DD` — write/update a single date
+- `--from YYYY-MM-DD --to YYYY-MM-DD` — write a date range
+- `--refresh` — re-enrich already-enriched posts (fetches fresh Slack data, regenerates journal)
+- *(no arguments)* — **default behavior**: find the last existing post in `docs/blog/posts/`, then create and enrich all posts from the day after that post through today (from `currentDate` context). If today's post already exists and is enriched, enter refresh mode for today only.
+
+## Process Overview
+
+```
+1. Determine date range (gap detection)
+2. Gather data for each date (git log, Slack, inbox images)
+3. Sort inbox images to correct date folders
+4. Create or update blog posts
+5. Wire images into posts
+6. Update manifest
+7. Clean inbox
+```
+
+## Step 1: Determine Date Range
+
+Find the most recent `.md` file in `docs/blog/posts/` by filename (they're named `YYYY-MM-DD.md`). The target range is **the day after that file's date** through **today**.
+
+- If no arguments are given and there's no gap (last post is today), enter refresh mode for today.
+- If `--date` or `--from/--to` is given, use those dates instead of gap detection.
+- Skip dates with zero git commits AND zero Slack messages — don't create empty posts.
+
+## Step 2: Gather Data Per Date
+
+For each date in the range, gather three data sources in parallel where possible:
+
+### 2a. Git Log
+
+**IMPORTANT**: Use fully expanded ISO date strings. Never use shell arithmetic like `$((d-1))` or command substitution — these trigger security prompts.
+
+```bash
+git log --format="%h %s" --since="2026-03-16T00:00:00" --until="2026-03-16T23:59:59"
+```
+
+Run one git log command per date with the full date string. Extract PR numbers, titles, and commit types. Group by category (Feature, Bug Fix, Performance, etc.).
+
+### 2b. Slack Journal
+
+Read messages from both channels for the target date:
+
+- **Primary**: `C0AHUQKEYB1` (#devblog) — project updates, debugging stories, screenshots
+- **Secondary**: `C064NSLUK19` (#artificial-intelligence) — AI tool discussions, Claude Code usage
+
+Use `mcp__claude_ai_Slack__slack_read_channel` with `oldest`/`latest` Unix timestamps for the target date (midnight to midnight PDT).
+
+Also use `mcp__claude_ai_Slack__slack_search_public_and_private` with `content_types="files"` and `type:images on:YYYY-MM-DD in:#devblog` to get the file list for the date. This is essential for matching images to messages.
+
+### 2c. Inbox Images
+
+Check `docs/blog/images/jwst-inbox/` for any files. These need to be sorted into date folders (Step 3).
+
+## Step 3: Sort Inbox Images
+
+This is the step that requires the most care. Images in the inbox are generic (`image (N).png`) with no date information in the filename. The process:
+
+### 3a. Count and categorize
+
+- **Timestamped files** (e.g., `jwst-composite-2026-03-10T15-57-55.png`) → date is embedded in the filename.
+- **Generic files** (`image (N).png`, `image.png`) → date must be determined from Slack.
+
+### 3b. Match generic images to Slack messages
+
+The numbered `image (N).png` files from the inbox correspond to the chronologically-ordered generic `image.png` file attachments across ALL dates in the range. To match them:
+
+1. Collect all Slack file search results for the date range, filtered to `type:images`
+2. Separate named files (composites, mosaics) from generic `image.png` files
+3. Sort the generic files chronologically by their Slack `Created` timestamp
+4. The inbox `image (7).png` through `image (N).png` map to this chronological list — image (7) is the 1st generic file, image (8) is the 2nd, etc. (The starting number depends on what's already been processed; check what's NOT already in a date folder.)
+5. Each generic file inherits its date from the Slack message it was attached to
+
+### 3c. Verify with content
+
+After the timestamp-based mapping, verify each image by reading it and confirming the visual content matches the Slack message context. For example:
+- Message says "feathering worked but not perfect" → image should show a composite with feathered edges
+- Message says "nasas version when you separate the two" → image should show a NASA reference comparison
+
+If any mapping looks wrong, flag it rather than silently placing the image in the wrong folder.
+
+### 3d. Copy to date folders and capture metadata
+
+For each image:
+
+1. Create `docs/blog/images/YYYY-MM-DD/` if it doesn't exist
+2. Copy with a descriptive filename (not `image (7).png` — use content-derived names like `cartwheel-composite.png`, `pillars-mobile-export.png`)
+3. Capture metadata using `sips -g pixelWidth -g pixelHeight`:
+   - `width` and `height` in pixels
+   - `message_context` from the Slack message text
+   - `timestamp` from the Slack message `ts` value
+   - `alt_text` — 10-20 word description based on visual content + message context
+
+### 3e. Remove sorted images from inbox
+
+**ONLY delete inbox images after the commit containing them has been pushed and merged to main.** Not after copying. Not after committing locally. After merge. The inbox is the only source of truth until images are safely in the remote repo — deleting before merge risks permanent data loss if a branch conflict requires re-checkout.
+
+## Step 4: Create or Update Blog Posts
+
+For each date in the range:
+
+### Post structure
+
+```markdown
+---
+date:
+  created: YYYY-MM-DD
+categories:
+  - [derived from PR types: Feature, Bug Fix, Performance, Compositing, etc.]
+tags:
+  - [derived from PR content: composite-processing, edge-feathering, etc.]
+authors:
+  - shanon
+---
+
+# Month DD: [Creative Title]
+
+[1-2 sentence summary of the day — what shipped, what broke, what was learned]
+
+<!-- more -->
+
+## Developer Journal
+
+### [Topic heading]
+
+[Narrative paragraphs with technical depth. Include code references where relevant.
+Wire in images at natural points in the narrative.]
+
+![Alt text](../images/YYYY-MM-DD/filename.png)
+
+### [Next topic]
+
+...
+
+## What shipped
+
+| PR | Title |
+|-----|-------|
+| #NNN | prefix: description |
+```
+
+### Writing the Developer Journal
+
+Synthesize from Slack messages + git history into a narrative. The style is:
+
+- **First person**, technically detailed, honest about failures
+- **Show the debugging journey** — not just "X was broken, fixed it" but "noticed X, tried Y (didn't work because Z), the real problem was W"
+- **Use Slack quotes as energy/tone reference** but paraphrase — don't dump raw quotes
+- **Technical specifics** — name the functions, the coordinate spaces, the pixel values. Readers are developers.
+- **Subsections** (`###`) for each distinct topic, not one giant blob
+- **Images inline** at the point in the narrative where they're most relevant, not grouped at the end
+- **"What shipped" table** at the end with PR numbers and titles
+
+### Creative titles
+
+The title should capture the session's character, not just list what happened. Examples from recent posts:
+- "Ghost Tests and Coordinate Lies"
+- "Blending Boundaries and the 13-Channel Cartwheel"
+- "Auto-Crop, Color Theory Humility, and Killing Dead Weight"
+
+### If post already exists
+
+- If `<!-- enriched -->` and refresh mode → regenerate the Developer Journal from fresh data, preserve structure
+- If `<!-- generated -->` → replace with full enriched content
+- If post was written manually (no marker) → update if needed (add missing PRs to table, etc.) but preserve existing narrative
+
+## Step 5: Update Manifest
+
+Write `docs/blog/images/manifest.json` with entries for each date. Each image entry includes:
+
+```json
+{
+  "filename": "descriptive-name.png",
+  "alt_text": "10-20 word description of visual content",
+  "message_context": "Slack message text that accompanied this image",
+  "timestamp": "1773158776.221009",
+  "width": 1678,
+  "height": 934,
+  "source": "inbox",
+  "downloaded": true
+}
+```
+
+- Preserve all existing entries for dates not being processed
+- Sort entries within each date by timestamp
+- Sort date keys chronologically
+
+## Step 6: Verification
+
+After all dates are processed, verify:
+
+1. No images remain in `jwst-inbox/` that belong to dates in the range
+2. Every image referenced in a blog post exists on disk
+3. Manifest entries have `width`, `height`, `message_context`, and `timestamp` (not just filename/alt_text)
+4. No friend names/usernames leaked (see Privacy Rules)
+5. "What shipped" tables match `git log` for each date
+
+## Privacy Rules (CRITICAL)
+
+- **NEVER quote friends directly** — summarize: "A friend tested the staging URL and gave feedback..."
+- **NEVER include friends' names or usernames** — use "a friend", "friends", "someone in the channel"
+- **Shanon's messages**: paraphrase in narrative voice. Capture intent and energy, not verbatim text.
+- **No timestamps** in output — narrative flow only
+- **No Slack links** in output
+- **Bot messages**: ignore completely
+- **Reactions/emoji**: can mention general sentiment but don't list specific emoji
+
+## Bash Safety Rules
+
+These patterns trigger security prompts and MUST be avoided:
+
+- **No `$()`** — never use command substitution in Bash commands
+- **No shell arithmetic** like `$((d-1))` — expand all dates to full strings before running
+- **No heredocs with `#` headers** — use the Write tool for markdown content, then reference the file
+- **No `/tmp` paths in Bash** — write temp files via the Write tool instead
+- **No for-loops with `$var` in paths** — `for f in ...; do head $path/$f.md; done` triggers permission prompts. Use individual Read tool calls or `ls` with a glob instead
+- **Run git log per-date** with full ISO strings: `--since="2026-03-16T00:00:00" --until="2026-03-16T23:59:59"`
+- **Use the Write tool** for blog post content, not Bash echo/cat
+- **Verify posts** with `ls -la docs/blog/posts/2026-03-1*.md` or individual Read calls, not for-loops
+
+## Edge Cases
+
+- **No git commits AND no Slack messages for a date** → skip that date entirely, don't create an empty post
+- **Git commits but no Slack messages** → create post with "What shipped" table only, no Developer Journal
+- **Slack messages but no git commits** → create post with Developer Journal only (rare — usually means planning/research day)
+- **Inbox images span dates outside the target range** → sort them to correct folders anyway, but only create posts for dates in the range
+- **Image already exists in a date folder** → skip copy, don't overwrite
+- **Slack MCP unavailable** → report error, proceed with git-only data, flag that images couldn't be sorted
+- **Ambiguous image-to-date mapping** → flag to user rather than guessing wrong

--- a/docs/blog/posts/2026-03-16.md
+++ b/docs/blog/posts/2026-03-16.md
@@ -1,0 +1,31 @@
+---
+date:
+  created: 2026-03-16
+categories:
+  - Feature
+  - Bug Fix
+tags:
+  - fov-overlap
+  - auth
+  - stretch-presets
+  - recipe-walkthrough
+authors:
+  - shanon
+---
+
+# March 16: Overlap Detection and the Auth Untangling
+
+Big feature day — FOV overlap detection landed in the composite wizard, the auth flow got simplified to remove race-prone refresh triggers, and MIRI got its own stretch presets separate from NIRCAM.
+
+<!-- more -->
+<!-- generated -->
+
+## What shipped
+
+| PR | Title |
+|-----|-------|
+| #850 | feat: instrument-aware stretch presets for MIRI vs NIRCAM |
+| #848 | fix: default edge feather to 0 + add recipe walkthrough script |
+| #847 | fix: update E2E test — composite button is now always enabled |
+| #846 | fix: simplify auth flow — remove race-prone refresh triggers |
+| #844 | feat: add FOV overlap detection to footprint endpoint and CompositeWizard |

--- a/docs/blog/posts/2026-03-17.md
+++ b/docs/blog/posts/2026-03-17.md
@@ -1,0 +1,39 @@
+---
+date:
+  created: 2026-03-17
+categories:
+  - Feature
+  - Bug Fix
+  - Performance
+  - Security
+tags:
+  - memory-management
+  - auto-stretch
+  - quality-scoring
+  - streaming-reprojection
+  - security-audit
+authors:
+  - shanon
+---
+
+# March 17: Memory Wars, Streaming Pixels, and a Security Sweep
+
+Massive infrastructure day. The composite pipeline got streaming reprojection to stop loading entire FITS files into memory, auto-stretch parameters learned to compute themselves from channel statistics, and a security audit scrubbed hardcoded paths and AWS IDs from the codebase.
+
+<!-- more -->
+<!-- generated -->
+
+## What shipped
+
+| PR | Title |
+|-----|-------|
+| #866 | fix: sensitive pattern guard in pre-commit hook and preflight |
+| #865 | fix: remove hardcoded local paths and AWS infrastructure IDs |
+| #863 | chore: integrate plan review and retro skills into workflow |
+| #861 | fix: mosaic memory guard + smart file selection for multi-tile targets |
+| #860 | fix: walkthrough multi-file channels + pre-commit hook improvements |
+| #858 | fix: reduce peak memory in composite pipeline (OOM on large NIRCAM) |
+| #857 | fix: E2E guided create flake |
+| #856 | chore: run-centric recipe grader UI with horizontal comparison |
+| #855 | feat: auto-detect optimal stretch parameters from channel statistics |
+| #854 | feat: versioned walkthrough output + grader with version history |

--- a/docs/blog/posts/2026-03-18.md
+++ b/docs/blog/posts/2026-03-18.md
@@ -1,0 +1,31 @@
+---
+date:
+  created: 2026-03-18
+categories:
+  - Feature
+  - Bug Fix
+  - Performance
+tags:
+  - compositing
+  - gain-normalization
+  - quality-scoring
+  - streaming-reprojection
+  - hdr-stretch
+authors:
+  - shanon
+---
+
+# March 18: Gain Normalization and the Crab Nebula Pipeline
+
+The composite pipeline gained per-tile gain normalization to eliminate exposure-level grid artifacts, quality scoring via HTTP response headers, and HDR auto-stretch for extreme dynamic range targets like the Crab Nebula. Coverage-aware filter selection in the recipe engine now handles RA wraparound correctly.
+
+<!-- more -->
+<!-- generated -->
+
+## What shipped
+
+| PR | Title |
+|-----|-------|
+| #872 | fix: coverage-aware filter selection in recipe engine |
+| #870 | feat: per-tile gain normalization to eliminate exposure-level grid artifacts |
+| #867 | feat: composite quality scoring, streaming reprojection, HDR auto-stretch, input file sorting |

--- a/docs/blog/posts/2026-03-19.md
+++ b/docs/blog/posts/2026-03-19.md
@@ -1,0 +1,40 @@
+---
+date:
+  created: 2026-03-19
+categories:
+  - Feature
+  - Bug Fix
+  - Performance
+tags:
+  - async-export
+  - memory-management
+  - compositing
+  - agentic-workflow
+authors:
+  - shanon
+---
+
+# March 19: Async Exports and the Agentic Levels
+
+The walkthrough generator moved to async export queues to stop timing out on large composites, and the channel-aware memory budget model got a conservative overhaul after OOM incidents on multi-channel composites.
+
+<!-- more -->
+<!-- enriched -->
+
+## Developer Journal
+
+### Async exports and memory budgets
+
+The recipe walkthrough had been timing out on large composites because the export was synchronous — the backend proxy would give up before the processing engine finished. Moved the export to an async queue with bumped proxy timeouts, which fixed the immediate problem. But the deeper issue was memory: multi-channel composites were blowing past the 2GB container limit because the memory budget calculation didn't account for channel count properly. Rewrote it to be channel-aware and conservative.
+
+### Agentic coding evolution
+
+Had a good conversation about the levels of agentic coding — from basic prompting through skills, hooks, and multi-agent coordination. I'm working at level 4 now with hooks enforcing quality structurally, and have tried level 5 (parallel agents) a few times but it usually breaks down. The interesting realization: the experience isn't unique anymore. Others are reaching similar levels with different tools.
+
+## What shipped
+
+| PR | Title |
+|-----|-------|
+| #879 | docs: trim agent coordination section |
+| #877 | feat: walkthrough uses async export queue, bump backend proxy timeouts |
+| #875 | fix: channel-aware memory budget prevents OOM on multi-channel composites |

--- a/docs/blog/posts/2026-03-20.md
+++ b/docs/blog/posts/2026-03-20.md
@@ -1,0 +1,54 @@
+---
+date:
+  created: 2026-03-20
+categories:
+  - Feature
+  - Bug Fix
+  - Compositing
+tags:
+  - instrument-blending
+  - feathering
+  - color-contribution
+  - multi-instrument
+  - miri
+  - nircam
+authors:
+  - shanon
+---
+
+# March 20: From Signal Fading to Palette Lerping
+
+The big multi-instrument compositing push. Started with per-channel feathering that couldn't fix the MIRI color palette shift, evolved to instrument-level blending, then realized signal fading destroys detail and invented color-contribution feathering — lerping between palette interpretations instead of fading signals.
+
+<!-- more -->
+<!-- enriched -->
+
+## Developer Journal
+
+### The MIRI boundary problem
+
+Multi-instrument composites (MIRI + NIRCAM) had a visible color palette shift at the MIRI FOV boundary. All MIRI channels share the same field of view footprint, so per-channel feathering produced identical masks for all of them — they all faded in lockstep. The result was an abrupt 6-channel to 4-channel palette change regardless of feather strength.
+
+### Instrument-level blending (attempt 1)
+
+The first fix grouped channels by instrument, produced per-group RGB images, and blended them with equal weight using instrument-level coverage masks. This worked for the yellow/green channels (F770W) — smooth transitions, no hard edge. But the red (F1500W) transition to background remained sharp, and cranking up the feather width just washed out detail in the transition zone.
+
+### The insight: feather the color, not the signal
+
+The key realization came from looking at what feathering actually does — it fades the entire signal (structure + color) to zero. But what you actually want is to preserve all structural detail and only transition the color palette. The fix: compute two RGB images (full 6-channel palette and NIRCAM-only palette) and lerp between them using the MIRI coverage mask. NIRCAM structure exists in both images, so nothing is lost in the transition.
+
+### CEO review auto-progression
+
+Also improved the workflow tooling — the CEO review skill now automatically progresses to the engineering review when the verdict is "proceed," eliminating the manual handoff that was slowing down the implementation pipeline.
+
+## What shipped
+
+| PR | Title |
+|-----|-------|
+| #890 | fix: color-contribution feathering for multi-instrument composites |
+| #888 | fix: instrument-level blending for multi-instrument composites |
+| #887 | chore: process improvements — trim AGENTS.md, add skills, docs audit |
+| #886 | fix: use line content as React key instead of array index |
+| #884 | fix: auto-enable feathering for multi-instrument composites |
+| #881 | fix: resolution blur, per-channel feathering, and instrument-aware stretch |
+| #880 | fix: exclude background/calibration targets from recipe generation |


### PR DESCRIPTION
## Summary
- Five blog posts covering March 16-20
- New `enrich-blog` skill with Bash safety rules

No linked issue — routine blog maintenance.

## Changes Made
- `docs/blog/posts/2026-03-16.md` through `2026-03-20.md` — new posts
- `.claude/skills/enrich-blog/SKILL.md` — new skill file

## Test Plan
- [x] Posts have valid frontmatter
- [x] What Shipped tables match git log
- [x] No privacy violations (no friend names/usernames)

## Documentation Checklist
- [x] Blog posts are the documentation

## Tech Debt Impact
- [x] No tech debt

## Risk & Rollback
Risk: None — docs only.
Rollback: Revert commit.
