### PR TITLE
fix: handle race condition in partial file cleanup

### DIFF
--- a/processing-engine/app/mast/download_state_manager.py
+++ b/processing-engine/app/mast/download_state_manager.py
@@ -362,14 +362,21 @@ class DownloadStateManager:
                     if filename.endswith(".part"):
                         file_path = os.path.join(obs_path, filename)
 
-                        # Check if file is very old (more than retention period)
-                        mtime = datetime.fromtimestamp(os.path.getmtime(file_path))
-                        cutoff = datetime.now(UTC) - timedelta(days=STATE_RETENTION_DAYS)
+                        # Check if file is very old (more than retention period).
+                        # Wrap in try/except: the file may be deleted by another
+                        # process between listdir() and getmtime()/remove().
+                        try:
+                            mtime = datetime.fromtimestamp(os.path.getmtime(file_path), tz=UTC)
+                            cutoff = datetime.now(UTC) - timedelta(days=STATE_RETENTION_DAYS)
 
-                        if mtime < cutoff:
-                            os.remove(file_path)
-                            removed += 1
-                            logger.debug(f"Removed orphaned partial file: {file_path}")
+                            if mtime < cutoff:
+                                os.remove(file_path)
+                                removed += 1
+                                logger.debug(f"Removed orphaned partial file: {file_path}")
+                        except OSError:
+                            logger.debug(
+                                f"Partial file already removed by another process: {file_path}"
+                            )
 
         except OSError as e:
             logger.error(f"Failed to cleanup orphaned partial files: {e}")

--- a/processing-engine/tests/test_download_state_manager.py
+++ b/processing-engine/tests/test_download_state_manager.py
@@ -1,0 +1,104 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Tests for DownloadStateManager, focusing on race-condition handling
+in cleanup_orphaned_partial_files.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.mast.download_state_manager import DownloadStateManager
+
+
+@pytest.fixture
+def state_manager(tmp_path):
+    """Create a DownloadStateManager with a temporary base directory."""
+    return DownloadStateManager(str(tmp_path))
+
+
+@pytest.fixture
+def obs_dir_with_part_file(tmp_path):
+    """Create an observation directory containing a .part file."""
+    obs_path = tmp_path / "obs_test"
+    obs_path.mkdir()
+    part_file = obs_path / "data.fits.part"
+    part_file.write_bytes(b"\x00" * 100)
+    return part_file
+
+
+class TestCleanupOrphanedPartialFilesRaceCondition:
+    """Tests for the race condition where a .part file disappears between
+    listdir() and getmtime()/remove()."""
+
+    @pytest.mark.usefixtures("obs_dir_with_part_file")
+    def test_file_deleted_before_getmtime(self, state_manager):
+        """If the .part file is removed between listdir and getmtime,
+        the cleanup should not crash (bug #1020)."""
+        with patch("app.mast.download_state_manager.os.path.getmtime") as mock_getmtime:
+            mock_getmtime.side_effect = FileNotFoundError("[Errno 2] No such file or directory")
+            # Should not raise
+            removed = state_manager.cleanup_orphaned_partial_files()
+
+        assert removed == 0
+
+    @pytest.mark.usefixtures("obs_dir_with_part_file")
+    def test_file_deleted_before_remove(self, state_manager):
+        """If the .part file is removed between getmtime and os.remove,
+        the cleanup should not crash."""
+        # Return an old mtime so the code tries to remove the file
+        old_timestamp = 0.0  # epoch — definitely older than retention period
+
+        with patch("app.mast.download_state_manager.os.remove") as mock_remove:
+            mock_remove.side_effect = FileNotFoundError("[Errno 2] No such file or directory")
+            with patch(
+                "app.mast.download_state_manager.os.path.getmtime",
+                return_value=old_timestamp,
+            ):
+                removed = state_manager.cleanup_orphaned_partial_files()
+
+        # The removal failed, so count should be 0
+        assert removed == 0
+
+    @pytest.mark.usefixtures("obs_dir_with_part_file")
+    def test_permission_error_handled(self, state_manager):
+        """OSError subclasses like PermissionError should also be caught."""
+        with patch("app.mast.download_state_manager.os.path.getmtime") as mock_getmtime:
+            mock_getmtime.side_effect = PermissionError("[Errno 13] Permission denied")
+            removed = state_manager.cleanup_orphaned_partial_files()
+
+        assert removed == 0
+
+    def test_normal_old_file_still_removed(self, state_manager, obs_dir_with_part_file):
+        """Verify that old .part files are still correctly removed
+        when no race condition occurs."""
+        old_timestamp = 0.0  # epoch
+
+        with patch(
+            "app.mast.download_state_manager.os.path.getmtime",
+            return_value=old_timestamp,
+        ):
+            removed = state_manager.cleanup_orphaned_partial_files()
+
+        assert removed == 1
+        assert not obs_dir_with_part_file.exists()
+
+    def test_recent_file_not_removed(self, state_manager, obs_dir_with_part_file):
+        """Verify that recent .part files are left alone."""
+        # Don't mock getmtime — the file was just created, so it's recent
+        removed = state_manager.cleanup_orphaned_partial_files()
+
+        assert removed == 0
+        assert obs_dir_with_part_file.exists()
+
+    @pytest.mark.usefixtures("obs_dir_with_part_file")
+    def test_debug_log_on_race_condition(self, state_manager):
+        """Verify that a debug log message is emitted on race condition."""
+        with patch("app.mast.download_state_manager.os.path.getmtime") as mock_getmtime:
+            mock_getmtime.side_effect = FileNotFoundError("[Errno 2] No such file or directory")
+            with patch("app.mast.download_state_manager.logger") as mock_logger:
+                state_manager.cleanup_orphaned_partial_files()
+                mock_logger.debug.assert_called_once()
+                assert "already removed" in mock_logger.debug.call_args[0][0]


### PR DESCRIPTION
Closes #1020

## Summary
Fix race condition in `cleanup_orphaned_partial_files()` where `os.path.getmtime()` crashes if a `.part` file is deleted by another process between `os.listdir()` and the `getmtime()` call. Also fixes a pre-existing naive vs aware datetime comparison bug.

## Why
A TOCTOU race condition causes an unhandled `OSError` that crashes the cleanup routine when another process deletes a `.part` file between listing and accessing it.

## Changes Made
- **`processing-engine/app/mast/download_state_manager.py`**: Wrap the mtime check + `os.remove()` in `try/except OSError` with a `logger.debug()` message. Add `tz=UTC` to `datetime.fromtimestamp()` to fix naive/aware datetime comparison.
- **`processing-engine/tests/test_download_state_manager.py`** (new): 6 tests covering race condition scenarios (FileNotFoundError on getmtime, FileNotFoundError on remove, PermissionError), normal cleanup behavior, and debug log emission.

## Test Plan
- [x] `docker exec jwst-processing python -m pytest tests/test_download_state_manager.py -v` — all 6 tests pass
- [x] `ruff check` and `ruff format` pass on both files
- [ ] CI gate passes

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: Low — isolated try/except around filesystem operations in a cleanup routine. No behavioral change for the happy path.
- Rollback: Revert the single commit.
