### PR TITLE
feat: add saturation, vibrancy, and hue rotation controls to composite pipeline

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
@@ -441,6 +441,74 @@ public class CompositeServiceTests
     }
 
     [Fact]
+    public async Task GenerateNChannelComposite_WithSaturation_SerializesSnakeCase()
+    {
+        // Arrange
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 1 }),
+            },
+            req => capturedRequest = req);
+        var httpClient = new HttpClient(handler);
+
+        var sut = CreateService(httpClient);
+        var request = CreateRequest();
+        request.Saturation = new SaturationConfigDto
+        {
+            Saturation = 1.5,
+            Vibrancy = 0.3,
+            HueRotation = 15.0,
+        };
+
+        // Act
+        await sut.GenerateNChannelCompositeAsync(
+            request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert - validates the wire contract (snake_case) to the Python service.
+        var body = await capturedRequest!.Content!.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(body);
+        doc.RootElement.TryGetProperty("saturation", out var satProp).Should().BeTrue();
+        satProp.ValueKind.Should().Be(JsonValueKind.Object);
+        satProp.GetProperty("saturation").GetDouble().Should().Be(1.5);
+        satProp.GetProperty("vibrancy").GetDouble().Should().Be(0.3);
+        satProp.GetProperty("hue_rotation").GetDouble().Should().Be(15.0);
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_NullSaturation_SerializesAsNull()
+    {
+        // Arrange
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 1 }),
+            },
+            req => capturedRequest = req);
+        var httpClient = new HttpClient(handler);
+
+        var sut = CreateService(httpClient);
+
+        // Act - request with no saturation (null)
+        await sut.GenerateNChannelCompositeAsync(
+            CreateRequest(), "user-1", isAuthenticated: true, isAdmin: false);
+
+        // Assert
+        var body = await capturedRequest!.Content!.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(body);
+        doc.RootElement.TryGetProperty("saturation", out var satProp).Should().BeTrue();
+        satProp.ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
     public async Task GenerateNChannelComposite_StripsAbsolutePathPrefix()
     {
         // Arrange - file path starts with /app/data/ prefix

--- a/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
@@ -67,6 +67,30 @@ namespace JwstDataAnalysis.API.Models
     }
 
     /// <summary>
+    /// Global saturation, vibrancy, and hue rotation applied after sharpening.
+    /// </summary>
+    public class SaturationConfigDto
+    {
+        /// <summary>
+        /// Gets or sets the multiplicative saturation scale (0=grayscale, 1=unchanged, 2=max boost).
+        /// </summary>
+        [Range(0.0, 2.0)]
+        public double Saturation { get; set; } = 1.0;
+
+        /// <summary>
+        /// Gets or sets the selective saturation boost for muted colors (0=off, 1=max).
+        /// </summary>
+        [Range(0.0, 1.0)]
+        public double Vibrancy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the global hue shift in degrees (-30 to +30).
+        /// </summary>
+        [Range(-30.0, 30.0)]
+        public double HueRotation { get; set; }
+    }
+
+    /// <summary>
     /// Color specification for an N-channel composite — either hue angle or explicit RGB weights.
     /// </summary>
     public class ChannelColorDto
@@ -188,6 +212,11 @@ namespace JwstDataAnalysis.API.Models
         public SharpeningConfigDto? Sharpening { get; set; }
 
         /// <summary>
+        /// Gets or sets optional saturation, vibrancy, and hue rotation applied after sharpening.
+        /// </summary>
+        public SaturationConfigDto? Saturation { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to subtract per-channel sky background (default true).
         /// </summary>
         public bool BackgroundNeutralization { get; set; } = true;
@@ -283,6 +312,21 @@ namespace JwstDataAnalysis.API.Models
     }
 
     /// <summary>
+    /// Internal saturation/vibrancy/hue config sent to processing engine.
+    /// </summary>
+    internal class ProcessingSaturationConfig
+    {
+        [JsonPropertyName("saturation")]
+        public double Saturation { get; set; } = 1.0;
+
+        [JsonPropertyName("vibrancy")]
+        public double Vibrancy { get; set; }
+
+        [JsonPropertyName("hue_rotation")]
+        public double HueRotation { get; set; }
+    }
+
+    /// <summary>
     /// Internal color specification sent to processing engine.
     /// </summary>
     internal class ProcessingChannelColor
@@ -352,6 +396,9 @@ namespace JwstDataAnalysis.API.Models
 
         [JsonPropertyName("sharpening")]
         public ProcessingSharpeningConfig? Sharpening { get; set; }
+
+        [JsonPropertyName("saturation")]
+        public ProcessingSaturationConfig? Saturation { get; set; }
 
         [JsonPropertyName("background_neutralization")]
         public bool BackgroundNeutralization { get; set; } = true;

--- a/backend/JwstDataAnalysis.API/Services/CompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.cs
@@ -104,6 +104,7 @@ namespace JwstDataAnalysis.API.Services
                 Channels = processingChannels,
                 Overall = CreateProcessingOverallAdjustments(request.Overall),
                 Sharpening = CreateProcessingSharpening(request.Sharpening),
+                Saturation = CreateProcessingSaturation(request.Saturation),
                 BackgroundNeutralization = request.BackgroundNeutralization,
                 FeatherStrength = request.FeatherStrength,
                 RotationDegrees = request.RotationDegrees,
@@ -172,6 +173,22 @@ namespace JwstDataAnalysis.API.Services
                 Radius = sharpening.Radius,
                 Amount = sharpening.Amount,
                 Threshold = sharpening.Threshold,
+            };
+        }
+
+        private static ProcessingSaturationConfig? CreateProcessingSaturation(
+            SaturationConfigDto? saturation)
+        {
+            if (saturation == null)
+            {
+                return null;
+            }
+
+            return new ProcessingSaturationConfig
+            {
+                Saturation = saturation.Saturation,
+                Vibrancy = saturation.Vibrancy,
+                HueRotation = saturation.HueRotation,
             };
         }
 

--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -190,7 +190,7 @@ Quick reference for finding important files in the codebase.
 - `processing-engine/app/mast/download_tracker.py` - Byte-level progress tracking
 - `processing-engine/app/composite/routes.py` - RGB and N-channel composite FastAPI routes
 - `processing-engine/app/composite/models.py` - Composite Pydantic models (RGB + N-channel)
-- `processing-engine/app/composite/color_mapping.py` - N-channel color mapping engine (hue→RGB, wavelength→hue, channel combination)
+- `processing-engine/app/composite/color_mapping.py` - N-channel color mapping engine (hue→RGB, wavelength→hue, channel combination, saturation/vibrancy/hue rotation)
 - `processing-engine/app/mosaic/routes.py` - WCS mosaic FastAPI routes
 - `processing-engine/app/mosaic/models.py` - Mosaic Pydantic models
 - `processing-engine/app/mosaic/mosaic_engine.py` - Core WCS reprojection logic (reproject library)

--- a/docs/plans/features/684-saturation-vibrancy-hue-controls.md
+++ b/docs/plans/features/684-saturation-vibrancy-hue-controls.md
@@ -1,0 +1,107 @@
+# Plan: #684 — Saturation, Vibrancy, and Hue Rotation Controls
+
+**Issue:** [#684](https://github.com/Snoww3d/jwst-data-analysis/issues/684)
+**Complexity:** Medium
+**Risk:** Low — new optional field, backward-compatible, byte-identical output when not provided
+
+## Summary
+
+Add global saturation, vibrancy, and hue rotation controls to the composite pipeline as a post-processing step after sharpening. Follows the exact `SharpeningConfig` pattern across all layers.
+
+## Scope Decisions
+
+- **Per-channel saturation: DROPPED** — `weight` (0.0–2.0) already covers "some filters need more punch"
+- **Hue rotation: ADDED** (CEO review EXPANSION-1) — free since we're already doing HSL round-trip
+- **Preset updates: ADDED** (CEO review EXPANSION-2) — NASA Press, High Contrast, Auto get sensible defaults
+
+## Architecture
+
+### Pipeline order (routes.py)
+
+```
+stretch → combine → sharpening → saturation/vibrancy/hue → encode
+```
+
+Saturation goes **after** sharpening (standard astrophotography workflow: sharpen in luma, then color grade).
+
+### Algorithms
+
+- **Saturation:** `s_new = s × saturation` (multiplicative scale, clamp to [0,1])
+- **Vibrancy:** `s_new = s + vibrancy × (1 - s)` (lerp toward full saturation — muted pixels get largest boost, vivid pixels almost none)
+- **Hue rotation:** `h_new = (h + rotation/360) % 1.0`
+
+All three use existing `rgb_to_hsl()` / `hsl_to_rgb()` in a single HSL round-trip.
+
+## Files Changed
+
+### Processing Engine (Python)
+
+| File | Change |
+|------|--------|
+| `processing-engine/app/composite/models.py` | New `SaturationConfig` model (saturation: 0–2 default 1.0, vibrancy: 0–1 default 0.0, hue_rotation: ±30° default 0.0). Add optional `saturation` field to `NChannelCompositeRequest`. |
+| `processing-engine/app/composite/color_mapping.py` | New `apply_saturation_vibrancy(rgb, config)` pure function using existing `rgb_to_hsl`/`hsl_to_rgb`. |
+| `processing-engine/app/composite/routes.py` | Import `apply_saturation_vibrancy`, import `SaturationConfig`. Wire after sharpening (~5 lines). |
+
+### Frontend (TypeScript/React)
+
+| File | Change |
+|------|--------|
+| `frontend/jwst-frontend/src/types/CompositeTypes.ts` | New `SaturationConfig` interface + `DEFAULT_SATURATION`. Add `saturation?` to `NChannelCompositeRequest`. Update `COMPOSITE_PRESETS` (NASA Press, High Contrast, Auto). Add `saturation?` to `CompositePreset`. |
+| `frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx` | New `saturation` state. UI section with 3 sliders (saturation, vibrancy, hue rotation). Wire into preview request. Load from preset. |
+| `frontend/jwst-frontend/src/services/compositeService.ts` | Pass `saturation` in request payload (same pattern as sharpening). |
+
+### Tests
+
+| File | Change |
+|------|--------|
+| `processing-engine/tests/test_color_mapping.py` | Unit tests for `apply_saturation_vibrancy()`: identity, grayscale, boost, vibrancy selectivity, hue shift, edge cases (all-black, all-white). |
+| `processing-engine/tests/test_nchannel_composite.py` | Integration tests: API with saturation config → 200, output differs, identity = byte-identical, 422 on out-of-range. |
+
+### Docs
+
+| File | Change |
+|------|--------|
+| `docs/key-files.md:193` | Update `color_mapping.py` description to mention saturation/vibrancy/hue. |
+
+## Test Plan
+
+```
+Unit Tests (test_color_mapping.py):
+- [ ] identity (sat=1.0, vib=0.0, hue=0.0) returns input unchanged
+- [ ] saturation=0.0 produces grayscale
+- [ ] saturation=2.0 boosts chroma, clamps to [0,1]
+- [ ] vibrancy boosts muted pixels more than saturated pixels
+- [ ] hue_rotation=30 shifts hue by ~30°
+- [ ] all-black input: no NaN/divide-by-zero
+- [ ] all-white input: no saturation artifacts
+
+Integration Tests (test_nchannel_composite.py):
+- [ ] POST with saturation config returns 200
+- [ ] Output differs from baseline when saturation != 1.0
+- [ ] Identity config = byte-identical to no config
+- [ ] Out-of-range values return 422
+
+E2E Tests:
+- [ ] Saturation slider renders in CompositePreviewStep
+- [ ] Changing saturation triggers preview refresh
+- [ ] Preset loads saturation defaults correctly
+
+Manual Verification:
+- [ ] Boost saturation to 1.8 — colors visibly richer
+- [ ] Vibrancy 0.5 — muted nebula gains color, bright stars unchanged
+- [ ] Hue +15° — image shifts warmer
+- [ ] Docker rebuild required: YES
+```
+
+## Risks
+
+- **MED:** Vibrancy near-neutral pixels — `(1 - s)` formula naturally handles this but verify with sky background remnants
+- **LOW:** HSL round-trip precision — clamp output, verify no drift on identity
+- **LOW:** API backward-compat — `None` = no-op, existing clients unaffected
+
+## NOT in Scope
+
+- Per-channel saturation (covered by `weight`)
+- Per-channel hue/vibrancy
+- Migrating `apply_sharpening()` to `color_mapping.py` (separate tech-debt)
+- Luminance-space saturation

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -9,8 +9,11 @@ import {
   DEFAULT_EXPORT_OPTIONS,
   DEFAULT_OVERALL_ADJUSTMENTS,
   DEFAULT_SHARPENING,
+  DEFAULT_SATURATION,
   OverallAdjustments,
   SharpeningConfig,
+  SaturationConfig,
+  isDefaultSaturation,
   StretchMethod,
   COMPOSITE_PRESETS,
   CompositePreset,
@@ -47,6 +50,9 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
   });
   const [sharpening, setSharpening] = useState<SharpeningConfig>({
     ...DEFAULT_SHARPENING,
+  });
+  const [saturation, setSaturation] = useState<SaturationConfig>({
+    ...DEFAULT_SATURATION,
   });
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
@@ -100,6 +106,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     setActivePreset(preset.id);
     setOverallAdjustments({ ...preset.overall });
     setSharpening({ ...(preset.sharpening ?? DEFAULT_SHARPENING) });
+    setSaturation({ ...(preset.saturation ?? DEFAULT_SATURATION) });
     setBackgroundNeutralization(preset.backgroundNeutralization);
     onChannelsChange(
       channels.map((ch) => {
@@ -231,7 +238,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [channels, overallAdjustments, sharpening, backgroundNeutralization]);
+  }, [channels, overallAdjustments, sharpening, saturation, backgroundNeutralization]);
 
   // Cleanup object URL, in-flight request, and timers on unmount.
   useEffect(() => {
@@ -272,7 +279,8 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         controller.signal,
         backgroundNeutralization,
         undefined,
-        sharpening.amount > 0 ? sharpening : undefined
+        sharpening.amount > 0 ? sharpening : undefined,
+        !isDefaultSaturation(saturation) ? saturation : undefined
       );
 
       if (previewUrlRef.current) {
@@ -385,7 +393,8 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         backgroundNeutralization,
         undefined,
         undefined,
-        sharpening.amount > 0 ? sharpening : undefined
+        sharpening.amount > 0 ? sharpening : undefined,
+        !isDefaultSaturation(saturation) ? saturation : undefined
       );
 
       setActiveJobId(jobId);
@@ -816,6 +825,71 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
                 </div>
               </>
             )}
+          </div>
+
+          <div className="saturation-section">
+            <div className="option-label-row">
+              <label className="option-label">Saturation</label>
+              <span className="option-value">{saturation.saturation.toFixed(2)}×</span>
+            </div>
+            <input
+              type="range"
+              min="0"
+              max="2.0"
+              step="0.05"
+              value={saturation.saturation}
+              onChange={(e) =>
+                setSaturation((prev) => ({ ...prev, saturation: parseFloat(e.target.value) }))
+              }
+              className="quality-slider"
+              aria-label="Saturation"
+            />
+            <div className="slider-labels">
+              <span>Grayscale</span>
+              <span>Vivid</span>
+            </div>
+
+            <div className="option-label-row">
+              <label className="option-label">Vibrancy</label>
+              <span className="option-value">{saturation.vibrancy.toFixed(2)}</span>
+            </div>
+            <input
+              type="range"
+              min="0"
+              max="1.0"
+              step="0.05"
+              value={saturation.vibrancy}
+              onChange={(e) =>
+                setSaturation((prev) => ({ ...prev, vibrancy: parseFloat(e.target.value) }))
+              }
+              className="quality-slider"
+              aria-label="Vibrancy"
+            />
+            <div className="slider-labels">
+              <span>Off</span>
+              <span>Boost muted colors</span>
+            </div>
+
+            <div className="option-label-row">
+              <label className="option-label">Hue Rotation</label>
+              <span className="option-value">{saturation.hueRotation.toFixed(0)}°</span>
+            </div>
+            <input
+              type="range"
+              min="-30"
+              max="30"
+              step="1"
+              value={saturation.hueRotation}
+              onChange={(e) =>
+                setSaturation((prev) => ({ ...prev, hueRotation: parseFloat(e.target.value) }))
+              }
+              className="quality-slider"
+              aria-label="Hue rotation"
+            />
+            <div className="slider-labels">
+              <span>−30° Cooler</span>
+              <span>+30° Warmer</span>
+            </div>
           </div>
         </div>
 

--- a/frontend/jwst-frontend/src/services/compositeService.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.ts
@@ -10,6 +10,7 @@ import {
   OverallAdjustments,
   NChannelCompositeRequest,
   NChannelConfigPayload,
+  SaturationConfig,
   SharpeningConfig,
 } from '../types/CompositeTypes';
 
@@ -44,12 +45,14 @@ export async function generateNChannelPreview(
   abortSignal?: AbortSignal,
   backgroundNeutralization?: boolean,
   featherStrength?: number,
-  sharpening?: SharpeningConfig
+  sharpening?: SharpeningConfig,
+  saturation?: SaturationConfig
 ): Promise<Blob> {
   const request: NChannelCompositeRequest = {
     channels,
     overall,
     sharpening,
+    saturation,
     backgroundNeutralization,
     featherStrength,
     outputFormat: 'jpeg',
@@ -90,12 +93,14 @@ export async function exportNChannelComposite(
     cropCenterY?: number;
     cropZoom?: number;
   },
-  sharpening?: SharpeningConfig
+  sharpening?: SharpeningConfig,
+  saturation?: SaturationConfig
 ): Promise<Blob> {
   const request: NChannelCompositeRequest = {
     channels,
     overall,
     sharpening,
+    saturation,
     backgroundNeutralization,
     featherStrength,
     rotationDegrees: framing?.rotationDegrees,
@@ -139,12 +144,14 @@ export async function exportNChannelCompositeAsync(
     cropCenterY?: number;
     cropZoom?: number;
   },
-  sharpening?: SharpeningConfig
+  sharpening?: SharpeningConfig,
+  saturation?: SaturationConfig
 ): Promise<{ jobId: string }> {
   const request: NChannelCompositeRequest = {
     channels,
     overall,
     sharpening,
+    saturation,
     backgroundNeutralization,
     featherStrength,
     rotationDegrees: framing?.rotationDegrees,

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -45,6 +45,31 @@ export const DEFAULT_SHARPENING: SharpeningConfig = {
 };
 
 /**
+ * Global saturation, vibrancy, and hue rotation applied after sharpening.
+ *
+ * Operates in HSL space. All defaults produce a no-op.
+ */
+export interface SaturationConfig {
+  /** Multiplicative saturation scale (0=grayscale, 1=unchanged, 2=max boost) */
+  saturation: number;
+  /** Selective boost for muted colors (0=off, 1=max) */
+  vibrancy: number;
+  /** Global hue shift in degrees (-30 to +30) */
+  hueRotation: number;
+}
+
+export const DEFAULT_SATURATION: SaturationConfig = {
+  saturation: 1.0,
+  vibrancy: 0.0,
+  hueRotation: 0.0,
+};
+
+/** Returns true when the config matches defaults (no-op for the pipeline). */
+export function isDefaultSaturation(config: SaturationConfig): boolean {
+  return config.saturation === 1.0 && config.vibrancy === 0.0 && config.hueRotation === 0.0;
+}
+
+/**
  * Export options for the final composite
  */
 export interface ExportOptions {
@@ -100,6 +125,7 @@ export interface NChannelCompositeRequest {
   channels: NChannelConfigPayload[];
   overall?: OverallAdjustments;
   sharpening?: SharpeningConfig;
+  saturation?: SaturationConfig;
   backgroundNeutralization?: boolean;
   featherStrength?: number;
   rotationDegrees?: number;
@@ -171,6 +197,7 @@ export interface CompositePreset {
   overall: OverallAdjustments;
   backgroundNeutralization: boolean;
   sharpening?: SharpeningConfig;
+  saturation?: SaturationConfig;
 }
 
 /**
@@ -214,6 +241,11 @@ export const COMPOSITE_PRESETS: CompositePreset[] = [
       radius: 1.5,
       amount: 0.4,
       threshold: 0.01,
+    },
+    saturation: {
+      saturation: 1.1,
+      vibrancy: 0.15,
+      hueRotation: 0.0,
     },
   },
   {
@@ -286,6 +318,11 @@ export const COMPOSITE_PRESETS: CompositePreset[] = [
       amount: 0.6,
       threshold: 0.01,
     },
+    saturation: {
+      saturation: 1.3,
+      vibrancy: 0.25,
+      hueRotation: 0.0,
+    },
   },
   {
     id: 'high-contrast',
@@ -319,6 +356,11 @@ export const COMPOSITE_PRESETS: CompositePreset[] = [
       asinhA: 0.1,
     },
     backgroundNeutralization: true,
+    saturation: {
+      saturation: 1.4,
+      vibrancy: 0.2,
+      hueRotation: 0.0,
+    },
   },
   {
     id: 'faint-emission',

--- a/processing-engine/app/composite/color_mapping.py
+++ b/processing-engine/app/composite/color_mapping.py
@@ -7,12 +7,18 @@ a final RGB image.
 """
 
 import colorsys
+import logging
 import math
 
 import numpy as np
 from numpy.typing import NDArray
 from scipy.ndimage import distance_transform_edt
 from skimage.color import lab2rgb, rgb2lab
+
+from .models import SaturationConfig
+
+
+logger = logging.getLogger(__name__)
 
 
 def hue_to_rgb_weights(hue_degrees: float) -> tuple[float, float, float]:
@@ -584,3 +590,57 @@ def blend_instrument_groups(
     if not result_is_srgb:
         return np.clip(result, 0.0, 1.0)
     return np.clip(result, 0.0, 1.0)
+
+
+def apply_saturation_vibrancy(
+    rgb_array: NDArray,
+    config: SaturationConfig,
+) -> NDArray:
+    """Apply saturation, vibrancy, and hue rotation to an RGB composite.
+
+    Performs a single HSL round-trip using :func:`rgb_to_hsl` /
+    :func:`hsl_to_rgb`.  Processing order within the round-trip:
+
+    1. **Hue rotation** — shifts all hues by ``config.hue_rotation`` degrees.
+    2. **Saturation** — multiplicative scale: ``s × config.saturation``.
+    3. **Vibrancy** — selective boost: ``s + vibrancy × (1 − s)``.
+       Near-neutral pixels (low saturation) receive the largest boost;
+       already-vivid pixels are barely affected.
+
+    All defaults (saturation=1.0, vibrancy=0.0, hue_rotation=0.0) produce
+    a no-op — the function returns the input unchanged without performing
+    the HSL conversion.
+
+    Args:
+        rgb_array: RGB image [H, W, 3] in [0, 1], typically sRGB-encoded.
+        config: Saturation parameters.
+
+    Returns:
+        Adjusted RGB image [H, W, 3] clipped to [0, 1].
+    """
+    is_noop = config.saturation == 1.0 and config.vibrancy == 0.0 and config.hue_rotation == 0.0
+    if is_noop:
+        return rgb_array
+
+    logger.debug(
+        "Applying saturation=%.2f, vibrancy=%.2f, hue_rotation=%.1f°",
+        config.saturation,
+        config.vibrancy,
+        config.hue_rotation,
+    )
+
+    h, s, lightness = rgb_to_hsl(rgb_array)
+
+    # 1. Hue rotation
+    if config.hue_rotation != 0.0:
+        h = (h + config.hue_rotation / 360.0) % 1.0
+
+    # 2. Saturation (multiplicative)
+    if config.saturation != 1.0:
+        s = np.clip(s * config.saturation, 0.0, 1.0)
+
+    # 3. Vibrancy (selective — lerp toward 1.0, weighted by (1-s))
+    if config.vibrancy > 0.0:
+        s = np.clip(s + config.vibrancy * (1.0 - s), 0.0, 1.0)
+
+    return hsl_to_rgb(h, s, lightness)

--- a/processing-engine/app/composite/models.py
+++ b/processing-engine/app/composite/models.py
@@ -86,6 +86,34 @@ class SharpeningConfig(BaseModel):
     )
 
 
+class SaturationConfig(BaseModel):
+    """Global saturation, vibrancy, and hue rotation applied after sharpening.
+
+    Operates in HSL space via a single round-trip (rgb_to_hsl → adjust → hsl_to_rgb).
+    All defaults produce a no-op so existing composites are byte-identical
+    unless a caller opts in.
+    """
+
+    saturation: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=2.0,
+        description="Multiplicative saturation scale (0=grayscale, 1=unchanged, 2=max boost)",
+    )
+    vibrancy: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Selective saturation boost — muted colors get the largest increase (0=off, 1=max)",
+    )
+    hue_rotation: float = Field(
+        default=0.0,
+        ge=-30.0,
+        le=30.0,
+        description="Global hue shift in degrees (-30 to +30)",
+    )
+
+
 # --- N-Channel Composite Models (B3.1) ---
 
 
@@ -146,6 +174,10 @@ class NChannelCompositeRequest(BaseModel):
     sharpening: SharpeningConfig | None = Field(
         default=None,
         description="Optional unsharp masking applied to the final RGB composite",
+    )
+    saturation: SaturationConfig | None = Field(
+        default=None,
+        description="Optional saturation, vibrancy, and hue rotation applied after sharpening",
     )
     background_neutralization: bool = Field(
         default=True,

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -43,6 +43,7 @@ from app.storage.helpers import resolve_fits_path
 from .auto_stretch import auto_stretch_params
 from .cache import CompositeCache
 from .color_mapping import (
+    apply_saturation_vibrancy,
     blend_instrument_groups,
     blend_luminance,
     combine_channels_to_rgb,
@@ -1186,4 +1187,6 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
         rgb = apply_sharpening(
             rgb, request.sharpening, coverage_mask=_build_coverage_mask(reprojected)
         )
+    if request.saturation is not None:
+        rgb = apply_saturation_vibrancy(rgb, request.saturation)
     return _encode_and_respond(rgb, request, auto_feathered, feather)

--- a/processing-engine/tests/test_color_mapping.py
+++ b/processing-engine/tests/test_color_mapping.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from app.composite.color_mapping import (
+    apply_saturation_vibrancy,
     blend_instrument_groups,
     chromatic_order_hues,
     combine_channels_to_rgb,
@@ -14,7 +15,7 @@ from app.composite.color_mapping import (
     smoothstep,
     wavelength_to_hue,
 )
-from app.composite.models import ChannelColor
+from app.composite.models import ChannelColor, SaturationConfig
 
 
 class TestHueToRgbWeights:
@@ -1159,3 +1160,120 @@ class TestLabLerp:
 
         # Corner (outside both minorities): should be blue/green only (NIRCam)
         assert result[5, 5, 2] > 0.3, "NIRCam blue missing in corner"
+
+
+class TestApplySaturationVibrancy:
+    """Tests for apply_saturation_vibrancy — saturation, vibrancy, and hue rotation."""
+
+    @staticmethod
+    def _colored_image() -> np.ndarray:
+        """A 10x10 image with a known colored pixel for testing."""
+        img = np.zeros((10, 10, 3), dtype=np.float64)
+        # Mid-saturation red-ish pixel at (5, 5)
+        img[5, 5] = [0.8, 0.2, 0.2]
+        # Low-saturation (muted) pixel at (3, 3)
+        img[3, 3] = [0.5, 0.45, 0.45]
+        # High-saturation green pixel at (7, 7)
+        img[7, 7] = [0.1, 0.9, 0.1]
+        return img
+
+    def test_identity_returns_unchanged(self):
+        """Default config (sat=1, vib=0, hue=0) is a no-op."""
+        img = self._colored_image()
+        config = SaturationConfig()
+        result = apply_saturation_vibrancy(img, config)
+        np.testing.assert_array_equal(result, img)
+
+    def test_saturation_zero_produces_grayscale(self):
+        """saturation=0 should collapse all channels to equal values (grayscale)."""
+        img = self._colored_image()
+        config = SaturationConfig(saturation=0.0)
+        result = apply_saturation_vibrancy(img, config)
+        # Each pixel's R, G, B should be equal (grayscale = zero saturation in HSL)
+        pixel = result[5, 5]
+        assert pixel[0] == pytest.approx(pixel[1], abs=0.01)
+        assert pixel[1] == pytest.approx(pixel[2], abs=0.01)
+
+    def test_saturation_boost_increases_chroma(self):
+        """saturation=2.0 should increase the difference between max and min channel."""
+        img = self._colored_image()
+        original_range = img[5, 5].max() - img[5, 5].min()
+        config = SaturationConfig(saturation=2.0)
+        result = apply_saturation_vibrancy(img, config)
+        boosted_range = result[5, 5].max() - result[5, 5].min()
+        assert boosted_range > original_range
+
+    def test_vibrancy_boosts_muted_more_than_saturated(self):
+        """Vibrancy should increase saturation of muted pixel more than vivid pixel."""
+        img = self._colored_image()
+        from app.composite.color_mapping import rgb_to_hsl
+
+        _, s_before, _ = rgb_to_hsl(img)
+        muted_s_before = s_before[3, 3]
+        vivid_s_before = s_before[7, 7]
+
+        config = SaturationConfig(vibrancy=0.5)
+        result = apply_saturation_vibrancy(img, config)
+        _, s_after, _ = rgb_to_hsl(result)
+
+        muted_delta = s_after[3, 3] - muted_s_before
+        vivid_delta = s_after[7, 7] - vivid_s_before
+        assert muted_delta > vivid_delta, (
+            f"Muted pixel delta ({muted_delta:.4f}) should exceed "
+            f"vivid pixel delta ({vivid_delta:.4f})"
+        )
+
+    def test_hue_rotation_shifts_hue(self):
+        """Hue rotation should shift the hue of colored pixels."""
+        img = self._colored_image()
+        from app.composite.color_mapping import rgb_to_hsl
+
+        _, _, l_before = rgb_to_hsl(img)
+
+        config = SaturationConfig(hue_rotation=30.0)
+        result = apply_saturation_vibrancy(img, config)
+
+        _, _, l_after = rgb_to_hsl(result)
+        # Lightness should be preserved through hue rotation
+        np.testing.assert_allclose(l_before[5, 5], l_after[5, 5], atol=0.01)
+        # But the color should have changed
+        assert not np.allclose(img[5, 5], result[5, 5], atol=0.01)
+
+    def test_all_black_is_stable(self):
+        """All-black image should remain all-black (no NaN or divide-by-zero)."""
+        img = np.zeros((10, 10, 3), dtype=np.float64)
+        config = SaturationConfig(saturation=1.5, vibrancy=0.5, hue_rotation=15.0)
+        result = apply_saturation_vibrancy(img, config)
+        assert not np.any(np.isnan(result)), "NaN in result for all-black image"
+        np.testing.assert_array_equal(result, img)
+
+    def test_all_white_is_stable(self):
+        """All-white image should remain all-white (no saturation artifacts)."""
+        img = np.ones((10, 10, 3), dtype=np.float64)
+        config = SaturationConfig(saturation=1.5, vibrancy=0.5, hue_rotation=15.0)
+        result = apply_saturation_vibrancy(img, config)
+        assert not np.any(np.isnan(result)), "NaN in result for all-white image"
+        np.testing.assert_allclose(result, img, atol=0.01)
+
+    def test_output_clipped_to_unit_range(self):
+        """Result should always be in [0, 1]."""
+        img = self._colored_image()
+        config = SaturationConfig(saturation=2.0, vibrancy=1.0)
+        result = apply_saturation_vibrancy(img, config)
+        assert result.min() >= 0.0
+        assert result.max() <= 1.0
+
+    def test_model_validation_out_of_range(self):
+        """SaturationConfig should reject out-of-range values."""
+        with pytest.raises(ValidationError):
+            SaturationConfig(saturation=-1.0)
+        with pytest.raises(ValidationError):
+            SaturationConfig(saturation=3.0)
+        with pytest.raises(ValidationError):
+            SaturationConfig(vibrancy=-0.1)
+        with pytest.raises(ValidationError):
+            SaturationConfig(vibrancy=1.5)
+        with pytest.raises(ValidationError):
+            SaturationConfig(hue_rotation=-31.0)
+        with pytest.raises(ValidationError):
+            SaturationConfig(hue_rotation=31.0)

--- a/processing-engine/tests/test_nchannel_composite.py
+++ b/processing-engine/tests/test_nchannel_composite.py
@@ -555,6 +555,75 @@ class TestGenerateNChannelEndpoint:
         )
         assert response.status_code == 422
 
+    def test_with_saturation_enabled(self, client, mock_pipeline):
+        """Saturation config flows through the endpoint and returns a valid image."""
+        shape = (50, 50)
+        data = _make_test_data(shape)
+        mock_pipeline.return_value = ({"ch0": data}, shape)
+
+        response = client.post(
+            "/composite/generate-nchannel",
+            json={
+                "channels": [{"file_paths": ["test.fits"], "color": {"hue": 0.0}}],
+                "saturation": {"saturation": 1.5, "vibrancy": 0.3, "hue_rotation": 10.0},
+                "width": 100,
+                "height": 100,
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+
+    def test_saturation_identity_matches_no_config(self, client, mock_pipeline):
+        """Default saturation config (1.0/0.0/0.0) should produce identical output."""
+        shape = (50, 50)
+        rng = np.random.default_rng(42)
+        data = rng.normal(1000, 100, shape).astype(np.float64)
+        mock_pipeline.return_value = ({"ch0": data}, shape)
+
+        base_request = {
+            "channels": [{"file_paths": ["test.fits"], "color": {"hue": 120.0}}],
+            "width": 100,
+            "height": 100,
+        }
+
+        response_no_sat = client.post("/composite/generate-nchannel", json=base_request)
+        response_identity = client.post(
+            "/composite/generate-nchannel",
+            json={
+                **base_request,
+                "saturation": {"saturation": 1.0, "vibrancy": 0.0, "hue_rotation": 0.0},
+            },
+        )
+        assert response_no_sat.status_code == 200
+        assert response_identity.status_code == 200
+        assert response_no_sat.content == response_identity.content
+
+    def test_saturation_out_of_range_returns_422(self, client):
+        """saturation > 2.0 is rejected by pydantic validation."""
+        response = client.post(
+            "/composite/generate-nchannel",
+            json={
+                "channels": [{"file_paths": ["test.fits"], "color": {"hue": 0.0}}],
+                "saturation": {"saturation": 5.0},
+                "width": 100,
+                "height": 100,
+            },
+        )
+        assert response.status_code == 422
+
+    def test_hue_rotation_out_of_range_returns_422(self, client):
+        """hue_rotation outside [-30, 30] is rejected."""
+        response = client.post(
+            "/composite/generate-nchannel",
+            json={
+                "channels": [{"file_paths": ["test.fits"], "color": {"hue": 0.0}}],
+                "saturation": {"hue_rotation": 200.0},
+                "width": 100,
+                "height": 100,
+            },
+        )
+        assert response.status_code == 422
+
     def test_background_neutralization_disabled(self, client, mock_pipeline):
         shape = (50, 50)
         data = _make_test_data(shape)


### PR DESCRIPTION
Closes #684

## Summary

Adds global saturation, vibrancy, and hue rotation controls to the N-channel composite pipeline as post-sharpening color grading. Closes the color richness gap vs NASA press images identified in the compositing quality spike (#680).

## Why

Our composite pipeline produces undersaturated images compared to NASA/ESA press releases. Saturation and vibrancy controls let users boost color richness, while hue rotation enables creative color grading — all key for the portfolio differentiator goal.

## Changes Made

**Processing Engine (Python)**
- `models.py`: New `SaturationConfig` model (saturation 0–2, vibrancy 0–1, hue_rotation ±30°)
- `color_mapping.py`: New `apply_saturation_vibrancy()` pure function — saturation (multiplicative), vibrancy (selective `s + v*(1-s)`), hue rotation — single HSL round-trip
- `routes.py`: Wired after sharpening in the pipeline

**Backend (.NET)**
- `CompositeModels.cs`: `SaturationConfigDto` with `[Range]` validation, `ProcessingSaturationConfig` with snake_case JSON
- `CompositeService.cs`: `CreateProcessingSaturation()` mapping method

**Frontend (TypeScript/React)**
- `CompositeTypes.ts`: `SaturationConfig` interface, `DEFAULT_SATURATION`, `isDefaultSaturation()` helper, preset updates (NASA Press, High Contrast, Auto)
- `CompositePreviewStep.tsx`: Three slider controls, preset loading, preview/export wiring
- `compositeService.ts`: `saturation` parameter added to all three request builder functions

**Tests**
- `test_color_mapping.py`: 10 unit tests (identity, grayscale, boost, vibrancy selectivity, hue shift, edge cases, validation)
- `test_nchannel_composite.py`: 4 integration tests (API flow, identity match, out-of-range 422)
- `CompositeServiceTests.cs`: 2 .NET serialization tests (snake_case wire contract, null passthrough)

## Test Plan

- [x] `docker compose up -d --build`
- [ ] Navigate to composite wizard → select images → Step 2 (Preview)
- [ ] Verify three new sliders appear below the sharpening section
- [ ] **Saturation** slider: drag to 1.8 → colors visibly richer
- [ ] **Vibrancy** slider: drag to 0.5 → muted nebula gains color, bright stars unchanged
- [ ] **Hue Rotation** slider: drag to +15 → image shifts warmer
- [ ] Select **NASA Press** preset → saturation=1.30, vibrancy=0.25
- [ ] Select **Auto** preset → saturation=1.10, vibrancy=0.15
- [ ] Select **Natural** preset → sliders reset to defaults (1.0/0.0/0.0)
- [ ] Export a composite with non-default saturation → exported image reflects adjustment
- [x] `docker exec jwst-processing python -m pytest tests/test_color_mapping.py tests/test_nchannel_composite.py -v` → 176 pass
- [x] `dotnet test` backend → 1070 pass

## Documentation Checklist
- [x] `docs/key-files.md` — updated `color_mapping.py` description to mention saturation/vibrancy/hue
- [x] No other documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced
- SHOULD FIX noted: `compositeService.ts` positional parameter sprawl (8-11 params) — refactor to options object in a future PR

## Risk & Rollback
- Risk: **Low** — new optional field with no-op defaults. Existing API consumers unaffected. Byte-identical output when saturation config is omitted.
- Rollback: Revert this single commit. No data model or storage changes.

