### PR TITLE
fix: guard normalize_array() against empty and all-NaN arrays

### DIFF
--- a/processing-engine/app/processing/utils.py
+++ b/processing-engine/app/processing/utils.py
@@ -85,8 +85,11 @@ def normalize_array(data: np.ndarray) -> np.ndarray | None:
     """
     Normalize array to 0-1 range.
     """
-    if data is None:
+    if data is None or data.size == 0:
         return None
+
+    if not np.any(np.isfinite(data)):
+        return np.zeros_like(data)
 
     min_val = np.nanmin(data)
     max_val = np.nanmax(data)

--- a/processing-engine/tests/test_utils.py
+++ b/processing-engine/tests/test_utils.py
@@ -227,3 +227,13 @@ class TestNormalizeArray:
         result = normalize_array(data)
         assert np.nanmin(result) == pytest.approx(0.0)
         assert np.nanmax(result) == pytest.approx(1.0)
+
+    def test_empty_array_returns_none(self):
+        data = np.array([])
+        result = normalize_array(data)
+        assert result is None
+
+    def test_all_nan_array_returns_zeros(self):
+        data = np.array([[np.nan, np.nan], [np.nan, np.nan]])
+        result = normalize_array(data)
+        np.testing.assert_array_equal(result, np.zeros_like(data))


### PR DESCRIPTION
## Summary

Guard `normalize_array()` against empty and all-NaN arrays that cause crashes or silent corruption in the processing pipeline.

Closes #1156

## Changes Made

- **`processing-engine/app/processing/utils.py`**: Added two guards before `np.nanmin`/`np.nanmax`:
  - `data.size == 0` → returns `None` (prevents `ValueError` on empty arrays)
  - `not np.any(np.isfinite(data))` → returns `np.zeros_like(data)` (handles all-NaN arrays that would silently produce NaN output due to NaN ≠ NaN comparison)
- **`processing-engine/tests/test_utils.py`**: Added two test cases covering both edge cases

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_utils.py -v` — all 19 tests pass
- [x] `test_empty_array_returns_none` — empty `np.array([])` returns `None`
- [x] `test_all_nan_array_returns_zeros` — 2×2 all-NaN array returns zeros
- [x] Existing normalization tests still pass (no regression)

## Documentation Checklist

- [x] No doc changes needed — internal utility function, no API surface change

## Tech Debt Impact

- [x] Eliminates a crash path in the FITS processing pipeline for corrupt/empty HDUs
- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — two additive guard clauses before existing logic, no behavioral change for valid inputs.
Rollback: Revert the commit.
