### PR TITLE
docs: add 4+1 architecture view documentation

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -1,0 +1,259 @@
+# API Contracts
+
+Service-to-service API boundary map showing which services expose what to whom. All inter-service communication uses HTTP/JSON with snake_case payloads.
+
+> **4+1 View**: Logical View
+
+## Service Boundary Diagram
+
+```mermaid
+flowchart LR
+    subgraph Client["Client (Browser)"]
+        React["React SPA"]
+        SR["SignalR Client"]
+    end
+
+    subgraph FE["Frontend (nginx :3000)"]
+        Static["Static Assets"]
+        Proxy["/api → backend:5000"]
+    end
+
+    subgraph BE["Backend API (.NET :5000)"]
+        Auth["AuthController"]
+        Data["JwstDataController"]
+        DM["DataManagementController"]
+        Mast["MastController"]
+        Disc["DiscoveryController"]
+        Comp["CompositeController"]
+        Mos["MosaicController"]
+        Ana["AnalysisController"]
+        Jobs["JobsController"]
+        Search["SearchController"]
+        Hub["JobProgressHub\n(SignalR)"]
+    end
+
+    subgraph PE["Processing Engine (Python :8000)"]
+        PComp["/composite"]
+        PMos["/mosaic"]
+        PAna["/analysis"]
+        PDisc["/discovery"]
+        PSem["/semantic"]
+    end
+
+    subgraph MP["MAST Proxy (Python :8000)"]
+        PMast["/mast"]
+    end
+
+    subgraph DB["MongoDB :27017"]
+        Collections["jwst_data\nusers\njobs"]
+    end
+
+    subgraph Ext["External"]
+        MAST["STScI MAST\nPortal"]
+    end
+
+    React -->|HTTP| FE
+    SR -->|WebSocket| Hub
+    FE -->|reverse proxy| BE
+    Comp -->|POST| PComp
+    Mos -->|POST| PMos
+    Ana -->|GET/POST| PAna
+    Disc -->|POST| PDisc
+    Search -->|POST| PSem
+    Mast -->|POST| PMast
+    PMast -->|astroquery| MAST
+    BE -->|MongoDB.Driver| DB
+```
+
+## Frontend → Backend API
+
+All calls go through the `apiClient` singleton which handles JWT injection and 401 refresh.
+
+### Authentication (`/api/auth`)
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| POST | `/login` | Public | Authenticate, returns access + refresh tokens |
+| POST | `/register` | Public | Create account |
+| POST | `/refresh` | Public | Refresh access token |
+| POST | `/logout` | Required | Revoke refresh token |
+| GET | `/me` | Required | Current user profile |
+
+### Discovery (`/api/discovery`)
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| GET | `/featured` | Public | Curated featured targets list |
+| POST | `/suggest-recipes` | Public | Recipe suggestions for a target → proxied to Processing Engine |
+
+### MAST (`/api/mast`)
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| POST | `/search/target` | Required | Search MAST by target name |
+| POST | `/search/coordinates` | Required | Search MAST by RA/Dec |
+| POST | `/search/observation` | Required | Search by observation ID |
+| POST | `/search/program` | Required | Search by program ID |
+| POST | `/import` | Required | Import observation (async job) |
+
+### Composite (`/api/composite`)
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| POST | `/generate-nchannel` | Public | Synchronous N-channel composite → returns image blob |
+| POST | `/export-nchannel` | Required | Async export job → returns `jobId` (202 Accepted) |
+
+### Mosaic (`/api/mosaic`)
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| POST | `/generate` | Public | Synchronous mosaic generation → returns image blob |
+| POST | `/generate-and-save` | Required | Generate mosaic FITS + save as data record (201) |
+| POST | `/footprint` | Public | WCS footprint polygons for preview |
+| POST | `/export` | Required | Async mosaic export job → returns `jobId` (202) |
+| POST | `/save` | Required | Async save-to-library job → returns `jobId` (202) |
+| GET | `/limits` | Required | Processing limits for current user |
+
+### Analysis (`/api/analysis`)
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| POST | `/region-statistics` | Public | Statistics for image region (mean, median, std, ...) |
+| POST | `/detect-sources` | Public | Astronomical source detection |
+| GET | `/table-info` | Public | FITS table HDU metadata |
+| GET | `/table-data` | Public | Paginated table rows |
+| GET | `/spectral-data` | Public | Spectral data for plotting |
+
+### Jobs (`/api/jobs`)
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| GET | `/` | Required | List user's jobs (filter by status, type) |
+| GET | `/{jobId}` | Required | Single job status |
+| POST | `/{jobId}/cancel` | Required | Cancel a running job |
+| GET | `/{jobId}/result` | Required | Stream job result (blob or data reference) |
+
+### Data Library (`/api/jwstdata`, `/api/data-management`)
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| GET | `/api/jwstdata` | Required | List user's data records |
+| GET | `/api/jwstdata/{id}` | Required | Single record |
+| POST | `/api/jwstdata/upload` | Required | Upload FITS file |
+| DELETE | `/api/jwstdata/{id}` | Required | Delete record |
+| Various | `/api/data-management/*` | Required | Bulk ops, tagging, sharing, archive |
+
+### Semantic Search (`/api/search`)
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| GET | `/semantic` | Public | Natural language search (`?q=...&topK=...&minScore=...`) |
+| POST | `/reindex` | Admin | Trigger full re-index |
+| GET | `/index-status` | Public | Semantic index statistics |
+
+### SignalR Hub (`/hubs/job-progress`)
+
+| Direction | Event | Payload |
+|-----------|-------|---------|
+| Client → Server | `SubscribeToJob(jobId)` | Job ID (ownership verified) |
+| Client → Server | `UnsubscribeFromJob(jobId)` | Job ID |
+| Server → Client | `JobSnapshot` | Full job state on subscription |
+| Server → Client | `JobProgress` | `{ jobId, percent, stage, message }` |
+| Server → Client | `JobCompleted` | `{ jobId, resultKind, resultDataId }` |
+| Server → Client | `JobFailed` | `{ jobId, error }` |
+
+Auth: JWT via `?access_token=` query parameter (WebSocket limitation).
+
+---
+
+## Backend → Processing Engine
+
+The .NET backend calls the Python Processing Engine via typed `HttpClient` instances with Polly resilience policies.
+
+### Composite Service
+
+| Method | Endpoint | Timeout | Resilience |
+|--------|----------|---------|------------|
+| POST | `/composite/generate-nchannel` | 30 min attempt / 60 min total | 3 retries, circuit breaker |
+
+### Mosaic Service
+
+| Method | Endpoint | Timeout | Resilience |
+|--------|----------|---------|------------|
+| POST | `/mosaic/generate` | 30 min attempt / 60 min total | 3 retries, circuit breaker |
+| POST | `/mosaic/footprint` | 30 min attempt / 60 min total | 3 retries, circuit breaker |
+
+### Analysis Service
+
+| Method | Endpoint | Timeout | Resilience |
+|--------|----------|---------|------------|
+| POST | `/analysis/region-statistics` | 2 min | Standard |
+| POST | `/analysis/detect-sources` | 2 min | Standard |
+| GET | `/analysis/table-info` | 2 min | Standard |
+| GET | `/analysis/table-data` | 2 min | Standard |
+| GET | `/analysis/spectral-data` | 2 min | Standard |
+
+### Discovery Service
+
+| Method | Endpoint | Timeout | Resilience |
+|--------|----------|---------|------------|
+| POST | `/discovery/suggest-recipes` | 2 min | Standard |
+
+### Semantic Search Service
+
+| Method | Endpoint | Timeout | Resilience |
+|--------|----------|---------|------------|
+| POST | `/semantic/search` | 5 min | Standard |
+| POST | `/semantic/embed` | 5 min | Standard |
+| POST | `/semantic/embed-batch` | 5 min | Standard |
+| GET | `/semantic/index-status` | 5 min | Standard |
+
+### Thumbnail Service
+
+| Method | Endpoint | Timeout | Resilience |
+|--------|----------|---------|------------|
+| POST | `/composite/generate-nchannel` | 60 sec | None (fire-and-forget) |
+
+---
+
+## Backend → MAST Proxy
+
+| Method | Endpoint | Timeout | Purpose |
+|--------|----------|---------|---------|
+| POST | `/mast/search/target` | 5 min | MAST target search |
+| POST | `/mast/download` | 5 min | Chunked FITS download |
+| POST | `/mast/s3-download` | 5 min | Direct S3 download |
+| POST | `/mast/chunked-download` | 5 min | Streaming download with progress |
+
+The MAST Proxy is separated from the main Processing Engine to isolate I/O-heavy downloads (2 uvicorn workers) from CPU-heavy processing (1 worker).
+
+---
+
+## Error Translation
+
+Backend translates Processing Engine errors to user-friendly messages:
+
+| Processing Engine Error | Backend Response | User Message |
+|------------------------|-----------------|--------------|
+| Connection refused | 503 | "Processing engine not reachable" |
+| HTTP 503 | 503 | "Processing engine temporarily unavailable" |
+| Timeout | 504 | "Processing timed out" |
+| HTTP 500 | 500 | "An unexpected error occurred" |
+| HTTP 413 | 413 | "File too large" |
+| KeyNotFoundException | 404 | Original message preserved |
+
+---
+
+## JSON Casing Convention
+
+| Boundary | Convention | Example |
+|----------|-----------|---------|
+| Frontend ↔ Backend | camelCase | `{ "jobId": "abc", "progressPercent": 50 }` |
+| Backend ↔ Processing Engine | snake_case | `{ "job_id": "abc", "progress_percent": 50 }` |
+| Backend ↔ MongoDB | PascalCase (C# default) | `{ "JobId": "abc", "ProgressPercent": 50 }` |
+
+The .NET backend handles conversion automatically via `JsonSerializerOptions` configured per boundary.
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/build-pipeline.md
+++ b/docs/architecture/build-pipeline.md
@@ -1,0 +1,242 @@
+# Build Pipeline
+
+CI/CD flow from local development through commit hooks, CI, and deployment.
+
+> **4+1 View**: Development View
+
+## Pipeline Overview
+
+```mermaid
+flowchart TB
+    subgraph Local["Local Development"]
+        Edit["Code Edit"]
+        Hook["Pre-Commit Hook"]
+        Push["Git Push"]
+        PrePush["Pre-Push Hook"]
+    end
+
+    subgraph CI["GitHub Actions CI"]
+        Detect["detect-changes\n(path filter)"]
+        subgraph Parallel["Parallel Jobs"]
+            Lint["lint\n(ESLint, Prettier, Ruff, docs)"]
+            BTest["backend-test\n(dotnet build + test)"]
+            FTest["frontend-test\n(tsc + vite build + vitest)"]
+            PTest["python-test\n(pytest)"]
+        end
+        Docker["docker-build\n(4 images, GHA cache)"]
+        E2E["e2e-test\n(Playwright, Chromium)"]
+        Gate["ci-gate\n(required check)"]
+    end
+
+    subgraph PR["Pull Request"]
+        PRStd["pr-standards\n(title + body validation)"]
+        Review["Code Review"]
+        Merge["Merge to main"]
+    end
+
+    subgraph Deploy["Deployment"]
+        Staging["staging.sh deploy\n(AWS EC2)"]
+        Prod["docker compose\n-f prod.yml up"]
+    end
+
+    Edit --> Hook
+    Hook -->|pass| Push
+    Push --> PrePush
+    PrePush -->|pass| CI
+    Detect --> Parallel
+    Parallel --> Docker
+    Docker --> E2E
+    Parallel --> Gate
+    Docker --> Gate
+    E2E -.->|informational| Gate
+    Gate --> Review
+    PRStd --> Review
+    Review --> Merge
+    Merge --> Staging
+    Staging --> Prod
+```
+
+## Stage 1: Local — Pre-Commit Hook
+
+Runs on `git commit`. Blocks commit on failure.
+
+```mermaid
+flowchart LR
+    subgraph PreCommit["Pre-Commit Hook"]
+        Main["Block main branch"]
+        Sensitive["Sensitive pattern scan\n(.sensitive-patterns)"]
+        Docs["check-docs-consistency.sh"]
+        FE["Frontend\n(if changed)"]
+        BE["Backend\n(if changed)"]
+        PE["Processing Engine\n(if changed)"]
+    end
+
+    subgraph FEChecks["Frontend Checks"]
+        ESLint["ESLint + auto-fix"]
+        Prettier["Prettier + auto-fix"]
+        TSC["tsc --noEmit"]
+        Vitest["vitest run"]
+    end
+
+    subgraph BEChecks["Backend Checks"]
+        Build["dotnet build\n--warnaserror"]
+        Test["dotnet test"]
+    end
+
+    subgraph PEChecks["Python Checks"]
+        Ruff["ruff check + format"]
+    end
+
+    Main --> Sensitive --> Docs
+    Docs --> FE --> FEChecks
+    Docs --> BE --> BEChecks
+    Docs --> PE --> PEChecks
+```
+
+**What gets checked**:
+- Commits to `main` are **blocked** (must use feature branches)
+- Staged diffs scanned against `.sensitive-patterns` (AWS IDs, IPs, emails, absolute paths)
+- Doc consistency (cross-references between architecture docs)
+- Service-specific checks run only if that service's files are staged
+
+## Stage 2: Local — Pre-Push Hook
+
+Runs on `git push`. Blocks pushes to `main`.
+
+- Prevents direct pushes to the `main` branch
+- Allows branch deletions (`git push --delete`)
+- All changes must go through feature branches + PRs
+
+## Stage 3: CI — GitHub Actions
+
+### Triggers
+
+| Workflow | Trigger |
+|----------|---------|
+| `ci.yml` | PR to main, push to main, manual dispatch |
+| `pr-standards.yml` | PR opened, edited, synchronized, ready for review |
+| `security.yml` | PR to main, push to main, weekly (Sunday), manual |
+| `docs.yml` | Push to main with `docs/**` or `mkdocs.yml` changes |
+
+### CI Pipeline (`ci.yml`)
+
+#### 1. detect-changes
+
+Uses `dorny/paths-filter` to determine which services changed:
+- `backend/**` → run backend tests
+- `frontend/**` → run frontend tests
+- `processing-engine/**` → run Python tests
+- `docker/**`, `scripts/**` → run Docker build
+
+**Docs fast path**: If only `docs/**` changed, all code jobs are skipped.
+
+#### 2. Parallel Test Jobs
+
+| Job | Setup | Steps | Threshold |
+|-----|-------|-------|-----------|
+| **lint** | Node 22 | ESLint, Prettier check, Ruff, docs consistency | Zero warnings |
+| **backend-test** | .NET 10 SDK | `dotnet restore` → `build` → `test` with Coverlet | 40% line coverage |
+| **frontend-test** | Node 22 | `npm ci` → `tsc -b && vite build` → `vitest` | Build must pass |
+| **python-test** | Python 3.12 | `pip install -r requirements.txt` → `pytest` | 60% coverage |
+
+#### 3. Docker Build
+
+Builds 4 images in parallel with GitHub Actions cache:
+
+| Image | Dockerfile | Cache Scope |
+|-------|-----------|-------------|
+| Backend | `backend/JwstDataAnalysis.API/Dockerfile` | `backend` |
+| Frontend | `frontend/jwst-frontend/Dockerfile.dev` | `frontend` |
+| Processing Engine | `processing-engine/Dockerfile` | `processing` |
+| MAST Proxy | `processing-engine/Dockerfile.mast` | `mast-proxy` |
+
+#### 4. E2E Tests
+
+- Depends on: docker-build (loads cached images)
+- Seeds MongoDB with fixture data
+- Runs Playwright (Chromium only)
+- **Informational only** — not a required check
+
+#### 5. CI Gate
+
+**Required checks** for merge: `lint` + `backend-test` + `frontend-test` + `python-test` + `docker-build` (must pass or be skipped via path filter).
+
+E2E is explicitly non-blocking.
+
+### PR Standards (`pr-standards.yml`)
+
+Validates PR metadata via `.github/scripts/validate-pr.js`:
+- Title format and length
+- Required body sections (Summary, Changes Made, Test Plan, etc.)
+- `Closes #N` or `No linked issue` present
+- Tech Debt Impact checkbox
+- Risk & Rollback section
+
+### Security Scanning (`security.yml`)
+
+Weekly + on-demand CodeQL scans:
+
+| Job | Language | Source |
+|-----|----------|--------|
+| `codeql-csharp` | C# | `backend/**` |
+| `codeql-javascript` | TypeScript/JS | `frontend/**` |
+| `codeql-python` | Python | `processing-engine/**` |
+
+## Stage 4: Deployment
+
+### Staging (AWS EC2)
+
+```
+git checkout staging
+git merge main (fast-forward)
+./scripts/staging.sh deploy
+  ↓
+SSH to EC2 → git pull → docker compose up -d --build
+  (uses docker-compose.yml + docker-compose.staging.yml)
+```
+
+### Production
+
+```
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+```
+
+Manual process — no automated production deployment pipeline. SSL certificates must be provisioned separately.
+
+## Claude Code Hooks (Development-Time)
+
+In addition to git hooks, Claude Code hooks run during development:
+
+| Hook | Trigger | Purpose |
+|------|---------|---------|
+| `post-edit-typecheck` | After Edit/Write on .ts/.tsx | Per-file `tsc` check |
+| `post-edit-lint` | After Edit/Write | Anti-pattern scan (inline styles, `any`, debug logging) |
+| `post-edit-doc-drift` | After Edit/Write | Warns when docs may need updating |
+| `validate-before-pr-create` | Before `gh pr create` | Validates PR body and branch prefix |
+| `block-pr-merge` | Before `gh pr merge` | Warns for merge approval |
+| `block-push-merged-branch` | Before `git push` | Blocks pushes to already-merged branches |
+
+## Build Matrix
+
+| Check | Pre-Commit | CI | Required for Merge |
+|-------|-----------|----|--------------------|
+| Block main commits | Yes | — | — |
+| Sensitive pattern scan | Yes | — | — |
+| ESLint + Prettier | Yes (auto-fix) | Yes (check only) | Yes |
+| TypeScript type check | Yes | Yes (via build) | Yes |
+| Vitest unit tests | Yes | Yes | Yes |
+| dotnet build (warnings as errors) | Yes | Yes | Yes |
+| dotnet test | Yes | Yes | Yes |
+| Ruff lint + format | Yes | Yes | Yes |
+| Python pytest | No (requires Docker) | Yes | Yes |
+| Docker image builds | No | Yes | Yes |
+| E2E (Playwright) | No | Yes | **No** (informational) |
+| CodeQL security scan | No | Weekly + PR | No |
+| PR standards validation | No | Yes | Yes |
+| Docs consistency | Yes | Yes | Yes |
+| Code coverage (backend) | No | Yes (40% threshold) | Yes |
+| Code coverage (Python) | No | Yes (60% threshold) | Yes |
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/concurrency-model.md
+++ b/docs/architecture/concurrency-model.md
@@ -1,0 +1,265 @@
+# Concurrency Model
+
+Runtime concurrency, threading, job queue behavior, and real-time communication patterns.
+
+> **4+1 View**: Process View
+
+## System Concurrency Overview
+
+```mermaid
+flowchart TB
+    subgraph Frontend["Frontend (Single-Threaded)"]
+        UI["React Event Loop"]
+        WS["SignalR WebSocket"]
+    end
+
+    subgraph Backend["Backend (.NET Thread Pool)"]
+        API["ASP.NET Request Pipeline"]
+        BG["Background Services"]
+        subgraph Queues["Bounded Channel Queues"]
+            CQ["Composite Queue\n(capacity: 10)"]
+            MQ["Mosaic Queue\n(capacity: 10)"]
+            EQ["Embedding Queue\n(capacity: 10)"]
+            TQ["Thumbnail Queue\n(unbounded)"]
+        end
+        Hub["SignalR Hub\n(Group-based push)"]
+        JT["JobTracker\n(MongoDB + in-memory cache)"]
+    end
+
+    subgraph Engine["Processing Engine (1 uvicorn worker)"]
+        PE["FastAPI async handler"]
+        Sci["NumPy / Astropy / reproject\n(CPU-bound, GIL)"]
+    end
+
+    subgraph MastP["MAST Proxy (2 uvicorn workers)"]
+        MP["FastAPI async handler"]
+        DL["HTTP/S3 Downloads\n(I/O-bound)"]
+    end
+
+    subgraph Mongo["MongoDB"]
+        Jobs["jobs collection"]
+        Data["jwst_data collection"]
+    end
+
+    UI -->|REST| API
+    WS <-->|WebSocket| Hub
+    API -->|enqueue| Queues
+    BG -->|dequeue + process| Queues
+    BG -->|HTTP| PE
+    API -->|HTTP| PE
+    API -->|HTTP| MP
+    BG -->|update| JT
+    JT -->|persist| Jobs
+    JT -->|notify| Hub
+    PE --> Sci
+    MP --> DL
+```
+
+## Job Queue Architecture
+
+The backend uses .NET `BoundedChannel<T>` for async job queues with dedicated `BackgroundService` consumers.
+
+### Queue Configuration
+
+| Queue | Capacity | Consumer | Concurrency | Purpose |
+|-------|----------|----------|-------------|---------|
+| Composite | 10 | `CompositeBackgroundService` | Sequential (1 reader) | N-channel composite exports |
+| Mosaic | 10 | `MosaicBackgroundService` | Sequential (1 reader) | Mosaic exports and saves |
+| Embedding | 10 | `EmbeddingBackgroundService` | Sequential (1 reader) | Semantic search indexing |
+| Thumbnail | Unbounded | `ThumbnailBackgroundService` | Sequential (1 reader) | Thumbnail generation |
+
+### Queue Behavior
+
+```
+API Request (POST /api/composite/export-nchannel)
+  ↓
+JobTracker.CreateJobAsync() → state: "queued"
+  ↓
+Channel.TryWrite(item)
+  ├─ Success → return jobId (202 Accepted)
+  └─ Full (10 items) → return 503 Service Unavailable
+  ↓
+BackgroundService reads from channel (blocking await)
+  ↓
+JobTracker.UpdateProgressAsync() → state: "running"
+  ↓
+HTTP call to Processing Engine
+  ↓
+  ├─ Success → store result → JobTracker.CompleteBlobJobAsync()
+  └─ Failure → JobTracker.FailJobAsync()
+  ↓
+SignalR push to subscribed clients
+```
+
+### Cancellation Flow
+
+```
+User clicks Cancel → POST /api/jobs/{jobId}/cancel
+  ↓
+JobTracker.RequestCancelAsync() → sets CancelRequested = true
+  ↓
+BackgroundService checks flag:
+  - Before processing: skip job
+  - After generation, before storage: discard result
+  - During Processing Engine call: not interrupted (completes, then discarded)
+```
+
+**Limitation**: Cancellation is cooperative — the Processing Engine itself does not receive cancel signals. Long-running composites/mosaics will complete on the Python side even if cancelled.
+
+## Processing Engine Concurrency
+
+### Worker Model
+
+| Service | Workers | Model | Why |
+|---------|---------|-------|-----|
+| Processing Engine | 1 | Single-process async | CPU-bound NumPy/Astropy work under GIL — additional workers don't help |
+| MAST Proxy | 2 | Multi-process async | I/O-bound downloads — 2 workers allow concurrent downloads |
+
+### Processing Engine (1 Worker)
+
+- **One request at a time** for CPU-bound work (composite, mosaic, analysis)
+- FastAPI async handlers allow I/O concurrency (file reads, storage writes)
+- NumPy/SciPy release the GIL for array operations, but reproject does not fully
+- Practical throughput: ~1 composite or mosaic at a time
+
+### MAST Proxy (2 Workers)
+
+- Each uvicorn worker is a separate Python process
+- Can handle 2 concurrent MAST downloads
+- Downloads are I/O-bound (network + disk), minimal CPU
+- aiohttp used for async HTTP requests
+
+## SignalR Real-Time Communication
+
+### Connection Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Hub as JobProgressHub
+    participant JT as JobTracker
+
+    Client->>Hub: Connect (JWT via ?access_token=)
+    Hub->>Hub: OnConnectedAsync() — log
+
+    Client->>Hub: SubscribeToJob(jobId)
+    Hub->>JT: Verify ownership
+    JT-->>Hub: OK
+    Hub->>Hub: Add to group "job-{jobId}"
+    Hub->>Client: JobSnapshot (current state)
+
+    loop While job runs
+        JT->>Hub: NotifyProgressAsync
+        Hub->>Client: JobProgress (percent, stage, message)
+    end
+
+    JT->>Hub: NotifyCompletedAsync
+    Hub->>Client: JobCompleted (result)
+
+    Client->>Hub: UnsubscribeFromJob(jobId)
+    Hub->>Hub: Remove from group
+
+    Client->>Hub: Disconnect
+    Hub->>Hub: OnDisconnectedAsync() — log
+```
+
+### Group-Based Delivery
+
+- Each job gets a SignalR group: `job-{jobId}`
+- Multiple clients can subscribe to the same job
+- Messages sent to group (not individual connections)
+- Ownership verified on subscribe (prevents cross-user snooping)
+
+### Snapshot Pattern (Race Condition Fix)
+
+When a client subscribes, the hub immediately sends a `JobSnapshot` with the current state. This prevents the race where:
+1. Client subscribes
+2. Job completes between subscribe and first push
+3. Client never receives completion event
+
+## Job State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> queued: CreateJobAsync()
+    queued --> running: UpdateProgressAsync() (auto-transition)
+    running --> running: UpdateProgressAsync()
+    running --> completed: CompleteBlobJobAsync() / CompleteDataIdJobAsync()
+    running --> failed: FailJobAsync()
+    queued --> cancelled: RequestCancelAsync()
+    running --> cancelled: RequestCancelAsync()
+    completed --> [*]: TTL expiry (30 min)
+    failed --> [*]: TTL expiry (30 min)
+    cancelled --> [*]: TTL expiry (30 min)
+```
+
+### Job Storage
+
+- **Primary**: MongoDB `jobs` collection (survives restarts)
+- **Cache**: `ConcurrentDictionary` in-memory (fast reads)
+- **Dual-write**: Cache updated first, then async MongoDB persist
+- **TTL**: 30 minutes after completion, cleaned by background reaper (every 5 min, 100 jobs/batch)
+
+### Import Jobs (Special Case)
+
+Import jobs use a separate `ImportJobTracker` with:
+- In-memory primary state (byte-level download progress)
+- Fire-and-forget writes to unified JobTracker for SignalR
+- Resumable: tracks `DownloadedBytes`, `TotalBytes`, `FileProgress`
+- MongoDB write failure doesn't block imports
+
+## Backend Thread Model
+
+### ASP.NET Core
+
+- **Thread pool**: Default .NET thread pool (min 12 threads on 2-core)
+- **Request handling**: Async throughout — no blocking calls
+- **Background services**: 4 hosted services, each on its own long-running thread
+- **SignalR**: Managed by ASP.NET, shares thread pool
+
+### Concurrent Access Patterns
+
+| Resource | Protection | Pattern |
+|----------|-----------|---------|
+| Job state (memory) | `ConcurrentDictionary` | Lock-free reads, atomic updates |
+| Job state (MongoDB) | Single writer per job | Background service is sole mutator |
+| Bounded channels | Thread-safe by design | Producer/consumer pattern |
+| SignalR groups | Framework-managed | No custom locking needed |
+| Storage writes | Atomic (write-then-record) | No partial state visible |
+
+## Rate Limiting
+
+Per-IP rate limiting via AspNetCoreRateLimit:
+
+| Endpoint Pattern | Limit | Period | Reason |
+|-----------------|-------|--------|--------|
+| `POST /api/mast/*` | 30 | 1 min | Prevent MAST API abuse |
+| `POST /api/jwstdata/*/process` | 10 | 1 min | Prevent job flooding |
+| `GET /api/mast/import-progress/*` | 1000 | 1 min | High — polling endpoint |
+| `*` (default) | 300 | 1 min | General protection |
+| `*` (hourly) | 5000 | 1 hour | Burst cap |
+
+## Capacity Planning
+
+### Current Limits (Single Node)
+
+| Metric | Limit | Bottleneck |
+|--------|-------|-----------|
+| Concurrent composite jobs | 10 queued, 1 processing | Processing Engine (1 worker) |
+| Concurrent mosaic jobs | 10 queued, 1 processing | Processing Engine (1 worker) |
+| Concurrent MAST downloads | 2 | MAST Proxy (2 workers) |
+| Max FITS file size | 2 GB | `MAX_FITS_FILE_SIZE_MB` |
+| Max array elements | 100M–200M | `MAX_FITS_ARRAY_ELEMENTS` |
+| Max mosaic output | 64M pixels | `MAX_MOSAIC_OUTPUT_PIXELS` |
+| Processing Engine memory | 4 GB | Docker `mem_limit` |
+| SignalR connections | ~1000 | ASP.NET default |
+
+### Scaling Constraints
+
+- **Vertical**: Increase Processing Engine memory for larger mosaics
+- **Horizontal**: Not currently supported — single backend instance assumed for job queues and SignalR
+- **Future**: Would require distributed job queue (Redis/RabbitMQ) and SignalR backplane (Redis) for multi-instance
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/deployment-architecture.md
+++ b/docs/architecture/deployment-architecture.md
@@ -1,0 +1,285 @@
+# Deployment Architecture
+
+Infrastructure topology for all deployment environments — local development, staging, and production.
+
+> **4+1 View**: Physical View
+
+## Environment Comparison
+
+| Aspect | Development | Staging | Production |
+|--------|-------------|---------|------------|
+| **Host** | Local machine | AWS EC2 t3.medium | AWS EC2 (t3.medium+) |
+| **OS** | macOS / Linux | Amazon Linux 2023 | Amazon Linux 2023 |
+| **Compose files** | base + override | base + staging | base + prod |
+| **Frontend** | Vite dev server (HMR) | nginx + static build | nginx + static build + TLS |
+| **External access** | localhost only | HTTP (Elastic IP) | HTTPS (domain + cert) |
+| **Storage** | Local filesystem | Local filesystem | S3-compatible (optional) |
+| **Debug ports** | Exposed (8000, 8002) | Not exposed | Not exposed |
+| **Cost** | $0 | ~$43/mo (24/7) | ~$43/mo+ |
+
+## Development Environment
+
+```mermaid
+flowchart TB
+    subgraph Host["Local Machine"]
+        Browser["Browser\nlocalhost port 3000"]
+
+        subgraph Docker["Docker Desktop"]
+            subgraph Network["jwst-network (bridge)"]
+                FE["Frontend\n:3000 (Vite dev)\nHot reload via bind mount"]
+                BE["Backend\n:5000 internal\n:5001 debug"]
+                PE["Processing Engine\n:8000\nmem_limit: 4GB"]
+                MP["MAST Proxy\n:8000 internal\n:8002 debug"]
+                DB["MongoDB 8.0\n:27017"]
+                Docs["MkDocs\n:8001"]
+            end
+
+            subgraph Optional["Profile: s3"]
+                S3["SeaweedFS\nS3 Gateway :8333"]
+            end
+        end
+
+        Data["./data/\n(bind mount)"]
+    end
+
+    Browser -->|"localhost:3000"| FE
+    FE -->|"/api → backend:5000"| BE
+    BE --> PE
+    BE --> MP
+    BE --> DB
+    PE --> Data
+    MP --> Data
+    MP -->|astroquery| MAST["STScI MAST"]
+
+    style FE fill:#e1f5fe
+    style Optional fill:#fff3e0
+```
+
+**Key characteristics**:
+- All ports bound to localhost loopback (not accessible from network)
+- Frontend uses Vite dev server with bind mount for instant HMR
+- Debug ports exposed for Processing Engine (8000) and MAST Proxy (8002)
+- MkDocs documentation site at :8001
+- SeaweedFS S3 available via `--profile s3` flag
+
+### Docker Compose Commands
+
+```bash
+# Standard development
+docker compose up -d
+
+# With S3 storage
+docker compose --profile s3 up -d
+
+# Rebuild after code changes
+docker compose up -d --build
+
+# Run E2E tests (mock processing engine)
+docker compose -f docker-compose.yml -f docker-compose.e2e.yml up -d
+```
+
+## Staging Environment (AWS EC2)
+
+```mermaid
+flowchart TB
+    subgraph AWS["AWS us-east-1"]
+        subgraph SG["Security Group\njwst-staging-sg"]
+            direction TB
+            subgraph EC2["EC2 t3.medium\n2 vCPU / 4 GB RAM"]
+                subgraph DockerStack["Docker Compose Stack"]
+                    FE["Frontend (nginx)\n:3000 → host :80"]
+                    BE["Backend (.NET)\n:5000 internal"]
+                    PE["Processing Engine\n:8000 internal\nmem_limit: 4GB"]
+                    MP["MAST Proxy\n:8000 internal\nmem_limit: 512MB"]
+                    DB["MongoDB 8.0\n:27017 internal"]
+                end
+                EBS["EBS gp3\n100 GB"]
+            end
+            EIP["Elastic IP\n(static public IP)"]
+        end
+    end
+
+    Internet["Internet Client"] -->|"HTTP :80"| EIP
+    EIP --> FE
+    FE -->|"/api → backend:5000\n/hubs → backend:5000"| BE
+    BE --> PE
+    BE --> MP
+    BE --> DB
+    MP -->|astroquery| MAST["STScI MAST"]
+
+    SSH["Developer SSH\n(:22)"] -->|"~/.ssh/jwst-staging.pem"| EC2
+
+    style EIP fill:#fff3e0
+    style FE fill:#e1f5fe
+```
+
+**Infrastructure**:
+- **Instance**: t3.medium (2 vCPU, 4 GB RAM, burstable)
+- **Storage**: 100 GB gp3 EBS volume
+- **Networking**: Elastic IP for stable public address; Security Group allows SSH (22), HTTP (80), HTTPS (443)
+- **No TLS** — staging is HTTP-only
+
+### Provisioning
+
+```bash
+# Provision EC2 + security group + EIP
+./scripts/deploy-aws.sh
+
+# SSH and bootstrap application
+scp scripts/server-setup.sh ec2-user@<IP>:~/
+ssh -i ~/.ssh/jwst-staging.pem ec2-user@<IP>
+./server-setup.sh
+```
+
+### Management
+
+```bash
+./scripts/staging.sh status    # Instance state + service health
+./scripts/staging.sh deploy    # Pull latest + rebuild
+./scripts/staging.sh ssh       # SSH into instance
+./scripts/staging.sh stop      # Stop EC2 (saves compute cost)
+./scripts/staging.sh start     # Resume EC2
+./scripts/staging.sh promote   # Fast-forward staging branch to main
+```
+
+### Cost
+
+| Resource | Monthly (24/7) | Monthly (stopped) |
+|----------|---------------|-------------------|
+| EC2 t3.medium | ~$30 | $0 |
+| EBS 100 GB gp3 | ~$8 | ~$8 |
+| Elastic IP | $3.65 | $3.65 |
+| **Total** | **~$43** | **~$12** |
+
+## Production Environment
+
+```mermaid
+flowchart TB
+    subgraph AWS["AWS Production"]
+        subgraph SG["Security Group"]
+            subgraph EC2["EC2 Instance"]
+                subgraph DockerStack["Docker Compose Stack"]
+                    FE["Frontend (nginx)\nTLS termination\n:80 → HTTPS redirect\n:443 → static + proxy"]
+                    BE["Backend (.NET)\n:5000 internal\nProduction mode"]
+                    PE["Processing Engine\n:8000 internal\nmem_limit: 4GB"]
+                    MP["MAST Proxy\n:8000 internal\nmem_limit: 512MB"]
+                    DB["MongoDB 8.0\n:27017 internal"]
+                end
+                SSL["./ssl/\nfullchain.pem\nprivkey.pem"]
+            end
+            EIP["Elastic IP / Domain DNS"]
+        end
+    end
+
+    Client["HTTPS Client"] -->|":443 TLS 1.2/1.3"| EIP
+    EIP --> FE
+    FE -->|"internal HTTP"| BE
+    BE --> PE
+    BE --> MP
+    BE --> DB
+
+    Certbot["Let's Encrypt\n(optional renewal)"] -.->|"ACME challenge"| FE
+
+    style FE fill:#c8e6c9
+    style SSL fill:#fff3e0
+```
+
+**Additional production features**:
+- **TLS termination** at nginx (TLS 1.2 + 1.3, modern ciphers)
+- **HSTS** header (max-age 31536000)
+- **CSP** header (restrictive content security policy)
+- **OCSP stapling** enabled
+- **HTTP → HTTPS redirect** on port 80
+- **Forwarded headers** enabled for correct client IP logging
+- **No debug ports** exposed
+- **CORS** restricted to production domain only
+
+### SSL Certificate Options
+
+1. **Let's Encrypt** (recommended): `certbot` with webroot challenge, auto-renewal
+2. **Manual**: Copy certificate files to `docker/ssl/`
+
+## Resource Allocation
+
+```mermaid
+pie title Container Memory Budget (4 GB host)
+    "Processing Engine" : 4096
+    "MAST Proxy" : 512
+    "Backend" : 256
+    "Frontend (nginx)" : 128
+    "MongoDB" : 512
+```
+
+Note: Processing Engine is allocated 4 GB (the full host RAM on t3.medium). In practice, it uses this only during large composite/mosaic operations. Other services share remaining system memory.
+
+| Service | Memory Limit | CPU | Workers |
+|---------|-------------|-----|---------|
+| Processing Engine | 4 GB | Shared | 1 uvicorn |
+| MAST Proxy | 512 MB | Shared | 2 uvicorn |
+| Backend | Unlimited (ASP.NET default) | Shared | Thread pool |
+| MongoDB | Unlimited (self-managed) | Shared | WiredTiger cache |
+| Frontend (nginx) | Minimal (~50 MB) | Shared | Worker processes |
+
+## Storage Architecture
+
+### Local Storage (Default)
+
+```
+/app/data/                     (Docker volume mount → ../data/)
+├── mast/                      (Downloaded FITS files from MAST)
+├── composites/                (Rendered composite images)
+├── mosaics/                   (Mosaic outputs)
+├── semantic/                  (FAISS index files)
+└── model-cache/               (sentence-transformers model weights)
+```
+
+Shared between Processing Engine and MAST Proxy via Docker volume mount.
+
+### S3 Storage (Optional)
+
+```
+SeaweedFS (local S3-compatible)     or     AWS S3
+├── jwst-data bucket                       ├── jwst-data bucket
+│   ├── mast/                              │   ├── mast/
+│   ├── composites/                        │   ├── composites/
+│   └── mosaics/                           │   └── mosaics/
+```
+
+Configured via `STORAGE_PROVIDER=s3` + S3 credentials in `.env`.
+
+## Scaling Path
+
+The current architecture is single-node. Here's the path to horizontal scaling if needed:
+
+```mermaid
+flowchart LR
+    subgraph Current["Current (Single Node)"]
+        All["All services\non one EC2"]
+    end
+
+    subgraph Phase1["Phase 1: Separate DB"]
+        App["App services\non EC2"]
+        RDS["MongoDB Atlas\nor DocumentDB"]
+    end
+
+    subgraph Phase2["Phase 2: Container Orchestration"]
+        ALB["Application\nLoad Balancer"]
+        ECS["ECS / EKS\n(multiple tasks)"]
+        Managed["Managed MongoDB"]
+        S3["AWS S3"]
+        Redis["Redis\n(SignalR backplane)"]
+    end
+
+    Current -->|"DB bottleneck"| Phase1
+    Phase1 -->|"CPU/concurrency\nbottleneck"| Phase2
+```
+
+| Phase | Trigger | Changes |
+|-------|---------|---------|
+| **Current** | < 10 concurrent users | Single EC2, all services |
+| **Phase 1** | DB performance or durability needs | Managed MongoDB (Atlas/DocumentDB); app stays on EC2 |
+| **Phase 2** | Compute bottleneck or HA requirements | ECS/EKS orchestration, ALB, Redis for SignalR backplane, AWS S3 for storage |
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -1,0 +1,229 @@
+# Domain Model
+
+Conceptual entity-relationship model for the JWST Data Analysis Application. This diagram shows the core domain objects, their key attributes, and how they relate to each other.
+
+> **4+1 View**: Logical View
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    User {
+        ObjectId Id PK
+        string Username UK
+        string Email UK
+        string Role "Admin | User"
+        string DisplayName
+        string Organization
+        bool IsActive
+        DateTime CreatedAt
+        DateTime LastLoginAt
+    }
+
+    JwstData {
+        ObjectId Id PK
+        string FileName
+        string DataType "image | spectral | calibration | ..."
+        string FileFormat "fits | csv | json | hdf5"
+        string ProcessingStatus "pending | processing | completed | failed"
+        string ProcessingLevel "L1 | L2a | L2b | L3"
+        string FilePath "S3 or local storage key"
+        long FileSize
+        string UserId FK
+        bool IsPublic
+        bool IsViewable
+        string ObservationBaseId "groups related files"
+        string ExposureId "fine-grained lineage"
+        string ParentId FK
+        list DerivedFrom "source data IDs"
+        list Tags
+    }
+
+    ImageMetadata {
+        string TargetName
+        string Instrument
+        string Filter
+        double Wavelength
+        int Width
+        int Height
+        string WCS "World Coordinate System"
+        int CalibrationLevel
+        string ProposalId
+    }
+
+    ProcessingResult {
+        string Id PK
+        string Algorithm
+        string Status "success | failed | partial"
+        DateTime ProcessedDate
+        dict Parameters
+        dict Results
+        string OutputFilePath
+        double ProcessingTime
+    }
+
+    JobStatus {
+        string JobId PK
+        string JobType "import | composite | mosaic"
+        string State "queued | running | completed | failed | cancelled"
+        string OwnerUserId FK
+        int ProgressPercent
+        string Stage
+        string ResultKind "blob | data_id"
+        string ResultStorageKey
+        string ResultDataId FK
+        DateTime CreatedAt
+        DateTime ExpiresAt
+    }
+
+    FeaturedTarget {
+        string Name
+        string CatalogId
+        string Category "nebula | galaxy | planetary | cluster"
+        string Description
+        list Instruments
+        int FilterCount
+        string CompositePotential "great | good | limited"
+    }
+
+    CompositeRecipe {
+        string Name
+        int Rank
+        list Filters
+        dict ColorMapping "filter to hex color"
+        bool RequiresMosaic
+        int EstimatedTimeSeconds
+        string Tag "e.g. NASA-style"
+    }
+
+    CompositeRequest {
+        list Channels "NChannelConfigDto[]"
+        string OutputFormat "png | jpeg"
+        int Width
+        int Height
+        bool BackgroundNeutralization
+        double RotationDegrees
+    }
+
+    ChannelConfig {
+        list DataIds FK
+        string Stretch "zscale | asinh | log | sqrt | ..."
+        double BlackPoint
+        double WhitePoint
+        double Gamma
+        string Curve "linear | s_curve | ..."
+        double Weight
+        double Hue
+        string Label
+    }
+
+    MosaicRequest {
+        list Files "MosaicFileConfigDto[]"
+        string OutputFormat "png | jpeg | fits"
+        string CombineMethod "mean | sum | first | last | min | max"
+        int Width
+        int Height
+    }
+
+    MosaicFileConfig {
+        string DataId FK
+        string Stretch
+        double BlackPoint
+        double WhitePoint
+    }
+
+    MastObservation {
+        string ObsId
+        string TargetName
+        double RA
+        double Dec
+        string Instrument
+        string Filters
+        int CalibLevel
+        string DataProductType "image | spectrum"
+        double ExposureTime
+    }
+
+    %% Relationships
+    User ||--o{ JwstData : "owns"
+    User ||--o{ JobStatus : "initiates"
+    JwstData ||--o| ImageMetadata : "has (embedded)"
+    JwstData ||--o{ ProcessingResult : "has (embedded)"
+    JwstData ||--o| JwstData : "parentId → derived from"
+    JobStatus |o--o| JwstData : "resultDataId → produces"
+    FeaturedTarget ||--o{ CompositeRecipe : "suggests"
+    CompositeRequest ||--|{ ChannelConfig : "contains"
+    ChannelConfig }o--o{ JwstData : "references via dataIds"
+    MosaicRequest ||--|{ MosaicFileConfig : "contains"
+    MosaicFileConfig }o--|| JwstData : "references via dataId"
+    MastObservation }o--o{ JwstData : "imported as"
+```
+
+## Domain Concepts
+
+### Data Lifecycle
+
+JWST data flows through a well-defined pipeline, modeled by the `ProcessingLevel` field:
+
+| Level | Description | FITS Suffix | Example |
+|-------|-------------|-------------|---------|
+| **L1** | Raw detector readout | `_uncal` | Uncalibrated frames |
+| **L2a** | Count rate images | `_rate`, `_rateints` | Detector-level calibration |
+| **L2b** | Calibrated exposures | `_cal`, `_crf` | Fully calibrated single exposures |
+| **L3** | Combined/mosaicked products | `_i2d`, `_s2d`, `_x1d` | Science-ready composites |
+
+Files are grouped by `ObservationBaseId` (e.g., `jw02733-o001_t001_nircam`) and linked via `ParentId` / `DerivedFrom` for full lineage tracking.
+
+### Observation Grouping
+
+```
+Observation (ObservationBaseId)
+├── L1: jw02733001001_02101_00001_nrca1_uncal.fits
+├── L2a: jw02733001001_02101_00001_nrca1_rate.fits
+├── L2b: jw02733001001_02101_00001_nrca1_cal.fits
+└── L3: jw02733-o001_t001_nircam_clear-f200w_i2d.fits
+```
+
+### Access Control Model
+
+- **MAST imports** are always `IsPublic = true` (public archive data)
+- **User uploads** default to private (`IsPublic = false`)
+- `SharedWith` list enables selective sharing by user ID
+- Admin role has full access to all records
+
+### Job Lifecycle
+
+Jobs progress through a state machine tracked by `JobStatus`:
+
+```
+queued → running → completed
+                 → failed
+         ↓
+       cancelled (via CancelRequested flag)
+```
+
+Results are stored as either:
+- **blob**: Binary file in S3/local storage (`ResultStorageKey` + `ResultContentType`)
+- **data_id**: Reference to a new `JwstData` document (`ResultDataId`)
+
+### Discovery & Recipes
+
+The discovery flow connects external MAST data to the compositing workflow:
+
+1. **FeaturedTarget** — curated list of photogenic JWST targets
+2. **CompositeRecipe** — filter combinations ranked by visual quality
+3. User selects a recipe → system resolves MAST observations → imports data → creates composite
+
+---
+
+## MongoDB Collections
+
+| Collection | Document Type | Indexes |
+|------------|--------------|---------|
+| `jwst_data` | JwstData + embedded metadata | userId, observationBaseId, processingLevel, tags, uploadDate |
+| `users` | User | username (unique), email (unique) |
+| `jobs` | JobStatus | ownerUserId, state, createdAt |
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/error-recovery.md
+++ b/docs/architecture/error-recovery.md
@@ -1,0 +1,276 @@
+# Error Recovery
+
+Failure modes, retry strategies, and recovery paths for each service boundary and operation type.
+
+> **4+1 View**: Process View
+
+## Error Recovery Overview
+
+```mermaid
+flowchart TB
+    subgraph Boundaries["Failure Boundaries"]
+        B1["Frontend ↔ Backend\n(HTTP + SignalR)"]
+        B2["Backend ↔ Processing Engine\n(HTTP with Polly)"]
+        B3["Backend ↔ MAST Proxy\n(HTTP)"]
+        B4["Backend ↔ MongoDB\n(MongoDB.Driver)"]
+        B5["MAST Proxy ↔ STScI\n(External HTTP)"]
+    end
+
+    subgraph Recovery["Recovery Strategies"]
+        R1["JWT refresh + retry"]
+        R2["Polly: 3 retries + circuit breaker"]
+        R3["Resumable downloads"]
+        R4["Connection pool + auto-reconnect"]
+        R5["User retry + resume"]
+    end
+
+    B1 --> R1
+    B2 --> R2
+    B3 --> R3
+    B4 --> R4
+    B5 --> R5
+```
+
+## Boundary 1: Frontend ↔ Backend
+
+### Authentication Failures
+
+| Trigger | Response | Recovery |
+|---------|----------|----------|
+| Access token expired | 401 Unauthorized | `apiClient` auto-refreshes token via `/api/auth/refresh`, retries original request |
+| Refresh token expired | 401 on refresh | Redirect to login page, clear local auth state |
+| Invalid credentials | 401 on login | Show error, user retries |
+
+### SignalR Disconnection
+
+| Trigger | Response | Recovery |
+|---------|----------|----------|
+| Network interruption | WebSocket close | SignalR auto-reconnect (built-in, exponential backoff) |
+| Token expired during connection | Auth failure | Reconnect with fresh token |
+| Server restart | Connection drop | Auto-reconnect + re-subscribe to active jobs |
+| Missed updates during disconnect | Stale UI | `JobSnapshot` sent on re-subscribe catches up state |
+
+### HTTP Request Failures
+
+| Trigger | Response | Recovery |
+|---------|----------|----------|
+| Network timeout | Fetch error | UI shows error toast, user retries |
+| 429 Rate Limited | `Retry-After` header | UI backs off, can retry after delay |
+| 503 Service Unavailable | Error response | UI shows "service busy" message |
+
+## Boundary 2: Backend ↔ Processing Engine
+
+### Polly Resilience Pipeline (Composite & Mosaic)
+
+```mermaid
+flowchart LR
+    Request["HTTP Request"] --> Retry["Retry Policy\n3 attempts\n2s exponential backoff"]
+    Retry --> CB["Circuit Breaker\n61 min sampling"]
+    CB --> Timeout1["Attempt Timeout\n30 minutes"]
+    Timeout1 --> Timeout2["Total Timeout\n60 minutes"]
+    Timeout2 --> Response["Response"]
+```
+
+**Retry Conditions**:
+
+| Error | Retried? | Reason |
+|-------|----------|--------|
+| `HttpRequestException` | Yes | Transient network error |
+| `TimeoutRejectedException` | Yes | Temporary overload |
+| HTTP 502 Bad Gateway | Yes | Proxy/container restart |
+| HTTP 503 Service Unavailable | Yes | Temporary unavailability |
+| HTTP 504 Gateway Timeout | Yes | Slow response |
+| HTTP 500 Internal Server Error | **No** | Application bug — retrying won't help |
+| HTTP 400 Bad Request | **No** | Client error — fix the request |
+| HTTP 413 Payload Too Large | **No** | Input too big — won't shrink on retry |
+
+### Error Translation
+
+The backend translates Processing Engine errors into user-friendly messages via `ProcessingErrorMessages`:
+
+```
+HttpRequestException + ServiceUnavailable → "Processing engine is temporarily unavailable"
+HttpRequestException + SocketException    → "Processing engine not reachable"
+TaskCanceledException                     → "Processing timed out"
+KeyNotFoundException                      → Original message preserved (e.g., "File not found")
+Default                                   → "An unexpected error occurred"
+```
+
+### Job Failure Pattern
+
+```mermaid
+sequenceDiagram
+    participant BG as BackgroundService
+    participant PE as Processing Engine
+    participant JT as JobTracker
+    participant Hub as SignalR
+
+    BG->>JT: UpdateProgress(10%, "generating")
+    BG->>PE: POST /composite/generate-nchannel
+
+    alt Success
+        PE-->>BG: 200 + image bytes
+        BG->>JT: CompleteBlobJobAsync()
+        JT->>Hub: JobCompleted
+    else Transient Error (502/503)
+        PE-->>BG: Error
+        Note over BG: Polly retries (up to 3x)
+        PE-->>BG: 200 + image bytes
+        BG->>JT: CompleteBlobJobAsync()
+    else Permanent Error
+        PE-->>BG: 500 / timeout
+        BG->>JT: FailJobAsync("Processing engine error")
+        JT->>Hub: JobFailed
+    end
+```
+
+## Boundary 3: Backend ↔ MAST Proxy (Imports)
+
+### Download Failure Recovery
+
+| Failure | Detection | Recovery |
+|---------|-----------|----------|
+| Network interruption mid-download | `HttpRequestException` | Job marked as resumable; user can restart |
+| STScI server 5xx | HTTP status code | Job fails; user retries (no automatic retry for downloads) |
+| Disk full | `IOException` | Job fails with storage error; no partial records saved |
+| Download timeout (5 min) | `TaskCanceledException` | Job fails; user can retry |
+| User cancellation | `CancelRequested` flag | `CancellationTokenSource` cancels HTTP request; job marked cancelled |
+
+### Resumable Import Pattern
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant BE as Backend
+    participant MP as MAST Proxy
+    participant STScI
+
+    User->>BE: POST /api/mast/import
+    BE->>MP: POST /mast/chunked-download
+    MP->>STScI: GET (streaming)
+
+    Note over MP,STScI: Network interruption
+
+    MP-->>BE: Error (partial download)
+    BE->>BE: Mark job as "failed" + "resumable"
+    BE->>BE: Record: downloadedBytes, fileProgress
+
+    User->>BE: GET /api/jobs (sees resumable job)
+    User->>BE: POST /api/mast/import (retry)
+    BE->>MP: POST /mast/chunked-download (with byte offset)
+    MP->>STScI: GET (Range header for resume)
+    STScI-->>MP: 206 Partial Content
+    MP-->>BE: Complete download
+    BE->>BE: Mark job completed
+```
+
+### Import Data Integrity
+
+- **Atomic record creation**: FITS metadata extracted and validated before MongoDB insert
+- **No partial records**: If import fails mid-file, no `JwstData` document is created for that file
+- **Checksum verification**: File checksums computed on download for integrity validation
+- **Cleanup on failure**: Partially downloaded files cleaned up; storage and DB stay consistent
+
+## Boundary 4: Backend ↔ MongoDB
+
+### Connection Resilience
+
+- **Connection pool**: MongoDB.Driver manages connection pool automatically
+- **Auto-reconnect**: Driver handles transient disconnections transparently
+- **No custom retry**: Relies on driver-level retry (retryable writes enabled by default in MongoDB 4.2+)
+
+### Failure Scenarios
+
+| Failure | Impact | Recovery |
+|---------|--------|----------|
+| MongoDB unreachable at startup | Backend won't start | Docker `depends_on` ensures MongoDB starts first; health check would catch |
+| MongoDB crash during operation | Write failure | Operation fails; user retries; MongoDB restarts via Docker |
+| Disk full (MongoDB) | Write failure | Docker container may crash-loop (exit 133); fix: `docker image prune -f && docker builder prune -f` |
+
+### Dual-Write Consistency (JobTracker)
+
+The JobTracker uses a write-through cache:
+
+```
+1. Update ConcurrentDictionary (in-memory) ← immediate
+2. Persist to MongoDB (async)              ← may fail
+3. Push via SignalR (async)                ← may fail
+```
+
+- **Memory is authoritative** for active jobs (fast reads)
+- **MongoDB is authoritative** for job recovery after restart
+- **If MongoDB write fails**: Job progress still visible in-memory; logged as warning; job can still complete
+- **On restart**: In-memory cache lost; running jobs appear as stale in MongoDB (need manual cleanup or TTL expiry)
+
+## Boundary 5: MAST Proxy ↔ STScI External
+
+### MAST API Resilience
+
+| Failure | Frequency | Handling |
+|---------|-----------|---------|
+| MAST API timeout | Occasional | 5-minute timeout; fail and surface to user |
+| MAST API 5xx | Rare | Fail with "MAST service unavailable" |
+| MAST API rate limit | Possible | Backend rate limits MAST calls to 30/min to stay well under MAST limits |
+| MAST API schema change | Very rare | Would cause parsing errors; manual code update needed |
+| STScI maintenance window | Periodic | Discovery/import unavailable; local features unaffected |
+
+### Isolation Principle
+
+MAST failures are isolated to MAST-dependent features:
+
+| Feature | MAST Dependency | Impact of MAST Outage |
+|---------|----------------|----------------------|
+| Discovery (featured targets) | None (curated list) | No impact |
+| MAST search | Direct | Unavailable |
+| Data import | Direct | Unavailable |
+| Recipe suggestions | Indirect (needs MAST data) | Limited (works with already-imported data) |
+| Compositing | None | No impact |
+| Mosaic | None | No impact |
+| Analysis | None | No impact |
+| Data library | None | No impact |
+
+## Container Restart Recovery
+
+### Processing Engine Restart
+
+| State | Detection | Recovery |
+|-------|-----------|---------|
+| No active job | Health check passes after restart | No impact |
+| Active HTTP request from backend | `HttpRequestException` on backend | Polly retries (up to 3x); may succeed after container restarts |
+| Active job in queue | Backend detects HTTP failure | Job marked failed; user can re-submit |
+
+### Backend Restart
+
+| State | Detection | Recovery |
+|-------|-----------|---------|
+| In-memory job cache | Lost on restart | Stale jobs in MongoDB; TTL cleans up in 30 min |
+| Bounded channel queues | Lost on restart | Queued jobs lost; users must re-submit |
+| SignalR connections | Dropped | Clients auto-reconnect; re-subscribe |
+| Active HTTP calls | Interrupted | Processing Engine may complete work that no one collects |
+
+### MongoDB Restart
+
+| State | Detection | Recovery |
+|-------|-----------|---------|
+| Clean restart | Brief unavailability | Backend operations fail during restart; auto-recover after |
+| Crash (exit 133 = OOM) | Container restart loop | Likely disk space issue; prune Docker images |
+| Data corruption | Startup failure | Restore from Docker volume backup |
+
+## Health Check Architecture
+
+```mermaid
+flowchart LR
+    Docker["Docker\nHealth Checks"] -->|HTTP GET /health| PE["Processing Engine\n(10s interval, 3 retries)"]
+    Docker -->|HTTP GET /health| MP["MAST Proxy\n(10s interval, 3 retries)"]
+    BE["Backend\n/api/health"] -->|HTTP GET /health| PE
+    BE -->|HTTP GET /health| MP
+    BE -->|"Status: Degraded\n(not Unhealthy)"| Report["Health Report"]
+```
+
+- Processing Engine or MAST Proxy down → backend reports **Degraded** (not Unhealthy)
+- Backend continues serving local operations (data library, auth)
+- Docker restarts containers after 3 consecutive health check failures (30 seconds)
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,36 +1,70 @@
 # Architecture Documentation
 
-Visual diagrams of the JWST Data Analysis Application architecture using Mermaid. Each diagram has its own page for full-width rendering.
+Architecture documentation for the JWST Data Analysis Application, organized using the [4+1 Architectural View Model](https://en.wikipedia.org/wiki/4%2B1_architectural_view_model).
 
-## Diagrams
+---
+
+## +1 Scenarios (Use Cases)
+
+The scenarios tie all views together — start here to understand what the system does.
+
+- **[Use Case Catalog](use-case-catalog.md)** — Primary use cases from discovery to composite creation
+- **[Quality Attributes](quality-attributes.md)** — Performance, scalability, security, and reliability scenarios
+
+## Logical View
+
+Structure of the system: domain model, API boundaries, and component responsibilities.
 
 - **[System Overview](system-overview.md)** — High-level microservices architecture and communication patterns
+- **[Domain Model](domain-model.md)** — Entity relationships (User, JwstData, Job, Composite, Mosaic, Target, Recipe)
+- **[API Contracts](api-contracts.md)** — Service-to-service API boundary map with all endpoints
+- **[Backend Service Layer](backend-service-layer.md)** — .NET repository pattern and service architecture
+- **[Frontend Architecture](frontend-architecture.md)** — Route structure and component hierarchy
+- **[Processing Engine](processing-engine.md)** — Python FastAPI scientific computing modules
+- **[MongoDB Documents](mongodb-document.md)** — Flexible document schema for JWST data records
+- **[Storage Layer](storage-layer.md)** — Storage abstraction across .NET and Python
+- **[Data Lineage](data-lineage.md)** — JWST data processing levels and observation grouping
+- **[Security & Authorization Model](security-model.md)** — User roles, data visibility, and access control
+
+## Process View
+
+Runtime behavior: concurrency, async jobs, real-time communication, and error handling.
+
+- **[Concurrency Model](concurrency-model.md)** — Job queues, worker threading, SignalR lifecycle, rate limiting
+- **[Error Recovery](error-recovery.md)** — Failure modes, Polly retry/circuit-breaker, resumable downloads
+- **[Job Queue & SignalR](job-queue-signalr.md)** — Async job pattern for composite, mosaic, and thumbnails
+- **[Authentication Flow](authentication-flow.md)** — JWT-based authentication with access and refresh tokens
 
 ### Data Flows
 
-- **[Local Upload Flow](local-upload-flow.md)** — Uploading JWST data files directly to the application
-- **[MAST Import Flow](mast-import-flow.md)** — Searching and importing data from the MAST portal with chunked downloads
 - **[Discovery & Recipe Flow](discovery-recipe-flow.md)** — Browsing featured targets, searching MAST, and recipe suggestions
 - **[GuidedCreate Flow](guidedcreate-flow.md)** — End-to-end user journey from recipe selection to composite result
-- **[Authentication Flow](authentication-flow.md)** — JWT-based authentication with access and refresh tokens
-- **[Security & Authorization Model](security-model.md)** — User roles, data visibility, endpoint authorization matrix, and access control patterns
-- **[Job Queue & SignalR](job-queue-signalr.md)** — Async job pattern for composite export, mosaic, and thumbnails
+- **[MAST Import Flow](mast-import-flow.md)** — Searching and importing data from the MAST portal with chunked downloads
+- **[Local Upload Flow](local-upload-flow.md)** — Uploading JWST data files directly to the application
 
-### System Components
+## Development View
 
-- **[Data Lineage](data-lineage.md)** — JWST data processing levels and observation grouping
-- **[Frontend Architecture](frontend-architecture.md)** — Route structure and component hierarchy
-- **[Storage Layer](storage-layer.md)** — Storage abstraction across .NET and Python
-- **[MongoDB Documents](mongodb-document.md)** — Flexible document schema for JWST data records
-- **[Backend Service Layer](backend-service-layer.md)** — .NET repository pattern and service architecture
-- **[Processing Engine](processing-engine.md)** — Python FastAPI scientific computing modules
-- **[Docker Compose](docker-compose.md)** — Application stack orchestration
+Code organization, build pipeline, dependencies, and versioning.
+
+- **[Module Dependencies](module-dependencies.md)** — Package and module dependency diagrams per service
+- **[Build Pipeline](build-pipeline.md)** — CI/CD flow from pre-commit hooks through GitHub Actions to deploy
+- **[Versioning Strategy](versioning-strategy.md)** — Service versioning, dependency pinning, and upgrade paths
+
+## Physical View
+
+Deployment topology, networking, and infrastructure.
+
+- **[Deployment Architecture](deployment-architecture.md)** — Dev, staging, and production topology with scaling path
+- **[Network Topology](network-topology.md)** — All ports, protocols, firewall rules, and TLS configuration
+- **[Docker Compose](docker-compose.md)** — Application stack orchestration details
 
 ---
 
 ## See Also
 
 - [Development Plan](../development-plan.md) — Project roadmap
+- [Key Files](../key-files.md) — Important file locations
+- [Quick Reference](../quick-reference.md) — API and CLI cheat sheet
 - [Backend Development Standards](../standards/backend-development.md)
 - [Frontend Development Standards](../standards/frontend-development.md)
 - [Database Models](../standards/database-models.md)

--- a/docs/architecture/module-dependencies.md
+++ b/docs/architecture/module-dependencies.md
@@ -1,0 +1,311 @@
+# Module Dependencies
+
+Package and module dependency structure for each service, showing how internal modules relate and which external libraries each service depends on.
+
+> **4+1 View**: Development View
+
+## Cross-Service Dependencies
+
+```mermaid
+flowchart TB
+    subgraph Build["Build Time"]
+        direction TB
+        FE_Build["Frontend Build\n(Node 22 + Vite)"]
+        BE_Build["Backend Build\n(.NET 10 SDK)"]
+        PE_Build["Processing Engine\n(Python 3.12 + pip)"]
+        MP_Build["MAST Proxy\n(Python 3.12 + pip)"]
+    end
+
+    subgraph Runtime["Runtime"]
+        FE["Frontend\n(nginx)"]
+        BE["Backend\n(ASP.NET)"]
+        PE["Processing Engine\n(uvicorn)"]
+        MP["MAST Proxy\n(uvicorn)"]
+        DB["MongoDB 8.0"]
+    end
+
+    FE_Build -.->|"independent"| BE_Build
+    FE_Build -.->|"independent"| PE_Build
+    BE_Build -.->|"independent"| PE_Build
+    PE_Build -.->|"shared requirements"| MP_Build
+
+    FE -->|HTTP /api| BE
+    BE -->|HTTP| PE
+    BE -->|HTTP| MP
+    BE -->|MongoDB.Driver| DB
+    MP -->|astroquery| STScI["STScI MAST"]
+```
+
+**Key point**: All services build independently. No shared code or compiled artifacts between services. The only coupling is runtime HTTP API contracts.
+
+## Backend (.NET 10)
+
+### Internal Module Structure
+
+```mermaid
+flowchart TB
+    subgraph Controllers
+        AuthC["AuthController"]
+        DataC["JwstDataController"]
+        DMC["DataManagementController"]
+        MastC["MastController"]
+        DiscC["DiscoveryController"]
+        CompC["CompositeController"]
+        MosC["MosaicController"]
+        AnaC["AnalysisController"]
+        JobsC["JobsController"]
+        SearchC["SearchController"]
+    end
+
+    subgraph Services
+        AuthS["AuthService"]
+        MongoS["MongoDBService"]
+        MastS["MastService"]
+        DiscS["DiscoveryService"]
+        CompS["CompositeService"]
+        MosS["MosaicService"]
+        AnaS["AnalysisService"]
+        JobT["JobTracker"]
+        ImpT["ImportJobTracker"]
+        ThumbS["ThumbnailService"]
+        SearchS["SemanticSearchService"]
+        StorS["IStorageProvider"]
+    end
+
+    subgraph BackgroundSvc["Background Services"]
+        CompBG["CompositeBackgroundService"]
+        MosBG["MosaicBackgroundService"]
+        EmbBG["EmbeddingBackgroundService"]
+        ThumbBG["ThumbnailBackgroundService"]
+        Notif["JobProgressNotifier"]
+    end
+
+    subgraph Models
+        JwstM["JwstDataModel"]
+        UserM["UserModels"]
+        JobM["JobStatus"]
+        CompM["CompositeModels"]
+        MosM["MosaicModels"]
+        DiscM["DiscoveryModels"]
+        MastM["MastModels"]
+        AnaM["AnalysisModels"]
+    end
+
+    subgraph Hubs
+        JPHub["JobProgressHub"]
+    end
+
+    Controllers --> Services
+    Services --> Models
+    BackgroundSvc --> Services
+    BackgroundSvc --> JobT
+    Notif --> JPHub
+    MongoS --> StorS
+    CompS -->|HTTP| PE["Processing Engine"]
+    MosS -->|HTTP| PE
+    AnaS -->|HTTP| PE
+    DiscS -->|HTTP| PE
+    SearchS -->|HTTP| PE
+    MastS -->|HTTP| MP["MAST Proxy"]
+```
+
+### NuGet Dependencies
+
+| Package | Version | Purpose | Category |
+|---------|---------|---------|----------|
+| `MongoDB.Driver` | 3.7.1 | Database access | Data |
+| `AWSSDK.S3` | 4.x | S3-compatible storage | Data |
+| `Microsoft.AspNetCore.Authentication.JwtBearer` | 10.0.5 | JWT authentication | Security |
+| `BCrypt.Net-Next` | 4.1.0 | Password hashing | Security |
+| `Microsoft.Extensions.Http.Resilience` | 10.4.0 | Polly retry/circuit-breaker | Resilience |
+| `AspNetCoreRateLimit` | 5.0.0 | Per-IP rate limiting | Security |
+| `Swashbuckle.AspNetCore` | 10.1.5 | Swagger/OpenAPI docs | Dev tooling |
+| `Microsoft.AspNetCore.OpenApi` | 10.0.5 | OpenAPI metadata | Dev tooling |
+
+### Test Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `xunit` | 2.9.3 | Test framework |
+| `Moq` | 4.20.72 | Mocking |
+| `FluentAssertions` | 8.8.0 | Assertion library |
+| `coverlet.msbuild` | 6.0.4 | Code coverage (40% threshold) |
+| `Microsoft.NET.Test.Sdk` | 17.14.1 | Test runner |
+
+## Frontend (React + TypeScript)
+
+### Internal Module Structure
+
+```mermaid
+flowchart TB
+    subgraph Pages["Pages (Routes)"]
+        Home["Home"]
+        Disc["Discovery"]
+        Guided["GuidedCreate"]
+        Comp["Composite"]
+        Mos["Mosaic"]
+        Lib["Library"]
+        Ana["Analysis"]
+        Login["Login/Register"]
+    end
+
+    subgraph Components["Shared Components"]
+        Header["Header"]
+        Cards["TargetCards"]
+        Viewer["ImageViewer"]
+        JobPanel["JobPanel"]
+    end
+
+    subgraph Services["API Services"]
+        ApiClient["apiClient\n(fetch wrapper)"]
+        AuthSvc["AuthService"]
+        DiscSvc["DiscoveryService"]
+        CompSvc["CompositeService"]
+        MosSvc["MosaicService"]
+        AnaSvc["AnalysisService"]
+        MastSvc["MastService"]
+        JobsSvc["JobsService"]
+        SignalRSvc["SignalRService"]
+    end
+
+    subgraph Context["React Context"]
+        AuthCtx["AuthContext\n(JWT state)"]
+    end
+
+    subgraph Types["Type Definitions"]
+        JwstT["JwstDataTypes"]
+        CompT["CompositeTypes"]
+        MosT["MosaicTypes"]
+        DiscT["DiscoveryTypes"]
+        MastT["MastTypes"]
+        JobT["JobTypes"]
+        AuthT["AuthTypes"]
+        AnaT["AnalysisTypes"]
+    end
+
+    Pages --> Components
+    Pages --> Services
+    Pages --> Context
+    Services --> ApiClient
+    Services --> Types
+    SignalRSvc -->|WebSocket| Backend["Backend SignalR Hub"]
+    ApiClient -->|HTTP| Backend2["Backend REST API"]
+```
+
+### npm Dependencies
+
+| Package | Version | Purpose | Category |
+|---------|---------|---------|----------|
+| `react` | ^19.1.0 | UI framework | Core |
+| `react-dom` | ^19.1.0 | DOM rendering | Core |
+| `react-router-dom` | ^7.13.1 | Client routing | Core |
+| `@microsoft/signalr` | ^10.0.0 | Real-time updates | Communication |
+| `react-plotly.js` | ^2.6.0 | Scientific charts | Visualization |
+| `plotly.js-basic-dist-min` | ^3.4.0 | Chart engine | Visualization |
+| `fitsjs` | ^0.6.6 | FITS file parsing | Astronomy |
+| `sonner` | ^2.0.7 | Toast notifications | UI |
+
+### Dev/Build Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `vite` | ^8.0.0 | Build tool |
+| `@vitejs/plugin-react` | ^6.0.1 | React HMR |
+| `typescript` | ^5.9.3 | Type checking |
+| `vitest` | ^4.0.18 | Unit testing |
+| `@testing-library/react` | latest | Component testing |
+| `@playwright/test` | ^1.58.2 | E2E testing |
+| `eslint` | ^10.1.0 | Linting |
+| `prettier` | ^3.4.2 | Formatting |
+
+## Processing Engine (Python 3.12)
+
+### Internal Module Structure
+
+```mermaid
+flowchart TB
+    subgraph Routers["FastAPI Routers"]
+        CompR["/composite"]
+        MosR["/mosaic"]
+        AnaR["/analysis"]
+        DiscR["/discovery"]
+        SemR["/semantic"]
+    end
+
+    subgraph Core["Core Modules"]
+        FitsUtil["fits_utils\n(FITS I/O, validation)"]
+        Storage["storage_provider\n(S3/local abstraction)"]
+        Config["config\n(env vars, limits)"]
+    end
+
+    subgraph Processing["Processing Modules"]
+        CompP["composite_processor\n(N-channel RGB)"]
+        MosP["mosaic_processor\n(WCS reprojection)"]
+        AnaP["analysis_processor\n(statistics, detection)"]
+        DiscP["discovery_processor\n(recipe engine)"]
+        SemP["semantic_processor\n(FAISS embeddings)"]
+    end
+
+    Routers --> Processing
+    Processing --> Core
+    Processing --> SciLibs["Scientific Libraries"]
+
+    subgraph SciLibs["Scientific Libraries"]
+        NP["NumPy"]
+        AP["Astropy"]
+        SP["SciPy"]
+        RP["reproject"]
+        PU["photutils"]
+        SK["scikit-image"]
+        PIL["Pillow"]
+        ST["sentence-transformers"]
+        FAISS["faiss-cpu"]
+    end
+```
+
+### pip Dependencies
+
+| Package | Version | Purpose | Category |
+|---------|---------|---------|----------|
+| `fastapi` | 0.135.1 | Web framework | Core |
+| `uvicorn` | 0.42.0 | ASGI server | Core |
+| `pydantic` | 2.12.5 | Data validation | Core |
+| `numpy` | 2.2.6 | Array operations | Scientific |
+| `scipy` | 1.15.3 | Scientific computing | Scientific |
+| `astropy` | 6.1.7 | Astronomy toolkit (FITS, WCS) | Astronomy |
+| `astroquery` | 0.4.11 | MAST API client | Astronomy |
+| `photutils` | >=1.10.0 | Source detection | Astronomy |
+| `reproject` | >=0.13.0 | WCS reprojection | Astronomy |
+| `scikit-image` | >=0.22.0 | Image processing | Image |
+| `pillow` | 12.1.1 | Image I/O | Image |
+| `matplotlib` | 3.10.8 | Colormaps, plotting | Visualization |
+| `pandas` | 2.3.3 | Table data handling | Data |
+| `sentence-transformers` | >=3.0.0,<6.0.0 | Text embeddings | ML |
+| `onnxruntime` | >=1.18.0,<2.0.0 | Model inference | ML |
+| `faiss-cpu` | >=1.9.0,<2.0.0 | Vector similarity search | ML |
+| `boto3` | >=1.34.0 | AWS S3 client | Storage |
+| `aiohttp` | 3.13.3 | Async HTTP | I/O |
+| `aiofiles` | 25.1.0 | Async file I/O | I/O |
+
+### MAST Proxy (Subset)
+
+The MAST Proxy uses `requirements-mast.txt` — a subset of the main requirements focused on I/O:
+- `fastapi`, `uvicorn`, `pydantic` (web framework)
+- `astroquery`, `astropy` (MAST queries)
+- `aiohttp`, `aiofiles`, `boto3` (downloads)
+- No scientific computing libraries (numpy, scipy, etc. not needed)
+
+## Dependency Weight Analysis
+
+| Service | Runtime Deps | Docker Image Size (approx) | Heaviest Dependencies |
+|---------|-------------|---------------------------|----------------------|
+| Frontend | 8 runtime | ~50 MB (nginx + static) | plotly.js (~3 MB), react |
+| Backend | 8 NuGet | ~200 MB (ASP.NET runtime) | MongoDB.Driver, AWSSDK.S3 |
+| Processing Engine | 20+ pip | ~2 GB (scientific stack) | sentence-transformers, PyTorch/ONNX, astropy |
+| MAST Proxy | 8 pip | ~500 MB (astroquery) | astroquery, astropy |
+
+The Processing Engine is by far the heaviest due to ML model dependencies (sentence-transformers + ONNX runtime).
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/network-topology.md
+++ b/docs/architecture/network-topology.md
@@ -1,0 +1,227 @@
+# Network Topology
+
+All ports, protocols, and service-to-service communication paths across deployment environments.
+
+> **4+1 View**: Physical View
+
+## Port Map
+
+### Development (localhost)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Host (localhost loopback)                                        │
+│                                                                   │
+│  :3000 ──→ Frontend (Vite dev server)                           │
+│  :5001 ──→ Backend (.NET API, debug access)                     │
+│  :8000 ──→ Processing Engine (debug access)                     │
+│  :8001 ──→ MkDocs (documentation site)                          │
+│  :8002 ──→ MAST Proxy (debug access)                           │
+│  :8333 ──→ SeaweedFS S3 Gateway (optional, profile=s3)         │
+│  :27017 ─→ MongoDB (direct access for tools)                   │
+│                                                                   │
+│  All bound to localhost loopback — not accessible from network   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Staging (AWS EC2)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Internet                                                        │
+│                                                                   │
+│  :22  ──→ SSH (key-based auth)                                  │
+│  :80  ──→ Frontend (nginx, public)                              │
+│  :443 ──→ (allowed by SG, unused — no TLS in staging)          │
+│                                                                   │
+│  All other ports internal only (Docker network)                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Production
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Internet                                                        │
+│                                                                   │
+│  :22  ──→ SSH (key-based auth)                                  │
+│  :80  ──→ HTTP → HTTPS redirect + ACME challenge                │
+│  :443 ──→ Frontend (nginx, TLS termination)                     │
+│                                                                   │
+│  All other ports internal only (Docker network)                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Internal Communication Map
+
+```mermaid
+flowchart TB
+    subgraph External["External Network"]
+        Client["Browser"]
+        MAST["STScI MAST\narchive.stsci.edu"]
+    end
+
+    subgraph DockerNet["Docker: jwst-network (bridge)"]
+        FE["Frontend\nnginx :3000"]
+        BE["Backend\nASP.NET :5000"]
+        PE["Processing Engine\nuvicorn :8000"]
+        MP["MAST Proxy\nuvicorn :8000"]
+        DB["MongoDB\n:27017"]
+    end
+
+    Client -->|"HTTP/HTTPS\n(host port)"| FE
+    FE -->|"HTTP /api/*\nreverse proxy"| BE
+    FE -->|"WebSocket /hubs/*\nupgrade + proxy"| BE
+    BE -->|"HTTP POST\nJSON (snake_case)"| PE
+    BE -->|"HTTP POST\nJSON (snake_case)"| MP
+    BE -->|"MongoDB Wire Protocol\nTCP"| DB
+    MP -->|"HTTPS\nastroquery"| MAST
+
+    linkStyle 0 stroke:#2196f3,stroke-width:2
+    linkStyle 1 stroke:#4caf50,stroke-width:2
+    linkStyle 2 stroke:#ff9800,stroke-width:2
+    linkStyle 3 stroke:#4caf50,stroke-width:2
+    linkStyle 4 stroke:#4caf50,stroke-width:2
+    linkStyle 5 stroke:#9c27b0,stroke-width:2
+    linkStyle 6 stroke:#f44336,stroke-width:2
+```
+
+## Protocol Details
+
+### Client ↔ Frontend (nginx)
+
+| Protocol | Port | Path | Purpose |
+|----------|------|------|---------|
+| HTTP/HTTPS | 80/443 | `/*` | Static assets (React SPA) |
+| HTTP/HTTPS | 80/443 | `/api/*` | Reverse proxy to backend |
+| WebSocket | 80/443 | `/hubs/*` | SignalR real-time updates |
+
+**nginx routing rules**:
+- `/` → serve static files; fallback to `index.html` (SPA routing)
+- `/api/*` → `proxy_pass http://backend:5000`
+- `/hubs/*` → `proxy_pass http://backend:5000` with WebSocket upgrade headers
+
+**Timeouts**:
+- `/api/*`: connect 60s, send/read 300s
+- `/hubs/*`: read 3600s (long-lived WebSocket)
+
+### Frontend ↔ Backend
+
+| Protocol | Transport | Auth | Casing |
+|----------|-----------|------|--------|
+| REST | HTTP/1.1 via nginx proxy | JWT Bearer token | camelCase |
+| SignalR | WebSocket via nginx proxy | JWT via `?access_token=` query param | camelCase |
+
+### Backend ↔ Processing Engine
+
+| Protocol | Transport | Auth | Casing | Timeout |
+|----------|-----------|------|--------|---------|
+| HTTP | Direct TCP (Docker network) | None (internal) | snake_case | 30 min attempt / 60 min total |
+
+Resilience: Polly retry (3x, 2s backoff) + circuit breaker for composite/mosaic calls.
+
+### Backend ↔ MAST Proxy
+
+| Protocol | Transport | Auth | Casing | Timeout |
+|----------|-----------|------|--------|---------|
+| HTTP | Direct TCP (Docker network) | None (internal) | snake_case | 5 min |
+
+No Polly resilience — MAST operations use application-level retry (user re-submits).
+
+### Backend ↔ MongoDB
+
+| Protocol | Transport | Auth | Port |
+|----------|-----------|------|------|
+| MongoDB Wire Protocol | TCP | Username/password (SCRAM) | 27017 |
+
+Connection string: `mongodb://admin:<password>@mongodb:27017`
+
+### MAST Proxy ↔ STScI
+
+| Protocol | Transport | Auth | Rate Limit |
+|----------|-----------|------|------------|
+| HTTPS | Public internet | None (public API) | Backend enforces 30 req/min |
+
+Uses `astroquery.mast` library — communicates with `archive.stsci.edu` and `mast.stsci.edu`.
+
+## Security Headers
+
+Applied by nginx in all environments:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `X-Content-Type-Options` | `nosniff` | Prevent MIME sniffing |
+| `X-Frame-Options` | `SAMEORIGIN` | Prevent clickjacking |
+| `X-XSS-Protection` | `1; mode=block` | XSS filter |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
+
+Production adds:
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `Strict-Transport-Security` | `max-age=31536000` | Force HTTPS for 1 year |
+| `Content-Security-Policy` | Restrictive policy | XSS/injection prevention |
+
+## CORS Configuration
+
+| Environment | Allowed Origins |
+|-------------|----------------|
+| Development | `http://localhost:3000`, `http://localhost:5173` (+ loopback equivalents) |
+| Staging | `http://<Elastic-IP>` |
+| Production | `https://yourdomain.com` (must be explicitly set) |
+
+Policy: `AllowAnyHeader()`, `AllowAnyMethod()`, `AllowCredentials()`.
+
+## DNS and TLS (Production)
+
+```
+yourdomain.com → A record → Elastic IP
+                             ↓
+                    nginx :443
+                    ├── TLS 1.2 / TLS 1.3
+                    ├── Ciphers: ECDHE-ECDSA-AES128-GCM-SHA256, ...
+                    ├── OCSP Stapling: on
+                    ├── Session cache: shared (50 MB)
+                    └── Cert: /etc/nginx/ssl/fullchain.pem
+```
+
+## Docker Network Architecture
+
+```mermaid
+flowchart TB
+    subgraph Default["jwst-network (default bridge)"]
+        FE["frontend"]
+        BE["backend"]
+        PE["processing-engine"]
+        MP["mast-proxy"]
+        DB["mongodb"]
+        S3["seaweedfs-s3\n(profile: s3)"]
+        Docs["docs"]
+    end
+
+    subgraph Shared["jwst-shared (external bridge)"]
+        Agent1["Agent Stack 1\n(optional)"]
+        Agent2["Agent Stack 2\n(optional)"]
+    end
+
+    Default <-->|"cross-network\n(when agents active)"| Shared
+```
+
+- **jwst-network**: Default bridge network for all services — automatic DNS resolution by container name
+- **jwst-shared**: External bridge for multi-agent stacks (experimental, not actively used)
+
+All services within `jwst-network` can reach each other by container name (e.g., `http://backend:5000`, `http://processing-engine:8000`).
+
+## Firewall Rules (AWS Security Group)
+
+| Rule | Protocol | Port | Source | Purpose |
+|------|----------|------|--------|---------|
+| Inbound | TCP | 22 | any | SSH access |
+| Inbound | TCP | 80 | any | HTTP traffic |
+| Inbound | TCP | 443 | any | HTTPS traffic |
+| Outbound | All | All | any | Internet access (MAST, package repos) |
+
+**Recommendation for production**: Restrict SSH to specific IP ranges.
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/quality-attributes.md
+++ b/docs/architecture/quality-attributes.md
@@ -1,0 +1,250 @@
+# Quality Attribute Scenarios
+
+Measurable quality attribute scenarios for the JWST Data Analysis Application. Each scenario defines a stimulus, environment, response, and response measure — following the SEI quality attribute scenario format.
+
+> **4+1 View**: +1 Scenarios — quality attributes that constrain and shape all other views.
+
+## Performance
+
+### QA-P1: Composite Rendering Time
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Astronomer |
+| **Stimulus** | Requests a 4-channel composite at 4096x4096 output resolution |
+| **Environment** | Normal operation, single concurrent job |
+| **Response** | Processing Engine renders and returns the composite image |
+| **Measure** | Complete in < 30 seconds |
+
+**Architectural Impact**: Processing Engine uses NumPy vectorized operations, not pixel-by-pixel loops. WCS alignment via `reproject` is the bottleneck — `reproject_interp` preferred over `reproject_exact` for speed.
+
+### QA-P2: MAST Import Throughput
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Astronomer |
+| **Stimulus** | Imports a full observation (10-20 FITS files, ~2 GB total) |
+| **Environment** | Normal operation, stable internet connection |
+| **Response** | Files downloaded from STScI, stored, metadata extracted |
+| **Measure** | Sustained download at available bandwidth; UI updates every 2 seconds via SignalR |
+
+**Architectural Impact**: Chunked downloads with streaming to storage. Progress tracking at byte level, not just file level. Resumable downloads for interrupted transfers.
+
+### QA-P3: Discovery Page Load
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Visitor or Astronomer |
+| **Stimulus** | Opens the Discovery home page |
+| **Environment** | Normal operation |
+| **Response** | Featured targets displayed with thumbnails and metadata |
+| **Measure** | First meaningful paint in < 2 seconds; target cards rendered in < 3 seconds |
+
+**Architectural Impact**: Featured targets are a curated static list (not dynamic MAST query). Thumbnails served from local storage. MAST queries only triggered on user action (target selection or search).
+
+### QA-P4: Data Library Search
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Astronomer |
+| **Stimulus** | Searches library with filters (instrument, target, tags) across 500+ records |
+| **Environment** | Normal operation |
+| **Response** | Filtered results returned with thumbnails |
+| **Measure** | Results in < 1 second; pagination for large result sets |
+
+**Architectural Impact**: MongoDB indexes on userId, tags, observationBaseId, processingLevel. Semantic search available for natural-language queries.
+
+---
+
+## Scalability
+
+### QA-S1: Concurrent Users
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Multiple astronomers |
+| **Stimulus** | 10 concurrent users performing imports, composites, and analysis |
+| **Environment** | Single-node deployment (current architecture) |
+| **Response** | All requests served without timeout or resource exhaustion |
+| **Measure** | No request queuing beyond 5 seconds; no OOM kills |
+
+**Architectural Impact**: Job queue serializes heavy compute work. FastAPI async handlers allow I/O concurrency. SignalR manages multiple WebSocket connections. Current target is small-team use, not public-scale.
+
+### QA-S2: Data Volume
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | System growth over time |
+| **Stimulus** | Library grows to 10,000+ records across 50+ users |
+| **Environment** | Normal operation |
+| **Response** | Search, browse, and metadata operations remain responsive |
+| **Measure** | No query exceeds 2 seconds; storage operations scale linearly |
+
+**Architectural Impact**: MongoDB document model with targeted indexes. S3-compatible storage (SeaweedFS or AWS S3) for file storage — decoupled from application tier. Archival flag for soft-deleting old data.
+
+### QA-S3: File Size Limits
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Astronomer uploads or imports large FITS files |
+| **Stimulus** | File up to 2 GB processed |
+| **Environment** | Normal operation |
+| **Response** | File accepted, processed without memory exhaustion |
+| **Measure** | MAX_FITS_FILE_SIZE_MB = 2048; MAX_FITS_ARRAY_ELEMENTS = 100M; MAX_MOSAIC_OUTPUT_PIXELS = 64M |
+
+**Architectural Impact**: Processing Engine enforces hard limits at the application level. Streaming file I/O where possible. Docker container memory limits should be sized accordingly (recommend 4+ GB for Processing Engine).
+
+---
+
+## Security
+
+### QA-SEC1: Authentication & Authorization
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Unauthenticated or malicious user |
+| **Stimulus** | Attempts to access another user's private data |
+| **Environment** | Normal operation |
+| **Response** | Request rejected with 401/403 |
+| **Measure** | Zero unauthorized data access; all private endpoints require valid JWT |
+
+**Architectural Impact**: JWT-based auth with short-lived access tokens + refresh tokens. User data scoped by `UserId` in all queries. Public data explicitly flagged (`IsPublic = true`). Role-based access (Admin/User).
+
+**Known Limitation**: Auth flow is currently fragile — identified as a risk area requiring careful changes.
+
+### QA-SEC2: Input Validation
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Malicious user |
+| **Stimulus** | Submits malformed FITS file or oversized request |
+| **Environment** | Normal operation |
+| **Response** | Input rejected before processing; no crash or resource exhaustion |
+| **Measure** | All file uploads validated; all numeric parameters bounded; DoS limits enforced |
+
+**Architectural Impact**: Backend validates all DTOs with range constraints. Processing Engine enforces file size and array element limits. CORS configured to restrict origins.
+
+### QA-SEC3: Credential Management
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Deployment configuration |
+| **Stimulus** | Application starts with credentials configured |
+| **Environment** | All environments |
+| **Response** | No credentials in code, logs, or client-visible responses |
+| **Measure** | All secrets via environment variables; `.env` files gitignored; no plaintext in Docker commands |
+
+**Architectural Impact**: `docker/.env` (from `.env.example`) for local dev. Container env vars for staging/production. Password hashing for user accounts. Refresh tokens stored in DB, not localStorage.
+
+---
+
+## Reliability
+
+### QA-R1: Job Failure Recovery
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Processing Engine or network |
+| **Stimulus** | Composite or import job fails mid-execution |
+| **Environment** | Normal operation |
+| **Response** | Job marked as failed with error details; no orphaned data; user can retry |
+| **Measure** | Failed jobs visible in UI within 5 seconds; import jobs are resumable |
+
+**Architectural Impact**: try/catch wrapping in all job execution paths. Job state tracked in MongoDB (survives restarts). Import jobs track byte-level progress for resume. Failed jobs do not leave partial records in the data collection.
+
+### QA-R2: External Service Unavailability
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | STScI MAST Portal |
+| **Stimulus** | MAST API returns timeout or 5xx error |
+| **Environment** | Degraded external service |
+| **Response** | Error surfaced to user with actionable message; local functionality unaffected |
+| **Measure** | MAST failures do not cascade to non-MAST features; import jobs can be retried |
+
+**Architectural Impact**: MAST operations are isolated to specific endpoints. Failures in MAST queries don't affect local data browsing, compositing, or analysis. Timeouts configured for external HTTP calls.
+
+### QA-R3: Container Restart Resilience
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Docker orchestration |
+| **Stimulus** | Processing Engine container restarts during a job |
+| **Environment** | Container failure or resource limit hit |
+| **Response** | Running jobs marked as failed; no data corruption |
+| **Measure** | Jobs in "running" state detected as stale after container restart; data store remains consistent |
+
+**Architectural Impact**: Job state in MongoDB (not in-memory). Storage operations are atomic (write-then-record). Docker health checks enable restart policies. No in-flight state that can't be reconstructed from the database.
+
+---
+
+## Usability
+
+### QA-U1: First-Time User Success
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | New astronomer |
+| **Stimulus** | User with no prior experience creates their first composite image |
+| **Environment** | Normal operation |
+| **Response** | Guided Discovery wizard leads user from target selection to finished composite |
+| **Measure** | Complete flow in < 10 minutes (including data import); no documentation required |
+
+**Architectural Impact**: Featured targets curated for visual impact. Recipe system pre-fills complex parameters. Presets (auto, natural, NASA) reduce decision points. Progressive disclosure of advanced controls.
+
+### QA-U2: Real-Time Feedback
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Astronomer |
+| **Stimulus** | Initiates any long-running operation (import, composite, mosaic) |
+| **Environment** | Normal operation |
+| **Response** | Progress bar with stage description, percentage, and ETA |
+| **Measure** | UI updates at least every 2 seconds; user can cancel at any time |
+
+**Architectural Impact**: SignalR WebSocket connection for push updates. Job stages provide granular progress (not just 0%/100%). Cancel flag checked at processing checkpoints.
+
+---
+
+## Maintainability
+
+### QA-M1: Service Independence
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Developer |
+| **Stimulus** | Modifies Processing Engine without touching Backend or Frontend |
+| **Environment** | Development |
+| **Response** | Change deployed independently; other services unaffected |
+| **Measure** | Each service has its own Dockerfile, test suite, and can be rebuilt independently |
+
+**Architectural Impact**: Three separate codebases (React, .NET, Python) communicating via HTTP APIs. No shared code or compiled dependencies between services. Docker Compose manages the stack.
+
+### QA-M2: Test Coverage
+
+| Aspect | Description |
+|--------|-------------|
+| **Source** | Developer |
+| **Stimulus** | Makes a code change to any service |
+| **Environment** | Development / CI |
+| **Response** | Pre-commit hooks run relevant tests; CI runs full suite |
+| **Measure** | Unit tests pass in < 30 seconds per service; E2E tests validate critical paths |
+
+**Architectural Impact**: Pre-commit hooks enforce lint + build + unit tests. CI pipeline runs full matrix. Interfaces (IMongoDBService, IMastService) enable unit testing with mocks. E2E tests validate cross-service flows.
+
+---
+
+## Summary Matrix
+
+| Quality Attribute | Priority | Current State | Key Risk |
+|-------------------|----------|---------------|----------|
+| **Performance** | High | Good for single-user; untested at scale | Large mosaic memory usage |
+| **Scalability** | Medium | Single-node; adequate for 10 users | No horizontal scaling path yet |
+| **Security** | High | JWT auth in place; DoS limits set | Auth flow fragility |
+| **Reliability** | High | Job recovery works; MAST isolation good | Container restart loses running jobs |
+| **Usability** | High | Guided flow complete; presets available | Complex parameter space for advanced users |
+| **Maintainability** | High | Good service separation; strong hook enforcement | Three-language stack increases cognitive load |
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/use-case-catalog.md
+++ b/docs/architecture/use-case-catalog.md
@@ -1,0 +1,243 @@
+# Use Case Catalog
+
+Primary use cases that exercise the JWST Data Analysis Application across all architectural views. Each use case references which views it touches and which architectural components are involved.
+
+> **4+1 View**: +1 Scenarios — these use cases tie the Logical, Process, Development, and Physical views together.
+
+## Actors
+
+| Actor | Description |
+|-------|-------------|
+| **Astronomer** | Authenticated user who imports, analyzes, and visualizes JWST data |
+| **Visitor** | Unauthenticated user browsing public data and featured targets |
+| **Admin** | User with elevated privileges for data management |
+| **MAST Portal** | External STScI archive providing JWST observations |
+| **Processing Engine** | Internal Python service performing scientific computation |
+
+---
+
+## Primary Use Cases
+
+### UC-1: Discover and Import JWST Data
+
+**Goal**: Astronomer finds interesting JWST observations and imports them for analysis.
+
+**Trigger**: User navigates to Discovery page.
+
+**Flow**:
+1. Frontend loads featured targets from backend (`GET /api/discovery/featured`)
+2. User selects a target (e.g., "Carina Nebula") or searches by name/coordinates
+3. Backend queries Processing Engine, which queries MAST via `astroquery`
+4. Results displayed with instrument/filter metadata and preview thumbnails
+5. User selects observations to import
+6. Backend creates an import job (`POST /api/mast/import`) → JobTracker assigns job ID
+7. Processing Engine downloads FITS files from STScI archive (chunked, resumable)
+8. Files stored via IStorageProvider (S3 or local), metadata saved to MongoDB
+9. SignalR pushes progress updates (bytes downloaded, files completed)
+10. Job completes → data appears in user's library with full lineage (L1→L3)
+
+**Views Exercised**:
+- **Logical**: JwstData, JobStatus, FeaturedTarget, MastObservation entities
+- **Process**: Async job queue, SignalR push, chunked download with resume
+- **Physical**: Frontend → Backend → Processing Engine → MAST (external)
+- **Development**: All three services coordinate
+
+**Error Scenarios**:
+- MAST timeout → retry with exponential backoff
+- Download interrupted → job marked resumable, user can restart
+- Disk full → job fails with storage error, no partial records saved
+
+---
+
+### UC-2: Create Multi-Band Color Composite
+
+**Goal**: Astronomer combines multiple JWST filter images into a single RGB color image.
+
+**Trigger**: User clicks "Create Composite" or follows a recipe suggestion.
+
+**Flow**:
+1. User selects 2+ FITS images from their library, assigns each to a color channel
+2. Per-channel controls: stretch algorithm, black/white points, gamma, tone curve, weight
+3. Color assignment via hue angle, explicit RGB, or luminance (LRGB mode)
+4. User can apply a preset (auto, natural, NASA, high-contrast, faint-emission, scientific)
+5. Frontend submits composite request (`POST /api/composite/n-channel`)
+6. Backend validates inputs, creates job, forwards to Processing Engine
+7. Processing Engine: loads FITS → WCS alignment → per-channel stretch → color mapping → stack → post-processing
+8. Result stored as PNG/JPEG blob, job marked complete
+9. SignalR notifies frontend → composite displayed in viewer
+10. User can adjust parameters and re-render, or save to library
+
+**Views Exercised**:
+- **Logical**: JwstData (inputs), CompositeRequest, ChannelConfig, JobStatus
+- **Process**: Compute-intensive job, progress stages, result as blob
+- **Physical**: CPU-bound work on Processing Engine container
+
+**Quality Attributes**: See QA-1 (performance) — composite of 4 channels at 4096x4096 should complete in < 30s.
+
+---
+
+### UC-3: Build WCS-Aligned Mosaic
+
+**Goal**: Astronomer combines multiple overlapping JWST pointings into a single seamless mosaic.
+
+**Trigger**: User selects multi-pointing observations, or recipe indicates `requiresMosaic = true`.
+
+**Flow**:
+1. User selects 2+ FITS files with WCS headers
+2. Backend requests footprint analysis from Processing Engine (`POST /api/mosaic/footprints`)
+3. Footprints displayed on a sky coordinate overlay (RA/Dec corners, bounding box)
+4. User configures: combine method (mean/sum/first/last/min/max), stretch, colormap, output size
+5. Frontend submits mosaic request (`POST /api/mosaic/create`)
+6. Processing Engine uses `reproject` library for WCS-aware reprojection and combination
+7. Result can be PNG/JPEG (for viewing) or FITS (for further analysis, saved as L3 data)
+8. Saved mosaics link back to source files via `DerivedFrom`
+
+**Views Exercised**:
+- **Logical**: JwstData (inputs + output), MosaicRequest, MosaicFileConfig, footprints
+- **Process**: Memory-intensive reprojection, DoS limits enforced (MAX_MOSAIC_OUTPUT_PIXELS)
+- **Physical**: RAM-constrained on Processing Engine container
+
+---
+
+### UC-4: Guided Discovery Experience
+
+**Goal**: New user follows a step-by-step wizard from target selection to finished composite.
+
+**Trigger**: User clicks a featured target card on the Discovery home page.
+
+**Flow**:
+1. Featured target cards load with thumbnails, categories, and composite potential ratings
+2. User selects a target → system queries MAST for available observations
+3. Processing Engine analyzes available filters and suggests ranked recipes
+4. User picks a recipe (e.g., "Pillars of Creation — NASA-style RGB")
+5. System checks which data is already imported; imports missing observations
+6. GuidedCreate wizard pre-fills channel assignments from the recipe's color mapping
+7. User can accept defaults or customize before rendering
+8. Composite created (UC-2 flow) → result displayed → user can save or share
+
+**Views Exercised**: All views — this is the end-to-end "golden path" through the application.
+
+---
+
+### UC-5: Analyze Astronomical Data
+
+**Goal**: Astronomer performs quantitative analysis on imported FITS data.
+
+**Trigger**: User opens a data file and selects an analysis tool.
+
+**Subflows**:
+
+**5a. Region Statistics**:
+- User draws a rectangle or ellipse on the image
+- Backend forwards region to Processing Engine
+- Returns: mean, median, std, min, max, sum, pixel count
+
+**5b. Source Detection**:
+- User configures threshold (sigma), FWHM, minimum pixels
+- Processing Engine runs photutils-based detection
+- Returns: detected sources with centroids, flux, sharpness, roundness
+
+**5c. Table/Spectral Viewer**:
+- FITS tables displayed with pagination and column metadata
+- Spectral data plotted as interactive charts (wavelength vs. flux)
+
+**Views Exercised**:
+- **Logical**: JwstData, AnalysisModels (region stats, source detection, table/spectral)
+- **Process**: Synchronous request-response (no job queue for simple analysis)
+- **Physical**: Processing Engine CPU for source detection
+
+---
+
+### UC-6: Upload and Manage Local Data
+
+**Goal**: Astronomer uploads their own FITS files and organizes their data library.
+
+**Trigger**: User clicks "Upload" or drags files into the application.
+
+**Flow**:
+1. Frontend validates file type and size client-side
+2. File uploaded via multipart POST to backend (`POST /api/jwstdata/upload`)
+3. Backend validates FITS headers, extracts metadata (instrument, filter, WCS)
+4. File stored via IStorageProvider, metadata document created in MongoDB
+5. Thumbnail generated asynchronously
+6. User can tag, describe, archive, and share uploaded data
+7. Data appears in library with `IsPublic = false` (private by default)
+
+**Supporting Operations**:
+- Search by filename, tags, target, instrument, filter
+- Semantic search across metadata fields
+- Archive/unarchive, version tracking
+- Bulk operations (tag, delete, share)
+
+---
+
+### UC-7: Authenticate and Manage Account
+
+**Goal**: User creates an account and manages their session.
+
+**Flow**:
+1. Register with username, email, password (+ optional display name, organization)
+2. Login → backend issues JWT access token + refresh token
+3. Access token used for API calls (short-lived)
+4. Refresh token extends session without re-login
+5. Admin can manage user accounts and access public data
+6. All user data scoped by `UserId` — users see only their own data + public data
+
+**Architectural Note**: Auth flow is currently fragile — documented as a known limitation. Extra care required for changes.
+
+---
+
+## Use Case Map
+
+```mermaid
+graph LR
+    subgraph Actors
+        A[Astronomer]
+        V[Visitor]
+        AD[Admin]
+    end
+
+    subgraph "Core Use Cases"
+        UC1[UC-1: Discover & Import]
+        UC2[UC-2: Create Composite]
+        UC3[UC-3: Build Mosaic]
+        UC4[UC-4: Guided Discovery]
+        UC5[UC-5: Analyze Data]
+        UC6[UC-6: Upload & Manage]
+        UC7[UC-7: Authenticate]
+    end
+
+    A --> UC1
+    A --> UC2
+    A --> UC3
+    A --> UC4
+    A --> UC5
+    A --> UC6
+    A --> UC7
+    V --> UC4
+    V --> UC1
+    AD --> UC6
+    AD --> UC7
+
+    UC4 -->|includes| UC1
+    UC4 -->|includes| UC2
+    UC2 -->|may include| UC3
+```
+
+---
+
+## Traceability to Architecture Views
+
+| Use Case | Logical View | Process View | Development View | Physical View |
+|----------|-------------|-------------|-----------------|--------------|
+| UC-1: Discover & Import | JwstData, JobStatus, FeaturedTarget | Async jobs, SignalR, chunked download | All 3 services | Frontend → Backend → Engine → MAST |
+| UC-2: Create Composite | CompositeRequest, ChannelConfig | Compute job, progress push | Backend + Engine | CPU on Engine container |
+| UC-3: Build Mosaic | MosaicRequest, JwstData lineage | Memory-intensive job, DoS limits | Backend + Engine | RAM on Engine container |
+| UC-4: Guided Discovery | All entities | Full async pipeline | All 3 services | Full stack + MAST |
+| UC-5: Analyze Data | Analysis models | Synchronous request-response | Backend + Engine | CPU on Engine container |
+| UC-6: Upload & Manage | JwstData, User | File upload, thumbnail gen | Frontend + Backend | Storage provider |
+| UC-7: Authenticate | User, tokens | JWT lifecycle, refresh | Frontend + Backend | Stateless (no session store) |
+
+---
+
+[Back to Architecture Overview](index.md)

--- a/docs/architecture/versioning-strategy.md
+++ b/docs/architecture/versioning-strategy.md
@@ -1,0 +1,118 @@
+# Versioning Strategy
+
+How services are versioned relative to each other, API compatibility approach, and dependency management.
+
+> **4+1 View**: Development View
+
+## Current State
+
+The application uses **implicit lockstep versioning** — all services are deployed together from the same repository and must be compatible at HEAD.
+
+### Application Versions
+
+| Service | Version | Source |
+|---------|---------|--------|
+| Frontend | 0.1.0 | `package.json` |
+| Processing Engine | 0.1.0 | `pyproject.toml` |
+| Backend | (none) | No explicit version in `.csproj` |
+
+These version numbers are not currently used for compatibility checks — they exist as metadata only.
+
+### Language/Runtime Versions
+
+| Runtime | Version | Pinning |
+|---------|---------|---------|
+| .NET | 10.0 | SDK `10.0.200` in CI; `mcr.microsoft.com/dotnet/aspnet:10.0` in Docker |
+| Node.js | 22 | `node:22-alpine` in Docker; Node 22 in CI |
+| Python | 3.12 | `python:3.12-slim-bullseye` in Docker; Python 3.12 in CI |
+| MongoDB | 8.0 | `mongo:8.0` in Docker |
+
+### Dependency Pinning Strategy
+
+| Service | Strategy | Example |
+|---------|----------|---------|
+| Backend (NuGet) | Exact versions | `MongoDB.Driver 3.7.1` |
+| Frontend (npm) | Caret ranges | `react: ^19.1.0` (minor/patch updates OK) |
+| Processing Engine (pip) | Mixed | Critical: exact (`fastapi==0.135.1`), Scientific: range (`photutils>=1.10.0`) |
+| Docker base images | Major.minor pinned | `dotnet/aspnet:10.0`, `python:3.12-slim-bullseye` |
+
+## API Versioning
+
+### Current Approach: No Explicit Versioning
+
+API routes use `/api/<resource>` without version prefix (e.g., `/api/composite/generate-nchannel`, not `/api/v1/composite/...`).
+
+**Why this works today**:
+- Monorepo — all services deployed together
+- Single deployment target — no multiple consumers at different versions
+- Pre-1.0 — breaking changes expected and acceptable
+
+### Inter-Service Contract
+
+| Boundary | Contract | Breaking Change Policy |
+|----------|---------|----------------------|
+| Frontend → Backend | REST endpoints + SignalR events | Update both in same PR |
+| Backend → Processing Engine | HTTP routes + JSON schemas | Update both in same PR |
+| Backend → MAST Proxy | HTTP routes + JSON schemas | Update both in same PR |
+| Backend → MongoDB | Document schemas (C# models) | Migration in same PR; MongoDB schema-less allows gradual changes |
+
+### JSON Schema Compatibility
+
+| Direction | Convention | Compatibility |
+|-----------|-----------|--------------|
+| Frontend → Backend | camelCase | Must match TypeScript types ↔ C# DTOs |
+| Backend → Processing Engine | snake_case | Must match C# serialization ↔ Pydantic models |
+
+Adding new optional fields is always safe. Removing or renaming fields requires coordinated changes across services.
+
+## Docker Image Tagging
+
+### Current: No Tags
+
+Docker images are built locally and not pushed to a registry. Docker Compose builds from source each time.
+
+### CI: Cache-Only
+
+GitHub Actions builds use GHA cache with scope keys (`backend`, `frontend`, `processing`, `mast-proxy`) but does not push tagged images to a registry.
+
+## Upgrade Procedures
+
+### Dependency Updates
+
+| Type | Frequency | Process |
+|------|-----------|---------|
+| Security patches | As needed | Dependabot PR or manual update |
+| Minor versions | Monthly | Batch update, run full test suite |
+| Major versions | Per release cycle | Dedicated branch, thorough testing |
+
+### Runtime Version Upgrades
+
+Upgrading a runtime (e.g., .NET 10 → 11) requires:
+1. Update Dockerfile base image
+2. Update CI matrix
+3. Update `.csproj` target framework
+4. Run full test suite + E2E
+5. Single PR with all changes
+
+### MongoDB Schema Changes
+
+MongoDB's flexible document model allows additive changes without migration:
+- **Adding fields**: Default values in C# model; existing documents unchanged
+- **Renaming fields**: Requires one-time migration script + code update
+- **Removing fields**: Remove from code; orphaned fields in documents are harmless
+
+No formal migration framework is used — changes are handled in application code.
+
+## Future Considerations
+
+When the application reaches 1.0 (Community Edition), consider:
+
+1. **API version prefix** (`/api/v1/...`) if external consumers emerge
+2. **Semantic versioning** with Git tags for releases
+3. **Docker image registry** (GitHub Container Registry) for reproducible deployments
+4. **Changelog generation** from conventional commit messages
+5. **Database migration tool** if schema changes become frequent
+
+---
+
+[Back to Architecture Overview](index.md)


### PR DESCRIPTION
## Summary
- Add complete 4+1 Architecture View Model documentation (11 new files, 1 updated)
- Reorganize architecture index under Logical, Process, Development, Physical, and Scenarios views

No linked issue

## Why
Gap analysis revealed missing documentation for domain model, API contracts, concurrency, error recovery, build pipeline, module dependencies, versioning, deployment topology, network topology, use cases, and quality attributes. This fills all gaps for a portfolio-ready 4+1 architecture doc set.

## Changes Made
- **Logical View**: `domain-model.md` (ER diagram), `api-contracts.md` (full endpoint map)
- **Process View**: `concurrency-model.md` (job queues, SignalR, rate limiting), `error-recovery.md` (Polly, resumable downloads, failure modes)
- **Development View**: `module-dependencies.md` (NuGet/npm/pip deps), `build-pipeline.md` (hooks → CI → deploy), `versioning-strategy.md`
- **Physical View**: `deployment-architecture.md` (dev/staging/prod topologies), `network-topology.md` (ports, protocols, TLS, firewall)
- **+1 Scenarios**: `use-case-catalog.md` (7 primary use cases), `quality-attributes.md` (13 SEI-format QA scenarios)
- Updated `index.md` with 4+1 view organization

## Test Plan
- [x] All docs use valid Mermaid syntax
- [x] All docs link back to index
- [x] Index links to all new and existing docs
- [x] No sensitive patterns (IPs, credentials) in content
- [x] Pre-commit hooks pass

## Documentation Checklist
- [x] Architecture docs updated (this IS the architecture docs PR)
- [x] No code changes — docs only

## Tech Debt Impact
- [x] None — documentation only

## Risk & Rollback
Risk: Low — docs-only change, no code impact
Rollback: Revert commit
