### PR TITLE
fix: include SharedWith data in search results

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/JwstDataControllerTests.cs
@@ -493,6 +493,72 @@ public class JwstDataControllerTests
     }
 
     [Fact]
+    public async Task Search_IncludesSharedWithData_ForAuthenticatedUser()
+    {
+        // Arrange — three items: one public, one owned, one shared with the current user
+        var request = TestDataFixtures.CreateSearchRequest(searchTerm: "test");
+        var publicItem = new DataResponse
+        {
+            Id = "public-1",
+            FileName = "public.fits",
+            DataType = "image",
+            IsPublic = true,
+            UserId = "other-user",
+            SharedWith = [],
+        };
+        var ownedItem = new DataResponse
+        {
+            Id = "owned-1",
+            FileName = "owned.fits",
+            DataType = "image",
+            IsPublic = false,
+            UserId = TestUserId,
+            SharedWith = [],
+        };
+        var sharedItem = new DataResponse
+        {
+            Id = "shared-1",
+            FileName = "shared.fits",
+            DataType = "image",
+            IsPublic = false,
+            UserId = "other-user",
+            SharedWith = [TestUserId],
+        };
+        var inaccessibleItem = new DataResponse
+        {
+            Id = "private-1",
+            FileName = "private.fits",
+            DataType = "image",
+            IsPublic = false,
+            UserId = "other-user",
+            SharedWith = ["someone-else"],
+        };
+
+        var searchResponse = new SearchResponse
+        {
+            Data = [publicItem, ownedItem, sharedItem, inaccessibleItem],
+            TotalCount = 4,
+            Page = 1,
+            PageSize = 20,
+            TotalPages = 1,
+            Facets = [],
+        };
+        mockMongoService.Setup(s => s.SearchWithFacetsAsync(It.IsAny<SearchRequest>()))
+            .ReturnsAsync(searchResponse);
+
+        // Act
+        var result = await sut.Search(request);
+
+        // Assert — the inaccessible item should be filtered out
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<SearchResponse>().Subject;
+        response.Data.Should().HaveCount(3);
+        response.Data.Select(d => d.Id).Should().Contain("shared-1", "shared items should be included in search results");
+        response.Data.Select(d => d.Id).Should().NotContain("private-1", "inaccessible items should be excluded from search results");
+        response.TotalCount.Should().Be(3);
+    }
+
+    [Fact]
     public async Task GetStatistics_ReturnsDataStatistics()
     {
         // Arrange

--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -1275,7 +1275,9 @@ namespace JwstDataAnalysis.API.Controllers
                 {
                     var userId = GetCurrentUserId();
                     response.Data = [.. response.Data.Where(d =>
-                        d.IsPublic || d.UserId == userId)];
+                        d.IsPublic
+                        || d.UserId == userId
+                        || (userId != null && d.SharedWith.Contains(userId)))];
                     response.TotalCount = response.Data.Count;
                     response.TotalPages = (int)Math.Ceiling((double)response.TotalCount / request.PageSize);
                 }


### PR DESCRIPTION
## Summary

Add `SharedWith` check to the Search endpoint's access filter, so data shared with a user appears in their search results.

Closes #1175

## Changes Made

- **`JwstDataController.cs`** (Search method): Added `|| (userId != null && d.SharedWith.Contains(userId))` to the filter predicate, matching the existing pattern in `DataManagementController.FilterAccessibleResponses`
- **`JwstDataControllerTests.cs`**: Added `Search_IncludesSharedWithData_ForAuthenticatedUser` test with four scenarios (public, owned, shared, inaccessible)

## Test Plan

- [x] All 1058 backend tests pass (1 new test)
- [x] Pre-commit hooks pass (build + test + secrets scan)
- [x] Verified filter predicate matches DataManagementController pattern
- [ ] Manual: share data with another user, verify it appears in their search results

## Documentation Checklist

- [x] No doc changes needed — internal filter logic, no API surface change

## Tech Debt Impact

- [x] Fixes access inconsistency between Search and FilterAccessibleResponses
- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — additive filter predicate, only adds results that were incorrectly excluded. SharedWith check is gated on `userId != null` so anonymous users are unaffected.
Rollback: Revert the commit.
