### PR TITLE
ci: harden Dependabot — exempt body checks, group react, set commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,9 @@
 version: 2
+
+# All ecosystems share the same conventional-commit prefix so PR titles
+# satisfy the `Validate PR Standards` workflow without manual editing.
+# (NuGet does NOT default to a conventional prefix — see #1126.)
+
 updates:
   # NPM (Frontend)
   - package-ecosystem: "npm"
@@ -6,9 +11,31 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
     labels:
       - "dependencies"
       - "frontend"
+    # Group related packages so they always move together. Without this,
+    # Dependabot opens separate PRs for `react` and `react-dom`, which breaks
+    # because the two MUST be at the exact same version (otherwise every
+    # test that touches react-dom fails with "Incompatible React versions").
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
 
   # NuGet (.NET Backend)
   - package-ecosystem: "nuget"
@@ -16,6 +43,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
     labels:
       - "dependencies"
       - "backend"
@@ -26,6 +56,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
     labels:
       - "dependencies"
       - "processing-engine"
@@ -35,6 +69,9 @@ updates:
     directory: "/docker"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
     labels:
       - "dependencies"
       - "docker"
@@ -44,6 +81,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
     labels:
       - "dependencies"
       - "ci"

--- a/.github/scripts/validate-pr.js
+++ b/.github/scripts/validate-pr.js
@@ -9,6 +9,13 @@ const prTitle = (process.env.PR_TITLE || "").trim();
 const prBody = (process.env.PR_BODY || "").replace(/\r\n/g, "\n");
 const prHeadRef = (process.env.PR_HEAD_REF || "").trim();
 
+// Dependabot generates PRs whose bodies are package changelogs, not the project
+// PR template. We still validate title prefix and branch prefix below (Dependabot
+// complies with both via .github/dependabot.yml), but skip the body/section
+// checks because they would always fail and would block the auto-merge tier
+// for dependency bumps.
+const isDependabot = /^dependabot\//i.test(prHeadRef);
+
 const errors = [];
 
 const VALID_TITLE_PREFIXES = "feat|fix|docs|refactor|test|chore|perf|ci";
@@ -110,88 +117,98 @@ if (!branchRegex.test(prHeadRef)) {
 }
 
 // --- Required sections ---
-for (const sectionName of REQUIRED_SECTIONS) {
-  if (!extractSection(sectionName)) {
-    errors.push(`Missing required section: \`## ${sectionName}\`.`);
+// Dependabot bodies are package changelogs, not the PR template — skip.
+if (!isDependabot) {
+  for (const sectionName of REQUIRED_SECTIONS) {
+    if (!extractSection(sectionName)) {
+      errors.push(`Missing required section: \`## ${sectionName}\`.`);
+    }
   }
 }
 
-// --- Summary ---
-const summarySection = extractSection("Summary");
-if (summarySection && stripComments(summarySection).length < 12) {
-  errors.push(
-    "`## Summary` must contain a meaningful description of the change.",
-  );
-}
-
-// --- Why (optional section, but validated if present) ---
-const whySection = extractSection("Why");
-if (whySection && stripComments(whySection).length < 12) {
-  errors.push("`## Why` must explain the reason for the change.");
-}
-
-// --- Changes Made ---
-const changesSection = extractSection("Changes Made");
-if (changesSection && !hasMeaningfulBullets(changesSection)) {
-  errors.push(
-    "`## Changes Made` must include at least one non-empty bullet item.",
-  );
-}
-
-// --- Test Plan ---
-const testPlanSection = extractSection("Test Plan");
-if (testPlanSection && checkedCount(testPlanSection) < 1) {
-  errors.push("`## Test Plan` must have at least one checked checkbox.");
-}
-
-// --- Documentation Checklist ---
-const docsChecklistSection = extractSection("Documentation Checklist");
-if (docsChecklistSection && checkedCount(docsChecklistSection) < 1) {
-  errors.push(
-    "`## Documentation Checklist` must have at least one checked checkbox.",
-  );
-}
-
-// --- Tech Debt Impact ---
-const techDebtSection = extractSection("Tech Debt Impact");
-if (techDebtSection) {
-  const total = totalCheckboxCount(techDebtSection);
-  const checked = checkedCount(techDebtSection);
-
-  if (total < 1) {
-    errors.push("`## Tech Debt Impact` must include checkbox items.");
-  } else if (checked < 1) {
-    errors.push("`## Tech Debt Impact` must have at least one checked option.");
-  }
-}
-
-// --- Risk & Rollback ---
-const riskSection = extractSection("Risk & Rollback");
-if (riskSection) {
-  const normalizedRiskSection = stripComments(riskSection);
-  if (!/Risk:\s*\S+/i.test(normalizedRiskSection)) {
+// All checks below this point inspect the PR body. Dependabot generates its
+// own changelog body, so skip them — title and branch prefix are still
+// validated above.
+if (!isDependabot) {
+  // --- Summary ---
+  const summarySection = extractSection("Summary");
+  if (summarySection && stripComments(summarySection).length < 12) {
     errors.push(
-      "`## Risk & Rollback` must include a non-empty `Risk:` value.",
+      "`## Summary` must contain a meaningful description of the change.",
     );
   }
-  if (!/Rollback:\s*\S+/i.test(normalizedRiskSection)) {
+
+  // --- Why (optional section, but validated if present) ---
+  const whySection = extractSection("Why");
+  if (whySection && stripComments(whySection).length < 12) {
+    errors.push("`## Why` must explain the reason for the change.");
+  }
+
+  // --- Changes Made ---
+  const changesSection = extractSection("Changes Made");
+  if (changesSection && !hasMeaningfulBullets(changesSection)) {
     errors.push(
-      "`## Risk & Rollback` must include a non-empty `Rollback:` value.",
+      "`## Changes Made` must include at least one non-empty bullet item.",
     );
   }
-}
 
-// --- Closes #N or "No linked issue" ---
-const strippedBody = stripComments(prBody);
-const hasClosingKeyword =
-  /\b(closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)\s+#\d+/i.test(
-    strippedBody,
-  );
-const hasNoIssueMarker = /no linked issue/i.test(strippedBody);
-if (!hasClosingKeyword && !hasNoIssueMarker) {
-  errors.push(
-    'PR body must include `Closes #N` to link an issue, or `No linked issue` if none applies.',
-  );
+  // --- Test Plan ---
+  const testPlanSection = extractSection("Test Plan");
+  if (testPlanSection && checkedCount(testPlanSection) < 1) {
+    errors.push("`## Test Plan` must have at least one checked checkbox.");
+  }
+
+  // --- Documentation Checklist ---
+  const docsChecklistSection = extractSection("Documentation Checklist");
+  if (docsChecklistSection && checkedCount(docsChecklistSection) < 1) {
+    errors.push(
+      "`## Documentation Checklist` must have at least one checked checkbox.",
+    );
+  }
+
+  // --- Tech Debt Impact ---
+  const techDebtSection = extractSection("Tech Debt Impact");
+  if (techDebtSection) {
+    const total = totalCheckboxCount(techDebtSection);
+    const checked = checkedCount(techDebtSection);
+
+    if (total < 1) {
+      errors.push("`## Tech Debt Impact` must include checkbox items.");
+    } else if (checked < 1) {
+      errors.push(
+        "`## Tech Debt Impact` must have at least one checked option.",
+      );
+    }
+  }
+
+  // --- Risk & Rollback ---
+  const riskSection = extractSection("Risk & Rollback");
+  if (riskSection) {
+    const normalizedRiskSection = stripComments(riskSection);
+    if (!/Risk:\s*\S+/i.test(normalizedRiskSection)) {
+      errors.push(
+        "`## Risk & Rollback` must include a non-empty `Risk:` value.",
+      );
+    }
+    if (!/Rollback:\s*\S+/i.test(normalizedRiskSection)) {
+      errors.push(
+        "`## Risk & Rollback` must include a non-empty `Rollback:` value.",
+      );
+    }
+  }
+
+  // --- Closes #N or "No linked issue" ---
+  const strippedBody = stripComments(prBody);
+  const hasClosingKeyword =
+    /\b(closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)\s+#\d+/i.test(
+      strippedBody,
+    );
+  const hasNoIssueMarker = /no linked issue/i.test(strippedBody);
+  if (!hasClosingKeyword && !hasNoIssueMarker) {
+    errors.push(
+      'PR body must include `Closes #N` to link an issue, or `No linked issue` if none applies.',
+    );
+  }
 }
 
 // --- Report ---
@@ -203,4 +220,10 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log("PR standards validation passed.");
+if (isDependabot) {
+  console.log(
+    "PR standards validation passed (Dependabot mode: title and branch prefix validated, body checks skipped).",
+  );
+} else {
+  console.log("PR standards validation passed.");
+}


### PR DESCRIPTION
## Summary
Two structural Dependabot fixes uncovered while merging the weekly bump batch (#1118–#1127). Together they should make next week's batch flow through with zero manual intervention. **No linked issue** — both fixes were caught in-flight on this session's batch and are tracked here.

## Changes Made
- `.github/scripts/validate-pr.js`: skip body / required-section / Closes #N / checkbox checks when `PR_HEAD_REF` starts with `dependabot/`. Title prefix and branch prefix checks still apply for everyone — Dependabot complies via the new `commit-message` config below.
- `.github/dependabot.yml`: add `commit-message.prefix: "chore(deps)"` (with `prefix-development: "chore(deps-dev)"` where applicable) to every ecosystem (npm, NuGet, pip, docker, github-actions). NuGet does NOT default to a conventional prefix — PR #1126 was caught by the validator because of this.
- `.github/dependabot.yml`: add a `groups:` block under npm grouping `react`/`react-dom`/`@types/react`/`@types/react-dom` (and a couple of other tightly-coupled families: `@typescript-eslint/*`, `vitest`+`@vitest/*`). Caught by #1128, where Dependabot bumped `react` alone and 46 frontend test suites failed with `Incompatible React versions: The "react" and "react-dom" packages must have the exact same version`.

## Why
The weekly Dependabot batch hit two friction points that turned a "merge 11 PRs" auto-merge tier task into a 90-minute incident:

1. Every Dependabot PR failed `Validate PR Standards` because Dependabot bodies are package changelogs, not the project PR template. The validator required `## Summary`, `## Changes Made`, `## Test Plan`, etc. — none of which Dependabot writes. We unblocked this batch by hand-editing all 10 PR bodies; this PR prevents that next week.
2. PR #1128 (react 19.2.4 → 19.2.5) actually broke 46 frontend test suites because Dependabot bumped `react` without bumping `react-dom`. Patch React bumps require both packages to move in lockstep. Replaced by #1134; this PR's grouping rule prevents recurrence.

## Test Plan
- [x] Local: `node .github/scripts/validate-pr.js` with Dependabot env vars (`PR_HEAD_REF=dependabot/...`) — passes with "Dependabot mode" message.
- [x] Local: same script with non-Dependabot env vars and an empty body — still fails with the full list of missing-section errors.
- [x] Local: Dependabot env vars + a non-conventional title — still fails on the title prefix check (the carve-out is body-only, by design).
- [ ] CI: `Validate PR Standards` passes on this PR (non-Dependabot — must use the strict path).
- [ ] Verify next week's Dependabot batch lands cleanly without manual body editing.

## Documentation Checklist
- [x] No documentation changes required (CI infra only).

## Tech Debt Impact
- [x] Reduces tech debt — eliminates a recurring weekly process drag.

## Risk & Rollback
Risk: Low. The validator change is additive (an early-skip for Dependabot branches). The dependabot.yml change only affects how new Dependabot PRs are filed — existing PRs are unaffected. The `groups:` block is the only behavior change Dependabot will see, and worst case it batches more aggressively than ideal (which is reversible).
Rollback: Revert the merge commit on `main`. Existing Dependabot PRs continue to behave as they did before the change.

Closes #1128
