### PR TITLE
feat: add gitleaks secret scanning to pre-commit hook and CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,6 +6,7 @@
 # Install with: ./scripts/setup-hooks.sh
 #
 # What this hook checks:
+# - Gitleaks: Secret scanning on staged changes (if installed)
 # - Frontend: ESLint, Prettier, Unit Tests (if frontend files changed)
 # - Backend: dotnet build (if backend files changed)
 # - Processing Engine: Ruff lint and format (if Python files changed)
@@ -82,6 +83,24 @@ if [ -f "$PATTERNS_FILE" ]; then
     else
         echo -e "${GREEN}  ✓ No sensitive patterns detected${NC}"
     fi
+    echo ""
+fi
+
+# ============================================
+# Gitleaks Secret Scanning (always runs — fast)
+# ============================================
+if command -v gitleaks &> /dev/null; then
+    echo "  → Scanning staged changes for secrets (gitleaks)..."
+    if ! gitleaks protect --staged --config "$REPO_ROOT/.gitleaks.toml" --no-banner 2>/dev/null; then
+        echo -e "${RED}  ❌ Gitleaks found potential secrets in staged changes${NC}"
+        echo -e "${YELLOW}     Review findings above. If false positive, update .gitleaks.toml allowlist.${NC}"
+        FAILED=1
+    else
+        echo -e "${GREEN}  ✓ No secrets detected${NC}"
+    fi
+    echo ""
+else
+    echo -e "${YELLOW}  ⚠ gitleaks not installed - skipping secret scan (brew install gitleaks)${NC}"
     echo ""
 fi
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,6 +35,18 @@ jobs:
               - 'processing-engine/**'
               - '.github/workflows/security.yml'
 
+  gitleaks:
+    name: Gitleaks Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   codeql-csharp:
     name: CodeQL (C#)
     needs: detect-changes

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,25 @@
+# Gitleaks configuration for JWST Data Analysis
+# https://github.com/gitleaks/gitleaks
+
+title = "JWST Data Analysis Secret Scanning"
+
+[extend]
+# Use the default gitleaks rules as a base
+useDefault = true
+
+# Allowlist paths and patterns that are known-safe
+[allowlist]
+  description = "Known-safe patterns"
+
+  # Example/template files with placeholder values
+  paths = [
+    '''docker/\.env\.example''',
+    '''\.gitleaks\.toml''',
+  ]
+
+  # Placeholder secrets used in example configs and tests
+  regexTarget = "match"
+  regexes = [
+    '''CHANGE_THIS_TO_A_SECURE_RANDOM_STRING''',
+    '''your-secret-key-change-this-in-production''',
+  ]


### PR DESCRIPTION
Closes #742

## Summary
Adds automated secret scanning via gitleaks at two layers: pre-commit hook (local) and GitHub Actions CI (remote).

## Why
No automated secret detection exists — hardcoded API keys, passwords, or tokens can be committed and pushed without detection. Identified in the March 2026 codebase review.

## Changes Made
- **`.gitleaks.toml`** (new) — gitleaks config extending default rules, with allowlist for `.env.example` placeholder values
- **`.githooks/pre-commit`** — added gitleaks section that scans staged changes; gracefully skips with a warning if gitleaks isn't installed (`brew install gitleaks`)
- **`.github/workflows/security.yml`** — added `gitleaks` job using `gitleaks/gitleaks-action@v2` with full history scan (`fetch-depth: 0`)

## Test Plan
- [x] `brew install gitleaks` already installed
- [x] Pre-commit hook runs gitleaks and passes on normal commits (verified during commit)
- [ ] Stage a file containing a test secret (e.g., `AWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE`) — verify pre-commit hook catches it
- [ ] Verify the Gitleaks Secret Scan job appears and passes in the Security workflow
- [x] Verify existing CodeQL jobs still run correctly (Security workflow in_progress)

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: Low — additive CI job and optional pre-commit check. Pre-commit gracefully skips if gitleaks not installed.
- Rollback: Revert the single commit and delete `.gitleaks.toml`.