### PR TITLE
fix: bound eviction retry loop in cacheUtils to prevent tab freeze

### DIFF
--- a/frontend/jwst-frontend/src/utils/cacheUtils.test.ts
+++ b/frontend/jwst-frontend/src/utils/cacheUtils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getCached, getStale, setCache, clearCacheByPrefix, getCacheStats } from './cacheUtils';
+import {
+  getCached,
+  getStale,
+  setCache,
+  clearCacheByPrefix,
+  getCacheStats,
+  MAX_EVICTION_ATTEMPTS,
+} from './cacheUtils';
 
 // Mock localStorage with optional quota simulation
 const mockStorage = new Map<string, string>();
@@ -264,6 +271,33 @@ describe('LRU eviction', () => {
     expect(() => setCache('huge', 'x'.repeat(1000))).not.toThrow();
     // Entry should not be stored
     expect(mockStorage.has('jwst_cache_huge')).toBe(false);
+  });
+
+  it('terminates after MAX_EVICTION_ATTEMPTS even when entries keep being evicted', () => {
+    // Seed more entries than MAX_EVICTION_ATTEMPTS so evictOldest always
+    // finds something to remove — this was the infinite-loop bug scenario.
+    for (let i = 0; i < MAX_EVICTION_ATTEMPTS + 10; i++) {
+      mockStorage.set(
+        `jwst_cache_filler_${i}`,
+        JSON.stringify({ data: 'x', timestamp: 1000 + i, version: 1 })
+      );
+    }
+
+    // Quota so tight that even after evictions the new entry never fits
+    quotaLimit = 1;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Must NOT hang — the bounded loop should give up
+    expect(() => setCache('too-big', 'y'.repeat(500))).not.toThrow();
+
+    // Entry should not be stored
+    expect(mockStorage.has('jwst_cache_too-big')).toBe(false);
+
+    // Should have logged the max-attempts warning
+    expect(warnSpy).toHaveBeenCalledWith('Cache: exceeded max eviction attempts, skipping storage');
+
+    warnSpy.mockRestore();
   });
 
   it('does not evict non-cache keys', () => {

--- a/frontend/jwst-frontend/src/utils/cacheUtils.ts
+++ b/frontend/jwst-frontend/src/utils/cacheUtils.ts
@@ -1,6 +1,9 @@
 const CACHE_PREFIX = 'jwst_cache_';
 const CACHE_VERSION = 1;
 
+/** Maximum eviction attempts before giving up on a setCache call. */
+export const MAX_EVICTION_ATTEMPTS = 20;
+
 interface CacheEntry<T> {
   data: T;
   timestamp: number;
@@ -91,7 +94,7 @@ export function setCache<T>(key: string, data: T): void {
   const json = JSON.stringify(entry);
   const fullKey = CACHE_PREFIX + key;
 
-  for (;;) {
+  for (let i = 0; i < MAX_EVICTION_ATTEMPTS; i++) {
     try {
       localStorage.setItem(fullKey, json);
       return;
@@ -103,6 +106,8 @@ export function setCache<T>(key: string, data: T): void {
       }
     }
   }
+  // Evicted MAX_EVICTION_ATTEMPTS entries but still over quota — give up
+  console.warn('Cache: exceeded max eviction attempts, skipping storage');
 }
 
 export function getCacheStats(): CacheStats {


### PR DESCRIPTION
Closes #1101

## Summary

Fix unbounded `for (;;)` eviction loop in `cacheUtils.setCache()` that could freeze the browser tab when `localStorage` quota is permanently exceeded but cache entries remain to evict. Adds a `MAX_EVICTION_ATTEMPTS = 20` bound so the loop gives up gracefully with a `console.warn`.

## Why

When `localStorage.setItem` throws a quota error and `evictOldest()` returns `true` (entries exist to evict) but the freed space is still insufficient for the new entry, the `for (;;)` loop never terminates. This freezes the browser tab — a denial-of-service bug triggered by normal cache pressure.

## Changes Made
- **`cacheUtils.ts`**: Replaced `for (;;)` with `for (let i = 0; i < MAX_EVICTION_ATTEMPTS; i++)`. Added exported `MAX_EVICTION_ATTEMPTS` constant. Added `console.warn` fallthrough after exhausting retries.
- **`cacheUtils.test.ts`**: Added test "terminates after MAX_EVICTION_ATTEMPTS even when entries keep being evicted" — seeds 30 filler entries with a quota of 1 byte, verifies `setCache` terminates and logs the warning.

## Test Plan
- [x] `npx vitest run src/utils/cacheUtils.test.ts --reporter=verbose` — all 33 tests pass
- [x] New test "terminates after MAX_EVICTION_ATTEMPTS even when entries keep being evicted" is present and green
- [x] Full test suite (941 tests across 73 files) passes with zero failures
- [x] TypeScript type check (`tsc --noEmit`) passes clean

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: **Low** — single-file utility change with a pure additive bound on an existing loop. No API surface changes. Existing behavior preserved for all non-pathological cases.
- Rollback: Revert the single commit.
