### PR TITLE
fix: restore guided step card container styles deleted by #917

### DIFF
--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.css
@@ -1,0 +1,114 @@
+.process-step {
+  padding: var(--space-6);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.process-step-title {
+  margin: 0 0 var(--space-1);
+  font-size: var(--text-xl);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.process-step-target {
+  margin: 0 0 var(--space-5);
+  font-size: var(--text-base);
+  color: var(--text-secondary);
+}
+
+/* Stage list */
+.process-stage-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.process-stage-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-base);
+}
+
+.process-stage-icon {
+  flex-shrink: 0;
+  width: 20px;
+  text-align: center;
+  font-size: var(--text-sm);
+}
+
+.stage-done {
+  color: var(--color-success, #10b981);
+}
+
+.stage-active {
+  color: var(--accent-primary);
+}
+
+.stage-active .process-stage-icon {
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.stage-pending {
+  color: var(--text-muted);
+}
+
+.process-stage-label {
+  font-weight: 500;
+}
+
+/* Hint */
+.process-step-hint {
+  margin: var(--space-5) 0 0;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* Error state */
+.process-step-error {
+  padding: var(--space-5);
+  background: var(--color-error-subtle);
+  border: 1px solid var(--border-error);
+  border-radius: var(--radius-md);
+  text-align: center;
+  color: var(--color-error, #ef4444);
+}
+
+.process-step-error p {
+  margin: 0 0 var(--space-3);
+}
+
+.process-step-retry {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 var(--space-4);
+  background: transparent;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.process-step-retry:hover {
+  background: var(--bg-elevated);
+}
+
+.process-step-retry:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -2,6 +2,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  padding: var(--space-6);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
 }
 
 /* Sidebar split layout — preview left, controls right */


### PR DESCRIPTION
## Summary
Restore ProcessStep card container styles deleted by #917 and add matching card treatment to ResultStep.

Closes #920

## Why
PR #917 emptied `ProcessStep.css` thinking all 114 lines were dead CSS. They weren't — the `.process-step` class provides the card background, border, and padding visible during composite processing. Without it, Step 2 content floats on the starfield with no container.

## Changes Made
- Restore full `ProcessStep.css` from pre-#917 state (card container, title, stages, hint, error, retry styles)
- Add card treatment (`background`, `border`, `border-radius`, `padding`) to `.result-step` in `ResultStep.css` for consistency across all three guided steps

## Test Plan
- [x] 883 frontend unit tests pass
- [x] TypeScript type check clean
- [x] ESLint, Prettier pass
- [ ] Visual: navigate guided create flow — all 3 steps (Download, Process, Result) should show card background

## Documentation Checklist
- [x] No docs update needed — CSS-only fix

## Tech Debt Impact
- [x] Reduces tech debt — fixes regression from #917's overly aggressive CSS cleanup

## Risk & Rollback
Risk: Low — CSS-only, restoring previously working styles.
Rollback: Revert the single commit.
