### PR TITLE
fix: processing engine correctness bugs (type hint, validation, bounds)

### DIFF
--- a/processing-engine/app/analysis/routes.py
+++ b/processing-engine/app/analysis/routes.py
@@ -40,6 +40,8 @@ def create_rectangle_mask(
     shape: tuple[int, int], x: int, y: int, width: int, height: int
 ) -> np.ndarray:
     """Create a boolean mask for a rectangular region."""
+    if width <= 0 or height <= 0:
+        raise ValueError(f"width and height must be positive, got width={width}, height={height}")
     mask = np.zeros(shape, dtype=bool)
     img_h, img_w = shape
     # Clamp to image bounds

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -111,8 +111,13 @@ def _auto_crop(rgb: np.ndarray, threshold: float = 0.005) -> np.ndarray:
     if not rows.any() or not cols.any():
         return rgb
 
-    r_min, r_max = np.where(rows)[0][[0, -1]]
-    c_min, c_max = np.where(cols)[0][[0, -1]]
+    row_indices = np.where(rows)[0]
+    col_indices = np.where(cols)[0]
+    if len(row_indices) == 0 or len(col_indices) == 0:
+        return rgb
+
+    r_min, r_max = row_indices[0], row_indices[-1]
+    c_min, c_max = col_indices[0], col_indices[-1]
 
     cropped = rgb[r_min : r_max + 1, c_min : c_max + 1]
     if cropped.shape != rgb.shape:

--- a/processing-engine/app/processing/utils.py
+++ b/processing-engine/app/processing/utils.py
@@ -81,7 +81,7 @@ def save_fits_data(data: np.ndarray, header: dict[str, Any], output_path: str) -
         return False
 
 
-def normalize_array(data: np.ndarray) -> np.ndarray:
+def normalize_array(data: np.ndarray) -> np.ndarray | None:
     """
     Normalize array to 0-1 range.
     """

--- a/processing-engine/tests/test_region_statistics.py
+++ b/processing-engine/tests/test_region_statistics.py
@@ -35,6 +35,18 @@ class TestRectangleMask:
         assert mask[4, 4]
         assert not mask[5, 5]
 
+    def test_negative_width_raises(self):
+        with pytest.raises(ValueError, match="width and height must be positive"):
+            create_rectangle_mask((100, 100), 10, 10, -5, 10)
+
+    def test_negative_height_raises(self):
+        with pytest.raises(ValueError, match="width and height must be positive"):
+            create_rectangle_mask((100, 100), 10, 10, 10, -5)
+
+    def test_zero_width_raises(self):
+        with pytest.raises(ValueError, match="width and height must be positive"):
+            create_rectangle_mask((100, 100), 10, 10, 0, 10)
+
 
 class TestEllipseMask:
     def test_circle(self):


### PR DESCRIPTION
Closes #1019
Closes #1030
Closes #1023
Closes #969

## Summary
Three processing engine correctness fixes: type hint mismatch, silent failure on invalid input, and defensive bounds guard.

## Why
- `normalize_array` declared `-> np.ndarray` but could return `None` (#1019/#1030)
- `create_rectangle_mask` silently returned an empty mask for negative width/height instead of raising (#1023)
- `_auto_crop` used fancy indexing on `np.where` results without an explicit empty-array guard (#969)

## Changes Made
- **`processing-engine/app/processing/utils.py`** — fix `normalize_array` return type to `np.ndarray | None`
- **`processing-engine/app/analysis/routes.py`** — add `ValueError` for non-positive width/height in `create_rectangle_mask`
- **`processing-engine/app/composite/routes.py`** — replace fancy indexing with explicit variable assignment and empty-array guard in `_auto_crop`
- **`processing-engine/tests/test_region_statistics.py`** — add 3 test cases for negative/zero width and height

## Test Plan
- [x] `docker exec jwst-processing python -m pytest tests/ -x -q` — 1139 passed (3 new tests)
- [ ] Verify negative width raises: `create_rectangle_mask((100,100), 10, 10, -5, 10)` → `ValueError`
- [ ] Verify zero width raises: `create_rectangle_mask((100,100), 10, 10, 0, 10)` → `ValueError`
- [ ] Verify `_auto_crop` still works on normal composite output

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] Existing tech debt reduced — GitHub Issues closed

## Risk & Rollback
- Risk: Low — type hint change is cosmetic, validation matches existing Pydantic constraint, bounds guard is redundant safety net
- Rollback: Revert commit