### PR TITLE
fix: validate max_pixels and array dimensions in downscale_for_composite

### DIFF
--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -198,7 +198,14 @@ def downscale_for_composite(
 
     Returns:
         Tuple of (possibly downscaled data, adjusted WCS)
+
+    Raises:
+        ValueError: If max_pixels <= 0 or data is not 2D.
     """
+    if max_pixels <= 0:
+        raise ValueError(f"max_pixels must be positive, got {max_pixels}")
+    if data.ndim != 2:
+        raise ValueError(f"Expected 2D array, got shape {data.shape}")
     total_pixels = data.shape[0] * data.shape[1]
     if total_pixels <= max_pixels:
         return data, wcs

--- a/processing-engine/tests/test_composite_downscale.py
+++ b/processing-engine/tests/test_composite_downscale.py
@@ -10,6 +10,7 @@ full quality.
 """
 
 import numpy as np
+import pytest
 from astropy.wcs import WCS
 from scipy.ndimage import gaussian_filter
 
@@ -40,6 +41,34 @@ def _make_wcs(naxis1: int = 100, naxis2: int = 100, cdelt: float = -0.001) -> WC
         "CDELT2": abs(cdelt),
     }
     return WCS(header, naxis=2)
+
+
+class TestDownscaleInputValidation:
+    """Tests for input validation in downscale_for_composite."""
+
+    def test_zero_max_pixels_raises_value_error(self):
+        """max_pixels=0 raises ValueError (would cause ZeroDivisionError)."""
+        data = np.ones((100, 100), dtype=np.float64)
+        wcs = _make_wcs(100, 100)
+
+        with pytest.raises(ValueError, match="max_pixels must be positive"):
+            downscale_for_composite(data, wcs, max_pixels=0)
+
+    def test_negative_max_pixels_raises_value_error(self):
+        """max_pixels=-1 raises ValueError."""
+        data = np.ones((100, 100), dtype=np.float64)
+        wcs = _make_wcs(100, 100)
+
+        with pytest.raises(ValueError, match="max_pixels must be positive"):
+            downscale_for_composite(data, wcs, max_pixels=-1)
+
+    def test_3d_array_raises_value_error(self):
+        """3D array raises ValueError (only 2D images are supported)."""
+        data = np.ones((100, 100, 3), dtype=np.float64)
+        wcs = _make_wcs(100, 100)
+
+        with pytest.raises(ValueError, match="Expected 2D array"):
+            downscale_for_composite(data, wcs, max_pixels=20_000)
 
 
 class TestDownscaleMaxPixels:


### PR DESCRIPTION
Closes #1147

## Summary
Add input validation guards to `downscale_for_composite()` to prevent `ZeroDivisionError` when `max_pixels <= 0` and wrong behavior on non-2D arrays.

## Changes Made
- **`processing-engine/app/composite/routes.py`**: Added two validation checks at the top of `downscale_for_composite()` — rejects `max_pixels <= 0` and `ndim != 2` with descriptive `ValueError` messages. Updated docstring with `Raises` section.
- **`processing-engine/tests/test_composite_downscale.py`**: Added `TestDownscaleInputValidation` class with three tests: `max_pixels=0`, `max_pixels=-1`, and 3D array input.

## Test Plan
- [x] Pre-commit hooks pass (ruff lint, ruff format, secrets scan)
- [x] New validation tests pass
- [x] Existing downscale tests unaffected

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — additive validation at function entry point. No changes to existing logic paths.
Rollback: Revert the single commit.
