### PR TITLE
fix: use union coverage mask for per-channel feathering

### DIFF
--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -766,19 +766,24 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
             and len(color_mapped) > 1
         )
 
-        # Per-channel feathering (legacy path): used for single-instrument
-        # composites or when instrument blending is not applicable.
+        # Per-channel feathering: compute a UNION coverage mask across all
+        # channels, then apply that single mask to every channel.  This avoids
+        # dimming signal where individual FITS tiles have slightly different
+        # footprints — only the overall FOV edge gets feathered.
         per_channel_masks: list[np.ndarray | None] = []
         if not use_instrument_blending and effective_feather > 0 and len(color_mapped) > 1:
+            ref_shape = color_mapped[0][0].shape
+            union_coverage = np.zeros(ref_shape, dtype=np.float64)
             for ch_name in color_ch_names:
                 ch_data = reprojected_channels[ch_name]
-                coverage = (ch_data != 0).sum() / ch_data.size
-                mask = compute_feather_weights(
-                    ch_data,
-                    fraction=effective_feather,
-                    coverage_fraction=coverage,
-                )
-                per_channel_masks.append(mask)
+                union_coverage = np.maximum(union_coverage, (ch_data != 0).astype(np.float64))
+            union_frac = union_coverage.sum() / union_coverage.size
+            shared_mask = compute_feather_weights(
+                union_coverage,
+                fraction=effective_feather,
+                coverage_fraction=union_frac,
+            )
+            per_channel_masks = [shared_mask] * len(color_mapped)
         else:
             per_channel_masks = [None] * len(color_mapped)
 


### PR DESCRIPTION
## Summary
Closes #906

Fixes per-channel feathering dimming signal on single-instrument composites by using a shared union coverage mask instead of independent per-FITS masks.

## Why
Per-channel feathering computed an independent mask for each FITS file's coverage footprint. When tiles within the same instrument had slightly different footprints (common with MIRI dithers), each channel got dimmed at different edges — causing dark vignetting and color shifts. Visible on M-16 Classic 3-color MIRI as lost brightness and a green cast.

## Changes Made
- **Union coverage mask**: Compute a single coverage mask as the union (max) of all channels' non-zero pixels, then apply that shared mask to every channel
- Only the overall FOV boundary gets feathered — individual tile edges within the same instrument are no longer dimmed

## Test Plan
- [x] 100 unit tests pass (test_color_mapping.py)
- [x] M-16 Classic 3-color MIRI recipe walkthrough: brightness and color match the no-feather version, tile edges softened correctly
- [x] Visual comparison of three versions (no-feather, per-channel, union-mask) confirms fix
- [x] Docker rebuild, service starts clean

## Documentation Checklist
- [x] No new endpoints or services — no docs update needed

## Tech Debt Impact
- [x] Reduces tech debt (fixes incorrect feathering behavior)

## Risk & Rollback
Risk: Low — single-file change in the composite pipeline's feathering path. Multi-instrument blending path is unchanged.
Rollback: Revert this commit to restore per-channel feathering.
