### PR TITLE
fix: validate coordinate bounds in region mask creation

### DIFF
--- a/processing-engine/app/analysis/routes.py
+++ b/processing-engine/app/analysis/routes.py
@@ -42,8 +42,14 @@ def create_rectangle_mask(
     """Create a boolean mask for a rectangular region."""
     if width <= 0 or height <= 0:
         raise ValueError(f"width and height must be positive, got width={width}, height={height}")
-    mask = np.zeros(shape, dtype=bool)
     img_h, img_w = shape
+    # Validate that the rectangle overlaps the image
+    if x >= img_w or y >= img_h or x + width <= 0 or y + height <= 0:
+        raise ValueError(
+            f"rectangle region (x={x}, y={y}, w={width}, h={height}) "
+            f"does not overlap image bounds (0..{img_w}, 0..{img_h})"
+        )
+    mask = np.zeros(shape, dtype=bool)
     # Clamp to image bounds
     x0 = max(0, x)
     y0 = max(0, y)
@@ -58,7 +64,15 @@ def create_ellipse_mask(
     shape: tuple[int, int], cx: float, cy: float, rx: float, ry: float
 ) -> np.ndarray:
     """Create a boolean mask for an elliptical region."""
+    if rx <= 0 or ry <= 0:
+        raise ValueError(f"radii must be positive, got rx={rx}, ry={ry}")
     img_h, img_w = shape
+    # Validate that the ellipse bounding box overlaps the image
+    if cx - rx >= img_w or cy - ry >= img_h or cx + rx <= 0 or cy + ry <= 0:
+        raise ValueError(
+            f"ellipse region (cx={cx}, cy={cy}, rx={rx}, ry={ry}) "
+            f"does not overlap image bounds (0..{img_w}, 0..{img_h})"
+        )
     yy, xx = np.ogrid[:img_h, :img_w]
     # Ellipse equation: ((x-cx)/rx)^2 + ((y-cy)/ry)^2 <= 1
     dist = ((xx - cx) / rx) ** 2 + ((yy - cy) / ry) ** 2

--- a/processing-engine/tests/test_region_statistics.py
+++ b/processing-engine/tests/test_region_statistics.py
@@ -24,9 +24,9 @@ class TestRectangleMask:
         # Should be clamped: x 40-50, y 40-50 = 10x10
         assert np.sum(mask) == 10 * 10
 
-    def test_rectangle_fully_outside(self):
-        mask = create_rectangle_mask((50, 50), 60, 60, 10, 10)
-        assert np.sum(mask) == 0
+    def test_rectangle_fully_outside_raises(self):
+        with pytest.raises(ValueError, match="does not overlap image bounds"):
+            create_rectangle_mask((50, 50), 60, 60, 10, 10)
 
     def test_rectangle_at_origin(self):
         mask = create_rectangle_mask((100, 100), 0, 0, 5, 5)
@@ -46,6 +46,24 @@ class TestRectangleMask:
     def test_zero_width_raises(self):
         with pytest.raises(ValueError, match="width and height must be positive"):
             create_rectangle_mask((100, 100), 10, 10, 0, 10)
+
+    def test_x_beyond_image_raises(self):
+        with pytest.raises(ValueError, match="does not overlap image bounds"):
+            create_rectangle_mask((100, 100), 100, 10, 10, 10)
+
+    def test_y_beyond_image_raises(self):
+        with pytest.raises(ValueError, match="does not overlap image bounds"):
+            create_rectangle_mask((100, 100), 10, 100, 10, 10)
+
+    def test_completely_outside_negative_raises(self):
+        with pytest.raises(ValueError, match="does not overlap image bounds"):
+            create_rectangle_mask((100, 100), -20, -20, 10, 10)
+
+    def test_partially_negative_overlapping_ok(self):
+        """Rectangle starting at negative coords but overlapping the image is valid."""
+        mask = create_rectangle_mask((100, 100), -5, -5, 15, 15)
+        # Clamped to (0,0)-(10,10) = 10x10 = 100 pixels
+        assert np.sum(mask) == 10 * 10
 
 
 class TestEllipseMask:
@@ -68,6 +86,35 @@ class TestEllipseMask:
         # Should be roughly quarter of full circle
         full_mask = create_ellipse_mask((100, 100), 50.0, 50.0, 10.0, 10.0)
         assert np.sum(mask) < np.sum(full_mask)
+
+    def test_zero_rx_raises(self):
+        with pytest.raises(ValueError, match="radii must be positive"):
+            create_ellipse_mask((100, 100), 50.0, 50.0, 0.0, 10.0)
+
+    def test_zero_ry_raises(self):
+        with pytest.raises(ValueError, match="radii must be positive"):
+            create_ellipse_mask((100, 100), 50.0, 50.0, 10.0, 0.0)
+
+    def test_negative_rx_raises(self):
+        with pytest.raises(ValueError, match="radii must be positive"):
+            create_ellipse_mask((100, 100), 50.0, 50.0, -5.0, 10.0)
+
+    def test_negative_ry_raises(self):
+        with pytest.raises(ValueError, match="radii must be positive"):
+            create_ellipse_mask((100, 100), 50.0, 50.0, 10.0, -5.0)
+
+    def test_center_beyond_image_raises(self):
+        with pytest.raises(ValueError, match="does not overlap image bounds"):
+            create_ellipse_mask((100, 100), 200.0, 200.0, 5.0, 5.0)
+
+    def test_completely_outside_negative_raises(self):
+        with pytest.raises(ValueError, match="does not overlap image bounds"):
+            create_ellipse_mask((100, 100), -20.0, -20.0, 5.0, 5.0)
+
+    def test_near_edge_overlapping_ok(self):
+        """Ellipse centered outside but with radius overlapping the image is valid."""
+        mask = create_ellipse_mask((100, 100), -3.0, 50.0, 10.0, 10.0)
+        assert np.sum(mask) > 0
 
 
 class TestRegionStatisticsEndpoint:


### PR DESCRIPTION
Closes #1137

## Summary
Add coordinate bounds validation to `create_rectangle_mask()` and `create_ellipse_mask()` in the processing engine, preventing degenerate masks from zero/negative ellipse radii and fully-out-of-bounds regions.

## Changes Made
- **`create_rectangle_mask()`**: Added validation that the rectangle overlaps the image bounds (rejects regions entirely outside the image with a descriptive `ValueError`)
- **`create_ellipse_mask()`**: Added validation that `rx` and `ry` are positive, and that the ellipse bounding box overlaps the image bounds
- Updated existing `test_rectangle_fully_outside` test to expect `ValueError` instead of an empty mask
- Added 11 new test cases covering: out-of-bounds coordinates, zero/negative radii, completely negative coordinates, and partial-overlap edge cases

## Test Plan
- [x] Pre-commit hooks pass (ruff lint, ruff format, secrets scan)
- [x] 11 new validation tests pass
- [x] Existing region statistics tests still pass
- [ ] Manual: verify region selection in UI still works for valid selections

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback

Risk: Low — pure function validation with no changes to the happy path. Clamping behavior for partially-overlapping regions is preserved unchanged.
Rollback: Revert this commit.
