### PR TITLE
fix: observe background tasks in MastController to prevent silent failures

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/MastController.Log.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.Log.cs
@@ -234,5 +234,10 @@ namespace JwstDataAnalysis.API.Controllers
         [LoggerMessage(EventId = 3001, Level = LogLevel.Warning,
             Message = "Path traversal attempt blocked for obsId: {ObsId}")]
         private partial void LogPathTraversalAttemptBlocked(string obsId);
+
+        // Background task events (31xx)
+        [LoggerMessage(EventId = 3101, Level = LogLevel.Error,
+            Message = "Unhandled exception escaped background task: {Context}")]
+        private partial void LogBackgroundTaskFailed(Exception? ex, string context);
     }
 }

--- a/backend/JwstDataAnalysis.API/Controllers/MastController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.cs
@@ -276,7 +276,7 @@ namespace JwstDataAnalysis.API.Controllers
             }
 
             // Start the import process in the background
-            _ = Task.Run(async () => await ExecuteImportAsync(jobId, request));
+            RunBackgroundTask(ExecuteImportAsync(jobId, request), $"ExecuteImportAsync job={jobId}");
 
             return Ok(new JobStartResponse
             {
@@ -389,8 +389,9 @@ namespace JwstDataAnalysis.API.Controllers
                 LogResumedImportJob(jobId, job.DownloadJobId);
 
                 // Start background task to continue polling and complete import
-                _ = Task.Run(async () => await ExecuteResumedImportAsync(
-                    jobId, job.ObsId, job.DownloadJobId, job.UserId, job.IsPublic));
+                RunBackgroundTask(
+                    ExecuteResumedImportAsync(jobId, job.ObsId, job.DownloadJobId, job.UserId, job.IsPublic),
+                    $"ExecuteResumedImportAsync job={jobId}");
 
                 return Ok(new { message = "Import resumed", jobId, downloadJobId = job.DownloadJobId });
             }
@@ -442,8 +443,9 @@ namespace JwstDataAnalysis.API.Controllers
                         // Recover userId/isPublic from job status if available
                         var resumeUserId = job.UserId ?? GetCurrentUserId();
                         var resumeIsPublic = job.IsPublic;
-                        _ = Task.Run(async () => await CompleteImportFromExistingFilesAsync(
-                            jobId, job.ObsId, existingFiles, resumeUserId, resumeIsPublic));
+                        RunBackgroundTask(
+                            CompleteImportFromExistingFilesAsync(jobId, job.ObsId, existingFiles, resumeUserId, resumeIsPublic),
+                            $"CompleteImportFromExistingFilesAsync job={jobId}");
 
                         return Ok(new
                         {
@@ -514,8 +516,9 @@ namespace JwstDataAnalysis.API.Controllers
             LogStartingImportFromExisting(obsId, existingFiles.Count);
 
             // MAST data is public; pass userId for ownership
-            _ = Task.Run(async () => await CompleteImportFromExistingFilesAsync(
-                jobId, obsId, existingFiles, currentUserId, isPublic: true));
+            RunBackgroundTask(
+                CompleteImportFromExistingFilesAsync(jobId, obsId, existingFiles, currentUserId, isPublic: true),
+                $"CompleteImportFromExistingFilesAsync job={jobId}");
 
             return Ok(new JobStartResponse
             {
@@ -1056,8 +1059,9 @@ namespace JwstDataAnalysis.API.Controllers
                 LogResumedImportJob(importJobId, downloadJobId);
 
                 // Start background task to continue polling and complete import
-                _ = Task.Run(async () => await ExecuteResumedImportAsync(
-                    importJobId, obsId, downloadJobId, currentUserId, isPublic: true));
+                RunBackgroundTask(
+                    ExecuteResumedImportAsync(importJobId, obsId, downloadJobId, currentUserId, isPublic: true),
+                    $"ExecuteResumedImportAsync job={importJobId}");
 
                 return Ok(new { message = "Import resumed", jobId = importJobId, downloadJobId });
             }
@@ -1070,6 +1074,22 @@ namespace JwstDataAnalysis.API.Controllers
                 LogFailedToResumeImport(ex, downloadJobId);
                 return ProcessingEngineError(ex);
             }
+        }
+
+        /// <summary>
+        /// Starts a background task and attaches an error observer via ContinueWith.
+        /// The target methods all have comprehensive internal try/catch blocks, so this
+        /// continuation fires only if an exception escapes those blocks — practically never.
+        /// Its presence ensures the task is observed (no UnobservedTaskException) and any
+        /// truly unexpected failure produces a log entry rather than silently disappearing.
+        /// </summary>
+        private void RunBackgroundTask(Task task, string context)
+        {
+            _ = task.ContinueWith(
+                t => LogBackgroundTaskFailed(t.Exception?.Flatten(), context),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
         }
 
         /// <summary>

--- a/backend/JwstDataAnalysis.API/appsettings.json
+++ b/backend/JwstDataAnalysis.API/appsettings.json
@@ -69,7 +69,7 @@
     "ClientIdHeader": "X-ClientId",
     "HttpStatusCode": 429,
     "QuotaExceededResponse": {
-      "Content": "{\"error\":\"Rate limit exceeded. Please try again later.\",\"retryAfter\":\"1\"}",
+      "Content": "{{\"error\":\"Rate limit exceeded. Please try again later.\",\"retryAfter\":\"{2}\"}}",
       "ContentType": "application/json"
     },
     "IpWhitelist": [],

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -8,6 +8,14 @@
 # semantic, discovery, mast) with valid but minimal responses.
 
 services:
+  backend:
+    environment:
+      # Disable rate limiting in E2E — parallel workers registering users in
+      # bulk will always exceed the per-hour registration limit, and the Docker
+      # NAT layer presents IPv4-mapped IPv6 addresses that don't match the IPv4
+      # CIDR entries in the development IP whitelist.
+      - IpRateLimiting__EnableEndpointRateLimiting=false
+
   processing-engine:
     image: docker-mock-processing-engine
     build:

--- a/docs/plans/design/job-queue-websocket-progress.md
+++ b/docs/plans/design/job-queue-websocket-progress.md
@@ -114,7 +114,7 @@ Hub server events: `JobProgress`, `JobCompleted`, `JobFailed`, `JobSnapshot`
 
 **Docker/proxy WebSocket config:** If Docker Compose has a reverse proxy (nginx, traefik) in front of the .NET API, it needs WebSocket passthrough (`Upgrade` and `Connection` headers). Verify during Phase 1 — if it's direct port forwarding, no action needed.
 
-**Import backpressure gap:** Import jobs stay as `Task.Run` (existing) and don't go through `Channel<T>`. The processing engine is the natural bottleneck for imports. This is an accepted inconsistency — not worth the migration cost in this phase.
+**Import backpressure gap:** Import jobs don't go through `Channel<T>`. Background import methods are invoked directly (no `Task.Run`) via a `RunBackgroundTask` helper in `MastController` that attaches a `ContinueWith(OnlyOnFaulted)` observer for safety. The processing engine is the natural bottleneck for imports. Full migration to a bounded channel queue is tracked but not in scope for this phase.
 
 **Structured logging:** Every job lifecycle event should be logged with structured fields: `Job {JobId} created by {UserId}, type={JobType}`, `Job {JobId} completed in {Duration}ms`, `Job {JobId} failed: {Error}`. Queue depth logged on enqueue/dequeue for observability.
 


### PR DESCRIPTION
Closes #1097

## Summary

- Replaces five fire-and-forget `_ = Task.Run(...)` calls in `MastController` with an observed `RunBackgroundTask` helper, eliminating silent exception swallowing and unnecessary thread pool overhead
- Fixes a `FormatException` crash in the `AspNetCoreRateLimit` middleware (regression from #1187) that was causing E2E tests to get 500s instead of 429s
- Disables rate limiting in the E2E Docker stack so parallel test workers can register users without hitting the per-hour limit

## Why

**#1097 — fire-and-forget tasks:** Unobserved `Task.Run` wrappers silently discard exceptions that escape the methods' internal `try/catch` blocks. The `Task.Run` itself was also unnecessary overhead — these are async I/O methods, not CPU-bound work.

**Rate limit crash (regression from #1187):** `QuotaExceededResponse.Content` contained bare `{` and `}` JSON delimiters. `AspNetCoreRateLimit` passes this string through `String.Format`, which interprets `{` as a format placeholder and throws `FormatException: Expected an ASCII digit`. E2E tests hit this because 6 parallel Playwright workers each register a user in `beforeAll`, exhausting the 5/hour registration limit. The development IP whitelist didn't prevent it because Docker NAT presents requests as IPv4-mapped IPv6 addresses (`::ffff:172.17.0.1`) that don't match the IPv4 CIDR whitelist entries.

## Changes Made

**`MastController.cs`**
- Added `RunBackgroundTask(Task, string)` private helper with `ContinueWith(OnlyOnFaulted, TaskScheduler.Default)` observer
- Replaced 5 `_ = Task.Run(async () => await MethodAsync(...))` call sites

**`MastController.Log.cs`**
- Added `LogBackgroundTaskFailed` (EventId 3101, new "Background task events (31xx)" block)

**`appsettings.json`**
- Escaped `{`/`}` in `QuotaExceededResponse.Content` to `{{`/`}}` so `String.Format` treats them as literals
- Replaced hardcoded `"retryAfter":"1"` with `{2}` so the actual rule's retry-after value is used

**`docker-compose.e2e.yml`**
- Added `IpRateLimiting__EnableEndpointRateLimiting=false` to the backend service for E2E runs

**`docs/plans/design/job-queue-websocket-progress.md`**
- Updated stale "Import backpressure gap" note

**`ImportJobTracker.DualWrite` left unchanged** — its `Task.Run` lambda already has a full `try/catch`, making the outer task effectively non-faulting.

## Test Plan

- [x] `dotnet test` — 1068/1068 passing
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] Pre-commit hook passed on both commits
- [ ] `docker compose up -d --build` and start a MAST import → confirm job reaches `completed` or `failed` state (regression check for #1097)
- [ ] Confirm E2E tests pass in CI (rate limit fix)

## Documentation Checklist

- [x] No new endpoints or services — no key-files, standards, quick-reference, or architecture updates needed
- [x] `docs/plans/design/job-queue-websocket-progress.md` updated

## Tech Debt Impact

- [x] Existing tech debt reduced — closes #1097

## Risk & Rollback

- **Risk:** Low. `RunBackgroundTask` is a private helper with no API surface. Config changes are non-code. E2E rate limiting disable only applies to the test compose stack.
- **Rollback:** Revert this PR. Two clean commits.
