### PR TITLE
fix: log and verify cache eviction results in temp_cache

### DIFF
--- a/processing-engine/app/storage/temp_cache.py
+++ b/processing-engine/app/storage/temp_cache.py
@@ -58,23 +58,25 @@ class TempFileCache:
         local_path.parent.mkdir(parents=True, exist_ok=True)
         return local_path
 
-    def evict_if_needed(self) -> int:
+    def evict_if_needed(self) -> bool:
         """
         Remove oldest files until total cache size is within budget.
 
-        Returns the number of files evicted.
+        Returns True if the cache is within budget after eviction,
+        False if eviction could not free enough space.
         """
         with self._lock:
             files = self._get_cached_files()
             total_size = sum(f.stat().st_size for f in files)
 
             if total_size <= self._max_bytes:
-                return 0
+                return True
 
             # Sort by access time (oldest first)
             files.sort(key=lambda f: f.stat().st_atime)
 
             evicted = 0
+            failed = 0
             for f in files:
                 if total_size <= self._max_bytes:
                     break
@@ -85,7 +87,12 @@ class TempFileCache:
                     evicted += 1
                     logger.debug("Evicted cached file: %s (%d bytes)", f, size)
                 except OSError:
-                    pass  # File may have been deleted by another thread
+                    failed += 1
+                    logger.warning(
+                        "Failed to delete cached file during eviction: %s",
+                        f,
+                        exc_info=True,
+                    )
 
             if evicted > 0:
                 logger.info(
@@ -95,9 +102,21 @@ class TempFileCache:
                     self._max_bytes,
                 )
 
+            within_budget = total_size <= self._max_bytes
+            if not within_budget:
+                excess = total_size - self._max_bytes
+                logger.warning(
+                    "Cache eviction incomplete: %d bytes over budget "
+                    "(%d bytes remaining, budget %d, %d files failed to delete)",
+                    excess,
+                    total_size,
+                    self._max_bytes,
+                    failed,
+                )
+
             # Clean up empty directories
             self._cleanup_empty_dirs()
-            return evicted
+            return within_budget
 
     def _key_to_path(self, key: str) -> Path:
         """Convert a storage key to a local cache path."""

--- a/processing-engine/tests/test_s3_storage.py
+++ b/processing-engine/tests/test_s3_storage.py
@@ -1,5 +1,6 @@
 """Unit tests for S3 storage provider and temp file cache."""
 
+import logging
 import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -32,12 +33,93 @@ class TestTempFileCache:
             path = cache.put(f"file{i}.fits")
             path.write_bytes(b"x" * 50)
 
-        evicted = cache.evict_if_needed()
-        assert evicted >= 1  # At least one file evicted
+        within_budget = cache.evict_if_needed()
+        assert within_budget is True
 
         # Total size should be within budget
         total = sum(f.stat().st_size for f in cache.cache_dir.rglob("*") if f.is_file())
         assert total <= 100
+
+    def test_eviction_returns_true_when_within_budget(self, tmp_path):
+        cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=1024)
+        path = cache.put("small.fits")
+        path.write_bytes(b"x" * 50)
+        assert cache.evict_if_needed() is True
+
+    def test_eviction_logs_warning_on_delete_failure(self, tmp_path, caplog):
+        cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=50)
+
+        # Create 3 files of 50 bytes each (150 total, budget 50)
+        # All 3 must be attempted — the first will fail, so the loop
+        # continues to try the remaining files.
+        for i in range(3):
+            path = cache.put(f"file{i}.fits")
+            path.write_bytes(b"x" * 50)
+
+        original_unlink = Path.unlink
+        attempted = []
+
+        def failing_unlink(self_path, *args, **kwargs):
+            """Fail to delete the first attempted file, succeed on the rest."""
+            attempted.append(str(self_path))
+            if len(attempted) == 1:
+                raise OSError("Permission denied")
+            original_unlink(self_path, *args, **kwargs)
+
+        with (
+            patch.object(Path, "unlink", failing_unlink),
+            caplog.at_level(logging.WARNING, logger="app.storage.temp_cache"),
+        ):
+            cache.evict_if_needed()
+
+        assert any("Failed to delete cached file" in msg for msg in caplog.messages)
+
+    def test_eviction_incomplete_when_all_deletes_fail(self, tmp_path, caplog):
+        cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=100)
+
+        # Create files totaling 150 bytes (over 100 budget)
+        for i in range(3):
+            path = cache.put(f"file{i}.fits")
+            path.write_bytes(b"x" * 50)
+
+        def always_fail(self_path, *args, **kwargs):
+            raise OSError("Permission denied")
+
+        with (
+            patch.object(Path, "unlink", always_fail),
+            caplog.at_level(logging.WARNING, logger="app.storage.temp_cache"),
+        ):
+            result = cache.evict_if_needed()
+
+        assert result is False
+        assert any("eviction incomplete" in msg.lower() for msg in caplog.messages)
+
+    def test_eviction_partial_delete_still_succeeds(self, tmp_path):
+        """If enough files are deleted to get within budget, return True even if some fail."""
+        cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=100)
+
+        # Create 3 files of 40 bytes = 120 total, budget 100, need to free 20+
+        for i in range(3):
+            path = cache.put(f"file{i}.fits")
+            path.write_bytes(b"x" * 40)
+
+        original_unlink = Path.unlink
+        call_count = 0
+
+        def fail_first_unlink(self_path, *args, **kwargs):
+            """Fail on the first attempt, succeed on subsequent ones."""
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise OSError("Permission denied")
+            original_unlink(self_path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", fail_first_unlink):
+            result = cache.evict_if_needed()
+
+        # One file failed, but deleting one of the remaining two frees 40 bytes
+        # which brings 120 - 40 = 80, within 100 budget
+        assert result is True
 
     def test_preserves_key_structure(self, tmp_path):
         cache = TempFileCache(cache_dir=tmp_path / "cache", max_bytes=1024)


### PR DESCRIPTION
Closes #1021

## Summary
Fix silent failure in `TempFileCache.evict_if_needed()` where `except OSError: pass` swallowed deletion errors without logging, and add post-eviction verification to detect when eviction couldn't free enough space.

## Why
The `evict_if_needed()` method could return without actually freeing the required space. When `os.remove` (via `Path.unlink`) failed, the `except OSError: pass` silently skipped files. After the eviction loop, there was no check that the target was actually achieved. This makes cache pressure issues invisible to operators.

## Changes Made
- **`processing-engine/app/storage/temp_cache.py`**:
  - Replace bare `except OSError: pass` with `logger.warning` including file path and traceback
  - Track `failed` deletion count alongside `evicted` count
  - After eviction loop, check if `total_size <= self._max_bytes`; if not, log warning with excess bytes and failure count
  - Return `bool` (within budget) instead of `int` (evicted count)
- **`processing-engine/tests/test_s3_storage.py`**:
  - Update existing eviction test for new `bool` return type
  - Add `test_eviction_returns_true_when_within_budget` — no eviction needed
  - Add `test_eviction_logs_warning_on_delete_failure` — mock `Path.unlink` to raise OSError, verify warning logged
  - Add `test_eviction_incomplete_when_all_deletes_fail` — all deletions fail, verify `False` return and warning
  - Add `test_eviction_partial_delete_still_succeeds` — some deletions fail but enough space freed, verify `True` return

## Test Plan
- [x] Run `docker exec jwst-processing python -m pytest tests/test_s3_storage.py -v` — all 19 tests pass
- [x] Verify `test_eviction_incomplete_when_all_deletes_fail` returns `False` and logs "eviction incomplete"
- [x] Verify `test_eviction_logs_warning_on_delete_failure` captures warning with "Failed to delete cached file"
- [x] Verify `test_eviction_partial_delete_still_succeeds` returns `True` when partial eviction is sufficient
- [x] Run `ruff check` on both changed files — no lint issues

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low — single method behavior change, return type change is non-breaking (sole caller in `s3_storage.py` ignores return value)
- Rollback: Revert commit; no data/schema changes
