### PR TITLE
docs: mark #741 and #742 as done in development plan

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -87,8 +87,8 @@ Visual polish, accessibility fixes, and compositing quality improvements needed 
 | [#459](https://github.com/Snoww3d/jwst-data-analysis/issues/459) | Internal exception details returned to clients |
 | [#460](https://github.com/Snoww3d/jwst-data-analysis/issues/460) | Public data responses expose owner UserId |
 | [#461](https://github.com/Snoww3d/jwst-data-analysis/issues/461) | Frontend dev dependency audit (18 high vulns) |
-| [#741](https://github.com/Snoww3d/jwst-data-analysis/issues/741) | Add security headers middleware to .NET gateway |
-| [#742](https://github.com/Snoww3d/jwst-data-analysis/issues/742) | Add secret scanning (gitleaks) to CI and pre-commit |
+| ~~[#741](https://github.com/Snoww3d/jwst-data-analysis/issues/741)~~ | ~~Add security headers middleware to .NET gateway~~ — Done |
+| ~~[#742](https://github.com/Snoww3d/jwst-data-analysis/issues/742)~~ | ~~Add secret scanning (gitleaks) to CI and pre-commit~~ — Done |
 
 ### Bugs
 


### PR DESCRIPTION
## Summary
Mark #741 (security headers) and #742 (gitleaks) as done in the development plan.

## Why
Both PRs (#954, #955) have been merged.

## Changes Made
- Strikethrough #741 and #742 entries in `docs/development-plan.md`

## Test Plan
- [x] Verified both PRs are merged

## Documentation Checklist
- [x] `docs/development-plan.md` (milestone/phase changes)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: None — docs-only change.
- Rollback: Revert commit.