### PR TITLE
fix: prevent data enumeration via analysis and composite endpoints

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/AnalysisControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/AnalysisControllerTests.cs
@@ -650,6 +650,27 @@ public class AnalysisControllerTests
         result.Should().BeOfType<OkObjectResult>();
     }
 
+    [Fact]
+    public async Task GetRegionStatistics_NotFoundMessages_AreIndistinguishable_ForAnonymous()
+    {
+        SetupAnonymousUser();
+
+        // Path 1: data doesn't exist
+        mockMongoDBService.Setup(s => s.GetAsync("nonexistent")).ReturnsAsync((JwstDataModel?)null);
+        var request1 = new RegionStatisticsRequestDto { DataId = "nonexistent", RegionType = "rectangle" };
+        var result1 = await sut.GetRegionStatistics(request1);
+        var body1 = ((NotFoundObjectResult)result1).Value;
+
+        // Path 2: data exists but is private
+        SetupPrivateData("private-1");
+        var request2 = new RegionStatisticsRequestDto { DataId = "private-1", RegionType = "rectangle" };
+        var result2 = await sut.GetRegionStatistics(request2);
+        var body2 = ((NotFoundObjectResult)result2).Value;
+
+        // Bodies must be indistinguishable to prevent enumeration
+        body1.Should().BeEquivalentTo(body2);
+    }
+
     private void SetupAuthenticatedUser(string userId, bool isAdmin = false)
     {
         var claims = new List<Claim>

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/AnalysisControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/AnalysisControllerTests.cs
@@ -577,6 +577,79 @@ public class AnalysisControllerTests
         statusResult.StatusCode.Should().Be(500);
     }
 
+    // === Anonymous user enumeration prevention tests (#1092) ===
+    [Fact]
+    public async Task GetRegionStatistics_ReturnsNotFound_WhenAnonymousAndNotAccessible()
+    {
+        SetupAnonymousUser();
+        SetupPrivateData("private-1");
+        var request = new RegionStatisticsRequestDto { DataId = "private-1", RegionType = "rectangle" };
+
+        var result = await sut.GetRegionStatistics(request);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task DetectSources_ReturnsNotFound_WhenAnonymousAndNotAccessible()
+    {
+        SetupAnonymousUser();
+        SetupPrivateData("private-1");
+        var request = new SourceDetectionRequestDto { DataId = "private-1" };
+
+        var result = await sut.DetectSources(request);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetTableInfo_ReturnsNotFound_WhenAnonymousAndNotAccessible()
+    {
+        SetupAnonymousUser();
+        SetupPrivateData("private-1");
+
+        var result = await sut.GetTableInfo("private-1");
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetTableData_ReturnsNotFound_WhenAnonymousAndNotAccessible()
+    {
+        SetupAnonymousUser();
+        SetupPrivateData("private-1");
+
+        var result = await sut.GetTableData("private-1");
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetSpectralData_ReturnsNotFound_WhenAnonymousAndNotAccessible()
+    {
+        SetupAnonymousUser();
+        SetupPrivateData("private-1");
+
+        var result = await sut.GetSpectralData("private-1");
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetRegionStatistics_ReturnsOk_WhenAnonymousAndPublicData()
+    {
+        SetupAnonymousUser();
+        var request = new RegionStatisticsRequestDto { DataId = "public-1", RegionType = "rectangle" };
+        mockMongoDBService.Setup(s => s.GetAsync("public-1"))
+            .ReturnsAsync(new JwstDataModel { Id = "public-1", IsPublic = true, FilePath = "test/path.fits" });
+        mockAnalysisService.Setup(s => s.GetRegionStatisticsAsync(request))
+            .ReturnsAsync(new RegionStatisticsResponseDto { Mean = 1.0, PixelCount = 10 });
+
+        var result = await sut.GetRegionStatistics(request);
+
+        result.Should().BeOfType<OkObjectResult>();
+    }
+
     private void SetupAuthenticatedUser(string userId, bool isAdmin = false)
     {
         var claims = new List<Claim>
@@ -596,9 +669,25 @@ public class AnalysisControllerTests
         };
     }
 
+    private void SetupAnonymousUser()
+    {
+        var identity = new ClaimsIdentity(); // No auth type = unauthenticated
+        var principal = new ClaimsPrincipal(identity);
+        sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = principal },
+        };
+    }
+
     private void SetupAccessibleData(string dataId, string ownerId = "test-user")
     {
         mockMongoDBService.Setup(s => s.GetAsync(dataId))
             .ReturnsAsync(new JwstDataModel { Id = dataId, UserId = ownerId, IsPublic = true, FilePath = "test/path.fits" });
+    }
+
+    private void SetupPrivateData(string dataId, string ownerId = "other-user")
+    {
+        mockMongoDBService.Setup(s => s.GetAsync(dataId))
+            .ReturnsAsync(new JwstDataModel { Id = dataId, UserId = ownerId, IsPublic = false });
     }
 }

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/AnalysisControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/AnalysisControllerTests.cs
@@ -671,6 +671,80 @@ public class AnalysisControllerTests
         body1.Should().BeEquivalentTo(body2);
     }
 
+    [Fact]
+    public async Task DetectSources_NotFoundMessages_AreIndistinguishable_ForAnonymous()
+    {
+        SetupAnonymousUser();
+
+        // Path 1: data doesn't exist
+        mockMongoDBService.Setup(s => s.GetAsync("nonexistent")).ReturnsAsync((JwstDataModel?)null);
+        var request1 = new SourceDetectionRequestDto { DataId = "nonexistent" };
+        var result1 = await sut.DetectSources(request1);
+        var body1 = ((NotFoundObjectResult)result1).Value;
+
+        // Path 2: data exists but is private
+        SetupPrivateData("private-1");
+        var request2 = new SourceDetectionRequestDto { DataId = "private-1" };
+        var result2 = await sut.DetectSources(request2);
+        var body2 = ((NotFoundObjectResult)result2).Value;
+
+        body1.Should().BeEquivalentTo(body2);
+    }
+
+    [Fact]
+    public async Task GetTableInfo_NotFoundMessages_AreIndistinguishable_ForAnonymous()
+    {
+        SetupAnonymousUser();
+
+        // Path 1: data doesn't exist
+        mockMongoDBService.Setup(s => s.GetAsync("nonexistent")).ReturnsAsync((JwstDataModel?)null);
+        var result1 = await sut.GetTableInfo("nonexistent");
+        var body1 = ((NotFoundObjectResult)result1).Value;
+
+        // Path 2: data exists but is private
+        SetupPrivateData("private-1");
+        var result2 = await sut.GetTableInfo("private-1");
+        var body2 = ((NotFoundObjectResult)result2).Value;
+
+        body1.Should().BeEquivalentTo(body2);
+    }
+
+    [Fact]
+    public async Task GetTableData_NotFoundMessages_AreIndistinguishable_ForAnonymous()
+    {
+        SetupAnonymousUser();
+
+        // Path 1: data doesn't exist
+        mockMongoDBService.Setup(s => s.GetAsync("nonexistent")).ReturnsAsync((JwstDataModel?)null);
+        var result1 = await sut.GetTableData("nonexistent");
+        var body1 = ((NotFoundObjectResult)result1).Value;
+
+        // Path 2: data exists but is private
+        SetupPrivateData("private-1");
+        var result2 = await sut.GetTableData("private-1");
+        var body2 = ((NotFoundObjectResult)result2).Value;
+
+        body1.Should().BeEquivalentTo(body2);
+    }
+
+    [Fact]
+    public async Task GetSpectralData_NotFoundMessages_AreIndistinguishable_ForAnonymous()
+    {
+        SetupAnonymousUser();
+
+        // Path 1: data doesn't exist
+        mockMongoDBService.Setup(s => s.GetAsync("nonexistent")).ReturnsAsync((JwstDataModel?)null);
+        var result1 = await sut.GetSpectralData("nonexistent");
+        var body1 = ((NotFoundObjectResult)result1).Value;
+
+        // Path 2: data exists but is private
+        SetupPrivateData("private-1");
+        var result2 = await sut.GetSpectralData("private-1");
+        var body2 = ((NotFoundObjectResult)result2).Value;
+
+        body1.Should().BeEquivalentTo(body2);
+    }
+
     private void SetupAuthenticatedUser(string userId, bool isAdmin = false)
     {
         var claims = new List<Claim>

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/CompositeControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/CompositeControllerTests.cs
@@ -382,6 +382,35 @@ public class CompositeControllerTests
     }
 
     /// <summary>
+    /// Tests that NotFound messages are indistinguishable for anonymous users
+    /// to prevent data enumeration via error message inspection.
+    /// </summary>
+    [Fact]
+    public async Task GenerateNChannelComposite_NotFoundMessages_AreIndistinguishable_ForAnonymous()
+    {
+        // Arrange
+        SetupUnauthenticatedUser();
+        var request = CreateValidNChannelRequest();
+
+        // Path 1: data doesn't exist (KeyNotFoundException)
+        mockCompositeService.Setup(s => s.GenerateNChannelCompositeAsync(
+                request, It.IsAny<string?>(), false, false))
+            .ThrowsAsync(new KeyNotFoundException("Data not found"));
+        var result1 = await sut.GenerateNChannelComposite(request);
+        var body1 = ((NotFoundObjectResult)result1).Value;
+
+        // Path 2: data exists but is private (UnauthorizedAccessException)
+        mockCompositeService.Setup(s => s.GenerateNChannelCompositeAsync(
+                request, It.IsAny<string?>(), false, false))
+            .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
+        var result2 = await sut.GenerateNChannelComposite(request);
+        var body2 = ((NotFoundObjectResult)result2).Value;
+
+        // Bodies must be indistinguishable to prevent enumeration
+        body1.Should().BeEquivalentTo(body2);
+    }
+
+    /// <summary>
     /// Tests that GenerateNChannelComposite returns 503 on HttpRequestException.
     /// </summary>
     [Fact]

--- a/backend/JwstDataAnalysis.API/Controllers/AnalysisController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/AnalysisController.cs
@@ -58,7 +58,8 @@ namespace JwstDataAnalysis.API.Controllers
 
                 if (!IsDataAccessible(data))
                 {
-                    return Forbid();
+                    var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+                    return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
                 }
 
                 LogComputingRegionStatistics(request.DataId, request.RegionType);
@@ -117,7 +118,8 @@ namespace JwstDataAnalysis.API.Controllers
 
                 if (!IsDataAccessible(data))
                 {
-                    return Forbid();
+                    var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+                    return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
                 }
 
                 if (request.ThresholdSigma < 1.0 || request.ThresholdSigma > 50.0)
@@ -194,7 +196,8 @@ namespace JwstDataAnalysis.API.Controllers
 
                 if (!IsDataAccessible(data))
                 {
-                    return Forbid();
+                    var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+                    return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
                 }
 
                 LogGettingTableInfo(dataId);
@@ -286,7 +289,8 @@ namespace JwstDataAnalysis.API.Controllers
 
                 if (!IsDataAccessible(data))
                 {
-                    return Forbid();
+                    var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+                    return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
                 }
 
                 LogGettingTableData(dataId, hduIndex);
@@ -352,7 +356,8 @@ namespace JwstDataAnalysis.API.Controllers
 
                 if (!IsDataAccessible(data))
                 {
-                    return Forbid();
+                    var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+                    return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
                 }
 
                 LogGettingSpectralData(dataId, hduIndex);

--- a/backend/JwstDataAnalysis.API/Controllers/AnalysisController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/AnalysisController.cs
@@ -53,7 +53,7 @@ namespace JwstDataAnalysis.API.Controllers
                 var data = await mongoDBService.GetAsync(request.DataId);
                 if (data == null)
                 {
-                    return NotFound(new { error = $"Data with ID {request.DataId} not found" });
+                    return NotFound(new { error = "The requested data was not found." });
                 }
 
                 if (!IsDataAccessible(data))
@@ -113,7 +113,7 @@ namespace JwstDataAnalysis.API.Controllers
                 var data = await mongoDBService.GetAsync(request.DataId);
                 if (data == null)
                 {
-                    return NotFound(new { error = $"Data with ID {request.DataId} not found" });
+                    return NotFound(new { error = "The requested data was not found." });
                 }
 
                 if (!IsDataAccessible(data))
@@ -191,7 +191,7 @@ namespace JwstDataAnalysis.API.Controllers
                 var data = await mongoDBService.GetAsync(dataId);
                 if (data == null)
                 {
-                    return NotFound(new { error = $"Data with ID {dataId} not found" });
+                    return NotFound(new { error = "The requested data was not found." });
                 }
 
                 if (!IsDataAccessible(data))
@@ -284,7 +284,7 @@ namespace JwstDataAnalysis.API.Controllers
                 var data = await mongoDBService.GetAsync(dataId);
                 if (data == null)
                 {
-                    return NotFound(new { error = $"Data with ID {dataId} not found" });
+                    return NotFound(new { error = "The requested data was not found." });
                 }
 
                 if (!IsDataAccessible(data))
@@ -351,7 +351,7 @@ namespace JwstDataAnalysis.API.Controllers
                 var data = await mongoDBService.GetAsync(dataId);
                 if (data == null)
                 {
-                    return NotFound(new { error = $"Data with ID {dataId} not found" });
+                    return NotFound(new { error = "The requested data was not found." });
                 }
 
                 if (!IsDataAccessible(data))

--- a/backend/JwstDataAnalysis.API/Controllers/AnalysisController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/AnalysisController.cs
@@ -328,7 +328,6 @@ namespace JwstDataAnalysis.API.Controllers
         [AllowAnonymous]
         [ProducesResponseType(typeof(SpectralDataResponseDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]

--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
@@ -95,7 +95,7 @@ namespace JwstDataAnalysis.API.Controllers
             {
                 LogInvalidOperation(ex.Message);
                 var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
-                return isAuthenticated ? Forbid() : NotFound(new { error = "Data not found" });
+                return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
             }
             catch (HttpRequestException ex)
             {

--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
@@ -35,7 +35,6 @@ namespace JwstDataAnalysis.API.Controllers
         /// <response code="404">One or more data IDs not found.</response>
         /// <response code="503">Processing engine unavailable.</response>
         [HttpPost("generate-nchannel")]
-        [AllowAnonymous]
         [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
@@ -35,6 +35,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// <response code="404">One or more data IDs not found.</response>
         /// <response code="503">Processing engine unavailable.</response>
         [HttpPost("generate-nchannel")]
+        [AllowAnonymous]
         [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/backend/JwstDataAnalysis.API/Controllers/MosaicController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MosaicController.cs
@@ -100,7 +100,7 @@ namespace JwstDataAnalysis.API.Controllers
             }
             catch (UnauthorizedAccessException)
             {
-                return isAuthenticated ? Forbid() : NotFound(new { error = "Data not found" });
+                return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
             }
             catch (KeyNotFoundException ex)
             {
@@ -259,7 +259,7 @@ namespace JwstDataAnalysis.API.Controllers
             }
             catch (UnauthorizedAccessException)
             {
-                return isAuthenticated ? Forbid() : NotFound(new { error = "Data not found" });
+                return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
             }
             catch (KeyNotFoundException ex)
             {

--- a/docs/architecture/security-model.md
+++ b/docs/architecture/security-model.md
@@ -184,11 +184,11 @@ All controllers inherit from `ApiControllerBase`, which provides identity extrac
 
 | Endpoint | Auth | Internal Check | Notes |
 |----------|------|----------------|-------|
-| `POST /region-statistics` | Open | + IsDataAccessible | Returns 403 if inaccessible |
-| `POST /detect-sources` | Open | + IsDataAccessible | |
-| `GET /table-info` | Open | + IsDataAccessible | |
-| `GET /table-data` | Open | + IsDataAccessible | |
-| `GET /spectral-data` | Open | + IsDataAccessible | |
+| `POST /region-statistics` | Open | + IsDataAccessible | Anon: 404 if inaccessible (anti-enumeration); Auth: 403 |
+| `POST /detect-sources` | Open | + IsDataAccessible | Anon: 404 if inaccessible (anti-enumeration); Auth: 403 |
+| `GET /table-info` | Open | + IsDataAccessible | Anon: 404 if inaccessible (anti-enumeration); Auth: 403 |
+| `GET /table-data` | Open | + IsDataAccessible | Anon: 404 if inaccessible (anti-enumeration); Auth: 403 |
+| `GET /spectral-data` | Open | + IsDataAccessible | Anon: 404 if inaccessible (anti-enumeration); Auth: 403 |
 
 ### MosaicController (`/api/mosaic`)
 

--- a/frontend/jwst-frontend/e2e/auth.spec.ts
+++ b/frontend/jwst-frontend/e2e/auth.spec.ts
@@ -117,8 +117,8 @@ test.describe('Authentication', () => {
 
       await page.getByLabel('Username').fill('testuser');
       await page.getByLabel('Email').fill('test@example.com');
-      await page.getByLabel('Password', { exact: true }).fill('password123');
-      await page.getByLabel('Confirm Password').fill('differentpassword');
+      await page.getByLabel('Password', { exact: true }).fill('ValidPass1!');
+      await page.getByLabel('Confirm Password').fill('DifferentPass1!');
       await page.getByRole('button', { name: 'Create Account' }).click();
 
       await expect(page.getByText('Passwords do not match')).toBeVisible();


### PR DESCRIPTION
## Summary

Fixes data enumeration vulnerability where anonymous callers could distinguish between "exists but forbidden" (403) and "doesn't exist" (404) on Analysis, Composite, and Mosaic endpoints, allowing them to probe valid dataset IDs without credentials.

Closes #1092

## Changes Made

### AnalysisController (5 endpoints)
- Changed all `return Forbid()` responses when `IsDataAccessible()` fails to: `isAuthenticated ? Forbid() : NotFound(...)`
- Standardized all NotFound messages to identical generic text (`"The requested data was not found."`) across both "data null" and "not accessible" paths — prevents enumeration via error message body inspection
- Authenticated users still get 403; anonymous users now get 404 (indistinguishable from "doesn't exist")
- Kept `[AllowAnonymous]` on all endpoints — guest access to public data analysis preserved
- Removed stale `[ProducesResponseType(Status403Forbidden)]` from SpectralData (other 4 endpoints don't declare it)

### CompositeController
- `generate-nchannel`: Kept `[AllowAnonymous]` (frontend GuidedCreate uses it for anonymous composite previews). Standardized the `UnauthorizedAccessException` NotFound message to match `KeyNotFoundException` message
- `export-nchannel`: already requires auth (unchanged)

### MosaicController
- Standardized `UnauthorizedAccessException` NotFound messages on `GenerateMosaic` and `GetFootprint` to match the `KeyNotFoundException` messages (`"The requested data was not found."`) — prevents enumeration via message body inspection

### Documentation
- Updated `docs/architecture/security-model.md` AnalysisController section to reflect new behavior: "Anon: 404 if inaccessible (anti-enumeration); Auth: 403"

### Tests (12 new)
- 5 anonymous-user enumeration prevention tests (one per Analysis endpoint)
- 1 anonymous+public regression guard (verify guest access still works)
- 5 indistinguishability tests asserting NotFound response bodies are identical between "data null" and "data inaccessible" paths (one per AnalysisController endpoint)
- 1 indistinguishability test for CompositeController

### E2E Fix
- Fixed pre-existing E2E failure: `auth.spec.ts` "mismatched passwords" test used `password123` which fails the complexity regex before reaching the mismatch check — updated to complexity-valid passwords

### Filed
- #1175: pre-existing bug where `JwstDataController.Search` excludes `SharedWith` data from results (found during review)

## Test Plan

- [x] All 1057 backend tests pass (12 new tests)
- [x] Pre-commit hooks pass (build + test + secrets scan)
- [x] Self-review: 3 rounds on original + 1 round addressing review findings
- [x] E2E mismatch-password test fixed (was pre-existing failure on main)
- [ ] Manual: as guest, run analysis on public MAST data — should return 200
- [ ] Manual: as guest, probe a private data ID via analysis endpoint — should return 404 with same body as missing data
- [ ] Manual: as authenticated user, access someone else's private data — should return 403
- [ ] Manual: anonymous composite preview still works in GuidedCreate wizard

## Documentation Checklist

- [x] `docs/architecture/security-model.md` updated — AnalysisController section reflects new 404/403 behavior

## Tech Debt Impact

- [x] Closes #1092 (high-priority security issue)
- [x] Filed #1173 for the same vulnerability in MosaicController (now also fixed in this PR)
- [x] Filed #1175 for pre-existing SharedWith bug in Search endpoint
- [x] No new tech debt introduced

## Risk & Rollback

**Risk: Low** — behavioral change to HTTP response codes only:
- Anonymous users: 403 → 404 for private data (security improvement, no UX change)
- Error messages standardized to prevent enumeration via body inspection
- No data model, storage, or API contract changes

Rollback: revert the commits on this branch.
