### PR TITLE
fix: disable per-channel feathering for single-instrument composites

### DIFF
--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -44,7 +44,6 @@ from .color_mapping import (
     blend_instrument_groups,
     blend_luminance,
     combine_channels_to_rgb,
-    compute_feather_weights,
     hue_to_rgb_weights,
     linear_to_srgb,
 )
@@ -772,26 +771,13 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
             and len(color_mapped) > 1
         )
 
-        # Per-channel feathering: compute a UNION coverage mask across all
-        # channels, then apply that single mask to every channel.  This avoids
-        # dimming signal where individual FITS tiles have slightly different
-        # footprints — only the overall FOV edge gets feathered.
-        per_channel_masks: list[np.ndarray | None] = []
-        if not use_instrument_blending and effective_feather > 0 and len(color_mapped) > 1:
-            ref_shape = color_mapped[0][0].shape
-            union_coverage = np.zeros(ref_shape, dtype=np.float64)
-            for ch_name in color_ch_names:
-                ch_data = reprojected_channels[ch_name]
-                union_coverage = np.maximum(union_coverage, (ch_data != 0).astype(np.float64))
-            union_frac = union_coverage.sum() / union_coverage.size
-            shared_mask = compute_feather_weights(
-                union_coverage,
-                fraction=effective_feather,
-                coverage_fraction=union_frac,
-            )
-            per_channel_masks = [shared_mask] * len(color_mapped)
-        else:
-            per_channel_masks = [None] * len(color_mapped)
+        # No per-channel feathering for single-instrument composites.
+        # Feathering at the FOV edge dims signal with nothing on the other
+        # side to blend with — only instrument-overlap boundaries (handled
+        # by blend_instrument_groups) are real blend zones.
+        # See #911 and design principle in project memory.
+        # Dead code cleanup tracked in #913.
+        per_channel_masks: list[np.ndarray | None] = [None] * len(color_mapped)
 
         # Debug masks: return per-channel coverage visualization instead of
         # the composite image.  Each channel becomes a grayscale panel showing


### PR DESCRIPTION
## Summary
Closes #911

Disables per-channel feathering for single-instrument composites. Feathering now only applies at instrument-overlap boundaries (multi-instrument path via `blend_instrument_groups`).

## Why
Per-channel feathering tapered signal at the FOV edge of single-instrument composites — the detector border, not a blend zone. There's nothing on the other side to blend with. This caused dark vignetting and color shifts, visible on M-16 Classic 3-color MIRI.

Design principle: "Is there data from another source on the other side of this boundary?" No → don't feather.

## Changes Made
- Remove the per-channel feathering block from `routes.py` — `per_channel_masks` is always `[None] * len(color_mapped)` now
- Remove unused `compute_feather_weights` import from routes.py
- Multi-instrument CIELAB lerp path (`blend_instrument_groups`) is unaffected — still feathers at instrument boundaries correctly

## Test Plan
- [x] 123 unit tests pass (test_color_mapping.py + test_composite_downscale.py)
- [x] M-16 Classic 3-color MIRI: full brightness, no dark vignetting (matches no-feather baseline)
- [x] M-16 Best 6-filter MIRI+NIRCAM: instrument boundary blending still works correctly
- [x] M-16 full walkthrough: 7/7 recipes pass
- [x] Docker rebuild, service starts clean

## Documentation Checklist
- [x] No new endpoints or services — no docs update needed

## Tech Debt Impact
- [x] Reduces tech debt — removes incorrect feathering behavior. Follow-up tracked: #912 (hide Edge Feather slider for single-instrument), #913 (dead code cleanup)

## Risk & Rollback
Risk: Low — removes a code path that was producing incorrect output. Single file change.
Rollback: Revert this commit to restore per-channel feathering (which dims FOV edges incorrectly).
