### PR TITLE
fix: replace assert with HTTPException for region parameter validation

### DIFF
--- a/processing-engine/app/analysis/routes.py
+++ b/processing-engine/app/analysis/routes.py
@@ -178,11 +178,19 @@ def compute_region_statistics(request: RegionStatisticsRequest):
         # Create region mask
         if request.region_type == "rectangle":
             r = request.rectangle
-            assert r is not None
+            if r is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Rectangle parameters required when region_type is 'rectangle'",
+                )
             mask = create_rectangle_mask(data.shape, r.x, r.y, r.width, r.height)
         else:
             e = request.ellipse
-            assert e is not None
+            if e is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Ellipse parameters required when region_type is 'ellipse'",
+                )
             mask = create_ellipse_mask(data.shape, e.cx, e.cy, e.rx, e.ry)
 
         # Extract pixels and filter NaNs


### PR DESCRIPTION
Closes #1001

## Summary
Replace `assert` statements with explicit `HTTPException(400)` checks in region statistics validation, preventing validation from being silently stripped under `python -O`.

## Why
`assert` statements are removed when Python runs with the `-O` (optimize) flag, meaning input validation would be silently skipped — a security gap that could lead to unhandled `NoneType` errors.

## Changes Made
- `processing-engine/app/analysis/routes.py`: Replace 2 `assert r/e is not None` with `if ... is None: raise HTTPException(400, detail="...")` for both rectangle and ellipse region types

## Test Plan
- [x] Existing `test_missing_rectangle` and `test_missing_ellipse` pass (13/13 tests green)
- [ ] Verify rectangle region stats still work: `POST /analysis/region-statistics` with `region_type: "rectangle"` and valid rectangle params returns 200
- [ ] Verify ellipse region stats still work: same with `region_type: "ellipse"` and valid ellipse params returns 200
- [ ] Verify missing rectangle params returns 400 with descriptive message
- [ ] Verify missing ellipse params returns 400 with descriptive message

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low — single-file change to validation logic, behavior preserved for valid inputs
- Rollback: Revert commit; no data/schema changes