### PR TITLE
fix: chunked CIELAB blending to prevent OOM on multi-instrument composites

### DIFF
--- a/processing-engine/app/composite/color_mapping.py
+++ b/processing-engine/app/composite/color_mapping.py
@@ -507,7 +507,8 @@ def blend_instrument_groups(
     h, w = ref_shape
 
     # Full palette: all channels combined (linear RGB — gamma applied at the end)
-    full_rgb = combine_channels_to_rgb(channels, _apply_gamma=False)
+    # result takes ownership; full_rgb is not kept separately to save memory.
+    result = combine_channels_to_rgb(channels, _apply_gamma=False)
 
     # Find the majority instrument by pixel coverage (not channel count).
     # A 2-channel NIRCam covering the full FOV should be majority over a
@@ -520,11 +521,9 @@ def blend_instrument_groups(
     majority_key = max(groups, key=_instrument_coverage)
     minority_keys = [k for k in groups if k != majority_key]
 
-    # Start with the full palette, then progressively lerp toward the base
-    # palette at each minority instrument's FOV boundary.  Each iteration
-    # blends the *accumulated* result (not full_rgb), so multiple minorities
-    # compose correctly.
-    result = full_rgb.copy()
+    # Progressively lerp toward the base palette at each minority
+    # instrument's FOV boundary.  Each iteration blends the *accumulated*
+    # result, so multiple minorities compose correctly.
     result_is_srgb = False  # tracks whether result has had gamma applied
 
     for minor_key in minority_keys:
@@ -535,8 +534,6 @@ def blend_instrument_groups(
 
         if not base_channels:
             continue
-
-        base_rgb = combine_channels_to_rgb(base_channels, _apply_gamma=False)
 
         # Compute minority instrument's coverage mask (union of its channels)
         minor_ch_names = [ch_names[i] for i in groups[minor_key]]
@@ -549,22 +546,30 @@ def blend_instrument_groups(
             # Full coverage — minority instrument covers everything, no transition needed
             continue
 
+        base_rgb = combine_channels_to_rgb(base_channels, _apply_gamma=False)
+
         # Lerp in CIELAB for perceptually uniform transitions.
         # Linear RGB lerp produces visible hue shifts at instrument boundaries
         # (especially NIRCam blue/green → MIRI red/orange) because equal steps
         # in linear RGB are not perceptually equal.
         #
-        # rgb2lab() expects sRGB input (it linearizes internally), so convert
-        # to sRGB first.  lab2rgb() returns sRGB, so the result stays sRGB.
-        result_srgb = result if result_is_srgb else linear_to_srgb(result)
-        base_srgb = linear_to_srgb(base_rgb)
-        result_lab = rgb2lab(result_srgb)
-        base_lab = rgb2lab(base_srgb)
+        # Memory-critical: rgb2lab/lab2rgb create large intermediates.
+        # Process everything in row chunks — sRGB conversion, LAB conversion,
+        # and lerp — so peak memory is O(chunk_size) not O(image_size).
+        # No full-res sRGB copies are needed.
+        chunk_rows = 1024
+        for r0 in range(0, h, chunk_rows):
+            r1 = min(r0 + chunk_rows, h)
+            mask_chunk = mask[r0:r1, :, np.newaxis]
+            # Convert chunks to sRGB for rgb2lab (which expects sRGB input)
+            res_chunk = result[r0:r1] if result_is_srgb else linear_to_srgb(result[r0:r1])
+            base_chunk = linear_to_srgb(base_rgb[r0:r1])
+            result_lab = rgb2lab(res_chunk)
+            base_lab = rgb2lab(base_chunk)
+            blended_lab = base_lab * (1.0 - mask_chunk) + result_lab * mask_chunk
+            result[r0:r1] = np.clip(lab2rgb(blended_lab), 0.0, 1.0)
 
-        mask_3d = mask[:, :, np.newaxis]
-        blended_lab = base_lab * (1.0 - mask_3d) + result_lab * mask_3d
-        # lab2rgb returns sRGB — result is now in sRGB space
-        result = np.clip(lab2rgb(blended_lab), 0.0, 1.0)
+        del base_rgb  # free after chunked iteration
         result_is_srgb = True
 
     if _apply_gamma:


### PR DESCRIPTION
## Summary
Closes #905

Fixes OOM crash in multi-instrument composites caused by CIELAB blending intermediates exceeding the 4GB container memory limit.

## Why
PR #903 introduced CIELAB palette lerp for perceptually uniform instrument transitions. The implementation created full-resolution sRGB and LAB intermediate arrays (~425MB each at 4K), pushing total memory past 4GB for any real JWST multi-instrument composite. Every multi-instrument recipe (NGC 3132, M16, Cartwheel Galaxy, etc.) OOM-killed the processing engine.

## Changes Made
- **Chunked CIELAB processing**: sRGB conversion, LAB conversion, and lerp all happen in 1024-row chunks instead of full-resolution. Peak memory for blending drops from ~2.5GB to ~50MB.
- **Eliminate full_rgb copy**: `result` takes ownership directly from `combine_channels_to_rgb` instead of copying a separate `full_rgb` array. Saves ~425MB.
- **Free base_rgb after use**: `del base_rgb` after the chunked loop completes.

## Test Plan
- [x] 100 unit tests pass (test_color_mapping.py)
- [x] NGC 3132 Best 5-filter MIRI+NIRCAM composite completes within 4GB container
- [x] Visual verification: smooth MIRI boundary transition, correct colors, no banding
- [x] Docker rebuild, service starts clean

## Documentation Checklist
- [x] No new endpoints or services — no docs update needed

## Tech Debt Impact
- [x] Reduces tech debt (fixes regression from #903)

## Risk & Rollback
Risk: Low — only changes memory allocation pattern in `blend_instrument_groups`, same numerical output.
Rollback: Revert this commit (composites will OOM again on real data).
