### PR TITLE
feat: auth rate limiting, account lockout, and user enumeration prevention

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/AuthControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/AuthControllerTests.cs
@@ -87,7 +87,8 @@ public class AuthControllerTests
     public async Task Register_ReturnsBadRequest_WhenValidationFails()
     {
         mockAuthService.Setup(s => s.RegisterAsync(It.IsAny<RegisterRequest>()))
-            .ThrowsAsync(new InvalidOperationException("Username taken"));
+            .ThrowsAsync(new InvalidOperationException(
+                "An account with these details already exists. Please try different credentials."));
 
         var result = await sut.Register(new RegisterRequest
         {

--- a/backend/JwstDataAnalysis.API.Tests/Services/AuthServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/AuthServiceTests.cs
@@ -258,6 +258,250 @@ public class AuthServiceTests
             Times.Once);
     }
 
+    // --- Account Lockout ---
+    [Fact]
+    public async Task Login_ReturnsNull_WhenAccountIsLocked()
+    {
+        // Arrange — account locked for another 10 minutes
+        var user = CreateTestUser();
+        user.PasswordHash = BCrypt.Net.BCrypt.HashPassword("correct-password");
+        user.LockedUntil = DateTime.UtcNow.AddMinutes(10);
+        user.FailedLoginAttempts = 5;
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync(Username))
+            .ReturnsAsync(user);
+
+        var request = new LoginRequest { Username = Username, Password = "correct-password" };
+
+        // Act
+        var result = await sut.LoginAsync(request);
+
+        // Assert — locked account returns null (same as invalid creds)
+        result.Should().BeNull();
+
+        // Should NOT attempt password verification or token generation
+        mockMongoDb.Verify(
+            m => m.UpdateRefreshTokenAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<string?>(),
+                It.IsAny<DateTime?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Login_IncrementsFailedAttempts_OnWrongPassword()
+    {
+        // Arrange
+        var user = CreateTestUser();
+        user.PasswordHash = BCrypt.Net.BCrypt.HashPassword("correct-password");
+        user.FailedLoginAttempts = 0;
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync(Username))
+            .ReturnsAsync(user);
+
+        var request = new LoginRequest { Username = Username, Password = "wrong-password" };
+
+        // Act
+        var result = await sut.LoginAsync(request);
+
+        // Assert
+        result.Should().BeNull();
+        mockMongoDb.Verify(
+            m => m.IncrementFailedLoginAttemptsAsync(UserId, null),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_LocksAccount_AfterMaxFailedAttempts()
+    {
+        // Arrange — user is at 4 failed attempts (one more triggers lockout at default max of 5)
+        var user = CreateTestUser();
+        user.PasswordHash = BCrypt.Net.BCrypt.HashPassword("correct-password");
+        user.FailedLoginAttempts = 4;
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync(Username))
+            .ReturnsAsync(user);
+
+        var request = new LoginRequest { Username = Username, Password = "wrong-password" };
+
+        // Act
+        var result = await sut.LoginAsync(request);
+
+        // Assert
+        result.Should().BeNull();
+        mockMongoDb.Verify(
+            m => m.IncrementFailedLoginAttemptsAsync(
+                UserId,
+                It.Is<DateTime?>(d => d.HasValue && d.Value > DateTime.UtcNow)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_ResetsFailedAttempts_OnSuccess()
+    {
+        // Arrange — user had some failed attempts before
+        var user = CreateTestUser();
+        user.PasswordHash = BCrypt.Net.BCrypt.HashPassword("correct-password");
+        user.FailedLoginAttempts = 3;
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync(Username))
+            .ReturnsAsync(user);
+
+        var request = new LoginRequest { Username = Username, Password = "correct-password" };
+
+        // Act
+        var result = await sut.LoginAsync(request);
+
+        // Assert
+        result.Should().NotBeNull();
+        mockMongoDb.Verify(
+            m => m.ResetFailedLoginAttemptsAsync(UserId),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_DoesNotResetAttempts_WhenAlreadyZero()
+    {
+        // Arrange — no prior failures, skip the reset call
+        var user = CreateTestUser();
+        user.PasswordHash = BCrypt.Net.BCrypt.HashPassword("correct-password");
+        user.FailedLoginAttempts = 0;
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync(Username))
+            .ReturnsAsync(user);
+
+        var request = new LoginRequest { Username = Username, Password = "correct-password" };
+
+        // Act
+        var result = await sut.LoginAsync(request);
+
+        // Assert
+        result.Should().NotBeNull();
+        mockMongoDb.Verify(
+            m => m.ResetFailedLoginAttemptsAsync(It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Login_AutoUnlocks_WhenLockoutExpired()
+    {
+        // Arrange — lockout expired 5 minutes ago
+        var user = CreateTestUser();
+        user.PasswordHash = BCrypt.Net.BCrypt.HashPassword("correct-password");
+        user.LockedUntil = DateTime.UtcNow.AddMinutes(-5);
+        user.FailedLoginAttempts = 5;
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync(Username))
+            .ReturnsAsync(user);
+
+        var request = new LoginRequest { Username = Username, Password = "correct-password" };
+
+        // Act
+        var result = await sut.LoginAsync(request);
+
+        // Assert — login succeeds, counter reset
+        result.Should().NotBeNull();
+        mockMongoDb.Verify(
+            m => m.ResetFailedLoginAttemptsAsync(UserId),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_AfterLockoutExpired_WrongPassword_DoesNotImmediatelyRelock()
+    {
+        // Arrange — lockout expired, counter was at max (5)
+        var user = CreateTestUser();
+        user.PasswordHash = BCrypt.Net.BCrypt.HashPassword("correct-password");
+        user.LockedUntil = DateTime.UtcNow.AddMinutes(-5);
+        user.FailedLoginAttempts = 5;
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync(Username))
+            .ReturnsAsync(user);
+
+        var request = new LoginRequest { Username = Username, Password = "wrong-password" };
+
+        // Act
+        var result = await sut.LoginAsync(request);
+
+        // Assert — returns null (wrong password) but NOT immediately re-locked
+        result.Should().BeNull();
+
+        // Counter was reset on lockout expiry, so this is attempt 1 (not 6)
+        mockMongoDb.Verify(
+            m => m.ResetFailedLoginAttemptsAsync(UserId),
+            Times.Once);
+        mockMongoDb.Verify(
+            m => m.IncrementFailedLoginAttemptsAsync(UserId, null),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_UserNotFound_NormalizesTimingWithDummyHash()
+    {
+        // Arrange — user does not exist
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync("nonexistent"))
+            .ReturnsAsync((User?)null);
+
+        var request = new LoginRequest { Username = "nonexistent", Password = "any-password" };
+
+        // Act — should not throw, should return null
+        var result = await sut.LoginAsync(request);
+
+        // Assert
+        result.Should().BeNull();
+
+        // No lockout methods should be called for nonexistent users
+        mockMongoDb.Verify(
+            m => m.IncrementFailedLoginAttemptsAsync(It.IsAny<string>(), It.IsAny<DateTime?>()),
+            Times.Never);
+    }
+
+    // --- Registration Enumeration ---
+    [Fact]
+    public async Task Register_ThrowsGenericMessage_WhenUsernameExists()
+    {
+        // Arrange
+        var existingUser = CreateTestUser();
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync("taken"))
+            .ReturnsAsync(existingUser);
+
+        var request = new RegisterRequest
+        {
+            Username = "taken",
+            Email = "new@example.com",
+            Password = "Password1!",
+        };
+
+        // Act
+        var act = () => sut.RegisterAsync(request);
+
+        // Assert — message does not reveal which field conflicted
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Be(
+            "An account with these details already exists. Please try different credentials.");
+    }
+
+    [Fact]
+    public async Task Register_ThrowsGenericMessage_WhenEmailExists()
+    {
+        // Arrange
+        mockMongoDb.Setup(m => m.GetUserByUsernameAsync("newuser"))
+            .ReturnsAsync((User?)null);
+        var existingUser = CreateTestUser();
+        mockMongoDb.Setup(m => m.GetUserByEmailAsync("taken@example.com"))
+            .ReturnsAsync(existingUser);
+
+        var request = new RegisterRequest
+        {
+            Username = "newuser",
+            Email = "taken@example.com",
+            Password = "Password1!",
+        };
+
+        // Act
+        var act = () => sut.RegisterAsync(request);
+
+        // Assert — message does not reveal which field conflicted
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Be(
+            "An account with these details already exists. Please try different credentials.");
+    }
+
     private static User CreateTestUser(
         string? refreshToken = "hashed-current-refresh-token",
         string? previousRefreshToken = null,

--- a/backend/JwstDataAnalysis.API/Configuration/JwtSettings.cs
+++ b/backend/JwstDataAnalysis.API/Configuration/JwtSettings.cs
@@ -48,5 +48,17 @@ namespace JwstDataAnalysis.API.Configuration
         /// plus network latency margin.
         /// </summary>
         public int RefreshTokenGraceWindowSeconds { get; set; } = 60;
+
+        /// <summary>
+        /// Gets or sets the maximum number of consecutive failed login attempts
+        /// before the account is temporarily locked.
+        /// </summary>
+        public int MaxFailedLoginAttempts { get; set; } = 5;
+
+        /// <summary>
+        /// Gets or sets the duration in minutes that an account remains locked
+        /// after exceeding <see cref="MaxFailedLoginAttempts"/>.
+        /// </summary>
+        public int AccountLockoutMinutes { get; set; } = 15;
     }
 }

--- a/backend/JwstDataAnalysis.API/Controllers/AuthController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/AuthController.cs
@@ -54,7 +54,7 @@ namespace JwstDataAnalysis.API.Controllers
             }
             catch (InvalidOperationException ex)
             {
-                // Messages are intentionally user-facing ("Username already exists", "Email already exists")
+                // Messages are intentionally generic to prevent user enumeration
                 LogRegistrationValidationError(ex.Message);
                 return BadRequest(new { error = ex.Message });
             }

--- a/backend/JwstDataAnalysis.API/Models/UserModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/UserModels.cs
@@ -61,6 +61,11 @@ namespace JwstDataAnalysis.API.Models
 
         public DateTime? PreviousRefreshTokenExpiresAt { get; set; }
 
+        // Account lockout
+        public int FailedLoginAttempts { get; set; }
+
+        public DateTime? LockedUntil { get; set; }
+
         // Optional profile fields
         public string? DisplayName { get; set; }
 

--- a/backend/JwstDataAnalysis.API/Services/AuthService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/AuthService.Log.cs
@@ -16,13 +16,21 @@ namespace JwstDataAnalysis.API.Services
             Message = "Login failed: user inactive: {Username}")]
         private partial void LogLoginFailedUserInactive(string username);
 
-        [LoggerMessage(EventId = 2003, Level = LogLevel.Warning,
-            Message = "Login failed: invalid password for: {Username}")]
-        private partial void LogLoginFailedInvalidPassword(string username);
-
         [LoggerMessage(EventId = 2004, Level = LogLevel.Information,
             Message = "Login successful for user {UserId} ({Username})")]
         private partial void LogLoginSuccessful(string userId, string username);
+
+        [LoggerMessage(EventId = 2005, Level = LogLevel.Warning,
+            Message = "Account locked after repeated failures: {Username}")]
+        private partial void LogAccountLocked(string username);
+
+        [LoggerMessage(EventId = 2006, Level = LogLevel.Information,
+            Message = "Account lockout expired, allowing login attempt: {Username}")]
+        private partial void LogAccountLockoutExpired(string username);
+
+        [LoggerMessage(EventId = 2007, Level = LogLevel.Warning,
+            Message = "Failed login attempt {AttemptCount} for: {Username}")]
+        private partial void LogFailedLoginAttempt(int attemptCount, string username);
 
         // Registration operations (21xx)
         [LoggerMessage(EventId = 2101, Level = LogLevel.Warning,

--- a/backend/JwstDataAnalysis.API/Services/AuthService.cs
+++ b/backend/JwstDataAnalysis.API/Services/AuthService.cs
@@ -17,6 +17,12 @@ namespace JwstDataAnalysis.API.Services
         IOptions<JwtSettings> jwtSettings,
         ILogger<AuthService> logger) : IAuthService
     {
+        // Pre-hashed dummy value for timing normalization on user-not-found path.
+        // The actual hash value doesn't matter — it just ensures BCrypt.Verify
+        // runs in constant time regardless of whether the user exists.
+        private static readonly string DummyPasswordHash =
+            BCrypt.Net.BCrypt.HashPassword("dummy-timing-normalization", workFactor: 12);
+
         private readonly IMongoDBService mongoDBService = mongoDBService;
         private readonly IJwtTokenService jwtTokenService = jwtTokenService;
         private readonly JwtSettings jwtSettings = jwtSettings.Value;
@@ -35,9 +41,17 @@ namespace JwstDataAnalysis.API.Services
 
             if (user == null)
             {
+                // Run dummy BCrypt.Verify to normalize response timing and prevent
+                // user enumeration via timing side-channel
+                BCrypt.Net.BCrypt.Verify(request.Password, DummyPasswordHash);
                 LogLoginFailedUserNotFound(request.Username);
                 return null;
             }
+
+            // Always run BCrypt.Verify before any early-return to normalize response
+            // timing — prevents user enumeration via timing side-channel on
+            // inactive/locked accounts
+            var passwordValid = BCrypt.Net.BCrypt.Verify(request.Password, user.PasswordHash);
 
             if (!user.IsActive)
             {
@@ -45,10 +59,44 @@ namespace JwstDataAnalysis.API.Services
                 return null;
             }
 
-            if (!BCrypt.Net.BCrypt.Verify(request.Password, user.PasswordHash))
+            // Check account lockout
+            if (user.LockedUntil.HasValue && user.LockedUntil.Value > DateTime.UtcNow)
             {
-                LogLoginFailedInvalidPassword(request.Username);
+                LogAccountLocked(request.Username);
                 return null;
+            }
+
+            // Reset counter when lockout has expired so the user gets fresh attempts
+            if (user.LockedUntil.HasValue && user.LockedUntil.Value <= DateTime.UtcNow)
+            {
+                await mongoDBService.ResetFailedLoginAttemptsAsync(user.Id);
+                user.FailedLoginAttempts = 0;
+                user.LockedUntil = null;
+                LogAccountLockoutExpired(request.Username);
+            }
+
+            if (!passwordValid)
+            {
+                var newAttemptCount = user.FailedLoginAttempts + 1;
+                LogFailedLoginAttempt(newAttemptCount, request.Username);
+
+                DateTime? lockedUntil = null;
+                if (newAttemptCount >= jwtSettings.MaxFailedLoginAttempts)
+                {
+                    lockedUntil = DateTime.UtcNow.AddMinutes(jwtSettings.AccountLockoutMinutes);
+                    LogAccountLocked(request.Username);
+                }
+
+                await mongoDBService.IncrementFailedLoginAttemptsAsync(user.Id, lockedUntil);
+                return null;
+            }
+
+            // Successful login — reset any failed attempt counter
+            if (user.FailedLoginAttempts > 0)
+            {
+                await mongoDBService.ResetFailedLoginAttemptsAsync(user.Id);
+                user.FailedLoginAttempts = 0;
+                user.LockedUntil = null;
             }
 
             // Generate tokens
@@ -60,7 +108,12 @@ namespace JwstDataAnalysis.API.Services
             // Store hashed refresh token
             await mongoDBService.UpdateRefreshTokenAsync(user.Id, hashedRefreshToken, refreshTokenExpiry);
 
-            // Update last login time
+            // Sync in-memory user before ReplaceOneAsync to avoid overwriting
+            // the refresh token we just stored above
+            user.RefreshToken = hashedRefreshToken;
+            user.RefreshTokenExpiresAt = refreshTokenExpiry;
+            user.PreviousRefreshToken = null;
+            user.PreviousRefreshTokenExpiresAt = null;
             user.LastLoginAt = DateTime.UtcNow;
             await mongoDBService.UpdateUserAsync(user);
 
@@ -79,11 +132,13 @@ namespace JwstDataAnalysis.API.Services
         public async Task<TokenResponse> RegisterAsync(RegisterRequest request)
         {
             // Check if username already exists
+            // Error messages are intentionally generic to prevent user enumeration
             var existingUser = await mongoDBService.GetUserByUsernameAsync(request.Username);
             if (existingUser != null)
             {
                 LogRegistrationFailedUsernameTaken(request.Username);
-                throw new InvalidOperationException("Username already exists");
+                throw new InvalidOperationException(
+                    "An account with these details already exists. Please try different credentials.");
             }
 
             // Check if email already exists (case-insensitive)
@@ -91,7 +146,8 @@ namespace JwstDataAnalysis.API.Services
             if (existingEmail != null)
             {
                 LogRegistrationFailedEmailTaken(request.Email);
-                throw new InvalidOperationException("Email already exists");
+                throw new InvalidOperationException(
+                    "An account with these details already exists. Please try different credentials.");
             }
 
             // Enforce password complexity at the service layer (defense in depth)

--- a/backend/JwstDataAnalysis.API/Services/IMongoDBService.cs
+++ b/backend/JwstDataAnalysis.API/Services/IMongoDBService.cs
@@ -137,6 +137,10 @@ namespace JwstDataAnalysis.API.Services
 
         Task UpdateUserAsync(User user);
 
+        Task IncrementFailedLoginAttemptsAsync(string userId, DateTime? lockedUntil = null);
+
+        Task ResetFailedLoginAttemptsAsync(string userId);
+
         Task UpdateRefreshTokenAsync(
             string userId,
             string? refreshToken,

--- a/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
+++ b/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
@@ -830,6 +830,29 @@ namespace JwstDataAnalysis.API.Services
         public async Task UpdateUserAsync(User user) =>
             await usersCollection.ReplaceOneAsync(x => x.Id == user.Id, user);
 
+        public async Task IncrementFailedLoginAttemptsAsync(string userId, DateTime? lockedUntil = null)
+        {
+            var filter = Builders<User>.Filter.Eq(u => u.Id, userId);
+            var update = Builders<User>.Update.Inc(u => u.FailedLoginAttempts, 1);
+
+            if (lockedUntil.HasValue)
+            {
+                update = update.Set(u => u.LockedUntil, lockedUntil.Value);
+            }
+
+            await usersCollection.UpdateOneAsync(filter, update);
+        }
+
+        public async Task ResetFailedLoginAttemptsAsync(string userId)
+        {
+            var filter = Builders<User>.Filter.Eq(u => u.Id, userId);
+            var update = Builders<User>.Update
+                .Set(u => u.FailedLoginAttempts, 0)
+                .Unset(u => u.LockedUntil);
+
+            await usersCollection.UpdateOneAsync(filter, update);
+        }
+
         public async Task UpdateRefreshTokenAsync(
             string userId,
             string? refreshToken,

--- a/backend/JwstDataAnalysis.API/appsettings.json
+++ b/backend/JwstDataAnalysis.API/appsettings.json
@@ -12,7 +12,10 @@
     "Audience": "JwstDataAnalysisClient",
     "AccessTokenExpirationMinutes": 60,
     "RefreshTokenExpirationDays": 7,
-    "ClockSkewSeconds": 30
+    "ClockSkewSeconds": 30,
+    "RefreshTokenGraceWindowSeconds": 60,
+    "MaxFailedLoginAttempts": 5,
+    "AccountLockoutMinutes": 15
   },
   "MongoDB": {
     "ConnectionString": "mongodb://localhost:27017",
@@ -71,6 +74,26 @@
     },
     "IpWhitelist": [],
     "GeneralRules": [
+      {
+        "Endpoint": "post:/api/auth/login",
+        "Period": "15m",
+        "Limit": 20
+      },
+      {
+        "Endpoint": "post:/api/auth/register",
+        "Period": "1h",
+        "Limit": 5
+      },
+      {
+        "Endpoint": "post:/api/auth/refresh",
+        "Period": "1m",
+        "Limit": 20
+      },
+      {
+        "Endpoint": "post:/api/auth/change-password",
+        "Period": "15m",
+        "Limit": 5
+      },
       {
         "Endpoint": "get:/api/mast/import-progress/*",
         "Period": "1m",

--- a/docs/plans/features/1096-auth-rate-limiting-lockout.md
+++ b/docs/plans/features/1096-auth-rate-limiting-lockout.md
@@ -1,0 +1,71 @@
+# Plan: Auth Rate Limiting & Account Lockout (#1096)
+
+## Context
+
+Issue #1096 identifies that auth endpoints (login, register, refresh, change-password) have no per-endpoint rate limiting and no account lockout policy. The global `AspNetCoreRateLimit` middleware applies a blanket 300 req/min limit, which is far too generous for auth endpoints. An attacker can brute-force credentials at scale. This is a security hardening task — auth is called out as "fragile" in CLAUDE.md, so changes must be careful and well-tested.
+
+**Decisions resolved in CEO/eng review:**
+- Lockout config → add to existing `JwtSettings` (no new settings class)
+- Lockout counter → atomic `$inc` via new `IMongoDBService` methods (race-condition-proof)
+- Registration errors → generic but hint-able ("An account with these details already exists")
+- Rate limits → config rules in `appsettings.json` (not `[EnableRateLimiting]` attributes — wrong library)
+- Admin unlock → out of scope, tracked as #1186
+
+## Changes
+
+### 1. `Configuration/JwtSettings.cs` — Add lockout config
+Add two properties:
+- `MaxFailedLoginAttempts` (int, default 5)
+- `AccountLockoutMinutes` (int, default 15)
+
+### 2. `Models/UserModels.cs` — Add lockout fields to User
+Add to `User` class:
+- `FailedLoginAttempts` (int, default 0)
+- `LockedUntil` (DateTime?, default null)
+
+### 3. `Services/IMongoDBService.cs` — New interface methods
+```csharp
+Task IncrementFailedLoginAttemptsAsync(string userId, DateTime? lockedUntil = null);
+Task ResetFailedLoginAttemptsAsync(string userId);
+```
+
+### 4. `Services/MongoDBService.cs` — Implement atomic lockout ops
+- `IncrementFailedLoginAttemptsAsync`: `FindOneAndUpdateAsync` with `$inc: { FailedLoginAttempts: 1 }` and conditionally `$set: { LockedUntil }`.
+- `ResetFailedLoginAttemptsAsync`: `UpdateOneAsync` with `$set: { FailedLoginAttempts: 0 }` and `$unset: { LockedUntil: "" }`.
+
+### 5. `Services/AuthService.cs` — Lockout logic in LoginAsync
+1. **User not found** → dummy `BCrypt.HashPassword` for timing normalization, return null
+2. **User locked** → `LockedUntil > UtcNow` → return null (same generic error)
+3. **Wrong password** → `IncrementFailedLoginAttemptsAsync`, lock if threshold reached, return null
+4. **Correct password** → `ResetFailedLoginAttemptsAsync`, proceed with tokens
+
+Registration: both duplicate errors → `"An account with these details already exists. Please try different credentials."`
+
+### 6. `Services/AuthService.Log.cs` — New log messages (EventIds 2005–2007)
+- `LogAccountLocked` — Warning
+- `LogAccountLockoutExpired` — Info
+- `LogFailedLoginAttempt` — Warning
+
+### 7. `appsettings.json` — Auth-specific rate limit rules
+```json
+{ "Endpoint": "post:/api/auth/login", "Period": "15m", "Limit": 10 },
+{ "Endpoint": "post:/api/auth/register", "Period": "1h", "Limit": 5 },
+{ "Endpoint": "post:/api/auth/refresh", "Period": "1m", "Limit": 20 },
+{ "Endpoint": "post:/api/auth/change-password", "Period": "15m", "Limit": 5 }
+```
+
+### 8. Tests
+- AuthServiceTests: lockout, increment, reset, auto-unlock, legacy null handling, generic reg errors
+- AuthControllerTests: update registration error assertion
+
+## NOT in scope
+- Admin unlock endpoint → #1186
+- CAPTCHA / IP blocklist
+- Email notification on lockout
+
+## Verification
+1. Docker rebuild + `dotnet test`
+2. Manual: wrong password 5x → locked → auto-unlock after duration
+3. Manual: correct login resets counter
+4. Manual: register duplicate → generic error
+5. Manual: rate limit 429 on excess login attempts


### PR DESCRIPTION
## Summary

Adds auth endpoint rate limiting, account lockout after repeated failed logins, and user enumeration prevention to close security gaps identified in #1096. Filed #1186 for admin unlock (out of scope).

Closes #1096

## Changes Made

### Rate Limiting (appsettings.json)
- Added per-endpoint rate limit rules via existing `AspNetCoreRateLimit` config:
  - `POST /api/auth/login`: 20 requests per 15 minutes
  - `POST /api/auth/register`: 5 requests per 1 hour
  - `POST /api/auth/refresh`: 20 requests per 1 minute
  - `POST /api/auth/change-password`: 5 requests per 15 minutes
- Rules placed before wildcard `*` rules for correct precedence

### Account Lockout (AuthService + MongoDBService)
- Added `FailedLoginAttempts` (int) and `LockedUntil` (DateTime?) fields to `User` model
- Added `MaxFailedLoginAttempts` (default 5) and `AccountLockoutMinutes` (default 15) to `JwtSettings`
- Implemented atomic `$inc`/`$set`/`$unset` operations via `IncrementFailedLoginAttemptsAsync` and `ResetFailedLoginAttemptsAsync` to prevent race conditions on concurrent login attempts
- On wrong password: atomically increments counter, locks account when threshold reached
- On successful login: resets counter to 0
- On lockout expiry: resets counter before evaluating new attempt (prevents immediate re-lock)
- Syncs in-memory `User` object (lockout fields + refresh token fields) before `UpdateUserAsync` (`ReplaceOneAsync`) to prevent overwriting atomically-stored values

### User Enumeration Prevention (AuthService)
- Added dummy `BCrypt.Verify` on user-not-found path to normalize response timing
- Moved `BCrypt.Verify` before inactive/locked checks so all paths have consistent timing
- Changed registration duplicate errors from specific ("Username already exists" / "Email already exists") to generic ("An account with these details already exists. Please try different credentials.")

### Logging (AuthService.Log.cs)
- Added `LogAccountLocked` (EventId 2005), `LogAccountLockoutExpired` (2006), `LogFailedLoginAttempt` (2007)
- Removed unused `LogLoginFailedInvalidPassword` (2003) — replaced by `LogFailedLoginAttempt`

## Test Plan

**Automated (11 new tests, all passing — 1068 total):**
- [x] `Login_ReturnsNull_WhenAccountIsLocked` — locked account returns null
- [x] `Login_IncrementsFailedAttempts_OnWrongPassword` — atomic increment called
- [x] `Login_LocksAccount_AfterMaxFailedAttempts` — lockedUntil set at threshold
- [x] `Login_ResetsFailedAttempts_OnSuccess` — counter reset on correct password
- [x] `Login_DoesNotResetAttempts_WhenAlreadyZero` — skip unnecessary DB call
- [x] `Login_AutoUnlocks_WhenLockoutExpired` — expired lockout allows login
- [x] `Login_AfterLockoutExpired_WrongPassword_DoesNotImmediatelyRelock` — counter resets before evaluating new attempt
- [x] `Login_UserNotFound_NormalizesTimingWithDummyHash` — no lockout calls for nonexistent users
- [x] `Register_ThrowsGenericMessage_WhenUsernameExists` — no field-specific error
- [x] `Register_ThrowsGenericMessage_WhenEmailExists` — no field-specific error
- [x] `Register_ReturnsBadRequest_WhenValidationFails` — updated assertion for generic message

**Manual verification:**
1. Docker rebuild: `docker compose up -d --build`
2. Login with wrong password 5 times — verify 401 (same error as bad creds, no "locked" hint)
3. Attempt correct login while locked — still returns 401
4. Wait for lockout to expire (or set `AccountLockoutMinutes: 1`) — verify login works
5. Verify successful login resets counter: wrong 3x, correct, wrong 5x — locks at 5 not 8
6. Register with taken username — verify generic error message
7. Hit login endpoint >20x in 15min — verify 429 rate limit response

## Documentation Checklist

- [x] Plan saved to `docs/plans/features/1096-auth-rate-limiting-lockout.md`
- [ ] `docs/quick-reference.md` — update if rate limit section exists (deferred to doc-update sweep)
- [x] No new endpoints or DTO changes — no key-files update needed

## Tech Debt Impact

- [x] Closes a known security gap (unlimited auth attempts) — net reduction
- [ ] `UpdateUserAsync` uses `ReplaceOneAsync` — future refactor to targeted field updates (#1186 may revisit)
- [ ] Pre-existing: `ChangePasswordAsync` controller missing `ArgumentException` catch (returns 500 instead of 400)

## Risk & Rollback

Risk: LOW-MEDIUM. Auth-adjacent but no changes to token generation, JWT validation, or auth middleware. Rate limit rules are config-only. Lockout logic is additive (new code paths, existing paths unchanged).

Rollback: Remove rate limit rules from `appsettings.json` (instant). Remove lockout fields from `User` model and revert `AuthService.LoginAsync` (MongoDB is schema-flexible, existing docs with lockout fields are harmless).

Self-review: Two rounds of code-reviewer agent. Round 1 found 3 MUST FIX (stale in-memory state, immediate re-lock, timing side-channel). Round 2 found 1 MUST FIX (refresh token overwrite). All fixed before push.