### PR TITLE
docs: add architecture documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ jwst-data-analysis/
 
 ## Documentation
 
+- [Setup Guide](./docs/setup-guide.md) - Full development setup instructions
+- [Architecture](./docs/architecture/index.md) - 4+1 architectural view model (system overview, domain model, API contracts, data flows, deployment)
 - [Development Plan](./docs/development-plan.md) - Project roadmap and phases
 - [Development Standards](./docs/standards/README.md) - Coding guidelines
 - [Quick Reference](./docs/quick-reference.md) - API endpoints, common patterns, troubleshooting
 - [Key Files Reference](./docs/key-files.md) - Important files in the codebase
 - [MAST Usage Guide](./docs/mast-usage.md) - Detailed MAST search examples
-- [Setup Guide](./docs/setup-guide.md) - Full development setup instructions
 - [API Reference](http://localhost:5001/swagger) - OpenAPI/Swagger docs (when running)
 
 ## Contributing


### PR DESCRIPTION
## Summary

- Add architecture documentation link to README documentation section

No linked issue

## Changes Made

- Reordered docs list: Setup Guide first, then Architecture, then the rest
- Added link to `docs/architecture/index.md` with brief description of the 4+1 view model contents

## Test Plan

- [x] Link resolves correctly (verified file exists)
- [x] No other changes

## Documentation Checklist

- [x] README updated

## Tech Debt Impact

- [x] N/A

## Risk & Rollback

Risk: None — docs-only change.

Rollback: Revert commit.
