### PR TITLE
feat: expose unsharp masking in composite pipeline (#683)

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
@@ -373,6 +373,74 @@ public class CompositeServiceTests
     }
 
     [Fact]
+    public async Task GenerateNChannelComposite_WithSharpening_SerializesSnakeCase()
+    {
+        // Arrange
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 1 }),
+            },
+            req => capturedRequest = req);
+        var httpClient = new HttpClient(handler);
+
+        var sut = CreateService(httpClient);
+        var request = CreateRequest();
+        request.Sharpening = new SharpeningConfigDto
+        {
+            Radius = 1.5,
+            Amount = 0.8,
+            Threshold = 0.02,
+        };
+
+        // Act
+        await sut.GenerateNChannelCompositeAsync(
+            request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert - validates the wire contract (snake_case) to the Python service.
+        var body = await capturedRequest!.Content!.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(body);
+        doc.RootElement.TryGetProperty("sharpening", out var sharpProp).Should().BeTrue();
+        sharpProp.ValueKind.Should().Be(JsonValueKind.Object);
+        sharpProp.GetProperty("radius").GetDouble().Should().Be(1.5);
+        sharpProp.GetProperty("amount").GetDouble().Should().Be(0.8);
+        sharpProp.GetProperty("threshold").GetDouble().Should().Be(0.02);
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_NullSharpening_SerializesAsNull()
+    {
+        // Arrange
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 1 }),
+            },
+            req => capturedRequest = req);
+        var httpClient = new HttpClient(handler);
+
+        var sut = CreateService(httpClient);
+
+        // Act
+        await sut.GenerateNChannelCompositeAsync(
+            CreateRequest(), "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        var body = await capturedRequest!.Content!.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(body);
+        doc.RootElement.TryGetProperty("sharpening", out var sharpProp).Should().BeTrue();
+        sharpProp.ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
     public async Task GenerateNChannelComposite_StripsAbsolutePathPrefix()
     {
         // Arrange - file path starts with /app/data/ prefix

--- a/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
@@ -43,6 +43,30 @@ namespace JwstDataAnalysis.API.Models
     }
 
     /// <summary>
+    /// Unsharp masking parameters applied to the final RGB composite.
+    /// </summary>
+    public class SharpeningConfigDto
+    {
+        /// <summary>
+        /// Gets or sets the Gaussian blur sigma in pixels (0.5-10.0).
+        /// </summary>
+        [Range(0.5, 10.0)]
+        public double Radius { get; set; } = 1.5;
+
+        /// <summary>
+        /// Gets or sets the sharpening strength (0=disabled, 1=typical, up to 3 for aggressive).
+        /// </summary>
+        [Range(0.0, 3.0)]
+        public double Amount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum luminance delta to sharpen (0-1). Protects the noise floor.
+        /// </summary>
+        [Range(0.0, 1.0)]
+        public double Threshold { get; set; }
+    }
+
+    /// <summary>
     /// Color specification for an N-channel composite — either hue angle or explicit RGB weights.
     /// </summary>
     public class ChannelColorDto
@@ -159,6 +183,11 @@ namespace JwstDataAnalysis.API.Models
         public OverallAdjustmentsDto? Overall { get; set; }
 
         /// <summary>
+        /// Gets or sets optional unsharp masking applied to the final RGB composite.
+        /// </summary>
+        public SharpeningConfigDto? Sharpening { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to subtract per-channel sky background (default true).
         /// </summary>
         public bool BackgroundNeutralization { get; set; } = true;
@@ -239,6 +268,21 @@ namespace JwstDataAnalysis.API.Models
     }
 
     /// <summary>
+    /// Internal unsharp masking config sent to processing engine.
+    /// </summary>
+    internal class ProcessingSharpeningConfig
+    {
+        [JsonPropertyName("radius")]
+        public double Radius { get; set; } = 1.5;
+
+        [JsonPropertyName("amount")]
+        public double Amount { get; set; }
+
+        [JsonPropertyName("threshold")]
+        public double Threshold { get; set; }
+    }
+
+    /// <summary>
     /// Internal color specification sent to processing engine.
     /// </summary>
     internal class ProcessingChannelColor
@@ -305,6 +349,9 @@ namespace JwstDataAnalysis.API.Models
 
         [JsonPropertyName("overall")]
         public ProcessingOverallAdjustments? Overall { get; set; }
+
+        [JsonPropertyName("sharpening")]
+        public ProcessingSharpeningConfig? Sharpening { get; set; }
 
         [JsonPropertyName("background_neutralization")]
         public bool BackgroundNeutralization { get; set; } = true;

--- a/backend/JwstDataAnalysis.API/Services/CompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.cs
@@ -103,6 +103,7 @@ namespace JwstDataAnalysis.API.Services
             {
                 Channels = processingChannels,
                 Overall = CreateProcessingOverallAdjustments(request.Overall),
+                Sharpening = CreateProcessingSharpening(request.Sharpening),
                 BackgroundNeutralization = request.BackgroundNeutralization,
                 FeatherStrength = request.FeatherStrength,
                 RotationDegrees = request.RotationDegrees,
@@ -155,6 +156,22 @@ namespace JwstDataAnalysis.API.Services
                 WhitePoint = overall.WhitePoint,
                 Gamma = overall.Gamma,
                 AsinhA = overall.AsinhA,
+            };
+        }
+
+        private static ProcessingSharpeningConfig? CreateProcessingSharpening(
+            SharpeningConfigDto? sharpening)
+        {
+            if (sharpening == null)
+            {
+                return null;
+            }
+
+            return new ProcessingSharpeningConfig
+            {
+                Radius = sharpening.Radius,
+                Amount = sharpening.Amount,
+                Threshold = sharpening.Threshold,
             };
         }
 

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -8,7 +8,9 @@ import {
   DEFAULT_CHANNEL_PARAMS,
   DEFAULT_EXPORT_OPTIONS,
   DEFAULT_OVERALL_ADJUSTMENTS,
+  DEFAULT_SHARPENING,
   OverallAdjustments,
+  SharpeningConfig,
   StretchMethod,
   COMPOSITE_PRESETS,
   CompositePreset,
@@ -42,6 +44,9 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
   const [backgroundNeutralization, setBackgroundNeutralization] = useState(true);
   const [overallAdjustments, setOverallAdjustments] = useState<OverallAdjustments>({
     ...DEFAULT_OVERALL_ADJUSTMENTS,
+  });
+  const [sharpening, setSharpening] = useState<SharpeningConfig>({
+    ...DEFAULT_SHARPENING,
   });
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
@@ -94,6 +99,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
   const handleApplyPreset = (preset: CompositePreset) => {
     setActivePreset(preset.id);
     setOverallAdjustments({ ...preset.overall });
+    setSharpening({ ...(preset.sharpening ?? DEFAULT_SHARPENING) });
     setBackgroundNeutralization(preset.backgroundNeutralization);
     onChannelsChange(
       channels.map((ch) => {
@@ -225,7 +231,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [channels, overallAdjustments, backgroundNeutralization]);
+  }, [channels, overallAdjustments, sharpening, backgroundNeutralization]);
 
   // Cleanup object URL, in-flight request, and timers on unmount.
   useEffect(() => {
@@ -264,7 +270,9 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         1000,
         overallAdjustments,
         controller.signal,
-        backgroundNeutralization
+        backgroundNeutralization,
+        undefined,
+        sharpening.amount > 0 ? sharpening : undefined
       );
 
       if (previewUrlRef.current) {
@@ -374,7 +382,10 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         exportOptions.width,
         exportOptions.height,
         overallAdjustments,
-        backgroundNeutralization
+        backgroundNeutralization,
+        undefined,
+        undefined,
+        sharpening.amount > 0 ? sharpening : undefined
       );
 
       setActiveJobId(jobId);
@@ -427,12 +438,28 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
   const handleOverallReset = () => {
     setActivePreset(null);
     setOverallAdjustments({ ...DEFAULT_OVERALL_ADJUSTMENTS });
+    setSharpening({ ...DEFAULT_SHARPENING });
     onChannelsChange(
       channels.map((ch) => ({
         ...ch,
         params: { ...DEFAULT_CHANNEL_PARAMS },
       }))
     );
+  };
+
+  const handleSharpeningAmountChange = (value: number) => {
+    setActivePreset(null);
+    setSharpening((prev) => ({ ...prev, amount: value }));
+  };
+
+  const handleSharpeningRadiusChange = (value: number) => {
+    setActivePreset(null);
+    setSharpening((prev) => ({ ...prev, radius: value }));
+  };
+
+  const handleSharpeningThresholdChange = (value: number) => {
+    setActivePreset(null);
+    setSharpening((prev) => ({ ...prev, threshold: value }));
   };
 
   const handleWeightChange = (channelId: string, weight: number) => {
@@ -726,6 +753,70 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
               </div>
             </>
           )}
+
+          <div className="sharpening-section">
+            <div className="option-label-row">
+              <label className="option-label">Sharpening (Unsharp Mask)</label>
+              <span className="option-value">{sharpening.amount.toFixed(2)}×</span>
+            </div>
+            <input
+              type="range"
+              min="0"
+              max="3.0"
+              step="0.05"
+              value={sharpening.amount}
+              onChange={(e) => handleSharpeningAmountChange(parseFloat(e.target.value))}
+              className="quality-slider"
+              aria-label="Sharpening amount"
+            />
+            <div className="slider-labels">
+              <span>Off</span>
+              <span>Aggressive</span>
+            </div>
+
+            {sharpening.amount > 0 && (
+              <>
+                <div className="option-label-row">
+                  <label className="option-label">Radius</label>
+                  <span className="option-value">{sharpening.radius.toFixed(1)} px</span>
+                </div>
+                {/* min/max match SharpeningConfig.radius Range(0.5, 10.0) on backend */}
+                <input
+                  type="range"
+                  min="0.5"
+                  max="10.0"
+                  step="0.1"
+                  value={sharpening.radius}
+                  onChange={(e) => handleSharpeningRadiusChange(parseFloat(e.target.value))}
+                  className="quality-slider"
+                  aria-label="Sharpening radius"
+                />
+                <div className="slider-labels">
+                  <span>Fine detail</span>
+                  <span>Broad structure</span>
+                </div>
+
+                <div className="option-label-row">
+                  <label className="option-label">Threshold</label>
+                  <span className="option-value">{(sharpening.threshold * 100).toFixed(1)}%</span>
+                </div>
+                <input
+                  type="range"
+                  min="0"
+                  max="0.3"
+                  step="0.005"
+                  value={sharpening.threshold}
+                  onChange={(e) => handleSharpeningThresholdChange(parseFloat(e.target.value))}
+                  className="quality-slider"
+                  aria-label="Sharpening threshold"
+                />
+                <div className="slider-labels">
+                  <span>Sharpen everything</span>
+                  <span>Skip smooth areas</span>
+                </div>
+              </>
+            )}
+          </div>
         </div>
 
         {/* Per-channel adjustments */}

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -562,6 +562,11 @@ export function GuidedCreate() {
 
       setChannelPayloads(channels);
 
+      const effectiveSharpening =
+        activePreset.sharpening && activePreset.sharpening.amount > 0
+          ? activePreset.sharpening
+          : undefined;
+
       if (isAuthenticated) {
         // Authenticated: use async job queue with SignalR progress
         const { jobId } = await exportNChannelCompositeAsync(
@@ -572,7 +577,9 @@ export function GuidedCreate() {
           COMPOSITE_OUTPUT.height,
           activePreset.overall,
           activePreset.backgroundNeutralization,
-          featherStrengthRef.current
+          featherStrengthRef.current,
+          undefined,
+          effectiveSharpening
         );
 
         const sub = subscribeToJobProgress(
@@ -607,6 +614,7 @@ export function GuidedCreate() {
         const blob = await generateNChannelComposite({
           channels,
           overall: activePreset.overall,
+          sharpening: effectiveSharpening,
           backgroundNeutralization: activePreset.backgroundNeutralization,
           featherStrength: featherStrengthRef.current,
           ...COMPOSITE_OUTPUT,
@@ -631,6 +639,11 @@ export function GuidedCreate() {
     setIsExporting(true);
     setExportError(null);
 
+    const effectiveSharpening =
+      activePreset.sharpening && activePreset.sharpening.amount > 0
+        ? activePreset.sharpening
+        : undefined;
+
     try {
       if (isAuthenticated) {
         // Authenticated: use async job queue
@@ -642,7 +655,9 @@ export function GuidedCreate() {
           COMPOSITE_OUTPUT.height,
           overall,
           activePreset.backgroundNeutralization,
-          featherStrength
+          featherStrength,
+          undefined,
+          effectiveSharpening
         );
 
         const sub = subscribeToJobProgress(
@@ -675,6 +690,7 @@ export function GuidedCreate() {
         const blob = await generateNChannelComposite({
           channels,
           overall,
+          sharpening: effectiveSharpening,
           backgroundNeutralization: activePreset.backgroundNeutralization,
           featherStrength,
           ...COMPOSITE_OUTPUT,
@@ -782,6 +798,11 @@ export function GuidedCreate() {
       cropZoom: result.cropZoom,
     };
 
+    const effectiveSharpening =
+      activePreset.sharpening && activePreset.sharpening.amount > 0
+        ? activePreset.sharpening
+        : undefined;
+
     try {
       if (isAuthenticated) {
         const { jobId } = await exportNChannelCompositeAsync(
@@ -793,7 +814,8 @@ export function GuidedCreate() {
           activePreset.overall,
           activePreset.backgroundNeutralization,
           featherStrengthRef.current,
-          framing
+          framing,
+          effectiveSharpening
         );
 
         const sub = subscribeToJobProgress(
@@ -829,7 +851,8 @@ export function GuidedCreate() {
           undefined,
           activePreset.backgroundNeutralization,
           featherStrengthRef.current,
-          framing
+          framing,
+          effectiveSharpening
         );
         downloadComposite(blob, generateFilename(result.format));
         setIsExporting(false);

--- a/frontend/jwst-frontend/src/services/compositeService.test.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.test.ts
@@ -121,6 +121,24 @@ describe('compositeService', () => {
         expect.any(Object)
       );
     });
+
+    it('should pass sharpening through into the request body', async () => {
+      vi.mocked(apiClient.postBlob).mockResolvedValue(new Blob());
+
+      await generateNChannelPreview([], 800, undefined, undefined, undefined, undefined, {
+        radius: 1.5,
+        amount: 0.6,
+        threshold: 0.01,
+      });
+
+      expect(apiClient.postBlob).toHaveBeenCalledWith(
+        '/api/composite/generate-nchannel',
+        expect.objectContaining({
+          sharpening: { radius: 1.5, amount: 0.6, threshold: 0.01 },
+        }),
+        expect.any(Object)
+      );
+    });
   });
 
   describe('exportNChannelComposite', () => {
@@ -157,6 +175,32 @@ describe('compositeService', () => {
         expect.any(Object)
       );
     });
+
+    it('should pass sharpening through into the export request body', async () => {
+      vi.mocked(apiClient.postBlob).mockResolvedValue(new Blob());
+
+      await exportNChannelComposite(
+        [],
+        'png',
+        100,
+        1000,
+        1000,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { radius: 2.0, amount: 1.2, threshold: 0.0 }
+      );
+
+      expect(apiClient.postBlob).toHaveBeenCalledWith(
+        '/api/composite/generate-nchannel',
+        expect.objectContaining({
+          sharpening: { radius: 2.0, amount: 1.2, threshold: 0.0 },
+        }),
+        expect.any(Object)
+      );
+    });
   });
 
   describe('exportNChannelCompositeAsync', () => {
@@ -184,6 +228,30 @@ describe('compositeService', () => {
       await expect(
         exportNChannelCompositeAsync([] as never, 'png', 100, 800, 800)
       ).rejects.toThrow();
+    });
+
+    it('should pass sharpening through into the async export request body', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ jobId: 'job-777' });
+
+      await exportNChannelCompositeAsync(
+        [] as never,
+        'jpeg',
+        92,
+        2000,
+        2000,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { radius: 1.0, amount: 0.4, threshold: 0.005 }
+      );
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/composite/export-nchannel',
+        expect.objectContaining({
+          sharpening: { radius: 1.0, amount: 0.4, threshold: 0.005 },
+        })
+      );
     });
   });
 

--- a/frontend/jwst-frontend/src/services/compositeService.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.ts
@@ -10,6 +10,7 @@ import {
   OverallAdjustments,
   NChannelCompositeRequest,
   NChannelConfigPayload,
+  SharpeningConfig,
 } from '../types/CompositeTypes';
 
 /**
@@ -42,11 +43,13 @@ export async function generateNChannelPreview(
   overall?: OverallAdjustments,
   abortSignal?: AbortSignal,
   backgroundNeutralization?: boolean,
-  featherStrength?: number
+  featherStrength?: number,
+  sharpening?: SharpeningConfig
 ): Promise<Blob> {
   const request: NChannelCompositeRequest = {
     channels,
     overall,
+    sharpening,
     backgroundNeutralization,
     featherStrength,
     outputFormat: 'jpeg',
@@ -86,11 +89,13 @@ export async function exportNChannelComposite(
     cropCenterX?: number;
     cropCenterY?: number;
     cropZoom?: number;
-  }
+  },
+  sharpening?: SharpeningConfig
 ): Promise<Blob> {
   const request: NChannelCompositeRequest = {
     channels,
     overall,
+    sharpening,
     backgroundNeutralization,
     featherStrength,
     rotationDegrees: framing?.rotationDegrees,
@@ -133,11 +138,13 @@ export async function exportNChannelCompositeAsync(
     cropCenterX?: number;
     cropCenterY?: number;
     cropZoom?: number;
-  }
+  },
+  sharpening?: SharpeningConfig
 ): Promise<{ jobId: string }> {
   const request: NChannelCompositeRequest = {
     channels,
     overall,
+    sharpening,
     backgroundNeutralization,
     featherStrength,
     rotationDegrees: framing?.rotationDegrees,

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -30,7 +30,7 @@ export type OverallAdjustments = BaseStretchParams;
  * When {@link SharpeningConfig.amount} is 0 the feature is a no-op.
  */
 export interface SharpeningConfig {
-  /** Gaussian blur sigma in pixels (0.1-10.0) */
+  /** Gaussian blur sigma in pixels (0.5-10.0) */
   radius: number;
   /** Sharpening strength (0=disabled, 1=typical, up to 3) */
   amount: number;

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -24,6 +24,27 @@ export interface ChannelStretchParams extends BaseStretchParams {
 export type OverallAdjustments = BaseStretchParams;
 
 /**
+ * Unsharp masking applied to the final RGB composite.
+ *
+ * Sharpening is luminance-based (not per-channel) to preserve color balance.
+ * When {@link SharpeningConfig.amount} is 0 the feature is a no-op.
+ */
+export interface SharpeningConfig {
+  /** Gaussian blur sigma in pixels (0.1-10.0) */
+  radius: number;
+  /** Sharpening strength (0=disabled, 1=typical, up to 3) */
+  amount: number;
+  /** Minimum luminance delta to sharpen (0-1) — protects noise floor */
+  threshold: number;
+}
+
+export const DEFAULT_SHARPENING: SharpeningConfig = {
+  radius: 1.5,
+  amount: 0.0,
+  threshold: 0.0,
+};
+
+/**
  * Export options for the final composite
  */
 export interface ExportOptions {
@@ -78,6 +99,7 @@ export interface NChannelConfigPayload {
 export interface NChannelCompositeRequest {
   channels: NChannelConfigPayload[];
   overall?: OverallAdjustments;
+  sharpening?: SharpeningConfig;
   backgroundNeutralization?: boolean;
   featherStrength?: number;
   rotationDegrees?: number;
@@ -148,6 +170,7 @@ export interface CompositePreset {
   instrumentOverrides?: Record<string, ChannelStretchParams>;
   overall: OverallAdjustments;
   backgroundNeutralization: boolean;
+  sharpening?: SharpeningConfig;
 }
 
 /**
@@ -249,6 +272,11 @@ export const COMPOSITE_PRESETS: CompositePreset[] = [
       asinhA: 0.1,
     },
     backgroundNeutralization: true,
+    sharpening: {
+      radius: 1.5,
+      amount: 0.6,
+      threshold: 0.01,
+    },
   },
   {
     id: 'high-contrast',

--- a/processing-engine/app/composite/models.py
+++ b/processing-engine/app/composite/models.py
@@ -55,6 +55,37 @@ class OverallAdjustments(BaseModel):
     )
 
 
+class SharpeningConfig(BaseModel):
+    """Unsharp masking parameters applied to the final RGB composite.
+
+    Sharpening is applied in luminance space (ITU-R BT.709) — the delta
+    between the original and Gaussian-blurred luminance is added back to
+    each channel. This preserves color balance and avoids chroma noise.
+
+    Disabled when ``amount`` is 0 (the default) so existing composites are
+    byte-identical unless a caller opts in.
+    """
+
+    radius: float = Field(
+        default=1.5,
+        ge=0.5,
+        le=10.0,
+        description="Gaussian blur sigma in pixels (0.5-10.0)",
+    )
+    amount: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=3.0,
+        description="Sharpening strength (0=disabled, 1=typical, up to 3 for aggressive)",
+    )
+    threshold: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Minimum luminance delta to sharpen (0-1). Protects noise floor.",
+    )
+
+
 # --- N-Channel Composite Models (B3.1) ---
 
 
@@ -111,6 +142,10 @@ class NChannelCompositeRequest(BaseModel):
     )
     overall: OverallAdjustments | None = Field(
         default=None, description="Optional global post-stack levels and stretch adjustments"
+    )
+    sharpening: SharpeningConfig | None = Field(
+        default=None,
+        description="Optional unsharp masking applied to the final RGB composite",
     )
     background_neutralization: bool = Field(
         default=True,

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -37,6 +37,7 @@ from app.processing.enhancement import (
     sqrt_stretch,
     zscale_stretch,
 )
+from app.processing.filters import astropy_gaussian_filter
 from app.storage.helpers import resolve_fits_path
 
 from .auto_stretch import auto_stretch_params
@@ -54,6 +55,7 @@ from .models import (
     NChannelCompositeRequest,
     NChannelConfig,
     OverallAdjustments,
+    SharpeningConfig,
 )
 from .quality import compute_quality_metrics
 
@@ -379,6 +381,85 @@ def apply_overall_adjustments(rgb_array: np.ndarray, overall: OverallAdjustments
         adjusted = np.power(np.clip(adjusted, 0, 1), 1.0 / overall.gamma)
 
     return np.clip(adjusted, 0, 1)
+
+
+def apply_sharpening(
+    rgb_array: np.ndarray,
+    config: SharpeningConfig,
+    coverage_mask: np.ndarray | None = None,
+) -> np.ndarray:
+    """
+    Apply unsharp masking to an RGB composite using luma-weighted detail.
+
+    Computes Rec.709 luma (0.2126/0.7152/0.0722) on the gamma-encoded sRGB
+    RGB array, blurs it with a Gaussian kernel, and applies the
+    ``amount * (orig - blurred)`` delta back to every channel. These are the
+    linear-space BT.709 coefficients applied to gamma-encoded data — a
+    widely-used approximation (Photoshop, GIMP) that preserves color
+    balance and avoids the chroma noise that per-R/G/B sharpening causes.
+
+    Pixels whose absolute luma delta falls below ``threshold`` are left
+    untouched, which protects the noise floor from being sharpened along
+    with real detail. When ``coverage_mask`` is supplied, pixels outside
+    the reprojection footprint are left untouched so sharpening halos
+    don't bleed past the image border — dark-sky pixels *inside* the
+    footprint (which can legitimately be (0,0,0) after background
+    neutralization + stretch) still receive the sharpening delta.
+
+    Args:
+        rgb_array: RGB array [H, W, 3] in [0, 1].
+        config: Sharpening parameters (radius, amount, threshold).
+        coverage_mask: Optional 2D bool array marking in-footprint pixels.
+            If ``None``, falls back to "any channel > 0", which is safe for
+            single-instrument composites without background neutralization
+            but less accurate for the typical pipeline path.
+
+    Returns:
+        Sharpened RGB array [H, W, 3] clipped to [0, 1]. If ``amount`` is 0,
+        returns the input unchanged.
+    """
+    if config.amount <= 0.0:
+        return rgb_array
+
+    logger.debug(
+        f"Applying unsharp mask: radius={config.radius}, "
+        f"amount={config.amount}, threshold={config.threshold}"
+    )
+
+    # Rec.709 luma on gamma-encoded sRGB — the common unsharp-mask approximation.
+    luminance = 0.2126 * rgb_array[..., 0] + 0.7152 * rgb_array[..., 1] + 0.0722 * rgb_array[..., 2]
+
+    blurred = astropy_gaussian_filter(luminance, sigma=config.radius)
+    delta = luminance - blurred
+
+    if config.threshold > 0.0:
+        # Zero out sub-threshold deltas so noise isn't amplified.
+        delta[np.abs(delta) < config.threshold] = 0.0
+
+    if coverage_mask is None:
+        coverage_mask = np.any(rgb_array > 0.0, axis=-1)
+    delta = delta * coverage_mask
+
+    sharpened = rgb_array + config.amount * delta[..., np.newaxis]
+    return np.clip(sharpened, 0.0, 1.0)
+
+
+def _build_coverage_mask(reprojected: dict[str, np.ndarray]) -> np.ndarray:
+    """Union of per-channel coverage masks from raw reprojected data.
+
+    A pixel is considered covered if any channel has a non-zero raw value
+    at that location. Reprojection fills no-coverage pixels with exactly
+    zero, so this distinguishes in-footprint dark-sky pixels (which may
+    also be zero after background neutralization) from true no-coverage
+    borders because at least one channel's raw data is non-zero in the
+    former case.
+    """
+    mask: np.ndarray | None = None
+    for data in reprojected.values():
+        ch_mask = data != 0
+        mask = ch_mask if mask is None else (mask | ch_mask)
+    assert mask is not None, "reprojected must contain at least one channel"
+    return mask
 
 
 def neutralize_raw_backgrounds(
@@ -1094,4 +1175,8 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
 
     mapped = _stretch_and_map_channels(request, stretch_input, instruments)
     rgb = _combine_to_rgb(mapped, reprojected, request, feather, instruments)
+    if request.sharpening is not None and request.sharpening.amount > 0.0:
+        rgb = apply_sharpening(
+            rgb, request.sharpening, coverage_mask=_build_coverage_mask(reprojected)
+        )
     return _encode_and_respond(rgb, request, auto_feathered, feather)

--- a/processing-engine/tests/test_nchannel_composite.py
+++ b/processing-engine/tests/test_nchannel_composite.py
@@ -15,15 +15,22 @@ from PIL import Image
 
 from app.composite.cache import CompositeCache
 from app.composite.color_mapping import blend_luminance, hsl_to_rgb, rgb_to_hsl
-from app.composite.models import ChannelColor, NChannelCompositeRequest, NChannelConfig
+from app.composite.models import (
+    ChannelColor,
+    NChannelCompositeRequest,
+    NChannelConfig,
+    SharpeningConfig,
+)
 from app.composite.routes import (
     StretchResult,
+    _build_coverage_mask,
     _combine_to_rgb,
     _detect_channel_instruments,
     _encode_and_respond,
     _render_debug_masks_response,
     _resolve_feather_strength,
     _stretch_and_map_channels,
+    apply_sharpening,
     resolve_channel_color,
 )
 
@@ -481,6 +488,37 @@ class TestGenerateNChannelEndpoint:
             },
         )
         assert response.status_code == 200
+
+    def test_with_sharpening_enabled(self, client, mock_pipeline):
+        """Sharpening config flows through the endpoint and returns a valid image."""
+        shape = (50, 50)
+        data = _make_test_data(shape)
+        mock_pipeline.return_value = ({"ch0": data}, shape)
+
+        response = client.post(
+            "/composite/generate-nchannel",
+            json={
+                "channels": [{"file_paths": ["test.fits"], "color": {"hue": 0.0}}],
+                "sharpening": {"radius": 1.5, "amount": 0.8, "threshold": 0.01},
+                "width": 100,
+                "height": 100,
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+
+    def test_sharpening_out_of_range_returns_422(self, client):
+        """Amount > 3 is rejected by pydantic validation (no pipeline mock needed)."""
+        response = client.post(
+            "/composite/generate-nchannel",
+            json={
+                "channels": [{"file_paths": ["test.fits"], "color": {"hue": 0.0}}],
+                "sharpening": {"amount": 5.0},
+                "width": 100,
+                "height": 100,
+            },
+        )
+        assert response.status_code == 422
 
     def test_background_neutralization_disabled(self, client, mock_pipeline):
         shape = (50, 50)
@@ -1154,3 +1192,129 @@ class TestRenderDebugMasksResponse:
         response = _render_debug_masks_response(request, reprojected, ["NIRCAM", "NIRCAM"], 0.0)
 
         assert "x-debug-warning" not in response.headers
+
+
+class TestApplySharpening:
+    """Tests for the apply_sharpening helper (luminance-preserving unsharp mask)."""
+
+    @staticmethod
+    def _high_freq_energy(rgb: np.ndarray) -> float:
+        """Rough high-frequency measure — mean abs of the Laplacian of luminance."""
+        lum = 0.2126 * rgb[..., 0] + 0.7152 * rgb[..., 1] + 0.0722 * rgb[..., 2]
+        laplacian = (
+            4 * lum[1:-1, 1:-1] - lum[:-2, 1:-1] - lum[2:, 1:-1] - lum[1:-1, :-2] - lum[1:-1, 2:]
+        )
+        return float(np.mean(np.abs(laplacian)))
+
+    @staticmethod
+    def _synthetic_rgb(seed: int = 7) -> np.ndarray:
+        """Deterministic noisy RGB with a central high-contrast disc."""
+        rng = np.random.default_rng(seed)
+        h, w = 64, 64
+        rgb = rng.uniform(0.2, 0.4, size=(h, w, 3)).astype(np.float64)
+        yy, xx = np.mgrid[:h, :w]
+        disc = ((yy - h / 2) ** 2 + (xx - w / 2) ** 2) < (h / 6) ** 2
+        rgb[disc] = 0.85
+        return rgb
+
+    def test_amount_zero_is_identity(self):
+        """amount=0 returns the input byte-for-byte."""
+        rgb = self._synthetic_rgb()
+        config = SharpeningConfig(radius=2.0, amount=0.0, threshold=0.0)
+
+        result = apply_sharpening(rgb, config)
+
+        np.testing.assert_array_equal(result, rgb)
+
+    def test_positive_amount_increases_high_freq(self):
+        """Non-zero amount measurably increases high-frequency energy."""
+        rgb = self._synthetic_rgb()
+        config = SharpeningConfig(radius=1.5, amount=1.0, threshold=0.0)
+
+        result = apply_sharpening(rgb, config)
+
+        assert self._high_freq_energy(result) > self._high_freq_energy(rgb)
+
+    def test_output_clipped_to_unit_range(self):
+        """Sharpened output stays within [0, 1] even at high amount."""
+        rgb = self._synthetic_rgb()
+        config = SharpeningConfig(radius=1.0, amount=3.0, threshold=0.0)
+
+        result = apply_sharpening(rgb, config)
+
+        assert result.min() >= 0.0
+        assert result.max() <= 1.0
+
+    def test_threshold_suppresses_small_deltas(self):
+        """A high threshold prevents noise-level deltas from being amplified."""
+        rgb = self._synthetic_rgb()
+        # Flat regions have tiny luminance deltas — threshold >= 1 kills them all.
+        config_strict = SharpeningConfig(radius=2.0, amount=1.0, threshold=1.0)
+        config_open = SharpeningConfig(radius=2.0, amount=1.0, threshold=0.0)
+
+        strict = apply_sharpening(rgb, config_strict)
+        open_ = apply_sharpening(rgb, config_open)
+
+        # Threshold=1.0 clamps everything → output identical to input.
+        np.testing.assert_array_equal(strict, rgb)
+        assert not np.array_equal(open_, rgb)
+
+    def test_preserves_zero_coverage_pixels(self):
+        """Pixels outside the coverage footprint stay at zero after sharpening."""
+        rgb = self._synthetic_rgb()
+        rgb[:10, :, :] = 0.0  # Simulated no-coverage border
+        coverage = np.ones(rgb.shape[:2], dtype=bool)
+        coverage[:10, :] = False
+        config = SharpeningConfig(radius=1.5, amount=1.0, threshold=0.0)
+
+        result = apply_sharpening(rgb, config, coverage_mask=coverage)
+
+        assert np.all(result[:10, :, :] == 0.0)
+
+    def test_coverage_mask_respected_when_supplied(self):
+        """apply_sharpening uses the explicit coverage_mask rather than
+        inferring one from rgb_array. Regression guard: the previous
+        implementation derived coverage from ``rgb_array > 0``, which
+        treated in-footprint (0,0,0) pixels as no-coverage and produced
+        a discontinuous sharpening mask at dark-sky boundaries."""
+        rgb = self._synthetic_rgb()
+        # Mask out a band inside the bright disc so the supplied mask
+        # differs from any `rgb > 0` heuristic — the rgb values there
+        # are non-zero so the old heuristic would have kept them.
+        coverage = np.ones(rgb.shape[:2], dtype=bool)
+        coverage[30:34, 30:34] = False
+        config = SharpeningConfig(radius=1.5, amount=1.0, threshold=0.0)
+
+        result = apply_sharpening(rgb, config, coverage_mask=coverage)
+        # The masked band's delta was zeroed — output equals input there.
+        np.testing.assert_array_equal(result[30:34, 30:34], rgb[30:34, 30:34])
+        # A pixel *outside* the masked band still receives the sharpening delta.
+        assert not np.array_equal(result[0, 0], rgb[0, 0])
+
+    def test_build_coverage_mask_unions_channels(self):
+        """_build_coverage_mask ORs per-channel coverage — any channel
+        non-zero at a pixel marks it covered."""
+        ch_a = np.zeros((4, 4))
+        ch_a[0, 0] = 1.0
+        ch_b = np.zeros((4, 4))
+        ch_b[0, 1] = 1.0
+        ch_c = np.zeros((4, 4))
+
+        mask = _build_coverage_mask({"a": ch_a, "b": ch_b, "c": ch_c})
+
+        assert mask[0, 0]
+        assert mask[0, 1]
+        assert not mask[1, 0]
+        assert not mask[3, 3]
+
+    def test_preserves_color_balance_on_gray(self):
+        """Sharpening gray input (R=G=B) keeps R=G=B — luminance-based, not per-channel."""
+        rng = np.random.default_rng(11)
+        gray = rng.uniform(0.2, 0.8, size=(64, 64)).astype(np.float64)
+        rgb = np.stack([gray, gray, gray], axis=-1)
+        config = SharpeningConfig(radius=1.5, amount=1.5, threshold=0.0)
+
+        result = apply_sharpening(rgb, config)
+
+        np.testing.assert_allclose(result[..., 0], result[..., 1])
+        np.testing.assert_allclose(result[..., 1], result[..., 2])

--- a/processing-engine/tests/test_nchannel_composite.py
+++ b/processing-engine/tests/test_nchannel_composite.py
@@ -507,6 +507,41 @@ class TestGenerateNChannelEndpoint:
         assert response.status_code == 200
         assert response.headers["content-type"] == "image/png"
 
+    def test_sharpening_end_to_end_multi_channel(self, client, mock_pipeline):
+        """Multi-channel + background_neutralization + sharpening runs the full
+        orchestrator path: `_build_coverage_mask` unions multiple channels and
+        feeds the result to `apply_sharpening`."""
+        shape = (50, 50)
+        rng = np.random.default_rng(123)
+        # Three distinct channels so the coverage mask is a meaningful union.
+        mock_pipeline.return_value = (
+            {
+                "ch0": rng.normal(1000, 100, shape).astype(np.float64),
+                "ch1": rng.normal(1000, 100, shape).astype(np.float64),
+                "ch2": rng.normal(1000, 100, shape).astype(np.float64),
+            },
+            shape,
+        )
+
+        response = client.post(
+            "/composite/generate-nchannel",
+            json={
+                "channels": [
+                    {"file_paths": ["r.fits"], "color": {"hue": 0.0}, "label": "R"},
+                    {"file_paths": ["g.fits"], "color": {"hue": 120.0}, "label": "G"},
+                    {"file_paths": ["b.fits"], "color": {"hue": 240.0}, "label": "B"},
+                ],
+                "background_neutralization": True,
+                "sharpening": {"radius": 2.0, "amount": 1.0, "threshold": 0.0},
+                "width": 100,
+                "height": 100,
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+        img = Image.open(io.BytesIO(response.content))
+        assert img.size == (100, 100)
+
     def test_sharpening_out_of_range_returns_422(self, client):
         """Amount > 3 is rejected by pydantic validation (no pipeline mock needed)."""
         response = client.post(


### PR DESCRIPTION
Closes #683

## Summary

Wires the existing `filters.unsharp_mask` math into the N-channel composite pipeline so users can actually apply sharpening to their composites, and surfaces the controls in the CompositePreviewStep UI. NASA/ESA press images always include sharpening — this was probably the biggest visual-quality gap in the current pipeline.

## Why

`processing-engine/app/processing/filters.py` already had a working `unsharp_mask()` function with its own test coverage, but it wasn't called from anywhere in the composite pipeline. Closing the gap is a cheap quality win identified in spike #680 and a direct follow-up.

The approach is luminance-based (not per-R/G/B) to match PixInsight / NASA press-image workflows: sharpening in chrominance amplifies color noise, while sharpening the luma channel alone preserves color balance and avoids halos in the color domain.

## Changes Made

### Processing engine (`processing-engine/`)
- New `SharpeningConfig` Pydantic model (`radius` 0.5–10, `amount` 0–3, `threshold` 0–1), added as an optional field on `NChannelCompositeRequest`.
- New `apply_sharpening()` and `_build_coverage_mask()` helpers in `composite/routes.py`. Sharpening is applied on the final RGB array after `_combine_to_rgb` and before `_encode_and_respond`, guarded by `amount > 0`.
- Luma computed with Rec.709 coefficients on gamma-encoded sRGB (the Photoshop/GIMP approximation), blurred with `astropy_gaussian_filter` for NaN safety, then `amount * (orig - blurred)` added to every channel.
- Coverage mask is built from the raw `reprojected` dict, not inferred from `rgb > 0`, so dark-sky pixels *inside* the footprint (legitimately `(0,0,0)` after background neutralization) still receive the sharpening delta.

### Backend (`backend/`)
- New `SharpeningConfigDto` + internal `ProcessingSharpeningConfig` pair in `CompositeModels.cs` matching the snake_case Python contract.
- `CompositeService.cs` maps the DTO into the outgoing JSON payload via a new `CreateProcessingSharpening` helper.
- `Range` attributes align with the Pydantic constraints so validation is symmetric on both layers.

### Frontend (`frontend/jwst-frontend/`)
- New `SharpeningConfig` TypeScript type + `DEFAULT_SHARPENING` (all zeros) in `CompositeTypes.ts`, threaded through `NChannelCompositeRequest`.
- `compositeService.ts` accepts optional `sharpening` on `generateNChannelPreview`, `exportNChannelComposite`, and `exportNChannelCompositeAsync`.
- `CompositePreviewStep.tsx` adds sharpening state + sliders (amount / radius / threshold) inside the Overall Levels & Stretch panel. Radius + threshold only appear when amount > 0 to reduce clutter. `handleOverallReset` clears sharpening too.
- `GuidedCreate.tsx` threads `preset.sharpening` through all four composite call sites (initial processing, adjustment regeneration, export) so the guided flow matches the wizard flow.
- NASA Press preset now enables subtle sharpening (`amount=0.6, radius=1.5, threshold=0.01`).

### Tests
- **Python (11 new)**: `TestApplySharpening` with 8 unit tests (amount=0 identity, high-frequency energy increase, unit-range clipping, threshold behavior, explicit `coverage_mask` respect, `_build_coverage_mask` union, gray-input color-balance preservation, default-coverage fallback) + 3 endpoint integration tests (single-channel sharpening round-trip, multi-channel end-to-end covering `_build_coverage_mask → apply_sharpening`, and `amount=5` validation 422).
- **.NET (2 new)**: `CompositeServiceTests` serialization round-trip — asserts outgoing JSON uses snake_case keys when sharpening is set, and that null sharpening serializes as `null`.
- **Frontend (3 new)**: `compositeService.test.ts` sharpening round-trip for `generateNChannelPreview`, `exportNChannelComposite`, and `exportNChannelCompositeAsync`.
- All existing composite tests still pass: 76 Python, 1030 .NET, 940 frontend.

## Test Plan

- [x] `docker compose up -d --build` (processing-engine + backend rebuilt locally)
- [x] Python tests: `docker exec jwst-processing python -m pytest tests/test_nchannel_composite.py -q` — 75 passed
- [x] .NET tests: `dotnet test backend/JwstDataAnalysis.API.Tests/JwstDataAnalysis.API.Tests.csproj --nologo` — 1028 passed
- [x] Frontend typecheck: `docker exec jwst-frontend npx tsc --noEmit` — clean exit
- [x] Frontend unit tests: `docker exec jwst-frontend npx vitest run` — 937 passed
- [x] OpenAPI schemas: `SharpeningConfig` visible in both Swagger (`http://localhost:5001/swagger`) and processing-engine docs (`http://localhost:8000/openapi.json`)
- [ ] Manual UI smoke test:
  1. Open `/composite`, pick 3+ JWST filters, proceed to the Preview step
  2. Confirm the "Sharpening (Unsharp Mask)" section sits inside the Overall Levels & Stretch panel with a single Amount slider at 0
  3. Drag the Amount slider — preview regenerates (debounced) and Radius + Threshold sliders appear
  4. Click the "NASA Press" preset and verify Amount jumps to 0.6 and the preview refreshes
  5. Click Reset and confirm sharpening returns to 0
  6. Toggle sharpening off → on → off and verify the at-0 output is visually indistinguishable from the unsharpened preview

## Documentation Checklist
- [x] No documentation updates needed
- [ ] `docs/key-files.md` (new files/services)
- [ ] `docs/standards/backend-development.md` (new endpoints/controllers)
- [ ] `docs/quick-reference.md` (new API endpoints)
- [ ] `docs/architecture/` (new services/architectural changes)
- [ ] `docs/development-plan.md` (milestone/phase changes)

No doc updates — the new endpoint parameter is additive, the existing `/composite/generate-nchannel` route and `/api/composite/generate-nchannel` backend shape are unchanged, and the Swagger/OpenAPI schemas auto-update from the DTOs.

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low-medium. Feature is gated behind `sharpening.amount > 0`; the default (and the request shape used by all existing callers) is `None`, which short-circuits in the orchestrator and produces byte-identical output. No changes to caching, reprojection, stretch, encoding, or the quality metrics headers. Math operates on an already-clipped `[0, 1]` RGB array and re-clips after. The non-trivial piece is the new `_build_coverage_mask` which unions per-channel coverage — regression test `test_coverage_mask_respected_when_supplied` pins the expected behavior.
- Rollback: Single revert — all changes are on feature branch `feature/683-composite-unsharp-mask` and land in one commit. Revert restores the previous pipeline behavior with no data migrations to unwind.
