### PR TITLE
fix: security quick wins — password complexity, private-by-default, proxy trust

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Models/ValidationTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Models/ValidationTests.cs
@@ -154,7 +154,7 @@ public class ValidationTests
         var model = new JwstDataModel();
 
         model.Version.Should().Be(1);
-        model.IsPublic.Should().BeTrue();
+        model.IsPublic.Should().BeFalse(); // secure default: private until explicitly shared
         model.IsValidated.Should().BeFalse();
         model.IsArchived.Should().BeFalse();
         model.IsViewable.Should().BeTrue();
@@ -307,6 +307,73 @@ public class ValidationTests
         FileFormats.HDF5.Should().Be("hdf5");
         FileFormats.ASCII.Should().Be("ascii");
         FileFormats.Binary.Should().Be("binary");
+    }
+
+    [Theory]
+    [InlineData("password1!", false)] // no uppercase
+    [InlineData("PASSWORD1!", false)] // no lowercase
+    [InlineData("Password!", false)] // no digit
+    [InlineData("Password1", false)] // no special character
+    [InlineData("Pass1!", false)] // too short
+    [InlineData("Password1!", true)] // valid
+    [InlineData("P@ssw0rd", true)] // valid
+    [InlineData("Str0ng!Pass", true)] // valid
+    public void PasswordPolicy_EnforcesComplexity(string password, bool expected)
+    {
+        PasswordPolicy.IsValid(password).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("password1!")]
+    [InlineData("PASSWORD1!")]
+    [InlineData("Password!")]
+    [InlineData("Password1")]
+    [InlineData("Pass1!")]
+    public void RegisterRequest_WeakPassword_FailsValidation(string password)
+    {
+        var request = new RegisterRequest
+        {
+            Username = "testuser",
+            Email = "test@example.com",
+            Password = password,
+        };
+
+        var results = ValidateModel(request);
+
+        results.Should().Contain(r => r.MemberNames.Contains("Password"));
+    }
+
+    [Theory]
+    [InlineData("Password1!")]
+    [InlineData("P@ssw0rd")]
+    public void RegisterRequest_StrongPassword_PassesValidation(string password)
+    {
+        var request = new RegisterRequest
+        {
+            Username = "testuser",
+            Email = "test@example.com",
+            Password = password,
+        };
+
+        var results = ValidateModel(request);
+
+        results.Where(r => r.MemberNames.Contains("Password")).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("password1!")]
+    [InlineData("Password1")]
+    public void ChangePasswordRequest_WeakPassword_FailsValidation(string password)
+    {
+        var request = new ChangePasswordRequest
+        {
+            CurrentPassword = "OldPass1!",
+            NewPassword = password,
+        };
+
+        var results = ValidateModel(request);
+
+        results.Should().ContainSingle(r => r.MemberNames.Contains("NewPassword"));
     }
 
     private static List<ValidationResult> ValidateModel(object model)

--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -946,6 +946,7 @@ namespace JwstDataAnalysis.API.Controllers
                     ProcessingStatus = ProcessingStatuses.Pending,
                     FileFormat = extension.TrimStart('.'),
                     UserId = GetCurrentUserId(),
+                    IsPublic = request.IsPublic,
 
                     // Basic image metadata if it's an image
                     ImageInfo = (dataType == DataTypes.Image) ? new ImageMetadata { Format = extension.TrimStart('.') } : null,
@@ -2371,5 +2372,7 @@ namespace JwstDataAnalysis.API.Controllers
         public List<string>? Tags { get; set; }
 
         public string? DataType { get; set; }
+
+        public bool IsPublic { get; set; }
     }
 }

--- a/backend/JwstDataAnalysis.API/Models/AuthModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/AuthModels.cs
@@ -2,9 +2,29 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
 
 namespace JwstDataAnalysis.API.Models
 {
+    /// <summary>
+    /// Shared password policy constants.
+    /// </summary>
+    public static partial class PasswordPolicy
+    {
+        /// <summary>
+        /// Regex requiring at least one uppercase, one lowercase, one digit, and one special character.
+        /// </summary>
+        public const string ComplexityPattern = @"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z\d]).{8,}$";
+
+        public const string ComplexityMessage = "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character.";
+
+        public static bool IsValid(string password) =>
+            !string.IsNullOrEmpty(password) && ComplexityRegexGenerated().IsMatch(password);
+
+        [GeneratedRegex(ComplexityPattern)]
+        private static partial Regex ComplexityRegexGenerated();
+    }
+
     /// <summary>
     /// Request model for user login.
     /// </summary>
@@ -35,6 +55,7 @@ namespace JwstDataAnalysis.API.Models
 
         [Required]
         [StringLength(100, MinimumLength = 8)]
+        [RegularExpression(PasswordPolicy.ComplexityPattern, ErrorMessage = PasswordPolicy.ComplexityMessage)]
         public string Password { get; set; } = string.Empty;
 
         [StringLength(100)]
@@ -101,6 +122,7 @@ namespace JwstDataAnalysis.API.Models
 
         [Required]
         [StringLength(100, MinimumLength = 8)]
+        [RegularExpression(PasswordPolicy.ComplexityPattern, ErrorMessage = PasswordPolicy.ComplexityMessage)]
         public string NewPassword { get; set; } = string.Empty;
     }
 }

--- a/backend/JwstDataAnalysis.API/Models/JwstDataModel.cs
+++ b/backend/JwstDataAnalysis.API/Models/JwstDataModel.cs
@@ -116,7 +116,7 @@ namespace JwstDataAnalysis.API.Models
         public string? ValidationError { get; set; }
 
         // Access control and sharing
-        public bool IsPublic { get; set; } = true;
+        public bool IsPublic { get; set; }
 
         public List<string> SharedWith { get; set; } = [];
 

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -22,9 +22,11 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
 
-    // Trust the reverse proxy network (Docker internal network)
-    options.KnownIPNetworks.Clear();
-    options.KnownProxies.Clear();
+    // Only trust RFC 1918 private networks (Docker bridge, compose networks),
+    // not arbitrary X-Forwarded-For headers from the internet
+    options.KnownIPNetworks.Add(new System.Net.IPNetwork(System.Net.IPAddress.Parse("172.16.0.0"), 12));
+    options.KnownIPNetworks.Add(new System.Net.IPNetwork(System.Net.IPAddress.Parse("10.0.0.0"), 8));
+    options.KnownIPNetworks.Add(new System.Net.IPNetwork(System.Net.IPAddress.Parse("192.168.0.0"), 16));
 });
 
 // Add services to the container.

--- a/backend/JwstDataAnalysis.API/Services/AuthService.cs
+++ b/backend/JwstDataAnalysis.API/Services/AuthService.cs
@@ -94,6 +94,12 @@ namespace JwstDataAnalysis.API.Services
                 throw new InvalidOperationException("Email already exists");
             }
 
+            // Enforce password complexity at the service layer (defense in depth)
+            if (!PasswordPolicy.IsValid(request.Password))
+            {
+                throw new ArgumentException(PasswordPolicy.ComplexityMessage, nameof(request));
+            }
+
             // Hash password with bcrypt
             var passwordHash = BCrypt.Net.BCrypt.HashPassword(request.Password, workFactor: 12);
 
@@ -241,6 +247,12 @@ namespace JwstDataAnalysis.API.Services
             {
                 LogPasswordChangeFailedInvalidCurrent(userId);
                 return false;
+            }
+
+            // Enforce password complexity at the service layer (defense in depth)
+            if (!PasswordPolicy.IsValid(newPassword))
+            {
+                throw new ArgumentException(PasswordPolicy.ComplexityMessage, nameof(newPassword));
             }
 
             user.PasswordHash = BCrypt.Net.BCrypt.HashPassword(newPassword, workFactor: 12);

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -40,8 +40,9 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.
 # Seed user credentials (only used when Seeding:Enabled=true AND environment=Development)
 # Usernames/emails are in appsettings.json; only passwords are externalized.
 # Mapped to ASP.NET config via docker-compose.override.yml.
-SEED_ADMIN_PASSWORD=changeme_admin
-SEED_DEMO_PASSWORD=changeme_demo
+# Must meet complexity requirements: uppercase, lowercase, digit, special character
+SEED_ADMIN_PASSWORD=Changeme_Admin1!
+SEED_DEMO_PASSWORD=Changeme_Demo1!
 
 # =============================================================================
 # Frontend Configuration (Vite)

--- a/docs/architecture/security-model.md
+++ b/docs/architecture/security-model.md
@@ -23,11 +23,11 @@ Each `JwstDataRecord` in MongoDB has four fields that determine who can access i
 | Field | Type | Default | Purpose |
 |-------|------|---------|---------|
 | `UserId` | `string?` | `null` | Owner of the record. Set at import/upload time. |
-| `IsPublic` | `bool` | `true` | When true, readable by everyone including anonymous users. |
+| `IsPublic` | `bool` | `false` | When true, readable by everyone including anonymous users. |
 | `SharedWith` | `List<string>` | `[]` | Additional user IDs granted read access to private data. |
 | `IsArchived` | `bool` | `false` | Soft-delete flag. Hidden from default listings but still accessible by ID. |
 
-**Design decision**: `IsPublic` defaults to `true` because JWST data is public domain. Users must explicitly make data private.
+**Design decision**: `IsPublic` defaults to `false` (secure by default). User-uploaded data is private until explicitly shared. MAST-imported data explicitly sets `IsPublic = true` since JWST observations are public domain.
 
 ---
 

--- a/frontend/jwst-frontend/e2e/auth.spec.ts
+++ b/frontend/jwst-frontend/e2e/auth.spec.ts
@@ -154,7 +154,7 @@ test.describe('Authentication', () => {
     test('should register, logout, and login successfully', async ({ page }) => {
       const username = `e2etest_${uniqueId()}`;
       const email = `${username}@example.com`;
-      const password = 'TestPassword123';
+      const password = 'TestPassword123!';
 
       // Step 1: Register
       await page.goto('/register');
@@ -198,7 +198,7 @@ test.describe('Authentication', () => {
     test('should persist authentication across page refresh', async ({ page }) => {
       const username = `e2etest_${uniqueId()}`;
       const email = `${username}@example.com`;
-      const password = 'TestPassword123';
+      const password = 'TestPassword123!';
 
       // Register a new user
       await page.goto('/register');
@@ -224,7 +224,7 @@ test.describe('Authentication', () => {
     test('should display user information in dropdown', async ({ page }) => {
       const username = `e2etest_${uniqueId()}`;
       const email = `${username}@example.com`;
-      const password = 'TestPassword123';
+      const password = 'TestPassword123!';
       const displayName = 'Menu Test User';
       const organization = 'Menu Test Org';
 

--- a/frontend/jwst-frontend/e2e/helpers.ts
+++ b/frontend/jwst-frontend/e2e/helpers.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 /* ------------------------------------------------------------------ */
 
 export const BACKEND_URL = 'http://localhost:5001';
-export const TEST_PASSWORD = 'TestPassword123';
+export const TEST_PASSWORD = 'TestPassword123!';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/frontend/jwst-frontend/e2e/smoke.spec.ts
+++ b/frontend/jwst-frontend/e2e/smoke.spec.ts
@@ -15,8 +15,8 @@ test.describe('Application Smoke Tests', () => {
         await page.goto('/register');
         await page.getByLabel('Username').fill(username);
         await page.getByLabel('Email').fill(`${username}@example.com`);
-        await page.getByLabel('Password', { exact: true }).fill('TestPassword123');
-        await page.getByLabel('Confirm Password').fill('TestPassword123');
+        await page.getByLabel('Password', { exact: true }).fill('TestPassword123!');
+        await page.getByLabel('Confirm Password').fill('TestPassword123!');
         await page.getByRole('button', { name: 'Create Account' }).click();
 
         // Should land on discovery home (/) after registration

--- a/frontend/jwst-frontend/src/pages/AuthPages.css
+++ b/frontend/jwst-frontend/src/pages/AuthPages.css
@@ -109,6 +109,12 @@
   color: var(--text-secondary);
 }
 
+.form-hint {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.4;
+}
+
 .auth-submit {
   background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-primary-hover) 100%);
   border: none;

--- a/frontend/jwst-frontend/src/pages/RegisterPage.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RegisterPage.test.tsx
@@ -31,11 +31,15 @@ const renderRegisterPage = () =>
     </MemoryRouter>
   );
 
+const VALID_PASSWORD = 'Password1!';
+
 const fillValidForm = () => {
   fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'testuser' } });
   fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
-  fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
-  fireEvent.change(screen.getByLabelText('Confirm Password'), { target: { value: 'password123' } });
+  fireEvent.change(screen.getByLabelText('Password'), { target: { value: VALID_PASSWORD } });
+  fireEvent.change(screen.getByLabelText('Confirm Password'), {
+    target: { value: VALID_PASSWORD },
+  });
 };
 
 describe('RegisterPage', () => {
@@ -119,15 +123,19 @@ describe('RegisterPage', () => {
     expect(mockRegister).not.toHaveBeenCalled();
   });
 
-  it('validation: short password (<8 characters)', () => {
+  it('validation: weak password (missing complexity)', () => {
     renderRegisterPage();
 
     fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'testuser' } });
     fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
-    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'short' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
     fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
 
-    expect(screen.getByText('Password must be at least 8 characters')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Password must be at least 8 characters with uppercase, lowercase, number, and special character'
+      )
+    ).toBeInTheDocument();
     expect(mockRegister).not.toHaveBeenCalled();
   });
 
@@ -136,8 +144,10 @@ describe('RegisterPage', () => {
 
     fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'testuser' } });
     fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
-    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
-    fireEvent.change(screen.getByLabelText('Confirm Password'), { target: { value: 'different' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: VALID_PASSWORD } });
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'Different1!' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
 
     expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
@@ -155,7 +165,7 @@ describe('RegisterPage', () => {
       expect(mockRegister).toHaveBeenCalledWith({
         username: 'testuser',
         email: 'test@example.com',
-        password: 'password123',
+        password: VALID_PASSWORD,
         displayName: undefined,
         organization: undefined,
       });

--- a/frontend/jwst-frontend/src/pages/RegisterPage.tsx
+++ b/frontend/jwst-frontend/src/pages/RegisterPage.tsx
@@ -57,8 +57,10 @@ export function RegisterPage() {
       setError('Password is required');
       return;
     }
-    if (password.length < 8) {
-      setError('Password must be at least 8 characters');
+    if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z\d]).{8,}$/.test(password)) {
+      setError(
+        'Password must be at least 8 characters with uppercase, lowercase, number, and special character'
+      );
       return;
     }
     if (password !== confirmPassword) {
@@ -142,10 +144,13 @@ export function RegisterPage() {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="Create a password (min. 8 characters)"
+              placeholder="Create a password"
               autoComplete="new-password"
               disabled={isSubmitting}
             />
+            <span className="form-hint">
+              Min. 8 characters with uppercase, lowercase, number, and special character
+            </span>
           </div>
 
           <div className="form-group">


### PR DESCRIPTION
## Summary

Three security quick wins addressing authentication, data visibility, and proxy trust vulnerabilities — plus client-side password requirements UX.

Closes #453
Closes #455
Closes #744

## Changes Made

### Password complexity (#744)
- Added `PasswordPolicy` static class with shared regex constant and `IsValid()` method
- `[RegularExpression]` attribute on `RegisterRequest.Password` and `ChangePasswordRequest.NewPassword`
- Service-layer validation in `AuthService.RegisterAsync()` and `ChangePasswordAsync()` (defense in depth — catches calls bypassing HTTP model validation)
- Updated seed passwords in `.env.example` to meet new requirements
- 17 new unit tests covering policy enforcement and model validation

### Password requirements hint (frontend)
- Added password requirements hint below the password field on the registration page ("Min. 8 characters with uppercase, lowercase, number, and special character")
- Added client-side complexity validation matching the backend regex — catches invalid passwords before round-tripping to the API
- Updated RegisterPage tests to use compliant passwords and test the new validation message

### Private-by-default (#455)
- Changed `JwstDataModel.IsPublic` default from `true` to `false`
- MAST imports unaffected — they explicitly set `IsPublic = true` (JWST data is public domain)
- Wired up `IsPublic` field in upload endpoint's `FileUploadRequest` (was declared but ignored)
- Updated `security-model.md` to reflect new default and rationale
- Updated existing test assertion to match new default

### Proxy trust (#453)
- Replaced `KnownIPNetworks.Clear(); KnownProxies.Clear();` (trust everything) with explicit RFC 1918 private network ranges (172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16)
- Prevents X-Forwarded-For spoofing from the public internet while trusting Docker/compose networks

## Test Plan

- [x] All 1045 backend tests pass (17 new tests added)
- [x] All 940 frontend tests pass (RegisterPage tests updated for complexity validation)
- [x] Pre-commit hooks pass (build + test + secrets scan)
- [ ] Manual: attempt registration with weak passwords (e.g., `aaaaaaaa`) — should see hint text and get client-side validation error
- [ ] Manual: upload a file — verify it defaults to private unless `IsPublic: true` is sent
- [ ] Manual: verify existing MAST imports still show as public

## Documentation Checklist

- [x] `docs/architecture/security-model.md` — updated IsPublic default and design decision rationale
- [x] `docker/.env.example` — updated seed passwords with complexity comment

## Tech Debt Impact

- [x] Closes 3 security issues (#453, #455, #744)
- [x] No new tech debt introduced
- [x] Frontend password validation now matches backend regex (previously showed generic 400 error)

## Risk & Rollback

**Risk: Low-Medium** — behavioral changes to auth and data visibility:
- New registrations require complex passwords (existing users unaffected)
- New records default to private (existing records unaffected, MAST imports explicitly public)
- Proxy trust narrowed to RFC 1918 (standard Docker networking)

- Rollback: Revert the commits on this branch.
