### PR TITLE
fix: replace hardcoded 10-min job timeout with configurable split timers

### DIFF
--- a/frontend/jwst-frontend/src/hooks/useJobProgress.test.ts
+++ b/frontend/jwst-frontend/src/hooks/useJobProgress.test.ts
@@ -1,0 +1,332 @@
+/**
+ * TDD tests for job progress timeout behavior — written BEFORE implementation.
+ * Issue #659: SignalR-only jobs have hardcoded 10-minute timeout causing false failures
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock signalRService — capture the callbacks so tests can simulate events
+let signalRCallbacks: Record<string, (...args: unknown[]) => void> = {};
+const mockUnsubscribe = vi.fn();
+vi.mock('../services/signalRService', () => ({
+  subscribeToJob: vi.fn((_jobId: string, cbs: Record<string, unknown>) => {
+    signalRCallbacks = cbs as Record<string, (...args: unknown[]) => void>;
+    return globalThis.Promise.resolve(mockUnsubscribe);
+  }),
+}));
+
+// Mock mastService (polling endpoint)
+vi.mock('../services/mastService', () => ({
+  getImportProgress: vi.fn(),
+}));
+
+import { subscribeToJobProgress } from './useJobProgress';
+
+describe('subscribeToJobProgress — timeout behavior', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    signalRCallbacks = {};
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- Initial timeout (signalROnly mode) ---
+
+  describe('initial timeout (signalROnly)', () => {
+    it('should fire onFailed after default initialTimeoutMs (2 min) when no events arrive', async () => {
+      const onFailed = vi.fn();
+      subscribeToJobProgress('job-1', { onFailed }, { signalROnly: true });
+
+      // Flush the subscribeToJob promise
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Advance to just before 2 minutes — should NOT fire
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000 - 1);
+      expect(onFailed).not.toHaveBeenCalled();
+
+      // Advance past 2 minutes — should fire
+      await vi.advanceTimersByTimeAsync(1);
+      expect(onFailed).toHaveBeenCalledTimes(1);
+      expect(onFailed.mock.calls[0][0].error).toMatch(/SignalR timeout/i);
+    });
+
+    it('should use custom initialTimeoutMs when provided', async () => {
+      const onFailed = vi.fn();
+      subscribeToJobProgress(
+        'job-1',
+        { onFailed },
+        { signalROnly: true, initialTimeoutMs: 30_000 }
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(onFailed).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(onFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT fire initial timeout after a progress event arrives', async () => {
+      const onFailed = vi.fn();
+      const onProgress = vi.fn();
+      subscribeToJobProgress('job-1', { onFailed, onProgress }, { signalROnly: true });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Simulate a progress event at 1 minute
+      await vi.advanceTimersByTimeAsync(60_000);
+      signalRCallbacks.onProgress?.({
+        jobId: 'job-1',
+        progressPercent: 10,
+        stage: 'Processing',
+        message: 'Working...',
+      });
+      expect(onProgress).toHaveBeenCalled();
+
+      // Advance past the initial timeout (2 min total) — should NOT fire
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+      expect(onFailed).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- Stale progress timeout (signalROnly mode) ---
+
+  describe('stale progress timeout (signalROnly)', () => {
+    it('should fire onFailed after default staleProgressTimeoutMs (5 min) of silence following progress', async () => {
+      const onFailed = vi.fn();
+      const onProgress = vi.fn();
+      subscribeToJobProgress('job-1', { onFailed, onProgress }, { signalROnly: true });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // First progress event at 30s
+      await vi.advanceTimersByTimeAsync(30_000);
+      signalRCallbacks.onProgress?.({
+        jobId: 'job-1',
+        progressPercent: 10,
+        stage: 'Processing',
+        message: 'Step 1',
+      });
+
+      // Advance 5 min of silence — should fire stale timeout
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      expect(onFailed).toHaveBeenCalledTimes(1);
+      expect(onFailed.mock.calls[0][0].error).toMatch(/stale|no progress/i);
+    });
+
+    it('should reset stale timeout on each progress event', async () => {
+      const onFailed = vi.fn();
+      subscribeToJobProgress('job-1', { onFailed, onProgress: vi.fn() }, { signalROnly: true });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Progress at 30s
+      await vi.advanceTimersByTimeAsync(30_000);
+      signalRCallbacks.onProgress?.({
+        jobId: 'job-1',
+        progressPercent: 10,
+        stage: 'Processing',
+        message: 'Step 1',
+      });
+
+      // Progress again at 4 min (before 5 min stale timeout)
+      await vi.advanceTimersByTimeAsync(3.5 * 60 * 1000);
+      signalRCallbacks.onProgress?.({
+        jobId: 'job-1',
+        progressPercent: 50,
+        stage: 'Processing',
+        message: 'Step 2',
+      });
+
+      // Wait another 4 min (still within 5 min of last progress)
+      await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+      expect(onFailed).not.toHaveBeenCalled();
+
+      // Wait past 5 min from last progress — NOW it should fire
+      await vi.advanceTimersByTimeAsync(1.5 * 60 * 1000);
+      expect(onFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use custom staleProgressTimeoutMs when provided', async () => {
+      const onFailed = vi.fn();
+      subscribeToJobProgress(
+        'job-1',
+        { onFailed, onProgress: vi.fn() },
+        { signalROnly: true, staleProgressTimeoutMs: 60_000 }
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Progress event
+      signalRCallbacks.onProgress?.({
+        jobId: 'job-1',
+        progressPercent: 10,
+        stage: 'Processing',
+        message: 'Working...',
+      });
+
+      // 59s — should NOT fire
+      await vi.advanceTimersByTimeAsync(59_000);
+      expect(onFailed).not.toHaveBeenCalled();
+
+      // 1 more second — should fire
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(onFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT fire stale timeout when job completes normally', async () => {
+      const onFailed = vi.fn();
+      const onCompleted = vi.fn();
+      subscribeToJobProgress(
+        'job-1',
+        { onFailed, onCompleted, onProgress: vi.fn() },
+        { signalROnly: true }
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Progress event
+      signalRCallbacks.onProgress?.({
+        jobId: 'job-1',
+        progressPercent: 50,
+        stage: 'Processing',
+        message: 'Half done',
+      });
+
+      // Completion event at 2 min
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+      signalRCallbacks.onCompleted?.({
+        jobId: 'job-1',
+        message: 'Done',
+        completedAt: new Date().toISOString(),
+      });
+      expect(onCompleted).toHaveBeenCalled();
+
+      // Wait past stale timeout — should NOT fire since job completed
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+      expect(onFailed).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- Ghost callback prevention ---
+
+  describe('no ghost callbacks after timeout', () => {
+    it('should ignore SignalR events after initial timeout fires', async () => {
+      const onFailed = vi.fn();
+      const onProgress = vi.fn();
+      subscribeToJobProgress('job-1', { onFailed, onProgress }, { signalROnly: true });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Let initial timeout fire (2 min)
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+      expect(onFailed).toHaveBeenCalledTimes(1);
+
+      // Late SignalR progress arrives — should be ignored
+      signalRCallbacks.onProgress?.({
+        jobId: 'job-1',
+        progressPercent: 50,
+        stage: 'Processing',
+        message: 'Late event',
+      });
+      expect(onProgress).not.toHaveBeenCalled();
+      expect(onFailed).toHaveBeenCalledTimes(1); // No second call
+    });
+  });
+
+  // --- Polling timeout ---
+
+  describe('polling timeout', () => {
+    it('should use configured pollingTimeoutMs instead of hardcoded 10 min', async () => {
+      const { getImportProgress } = await import('../services/mastService');
+      const mockGetProgress = vi.mocked(getImportProgress);
+      // Return in-progress status forever
+      mockGetProgress.mockResolvedValue({
+        jobId: 'job-1',
+        obsId: 'obs-1',
+        progress: 50,
+        stage: 'Running',
+        message: 'Still going',
+        isComplete: false,
+        startedAt: new Date().toISOString(),
+      });
+
+      const onFailed = vi.fn();
+      subscribeToJobProgress(
+        'job-1',
+        { onFailed, onProgress: vi.fn() },
+        { pollingTimeoutMs: 5 * 60 * 1000, pollIntervalMs: 1000 }
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Advance to just before 5 min
+      for (let i = 0; i < 299; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+      expect(onFailed).not.toHaveBeenCalled();
+
+      // Advance past 5 min
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(onFailed).toHaveBeenCalledTimes(1);
+      expect(onFailed.mock.calls[0][0].error).toMatch(/timed out/i);
+    });
+
+    it('should default pollingTimeoutMs to 30 minutes', async () => {
+      const { getImportProgress } = await import('../services/mastService');
+      const mockGetProgress = vi.mocked(getImportProgress);
+      mockGetProgress.mockResolvedValue({
+        jobId: 'job-1',
+        obsId: 'obs-1',
+        progress: 50,
+        stage: 'Running',
+        message: 'Still going',
+        isComplete: false,
+        startedAt: new Date().toISOString(),
+      });
+
+      const onFailed = vi.fn();
+      subscribeToJobProgress(
+        'job-1',
+        { onFailed, onProgress: vi.fn() },
+        { pollIntervalMs: 10_000 }
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // At 10 min (old hardcoded timeout) — should NOT fire
+      for (let i = 0; i < 60; i++) {
+        await vi.advanceTimersByTimeAsync(10_000);
+      }
+      expect(onFailed).not.toHaveBeenCalled();
+
+      // Continue to 30 min + buffer
+      for (let i = 0; i < 121; i++) {
+        await vi.advanceTimersByTimeAsync(10_000);
+      }
+      expect(onFailed).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // --- Cleanup ---
+
+  describe('cleanup', () => {
+    it('should not fire any timeout after unsubscribe', async () => {
+      const onFailed = vi.fn();
+      const sub = subscribeToJobProgress('job-1', { onFailed }, { signalROnly: true });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Unsubscribe before timeout
+      sub.unsubscribe();
+
+      // Advance past all timeouts
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      expect(onFailed).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/jwst-frontend/src/hooks/useJobProgress.ts
+++ b/frontend/jwst-frontend/src/hooks/useJobProgress.ts
@@ -40,6 +40,22 @@ export interface SubscribeOptions {
    * endpoint doesn't apply. Default: false.
    */
   signalROnly?: boolean;
+  /**
+   * How long to wait for the first SignalR event before declaring failure.
+   * Only applies in signalROnly mode. Default: 2 minutes (120_000).
+   */
+  initialTimeoutMs?: number;
+  /**
+   * How long to wait after the last progress event before declaring stale.
+   * Resets on each progress event. Only applies in signalROnly mode.
+   * Default: 5 minutes (300_000).
+   */
+  staleProgressTimeoutMs?: number;
+  /**
+   * Maximum duration for HTTP polling before declaring timeout.
+   * Only applies when signalROnly is false. Default: 30 minutes (1_800_000).
+   */
+  pollingTimeoutMs?: number;
 }
 
 /** Return value from subscribeToJobProgress. */
@@ -165,6 +181,58 @@ export function subscribeToJobProgress(
     }
   }
 
+  // --- Timeout management for signalROnly mode ---
+  // Two separate timers:
+  // 1. Initial timeout: fires if SignalR never delivers any event (connection failure).
+  // 2. Stale progress timeout: fires if progress goes silent mid-job. Resets on each event.
+  let initialTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  let staleTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const initialTimeoutMs = options?.initialTimeoutMs ?? 2 * 60 * 1000; // 2 min default
+  const staleProgressTimeoutMs = options?.staleProgressTimeoutMs ?? 5 * 60 * 1000; // 5 min default
+
+  function fireTimeoutFailure(message: string): void {
+    if (cancelled) return;
+    cancelled = true; // Prevent double-fire and ghost callbacks after timeout
+    clearAllTimeoutTimers();
+    signalRUnsub?.();
+    if (pollTimer) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+    const timeoutStatus: ImportJobStatus = {
+      jobId,
+      obsId: options?.obsId ?? currentStatus?.obsId ?? '',
+      progress: currentStatus?.progress ?? 0,
+      stage: 'Failed',
+      message,
+      isComplete: true,
+      error: message,
+      startedAt: currentStatus?.startedAt ?? new Date().toISOString(),
+    };
+    callbacks.onFailed?.(timeoutStatus);
+  }
+
+  function clearAllTimeoutTimers(): void {
+    if (initialTimeoutTimer) {
+      clearTimeout(initialTimeoutTimer);
+      initialTimeoutTimer = null;
+    }
+    if (staleTimeoutTimer) {
+      clearTimeout(staleTimeoutTimer);
+      staleTimeoutTimer = null;
+    }
+  }
+
+  function resetStaleTimeout(): void {
+    if (!options?.signalROnly) return; // Stale timeout only applies in signalROnly mode
+    if (staleTimeoutTimer) clearTimeout(staleTimeoutTimer);
+    staleTimeoutTimer = setTimeout(() => {
+      if (cancelled) return;
+      fireTimeoutFailure('No progress updates received (stale SignalR timeout)');
+    }, staleProgressTimeoutMs);
+  }
+
   // Try SignalR — but also start polling immediately as safety net.
   // If SignalR delivers an event, polling is stopped. If the dual-write
   // failed (job doesn't exist in unified tracker), polling keeps working
@@ -174,6 +242,11 @@ export function subscribeToJobProgress(
       if (cancelled) return;
       signalRDelivered = true;
       stopPolling();
+      if (initialTimeoutTimer) {
+        clearTimeout(initialTimeoutTimer);
+        initialTimeoutTimer = null;
+      }
+      resetStaleTimeout();
       currentStatus = mapProgressToImportStatus(update, options?.obsId, currentStatus);
       callbacks.onProgress?.(currentStatus);
     },
@@ -181,6 +254,7 @@ export function subscribeToJobProgress(
       if (cancelled) return;
       signalRDelivered = true;
       stopPolling();
+      clearAllTimeoutTimers();
 
       if (options?.signalROnly) {
         // Non-import jobs: construct completed status from SignalR event directly
@@ -227,6 +301,7 @@ export function subscribeToJobProgress(
       if (cancelled) return;
       signalRDelivered = true;
       stopPolling();
+      clearAllTimeoutTimers();
       const failedStatus: ImportJobStatus = {
         jobId: update.jobId,
         obsId: options?.obsId ?? currentStatus?.obsId ?? '',
@@ -244,14 +319,20 @@ export function subscribeToJobProgress(
       if (cancelled) return;
       signalRDelivered = true;
       stopPolling();
+      if (initialTimeoutTimer) {
+        clearTimeout(initialTimeoutTimer);
+        initialTimeoutTimer = null;
+      }
       currentStatus = mapSnapshotToImportStatus(snapshot, options?.obsId);
       if (currentStatus.isComplete) {
+        clearAllTimeoutTimers();
         if (currentStatus.error) {
           callbacks.onFailed?.(currentStatus);
         } else {
           callbacks.onCompleted?.(currentStatus);
         }
       } else {
+        resetStaleTimeout();
         callbacks.onProgress?.(currentStatus);
       }
     },
@@ -273,47 +354,32 @@ export function subscribeToJobProgress(
     startPolling();
   }
 
-  // Safety timeout for signalROnly mode: if SignalR never delivers an event
-  // (silent connection failure, subscription miss), fire a failure after 2 minutes
-  // so the UI doesn't hang forever.
-  let signalRTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
   if (options?.signalROnly) {
-    signalRTimeoutTimer = setTimeout(
-      () => {
-        if (cancelled || signalRDelivered) return;
-        const timeoutStatus: ImportJobStatus = {
-          jobId,
-          obsId: options?.obsId ?? currentStatus?.obsId ?? '',
-          progress: currentStatus?.progress ?? 0,
-          stage: 'Failed',
-          message: 'No progress updates received (SignalR timeout)',
-          isComplete: true,
-          error: 'No progress updates received (SignalR timeout)',
-          startedAt: currentStatus?.startedAt ?? new Date().toISOString(),
-        };
-        callbacks.onFailed?.(timeoutStatus);
-      },
-      10 * 60 * 1000
-    );
+    // Initial timeout: fires if no SignalR events arrive at all
+    initialTimeoutTimer = setTimeout(() => {
+      if (cancelled || signalRDelivered) return;
+      fireTimeoutFailure('No progress updates received (SignalR timeout)');
+    }, initialTimeoutMs);
   }
 
   function startPolling(): void {
     const pollingStartTime = Date.now();
-    const maxPollingDuration = 10 * 60 * 1000; // 10 minutes
+    const maxPollingDuration = options?.pollingTimeoutMs ?? 30 * 60 * 1000; // 30 min default
 
     async function poll(): Promise<void> {
       if (cancelled || signalRDelivered) return;
 
-      // Safety: stop polling after 10 minutes to prevent infinite hang
+      // Safety: stop polling after configured duration to prevent infinite hang
       if (Date.now() - pollingStartTime > maxPollingDuration) {
+        const minutes = Math.round(maxPollingDuration / 60_000);
         const timeoutStatus: ImportJobStatus = {
           jobId,
           obsId: options?.obsId ?? currentStatus?.obsId ?? '',
           progress: currentStatus?.progress ?? 0,
           stage: 'Failed',
-          message: 'Polling timed out after 10 minutes',
+          message: `Polling timed out after ${minutes} minutes`,
           isComplete: true,
-          error: 'Polling timed out after 10 minutes',
+          error: `Polling timed out after ${minutes} minutes`,
           startedAt: currentStatus?.startedAt ?? new Date().toISOString(),
         };
         callbacks.onFailed?.(timeoutStatus);
@@ -350,7 +416,7 @@ export function subscribeToJobProgress(
       cancelled = true;
       signalRUnsub?.();
       if (pollTimer) clearTimeout(pollTimer);
-      if (signalRTimeoutTimer) clearTimeout(signalRTimeoutTimer);
+      clearAllTimeoutTimers();
     },
   };
 }
@@ -367,7 +433,11 @@ export function subscribeToJobProgress(
 export function useJobProgress(
   jobId: string | null,
   obsId?: string,
-  signalROnly?: boolean
+  signalROnly?: boolean,
+  timeoutOptions?: Pick<
+    SubscribeOptions,
+    'initialTimeoutMs' | 'staleProgressTimeoutMs' | 'pollingTimeoutMs'
+  >
 ): {
   progress: ImportJobStatus | null;
   isComplete: boolean;
@@ -404,11 +474,18 @@ export function useJobProgress(
           setState({ progress: status, isComplete: true, error: status.error ?? status.message });
         },
       },
-      { obsId, signalROnly }
+      { obsId, signalROnly, ...timeoutOptions }
     );
 
     return () => sub.unsubscribe();
-  }, [jobId, obsId, signalROnly]);
+  }, [
+    jobId,
+    obsId,
+    signalROnly,
+    timeoutOptions?.initialTimeoutMs,
+    timeoutOptions?.staleProgressTimeoutMs,
+    timeoutOptions?.pollingTimeoutMs,
+  ]);
 
   const { progress, isComplete, error } = state;
 


### PR DESCRIPTION
## Summary

Replace the single hardcoded 10-minute SignalR timeout with three purpose-specific, configurable timers for job progress tracking.

## Why

Composite and mosaic jobs using `signalROnly` mode had a hardcoded 10-minute timeout that could fire false failures for long-running jobs. The timeout also couldn't distinguish between "SignalR never connected" (should fail fast) and "progress went stale mid-job" (should wait longer). Additionally, `fireTimeoutFailure` didn't set `cancelled=true`, enabling double `onFailed` calls and ghost callbacks after timeout.

Closes #659

## Changes Made

- Split single timeout into `initialTimeoutMs` (2 min default — fires if zero SignalR events arrive) and `staleProgressTimeoutMs` (5 min default — resets on each progress event, catches mid-job drops)
- Make polling timeout configurable via `pollingTimeoutMs` (30 min default, up from hardcoded 10 min)
- Guard stale timeout to only apply in `signalROnly` mode — prevents false failures in polling mode if SignalR delivers then goes quiet
- Set `cancelled=true` in `fireTimeoutFailure` and clean up all timers/subscriptions to prevent double `onFailed` and ghost callbacks
- Move timeout declarations above `subscribeToJob` call to eliminate forward-reference confusion
- Extend `useJobProgress` hook to accept optional `timeoutOptions`
- Add 11 TDD tests covering initial timeout, stale timeout, reset-on-progress, custom values, polling timeout, ghost callback prevention, and cleanup

## Test Plan

- [x] 11 new unit tests for timeout behavior (TDD approach)
- [x] All 907 existing tests pass (73 test files)
- [x] ESLint clean (0 errors), tsc clean
- [x] Self-review caught two bugs: stale timeout firing in non-signalROnly mode, and missing cancelled flag in fireTimeoutFailure — both fixed

## Documentation Checklist

- [x] `docs/development-plan.md` — mark #659 done after merge

## Tech Debt Impact

- [x] Reduces tech debt — eliminates hardcoded timeout, adds first test coverage for useJobProgress hook

## Risk & Rollback

Risk: LOW — frontend-only, no API changes. Default values change from 10 min to 2 min (initial) / 5 min (stale) / 30 min (polling), all improvements. Existing callers pass no timeout options so they get the new defaults.
Rollback: Revert commit and restore hardcoded 10-minute timeout.
