### PR TITLE
fix: validate required fields in resolve_s3_keys_from_products

### DIFF
--- a/processing-engine/app/mast/s3_resolver.py
+++ b/processing-engine/app/mast/s3_resolver.py
@@ -67,8 +67,16 @@ def resolve_s3_keys_from_products(product_list: list[dict[str, Any]]) -> list[di
         Products where the key cannot be resolved are excluded.
     """
     resolved: list[dict[str, Any]] = []
-    for product in product_list:
-        filename = product.get("productFilename") or product.get("filename", "")
+    for idx, product in enumerate(product_list):
+        filename = product.get("productFilename") or product.get("filename")
+        if not filename:
+            logger.warning(
+                "Skipping product at index %d: missing required filename "
+                "(neither 'productFilename' nor 'filename' present or non-empty)",
+                idx,
+            )
+            continue
+
         obs_id = product.get("obs_id", "")
         proposal_id = product.get("proposal_id", "")
 

--- a/processing-engine/tests/test_s3_resolver.py
+++ b/processing-engine/tests/test_s3_resolver.py
@@ -93,3 +93,49 @@ class TestResolveS3KeysFromProducts:
         result = resolve_s3_keys_from_products(products)
         assert len(result) == 1
         assert result[0]["s3_key"] == "jwst/public/01234/jw01234-o001_t001_miri_f770w_i2d.fits"
+
+    def test_skips_product_missing_both_filename_keys(self):
+        """Product with neither productFilename nor filename should be skipped."""
+        products = [
+            {"obs_id": "jw02733-o001", "proposal_id": "2733"},
+        ]
+        result = resolve_s3_keys_from_products(products)
+        assert len(result) == 0
+
+    def test_skips_product_with_none_filename_values(self):
+        """Product where both filename keys are explicitly None should be skipped."""
+        products = [
+            {"productFilename": None, "filename": None, "proposal_id": "2733"},
+        ]
+        result = resolve_s3_keys_from_products(products)
+        assert len(result) == 0
+
+    def test_skips_product_with_empty_string_filenames(self):
+        """Product where both filename keys are empty strings should be skipped."""
+        products = [
+            {"productFilename": "", "filename": "", "proposal_id": "2733"},
+        ]
+        result = resolve_s3_keys_from_products(products)
+        assert len(result) == 0
+
+    def test_mixed_valid_and_missing_filename_products(self):
+        """Valid products are resolved; ones missing filenames are skipped."""
+        products = [
+            {
+                "productFilename": "jw02733-o001_t001_nircam_clear-f090w_i2d.fits",
+                "proposal_id": "2733",
+            },
+            {"obs_id": "jw02733-o001", "proposal_id": "2733"},  # No filename
+            {"productFilename": None, "proposal_id": "2733"},  # None filename
+        ]
+        result = resolve_s3_keys_from_products(products)
+        assert len(result) == 1
+        assert "jw02733" in result[0]["s3_key"]
+
+    def test_logs_warning_for_missing_filename(self, caplog):
+        """Skipped products should produce a warning log."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            resolve_s3_keys_from_products([{"proposal_id": "2733"}])
+        assert "missing required filename" in caplog.text


### PR DESCRIPTION
Closes #1142

## Summary

Fixes `resolve_s3_keys_from_products()` silently producing broken S3 keys when product dicts lack both `productFilename` and `filename` keys (or have None/empty values). Products with missing filenames are now skipped with a descriptive warning log instead of generating `jwst/public/{pid}/` keys that cause confusing `NoSuchKey` errors at AWS.

## Why

When MAST returns product dicts without filename fields, the resolver silently builds S3 keys like `jwst/public/02733/` (no filename). These keys look valid but fail with cryptic `NoSuchKey` errors at AWS, making debugging difficult. The root cause is `.get()` calls without validation.

## Changes Made
- **`processing-engine/app/mast/s3_resolver.py`**: Added early validation in `resolve_s3_keys_from_products()` — products missing a usable filename are skipped with a warning log (includes product index for debugging)
- **`processing-engine/tests/test_s3_resolver.py`**: Added 5 test cases covering missing keys, None values, empty strings, mixed valid/invalid batches, and warning log verification

## Test Plan
- [x] `docker exec jwst-processing python -m pytest tests/test_s3_resolver.py -v` — all 16 tests pass
- [x] s3_resolver.py maintains 100% coverage
- [x] Ruff lint passes clean on both files

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: Low — validation-only change that converts a silent data corruption path into an explicit skip-with-warning. No behavioral change for valid inputs.
- Rollback: Revert the single commit. No migration or data changes.
