### PR TITLE
fix: log JWT validation failures instead of swallowing silently

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/JwtTokenServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/JwtTokenServiceTests.cs
@@ -11,6 +11,7 @@ using JwstDataAnalysis.API.Configuration;
 using JwstDataAnalysis.API.Models;
 using JwstDataAnalysis.API.Services;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
@@ -196,7 +197,7 @@ public class JwtTokenServiceTests
             Audience = TestAudience,
         });
 
-        var act = () => new JwtTokenService(settings);
+        var act = () => new JwtTokenService(settings, NullLogger<JwtTokenService>.Instance);
 
         act.Should().Throw<ArgumentException>().WithMessage("*at least 32 characters*");
     }
@@ -220,7 +221,7 @@ public class JwtTokenServiceTests
             RefreshTokenExpirationDays = 7,
             ClockSkewSeconds = clockSkewSeconds,
         });
-        return new JwtTokenService(settings);
+        return new JwtTokenService(settings, NullLogger<JwtTokenService>.Instance);
     }
 
     private static User CreateTestUser() => new()

--- a/backend/JwstDataAnalysis.API/Services/JwtTokenService.cs
+++ b/backend/JwstDataAnalysis.API/Services/JwtTokenService.cs
@@ -9,6 +9,7 @@ using System.Text;
 
 using JwstDataAnalysis.API.Configuration;
 using JwstDataAnalysis.API.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
@@ -17,13 +18,15 @@ namespace JwstDataAnalysis.API.Services
     /// <summary>
     /// Service for generating and validating JWT tokens.
     /// </summary>
-    public class JwtTokenService : IJwtTokenService
+    public partial class JwtTokenService : IJwtTokenService
     {
         private readonly JwtSettings settings;
         private readonly SymmetricSecurityKey signingKey;
+        private readonly ILogger<JwtTokenService> logger;
 
-        public JwtTokenService(IOptions<JwtSettings> settings)
+        public JwtTokenService(IOptions<JwtSettings> settings, ILogger<JwtTokenService> logger)
         {
+            this.logger = logger;
             this.settings = settings.Value;
 
             if (string.IsNullOrEmpty(this.settings.SecretKey) || this.settings.SecretKey.Length < 32)
@@ -104,10 +107,14 @@ namespace JwstDataAnalysis.API.Services
                 return principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
                     ?? principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
             }
-            catch
+            catch (Exception ex)
             {
+                LogJwtValidationFailed(ex);
                 return null;
             }
         }
+
+        [LoggerMessage(Level = LogLevel.Warning, Message = "JWT token validation failed")]
+        private partial void LogJwtValidationFailed(Exception ex);
     }
 }


### PR DESCRIPTION
Closes #988

## Summary
Add logging for JWT validation failures so security-relevant events are auditable instead of silently returning null.

## Why
`JwtTokenService.ValidateTokenAndGetUserId` had a bare `catch` that silently swallowed all exceptions, making it impossible to detect brute-force attempts, expired tokens, or misconfigured JWT settings in logs.

## Changes Made
- `backend/JwstDataAnalysis.API/Services/JwtTokenService.cs`:
  - Inject `ILogger<JwtTokenService>` via constructor
  - Make class `partial` to use `LoggerMessage` source generator
  - Replace bare `catch` with `catch (Exception ex)` + `LogJwtValidationFailed(ex)` (LogLevel.Warning)
- `backend/JwstDataAnalysis.API.Tests/Services/JwtTokenServiceTests.cs`:
  - Pass `NullLogger<JwtTokenService>.Instance` to updated constructor in tests

## Test Plan
- [x] All 1019 backend tests pass
- [ ] Attempt login with valid credentials → no warning logged
- [ ] Attempt with expired token → warning logged with `SecurityTokenExpiredException` details
- [ ] Attempt with tampered token → warning logged with `SecurityTokenSignatureKeyNotFoundException` details
- [ ] Check structured logging output includes exception type and message

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low — adds a logger parameter to constructor (DI resolves automatically) and a log call in the catch block
- Rollback: Revert commit; no data/schema changes