### PR TITLE
fix: enable gentle sharpening in Auto composite preset

### DIFF
--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -206,6 +206,15 @@ export const COMPOSITE_PRESETS: CompositePreset[] = [
       asinhA: 0.1,
     },
     backgroundNeutralization: true,
+    // Gentle unsharp mask by default — counteracts the resolution-blur
+    // step the pipeline applies to coarser-resolution channels in
+    // mixed-instrument (NIRCam + MIRI) composites. Less aggressive than
+    // the NASA Press preset (0.6) so the "Auto" character stays balanced.
+    sharpening: {
+      radius: 1.5,
+      amount: 0.4,
+      threshold: 0.01,
+    },
   },
   {
     id: 'natural',


### PR DESCRIPTION
Closes #680 (partially — first visible quality win from the spike)

## Summary

Enable a gentle unsharp mask in the Auto composite preset so new composites get the benefit of the sharpening pipeline merged in #1129 by default.

## Why

#1129 wired unsharp masking into the composite pipeline end-to-end and turned it on for the NASA Press preset. The Auto preset — which is the default for both the wizard and the guided-create flow — was left untouched, so the first composite a new user generates still came out soft.

Observed while smoke-testing the staging build: Cartwheel Galaxy composite (6 channels: 3 NIRCam + 3 MIRI) looked visibly blurry despite the auto-stretch math being correct. The cause isn't the stretch — it's that the pipeline's `_apply_resolution_blur` step gaussian-blurs MIRI channels to match NIRCam's finer pixel scale (by design, to make resolution differences honest rather than upsampling artifacts), and without a compensating sharpening step the final composite inherits all of that softness.

## Changes Made

- `frontend/jwst-frontend/src/types/CompositeTypes.ts` — add `sharpening: { radius: 1.5, amount: 0.4, threshold: 0.01 }` to the Auto preset.

Parameter rationale:
- `amount=0.4` is ~67% of the NASA Press preset (`0.6`) — Auto stays balanced/subtle rather than punchy.
- `radius=1.5px` matches NASA Press, which is the sweet spot for JWST pixel-scale ratios.
- `threshold=0.01` protects the noise floor — important because Auto's auto-stretch often aggressively clips the black point (`bp=0.15` in typical runs).

## Test Plan

- [x] `docker exec jwst-frontend npx tsc --noEmit` — clean
- [x] `docker exec jwst-frontend npx vitest run src/services/compositeService.test.ts src/components/wizard/CompositePreviewStep.test.tsx` — 18 passed
- [x] Pre-commit hook: 940 frontend tests, lint, format, types — all green
- [ ] Manual: regenerate Cartwheel Galaxy composite via /discover → NGC 4038 and confirm the result is perceptibly sharper with no visible halos. Compare against main (pre-#1129 output) to verify the improvement is visible but not over-sharpened.

## Documentation Checklist
- [x] No documentation updates needed
- [ ] `docs/key-files.md` (new files/services)
- [ ] `docs/standards/backend-development.md` (new endpoints/controllers)
- [ ] `docs/quick-reference.md` (new API endpoints)
- [ ] `docs/architecture/` (new services/architectural changes)
- [ ] `docs/development-plan.md` (milestone/phase changes)

The sharpening plumbing is already documented implicitly via the DTOs and the #1129 PR body — this change is a constant tweak to a preset config object.

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Very low. Single preset config value on the frontend. All existing test coverage still passes. The sharpening math itself is locked behind `amount > 0` and was tested end-to-end in #1129. The only user-visible change is that Auto-preset composites now go through the `apply_sharpening` step — the same step that NASA Press has been using since #1129 merged.
- Rollback: Single revert. No schema, DB, or API changes.
