### PR TITLE
feat: add security headers middleware to .NET gateway

### DIFF
--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -361,6 +361,18 @@ else
     app.UseHsts();
 }
 
+// Security headers — applied to all responses
+app.Use(async (context, next) =>
+{
+    var headers = context.Response.Headers;
+    headers["X-Content-Type-Options"] = "nosniff";
+    headers["X-Frame-Options"] = "DENY";
+    headers["X-XSS-Protection"] = "0"; // Disable legacy XSS filter (can introduce vulnerabilities)
+    headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+    headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(), payment=()";
+    await next();
+});
+
 // CORS must be before rate limiting so 429 responses include CORS headers
 app.UseCors("AllowReactApp");
 


### PR DESCRIPTION
Closes #741

## Summary
Adds security headers middleware to the .NET API gateway, setting standard protective headers on all HTTP responses.

## Why
The API has no security headers, leaving it vulnerable to clickjacking, MIME-sniffing, and referrer leakage. Identified in the March 2026 codebase review.

## Changes Made
- Added inline `app.Use()` middleware in `Program.cs` (before CORS) that sets:
  - `X-Content-Type-Options: nosniff` — prevents MIME-type sniffing
  - `X-Frame-Options: DENY` — blocks clickjacking via iframes
  - `X-XSS-Protection: 0` — disables legacy XSS filter (can introduce vulnerabilities)
  - `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage
  - `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()` — restricts browser APIs

## Test Plan
- [x] `docker compose up -d --build` to rebuild backend
- [x] `curl -I http://localhost:5001/api/health` — all 5 headers present in response
- [ ] Open browser DevTools → Network → check response headers on any API call
- [ ] Verify Swagger UI still loads at `/swagger` in development mode
- [x] Verify CORS preflight (OPTIONS) responses also include security headers

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: Low — additive middleware, no behavioral changes. Headers are inert for existing clients.
- Rollback: Revert the single commit.