### PR TITLE
chore: CEO review skill auto-files risk issues + relax tech debt validator

### DIFF
--- a/.claude/skills/plan-ceo-review/SKILL.md
+++ b/.claude/skills/plan-ceo-review/SKILL.md
@@ -120,6 +120,15 @@ Produce:
 
 If the plan requires EnterPlanMode (load-bearing change), say so explicitly and trigger it.
 
+## Step 5b: Risk → Issue Triage
+
+After producing the risks list, triage each risk for whether it should become a GitHub issue:
+
+- For EACH identified risk, ask: "Does this risk have a concrete follow-up action that won't be addressed in this PR?"
+- If **yes** → file a GitHub issue immediately (using `--body-file`, not inline `--body`). Include the risk description, why it matters, and link it to the current issue.
+- If **no** → the risk is handled by the current implementation or is informational only. Note it in the review but don't file an issue.
+- **Do not defer issue creation** — if a risk warrants tracking, create the issue as part of the review output, before moving to eng review. Risks that go untracked go unresolved.
+
 ## Step 6: Auto-Progression to Engineering Review
 
 When the recommendation is **"proceed as-is"** or **"proceed with changes"**:

--- a/.github/scripts/validate-pr.js
+++ b/.github/scripts/validate-pr.js
@@ -161,9 +161,7 @@ if (techDebtSection) {
   if (total < 1) {
     errors.push("`## Tech Debt Impact` must include checkbox items.");
   } else if (checked < 1) {
-    errors.push("`## Tech Debt Impact` must have one checked option.");
-  } else if (checked > 1) {
-    errors.push("`## Tech Debt Impact` must have exactly one checked option.");
+    errors.push("`## Tech Debt Impact` must have at least one checked option.");
   }
 }
 


### PR DESCRIPTION
## Summary
No linked issue

Process improvements from the #891 compositing session.

## Why
Two process gaps identified during the session:
1. CEO review identified risks that should have been filed as issues but were not — the skill did not prompt for it
2. Tech Debt Impact validator rejected PRs with two checked checkboxes (e.g., reduces tech debt + follow-up tracked) even though both were valid

## Changes Made
- **CEO review skill**: Add Step 5b — after identifying risks, triage each for whether it should become a GitHub issue. File immediately, do not defer.
- **validate-pr.js**: Relax Tech Debt Impact from exactly one to at least one checked checkbox

## Test Plan
- [x] Skill change is documentation only — no runtime test needed
- [x] Validator change: PRs with 1 or 2 checked Tech Debt checkboxes now pass; PRs with 0 still fail

## Documentation Checklist
- [x] No docs update needed — skill and CI config changes only

## Tech Debt Impact
- [x] Reduces tech debt — prevents risks from going untracked and removes unnecessary PR friction

## Risk & Rollback
Risk: Low — documentation-only skill change and a 3-line validator relaxation.
Rollback: Revert this commit.
