### PR TITLE
feat: smart auto-stretch with histogram analysis and per-channel controls

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.Log.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.Log.cs
@@ -49,5 +49,11 @@ namespace JwstDataAnalysis.API.Controllers
             Level = LogLevel.Information,
             Message = "Observation mosaic in progress for {ObservationBaseId} (job {JobId}), returning 409")]
         private partial void LogMosaicInProgress(string observationBaseId, string jobId);
+
+        [LoggerMessage(
+            EventId = 9,
+            Level = LogLevel.Information,
+            Message = "Analyzing channels: {ChannelCount} channel(s)")]
+        private partial void LogAnalyzingChannels(int channelCount);
     }
 }

--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
@@ -168,16 +168,92 @@ namespace JwstDataAnalysis.API.Controllers
         }
 
         /// <summary>
+        /// Analyze channels — returns auto-stretch parameters, histograms, and detection metadata.
+        /// </summary>
+        /// <param name="request">Channel configurations to analyze.</param>
+        /// <returns>JSON analysis results per channel.</returns>
+        /// <response code="200">Returns analysis results for each channel.</response>
+        /// <response code="400">Invalid request parameters.</response>
+        /// <response code="404">One or more data IDs not found.</response>
+        /// <response code="503">Processing engine unavailable.</response>
+        [HttpPost("analyze-channels")]
+        [AllowAnonymous]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public async Task<IActionResult> AnalyzeChannels([FromBody] AnalyzeChannelsRequestDto request)
+        {
+            try
+            {
+                var validationResult = ValidateChannelConfigs(request.Channels);
+                if (validationResult is not null)
+                {
+                    return validationResult;
+                }
+
+                LogAnalyzingChannels(request.Channels.Count);
+
+                var userId = GetCurrentUserId();
+                var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+                var isAdmin = IsCurrentUserAdmin();
+
+                var result = await compositeService.AnalyzeChannelsAsync(
+                    request,
+                    userId,
+                    isAuthenticated,
+                    isAdmin);
+
+                return Ok(result);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                LogDataNotFound(ex.Message);
+                return NotFound(new { error = "The requested data was not found." });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LogInvalidOperation(ex.Message);
+                var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+                return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
+            }
+            catch (HttpRequestException ex)
+            {
+                LogProcessingEngineError(ex);
+                return StatusCode(503, new { error = "Processing engine is temporarily unavailable. Please retry." });
+            }
+            catch (TaskCanceledException)
+            {
+                return StatusCode(504, new { error = "Analysis timed out. Try with fewer channels." });
+            }
+            catch (Exception ex)
+            {
+                LogUnexpectedError(ex);
+                return StatusCode(500, new { error = "Channel analysis failed. Please retry." });
+            }
+        }
+
+        /// <summary>
         /// Validate an N-channel composite request. Returns an error result, or null if valid.
         /// </summary>
         private BadRequestObjectResult? ValidateNChannelRequest(NChannelCompositeRequestDto request)
         {
-            if (request.Channels == null || request.Channels.Count == 0)
+            return ValidateChannelConfigs(request.Channels);
+        }
+
+        /// <summary>
+        /// Validate a list of channel configurations. Returns an error result, or null if valid.
+        /// Shared by generate-nchannel, export-nchannel, and analyze-channels endpoints.
+        /// </summary>
+        private BadRequestObjectResult? ValidateChannelConfigs(List<NChannelConfigDto>? channels)
+        {
+            if (channels == null || channels.Count == 0)
             {
                 return BadRequest(new { error = "At least one channel configuration is required" });
             }
 
-            foreach (var channel in request.Channels)
+            foreach (var channel in channels)
             {
                 if (channel.DataIds == null || channel.DataIds.Count == 0)
                 {

--- a/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
@@ -276,6 +276,24 @@ namespace JwstDataAnalysis.API.Models
     }
 
     /// <summary>
+    /// Request to analyze channels — returns stretch params, histograms, and metadata.
+    /// </summary>
+    public class AnalyzeChannelsRequestDto
+    {
+        /// <summary>
+        /// Gets or sets channel configurations to analyze.
+        /// </summary>
+        [Required]
+        [MinLength(1)]
+        public List<NChannelConfigDto> Channels { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether background neutralization is enabled.
+        /// </summary>
+        public bool BackgroundNeutralization { get; set; } = true;
+    }
+
+    /// <summary>
     /// Internal global adjustments sent to processing engine.
     /// </summary>
     internal class ProcessingOverallAdjustments
@@ -381,6 +399,18 @@ namespace JwstDataAnalysis.API.Models
 
         [JsonPropertyName("auto_stretch")]
         public bool AutoStretch { get; set; }
+    }
+
+    /// <summary>
+    /// Internal analyze-channels request sent to processing engine (with file paths).
+    /// </summary>
+    internal class ProcessingAnalyzeChannelsRequest
+    {
+        [JsonPropertyName("channels")]
+        public List<ProcessingNChannelConfig> Channels { get; set; } = new();
+
+        [JsonPropertyName("background_neutralization")]
+        public bool BackgroundNeutralization { get; set; } = true;
     }
 
     /// <summary>

--- a/backend/JwstDataAnalysis.API/Services/CompositeService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.Log.cs
@@ -81,5 +81,17 @@ namespace JwstDataAnalysis.API.Services
             Level = LogLevel.Information,
             Message = "Inline observation mosaic completed for {ObservationBaseId}: dataId={MosaicDataId}")]
         private partial void LogInlineMosaicCompleted(string observationBaseId, string mosaicDataId);
+
+        [LoggerMessage(
+            EventId = 14,
+            Level = LogLevel.Information,
+            Message = "Analyzing channels: {ChannelCount} channel(s)")]
+        private partial void LogAnalyzingChannels(int channelCount);
+
+        [LoggerMessage(
+            EventId = 15,
+            Level = LogLevel.Information,
+            Message = "Channel analysis complete: {ChannelCount} channel(s)")]
+        private partial void LogChannelAnalysisComplete(int channelCount);
     }
 }

--- a/backend/JwstDataAnalysis.API/Services/CompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.cs
@@ -142,6 +142,80 @@ namespace JwstDataAnalysis.API.Services
             return imageBytes;
         }
 
+        /// <inheritdoc/>
+        public async Task<JsonElement> AnalyzeChannelsAsync(
+            AnalyzeChannelsRequestDto request,
+            string? userId,
+            bool isAuthenticated,
+            bool isAdmin,
+            CancellationToken cancellationToken = default)
+        {
+            LogAnalyzingChannels(request.Channels.Count);
+
+            var processingChannels = new List<ProcessingNChannelConfig>();
+
+            foreach (var channel in request.Channels)
+            {
+                var filePaths = await ResolveDataIdsToFilePathsAsync(
+                    channel.DataIds,
+                    userId,
+                    isAuthenticated,
+                    isAdmin,
+                    cancellationToken: cancellationToken);
+
+                processingChannels.Add(new ProcessingNChannelConfig
+                {
+                    FilePaths = filePaths,
+                    Stretch = channel.Stretch,
+                    BlackPoint = channel.BlackPoint,
+                    WhitePoint = channel.WhitePoint,
+                    Gamma = channel.Gamma,
+                    AsinhA = channel.AsinhA,
+                    Curve = channel.Curve,
+                    Weight = channel.Weight,
+                    Color = new ProcessingChannelColor
+                    {
+                        Hue = channel.Color.Hue,
+                        Rgb = channel.Color.Rgb,
+                        Luminance = channel.Color.Luminance,
+                    },
+                    Label = channel.Label,
+                    WavelengthUm = channel.WavelengthUm,
+                    AutoStretch = channel.AutoStretch,
+                });
+            }
+
+            var processingRequest = new ProcessingAnalyzeChannelsRequest
+            {
+                Channels = processingChannels,
+                BackgroundNeutralization = request.BackgroundNeutralization,
+            };
+
+            var json = JsonSerializer.Serialize(processingRequest, jsonOptions);
+            LogCallingProcessingEngine(json);
+
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await httpClient.PostAsync(
+                $"{processingEngineUrl}/composite/analyze-channels",
+                content,
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                LogProcessingEngineError(response.StatusCode, errorBody);
+                throw new HttpRequestException(
+                    $"Processing engine error: {response.StatusCode} - {errorBody}",
+                    null,
+                    response.StatusCode);
+            }
+
+            var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            LogChannelAnalysisComplete(request.Channels.Count);
+
+            return JsonSerializer.Deserialize<JsonElement>(responseBody);
+        }
+
         private static ProcessingOverallAdjustments? CreateProcessingOverallAdjustments(
             OverallAdjustmentsDto? overall)
         {

--- a/backend/JwstDataAnalysis.API/Services/ICompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/ICompositeService.cs
@@ -1,6 +1,8 @@
 // Copyright (c) JWST Data Analysis. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
+
 using JwstDataAnalysis.API.Models;
 
 namespace JwstDataAnalysis.API.Services
@@ -28,6 +30,22 @@ namespace JwstDataAnalysis.API.Services
             bool isAdmin,
             bool allowInlineMosaic = false,
             Func<int, string, string, Task>? onProgress = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Analyze channels — returns auto-stretch params, histograms, and detection metadata.
+        /// </summary>
+        /// <param name="request">Channel configurations to analyze.</param>
+        /// <param name="userId">Current user ID when authenticated, otherwise null.</param>
+        /// <param name="isAuthenticated">Whether the request is authenticated.</param>
+        /// <param name="isAdmin">Whether the current user has Admin role.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>JSON response from the processing engine (pass-through).</returns>
+        Task<JsonElement> AnalyzeChannelsAsync(
+            AnalyzeChannelsRequestDto request,
+            string? userId,
+            bool isAuthenticated,
+            bool isAdmin,
             CancellationToken cancellationToken = default);
     }
 }

--- a/docs/architecture/security-model.md
+++ b/docs/architecture/security-model.md
@@ -207,6 +207,7 @@ All controllers inherit from `ApiControllerBase`, which provides identity extrac
 |----------|------|----------------|-------|
 | `POST /generate-nchannel` | Open | + Service-level access check per input | 404 if inaccessible to anon |
 | `POST /export-nchannel` | Auth | UserId null-check | |
+| `POST /analyze-channels` | Open | + Service-level access check per input | 404 if inaccessible to anon |
 
 ### MastController (`/api/mast`)
 

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -111,10 +111,10 @@ Visual polish, accessibility fixes, and compositing quality improvements needed 
 | [#680](https://github.com/Snoww3d/jwst-data-analysis/issues/680) | **Spike**: Research compositing pipeline to match NASA press image quality | Done (see `docs/plans/compositing-quality-spike.md`) |
 | [#687](https://github.com/Snoww3d/jwst-data-analysis/issues/687) | Optimize composite stretch defaults and add NASA-style presets | Done (#689) |
 | [#690](https://github.com/Snoww3d/jwst-data-analysis/issues/690) | Extract shared stretch types from composite and mosaic wizards | Done (#692) |
-| [#683](https://github.com/Snoww3d/jwst-data-analysis/issues/683) | Expose unsharp masking in composite pipeline | Open |
-| [#684](https://github.com/Snoww3d/jwst-data-analysis/issues/684) | Add saturation and vibrancy controls | Open |
+| [#683](https://github.com/Snoww3d/jwst-data-analysis/issues/683) | Expose unsharp masking in composite pipeline | Done (#1203) |
+| [#684](https://github.com/Snoww3d/jwst-data-analysis/issues/684) | Add saturation and vibrancy controls | Done (#1203) |
 | [#685](https://github.com/Snoww3d/jwst-data-analysis/issues/685) | Add noise reduction pre-composite step | Open |
-| [#688](https://github.com/Snoww3d/jwst-data-analysis/issues/688) | Smart auto-stretch based on histogram analysis | Open |
+| [#688](https://github.com/Snoww3d/jwst-data-analysis/issues/688) | Smart auto-stretch based on histogram analysis | In Progress |
 | [#686](https://github.com/Snoww3d/jwst-data-analysis/issues/686) | Multi-scale processing / star separation | Open (Phase 6+) |
 | [#691](https://github.com/Snoww3d/jwst-data-analysis/issues/691) | Add stretch presets to mosaic wizard | Open (deferred, low priority) |
 | ~~[#731](https://github.com/Snoww3d/jwst-data-analysis/issues/731)~~ | ~~Background job queue dashboard~~ | Done |

--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -188,8 +188,9 @@ Quick reference for finding important files in the codebase.
 - `processing-engine/app/mast/s3_downloader.py` - S3 multipart download engine with progress
 - `processing-engine/app/mast/download_state_manager.py` - State persistence for resume
 - `processing-engine/app/mast/download_tracker.py` - Byte-level progress tracking
-- `processing-engine/app/composite/routes.py` - RGB and N-channel composite FastAPI routes
-- `processing-engine/app/composite/models.py` - Composite Pydantic models (RGB + N-channel)
+- `processing-engine/app/composite/routes.py` - RGB and N-channel composite FastAPI routes (POST /composite/generate-nchannel, POST /composite/analyze-channels)
+- `processing-engine/app/composite/auto_stretch.py` - Auto-stretch parameter detection from pixel statistics (histogram, SNR, HDR detection)
+- `processing-engine/app/composite/models.py` - Composite Pydantic models (RGB + N-channel + channel analysis)
 - `processing-engine/app/composite/color_mapping.py` - N-channel color mapping engine (hue→RGB, wavelength→hue, channel combination, saturation/vibrancy/hue rotation)
 - `processing-engine/app/mosaic/routes.py` - WCS mosaic FastAPI routes
 - `processing-engine/app/mosaic/models.py` - Mosaic Pydantic models

--- a/docs/plans/features/688-smart-auto-stretch.md
+++ b/docs/plans/features/688-smart-auto-stretch.md
@@ -1,0 +1,195 @@
+# #688 — Smart Auto-Stretch Based on Histogram Analysis
+
+## Summary
+
+Expose the existing `auto_stretch_params()` backend to users via per-channel Auto
+buttons, with histogram visualization, detection metadata, named preset library,
+and before/after comparison toggle.
+
+**Issue:** [#688](https://github.com/Snoww3d/jwst-data-analysis/issues/688)
+**Complexity:** Large (8 production files, 1 new endpoint, no data model changes)
+**Reversal cost:** < 1 hour — all frontend-only except one new read-only endpoint
+
+## CEO Review Decisions
+
+- **Mode:** A (Scope Expansion)
+- **EXPANSION-1:** Per-channel histogram panel — ACCEPTED (S effort, LOW risk)
+- **EXPANSION-2:** Auto-stretch explanation card — ACCEPTED (S effort, LOW risk)
+- **EXPANSION-3:** Named stretch preset library (localStorage) — ACCEPTED (L effort, MED risk)
+- **EXPANSION-4:** Before/after comparison toggle — ACCEPTED (M effort, LOW risk)
+
+## Architecture Decision
+
+- **ARCH-1:** New `POST /composite/analyze-channels` endpoint (not response headers)
+  - Returns JSON with per-channel histogram + auto-stretch params + detection metadata
+  - Separate from binary image endpoint for clean separation
+  - Called on user "Auto" click, not on every preview
+
+## What Already Exists
+
+| Component | Status |
+|---|---|
+| `auto_stretch_params()` in `auto_stretch.py` | Fully implemented |
+| `auto_stretch: bool` on `NChannelConfig` model | Wired |
+| Backend auto-stretch in `/generate-nchannel` | Working |
+| `HistogramPanel.tsx` component | Working (not wired per-channel) |
+| Global "auto" preset in `CompositePreviewStep` | Working |
+| `statistics.py` histogram/stats framework | Working |
+
+## File-by-File Changes
+
+### Backend (Python — processing engine)
+
+#### 1. `processing-engine/app/composite/auto_stretch.py`
+
+- **Modify** `auto_stretch_params()` to return detection metadata alongside stretch params
+- Add `_meta` key to return dict with: `dynamic_range`, `noise`, `snr`, `hdr_detected`,
+  `curve_reason`, `instrument_adjusted`, `valid_pixels`, `zero_coverage_frac`
+- Computed from variables already in scope — no new analysis needed
+- No signature change — callers that ignore `_meta` are unaffected
+
+#### 2. `processing-engine/app/composite/models.py`
+
+- **Add** `AnalyzeChannelsRequest` model:
+  - `channels: list[NChannelConfig]` (reuse existing)
+  - `background_neutralization: bool = True`
+- **Add** `AutoStretchMeta` model:
+  - `dynamic_range`, `noise`, `snr`, `hdr_detected`, `curve_reason`,
+    `instrument_adjusted`, `valid_pixels`, `zero_coverage_frac`
+- **Add** `ChannelHistogram` model:
+  - `counts: list[int]`, `bin_centers: list[float]`, `bin_edges: list[float]`, `n_bins: int`
+- **Add** `ChannelAnalysisResult` model:
+  - `channel_name`, `label`, `params: dict`, `histogram`, `meta`, `stats`
+- **Add** `AnalyzeChannelsResponse` model:
+  - `channels: list[ChannelAnalysisResult]`
+
+#### 3. `processing-engine/app/composite/routes.py`
+
+- **Add** `POST /composite/analyze-channels` endpoint:
+  - Accept `AnalyzeChannelsRequest`
+  - Reuse `_detect_channel_instruments()` and `_load_reprojected_channels()` with
+    small fixed input budget (~262,144 px for speed)
+  - Optionally apply `neutralize_raw_backgrounds()`
+  - Per channel: `np.histogram(valid, bins=100)`, `auto_stretch_params()`, basic stats
+  - Return `AnalyzeChannelsResponse` as JSON
+- **Import** the new models
+
+### Frontend (TypeScript/React)
+
+#### 4. `frontend/jwst-frontend/src/types/CompositeTypes.ts`
+
+- **Add** interfaces: `AutoStretchMeta`, `ChannelHistogram`, `ChannelAnalysis`,
+  `AnalyzeChannelsResponse`, `SavedStretchPreset`
+- **Extend** `NChannelState` with optional `analysis?: ChannelAnalysis` field
+
+#### 5. `frontend/jwst-frontend/src/services/compositeService.ts`
+
+- **Add** `analyzeChannels()` function:
+  - POSTs to `/api/composite/analyze-channels`
+  - Returns `AnalyzeChannelsResponse`
+
+#### 6. `frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx`
+
+- **Add state:** `analyzing`, `beforePreviewUrl`, `showBefore`, `savedPresets`
+- **Add** `handleAutoChannel(channelId)`:
+  - Calls `analyzeChannels()` for one channel
+  - Populates channel's `params` with computed values (lock-and-refine)
+  - Stores `analysis` on `NChannelState`
+- **Add** `handleAutoAll()`:
+  - Batch call for all channels
+  - Stores `previewUrl` as `beforePreviewUrl` before applying
+- **Modify** per-channel section (~line 917-945):
+  - "Auto" button per channel header
+  - `HistogramPanel` per channel (collapsed by default) below stretch controls
+  - Auto-stretch explanation card (collapsible) below histogram
+- **Add** "Auto All" button next to "Per-Channel Adjustments" toggle (~line 898)
+- **Add** before/after toggle in preview container (~line 511)
+- **Add** preset save/load UI after built-in presets (~line 591):
+  - "Save Current" button, name prompt, localStorage `jwst_stretch_presets_v1`
+  - Saved presets render as additional buttons with delete "x"
+
+#### 7. `frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.css`
+
+- Styles for: `.auto-btn`, `.auto-all-btn`, `.analysis-card`, `.analysis-badge-hdr`,
+  `.before-after-toggle`, `.saved-preset-btn`, `.saved-preset-delete`, `.analyzing-spinner`
+
+### Tests
+
+#### 8. `processing-engine/tests/test_auto_stretch.py`
+
+- `_meta` key present with all expected fields
+- `hdr_detected=True` when dynamic range > 5000
+- `curve_reason` matches branch logic
+- Safe defaults still return `_meta`
+
+#### 9. `processing-engine/tests/test_analyze_channels.py` (new)
+
+- Happy path: returns histogram + params per channel
+- `background_neutralization=False` variant
+- Degenerate data (< 100 valid pixels)
+
+#### 10. `frontend/jwst-frontend/src/services/compositeService.test.ts`
+
+- Test `analyzeChannels()` service method
+
+#### 11. `frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.test.tsx`
+
+- Auto button triggers analyze call
+- Saved preset save/load round-trip
+
+### Docs
+
+#### 12. `docs/key-files.md` — add `/composite/analyze-channels` endpoint
+#### 13. `docs/development-plan.md` — mark #688 status
+
+## Risks
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| MED | Backend response doesn't currently return histogram or detection metadata | New `/analyze-channels` endpoint handles this cleanly |
+| MED | Per-channel histogram needs a data source before compositing | Analyze endpoint computes at low res (512x512 budget) |
+| LOW | localStorage presets stale on schema change | Versioned key `jwst_stretch_presets_v1`; discard on mismatch |
+| LOW | Before/after preview can desync if inputs change | Capture snapshot at toggle-on time; clear on channel change |
+
+## NOT in Scope
+
+- Per-instrument tuning exposed as explicit UI controls
+- Real-time histogram recompute on every slider move
+- MongoDB-backed or cloud-synced preset library
+- Changes to the stretch algorithm itself
+- HistEqStretch auto-selection in auto_stretch_params
+
+## Test Plan
+
+```
+Unit Tests (Python):
+- [ ] auto_stretch_params: returns _meta with all expected fields
+- [ ] auto_stretch_params: _meta.hdr_detected=True when dynamic_range > 5000
+- [ ] auto_stretch_params: _meta.curve_reason matches branch logic
+- [ ] auto_stretch_params: safe defaults path returns _meta
+
+Integration Tests (Python):
+- [ ] POST /composite/analyze-channels: happy path returns histogram + params
+- [ ] POST /composite/analyze-channels: responds in < 5s (512px budget)
+
+Unit Tests (TypeScript):
+- [ ] analyzeChannels service: maps response correctly
+- [ ] preset save/load: version mismatch discards stale presets
+- [ ] buildPayloads: per-channel autoStretch only when Auto active
+
+E2E Tests:
+- [ ] Auto All: triggers analyze, updates sliders, preview regenerates
+- [ ] Per-channel Auto: only affects that channel's params
+- [ ] Lock-and-refine: after Auto, slider override works
+- [ ] HistogramPanel: appears per-channel after Auto click
+- [ ] Explanation card: shows HDR badge when hdr_detected=true
+- [ ] Before/after toggle: appears after second preview, switches images
+- [ ] Preset save: persists on page reload
+- [ ] Preset load: applies params and regenerates preview
+
+Manual Verification:
+- [ ] Docker rebuild required: yes
+- [ ] MIRI + NIRCam composite: MIRI shows lower asinh_a after Auto All
+- [ ] HDR data: explanation card shows HDR badge
+- [ ] Preset library survives page refresh
+```

--- a/frontend/jwst-frontend/package-lock.json
+++ b/frontend/jwst-frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@microsoft/signalr": "^10.0.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
         "@types/react-plotly.js": "^2.6.4",
         "fitsjs": "^0.6.6",
         "plotly.js-basic-dist-min": "^3.5.0",

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.css
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.css
@@ -702,6 +702,252 @@
 }
 
 /* Responsive */
+/* --- Before/After Toggle --- */
+
+.preview-container.large {
+  position: relative;
+}
+
+.before-after-toggle {
+  position: absolute;
+  bottom: var(--space-3);
+  right: var(--space-3);
+  padding: var(--space-1) var(--space-3);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  background: rgba(0, 0, 0, 0.65);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--radius-sm);
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: background 0.15s ease;
+  z-index: 2;
+}
+
+.before-after-toggle:hover {
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.before-after-toggle.showing-before {
+  border-color: var(--accent-amber);
+  color: var(--accent-amber);
+}
+
+/* --- Auto Buttons --- */
+
+.per-channel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.per-channel-header .per-channel-toggle {
+  flex: 1;
+}
+
+.auto-all-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent-blue);
+  border-color: var(--accent-blue);
+  white-space: nowrap;
+}
+
+.auto-all-btn:hover:not(:disabled) {
+  background: rgba(var(--accent-blue-rgb, 59, 130, 246), 0.1);
+}
+
+.auto-all-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.auto-btn {
+  margin-left: auto;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent-blue);
+  border-color: var(--accent-blue);
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.auto-btn:hover:not(:disabled) {
+  background: rgba(var(--accent-blue-rgb, 59, 130, 246), 0.1);
+}
+
+.auto-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.analyzing-spinner {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* --- Analysis Card --- */
+
+.analysis-card {
+  margin-top: var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.analysis-card-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  border: none;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.analysis-card-toggle:hover {
+  background: var(--bg-interactive);
+}
+
+.analysis-card-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-weight: 600;
+}
+
+.analysis-badge-hdr {
+  display: inline-block;
+  padding: 1px 5px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--accent-amber);
+  color: var(--bg-deep);
+  border-radius: var(--radius-xs, 3px);
+}
+
+.analysis-badge-instrument {
+  display: inline-block;
+  padding: 1px 5px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--accent-purple, #a78bfa);
+  color: var(--bg-deep);
+  border-radius: var(--radius-xs, 3px);
+}
+
+.analysis-card-body {
+  padding: var(--space-2) var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.analysis-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.analysis-row span:first-child {
+  font-weight: 500;
+}
+
+.analysis-row span:last-child {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.analysis-card.collapsed .analysis-card-toggle svg {
+  transform: rotate(-90deg);
+}
+
+/* --- Saved Presets --- */
+
+.saved-preset-wrapper {
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+}
+
+.saved-preset-btn {
+  border-style: dashed;
+  padding-right: 18px;
+}
+
+.saved-preset-delete {
+  position: absolute;
+  right: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease;
+}
+
+.saved-preset-wrapper:hover .saved-preset-delete {
+  opacity: 1;
+}
+
+.saved-preset-delete:hover {
+  color: var(--accent-red, #ef4444);
+}
+
+.save-preset-btn {
+  border-style: dashed;
+  color: var(--text-muted);
+}
+
+.save-preset-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
 @media (max-width: 900px) {
   .composite-preview-step {
     grid-template-columns: 1fr;

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -4,6 +4,7 @@ import {
   NChannelState,
   NChannelConfigPayload,
   ChannelStretchParams,
+  ChannelAnalysis,
   ExportOptions,
   DEFAULT_CHANNEL_PARAMS,
   DEFAULT_EXPORT_OPTIONS,
@@ -13,11 +14,13 @@ import {
   OverallAdjustments,
   SharpeningConfig,
   SaturationConfig,
+  SavedStretchPreset,
   isDefaultSaturation,
   StretchMethod,
   COMPOSITE_PRESETS,
   CompositePreset,
   STRETCH_OPTIONS,
+  SAVED_PRESETS_STORAGE_KEY,
 } from '../../types/CompositeTypes';
 import { compositeService, ApiError } from '../../services';
 import { getFilterLabel, channelColorToHex, filterToInstrument } from '../../utils/wavelengthUtils';
@@ -25,6 +28,7 @@ import { useJobProgress } from '../../hooks/useJobProgress';
 import { useSimulatedProgress } from '../../hooks/useSimulatedProgress';
 import { apiClient } from '../../services/apiClient';
 import StretchControls, { StretchParams } from '../StretchControls';
+import HistogramPanel, { HistogramData, HistogramStats } from '../HistogramPanel';
 import './CompositePreviewStep.css';
 
 interface CompositePreviewStepProps {
@@ -98,9 +102,24 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
 
   const [activePreset, setActivePreset] = useState<string | null>(null);
   const [perChannelExpanded, setPerChannelExpanded] = useState(false);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [beforePreviewUrl, setBeforePreviewUrl] = useState<string | null>(null);
+  const [showBefore, setShowBefore] = useState(false);
+  const [savedPresets, setSavedPresets] = useState<SavedStretchPreset[]>(() => {
+    try {
+      const stored = localStorage.getItem(SAVED_PRESETS_STORAGE_KEY);
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  });
+  const [histogramCollapsed, setHistogramCollapsed] = useState<Record<string, boolean>>({});
+  const [analysisCardCollapsed, setAnalysisCardCollapsed] = useState<Record<string, boolean>>({});
+  const analyzeControllerRef = useRef<AbortController | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previewUrlRef = useRef<string | null>(null);
+  const beforePreviewUrlRef = useRef<string | null>(null);
 
   const handleApplyPreset = (preset: CompositePreset) => {
     setActivePreset(preset.id);
@@ -222,6 +241,215 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
       }));
   };
 
+  // Convert backend snake_case analysis to frontend ChannelAnalysis
+  const mapAnalysisResult = (raw: Record<string, unknown>): ChannelAnalysis => {
+    const rawMeta = raw.meta as Record<string, unknown>;
+    const rawHist = raw.histogram as Record<string, unknown>;
+    const rawStats = raw.stats as Record<string, unknown>;
+    const rawParams = raw.params as Record<string, unknown>;
+    return {
+      channelName: raw.channel_name as string,
+      label: (raw.label as string | null) ?? null,
+      params: {
+        stretch: ((rawParams.stretch as string) || 'asinh') as ChannelStretchParams['stretch'],
+        blackPoint: (rawParams.black_point as number) ?? 0,
+        whitePoint: (rawParams.white_point as number) ?? 1,
+        gamma: (rawParams.gamma as number) ?? 1,
+        asinhA: (rawParams.asinh_a as number) ?? 0.05,
+        curve: ((rawParams.curve as string) || 'linear') as ChannelStretchParams['curve'],
+        weight: 1.0,
+      },
+      histogram: {
+        counts: rawHist.counts as number[],
+        binCenters: rawHist.bin_centers as number[],
+        binEdges: rawHist.bin_edges as number[],
+        nBins: rawHist.n_bins as number,
+      },
+      meta: {
+        dynamicRange: rawMeta.dynamic_range as number,
+        noise: rawMeta.noise as number,
+        snr: rawMeta.snr as number,
+        hdrDetected: rawMeta.hdr_detected as boolean,
+        curveReason: rawMeta.curve_reason as string,
+        instrumentAdjusted: rawMeta.instrument_adjusted as boolean,
+        validPixels: rawMeta.valid_pixels as number,
+        zeroCoverageFrac: rawMeta.zero_coverage_frac as number,
+      },
+      stats: {
+        min: rawStats.min as number,
+        max: rawStats.max as number,
+        mean: rawStats.mean as number,
+        std: rawStats.std as number,
+      },
+    };
+  };
+
+  // Analyze a single channel and apply auto-stretch params (lock-and-refine)
+  const handleAutoChannel = async (channelId: string) => {
+    const ch = channels.find((c) => c.id === channelId);
+    if (!ch || ch.dataIds.length === 0) return;
+
+    setAnalyzing(true);
+    if (analyzeControllerRef.current) analyzeControllerRef.current.abort();
+    const controller = new AbortController();
+    analyzeControllerRef.current = controller;
+
+    try {
+      // Build a single-channel payload directly instead of filtering from all payloads,
+      // which could match wrong channels if they share dataIds
+      const singlePayload: NChannelConfigPayload[] = [
+        {
+          dataIds: ch.dataIds,
+          color: ch.color,
+          label: ch.label,
+          wavelengthUm: ch.wavelengthUm,
+          stretch: ch.params.stretch,
+          blackPoint: ch.params.blackPoint,
+          whitePoint: ch.params.whitePoint,
+          gamma: ch.params.gamma,
+          asinhA: ch.params.asinhA,
+          curve: ch.params.curve,
+          weight: ch.params.weight,
+        },
+      ];
+
+      const response = await compositeService.analyzeChannels(
+        singlePayload,
+        backgroundNeutralization,
+        controller.signal
+      );
+
+      if (response.channels.length > 0) {
+        const analysis = mapAnalysisResult(response.channels[0] as Record<string, unknown>);
+        onChannelsChange(
+          channels.map((c) => {
+            if (c.id !== channelId) return c;
+            return {
+              ...c,
+              params: { ...analysis.params, weight: c.params.weight },
+              analysis,
+            };
+          })
+        );
+        setActivePreset(null);
+      }
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        console.error('Auto-stretch analysis error:', err);
+        setPreviewError('Auto-stretch analysis failed. Try again or adjust parameters manually.');
+      }
+    } finally {
+      if (analyzeControllerRef.current === controller) {
+        setAnalyzing(false);
+      }
+    }
+  };
+
+  // Analyze all channels at once
+  const handleAutoAll = async () => {
+    const payloads = buildPayloads();
+    if (payloads.length === 0) return;
+
+    // Capture current preview for before/after comparison
+    if (previewUrl) {
+      // Revoke any previous "before" URL that's no longer needed
+      if (beforePreviewUrlRef.current && beforePreviewUrlRef.current !== previewUrl) {
+        URL.revokeObjectURL(beforePreviewUrlRef.current);
+      }
+      beforePreviewUrlRef.current = previewUrl;
+      setBeforePreviewUrl(previewUrl);
+      setShowBefore(false);
+    }
+
+    setAnalyzing(true);
+    if (analyzeControllerRef.current) analyzeControllerRef.current.abort();
+    const controller = new AbortController();
+    analyzeControllerRef.current = controller;
+
+    try {
+      const response = await compositeService.analyzeChannels(
+        payloads,
+        backgroundNeutralization,
+        controller.signal
+      );
+
+      const analysisResults = response.channels.map((raw) =>
+        mapAnalysisResult(raw as Record<string, unknown>)
+      );
+
+      // Map analysis results back to channels by index (same order as payloads)
+      let resultIdx = 0;
+      onChannelsChange(
+        channels.map((ch) => {
+          if (ch.dataIds.length === 0) return ch;
+          const analysis = analysisResults[resultIdx];
+          resultIdx++;
+          if (!analysis) return ch;
+          return {
+            ...ch,
+            params: { ...analysis.params, weight: ch.params.weight },
+            analysis,
+          };
+        })
+      );
+      setActivePreset(null);
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        console.error('Auto-stretch analysis error:', err);
+        setPreviewError('Auto-stretch analysis failed. Try again or adjust parameters manually.');
+      }
+    } finally {
+      if (analyzeControllerRef.current === controller) {
+        setAnalyzing(false);
+      }
+    }
+  };
+
+  // Saved presets — persist to localStorage
+  const persistPresets = (presets: SavedStretchPreset[]) => {
+    setSavedPresets(presets);
+    try {
+      localStorage.setItem(SAVED_PRESETS_STORAGE_KEY, JSON.stringify(presets));
+    } catch {
+      // QuotaExceededError — silently ignore
+    }
+  };
+
+  const handleSavePreset = () => {
+    const name = prompt('Preset name:');
+    if (!name?.trim()) return;
+
+    const preset: SavedStretchPreset = {
+      id: `saved-${Date.now()}`,
+      name: name.trim(),
+      createdAt: new Date().toISOString(),
+      channelParams: channels[0]?.params ?? { ...DEFAULT_CHANNEL_PARAMS },
+      overall: { ...overallAdjustments },
+      sharpening: sharpening.amount > 0 ? { ...sharpening } : undefined,
+      saturation: !isDefaultSaturation(saturation) ? { ...saturation } : undefined,
+      backgroundNeutralization,
+    };
+    persistPresets([...savedPresets, preset]);
+  };
+
+  const handleLoadPreset = (preset: SavedStretchPreset) => {
+    setActivePreset(null);
+    setOverallAdjustments({ ...preset.overall });
+    if (preset.sharpening) setSharpening({ ...preset.sharpening });
+    if (preset.saturation) setSaturation({ ...preset.saturation });
+    setBackgroundNeutralization(preset.backgroundNeutralization);
+    onChannelsChange(
+      channels.map((ch) => ({
+        ...ch,
+        params: { ...preset.channelParams, weight: ch.params.weight },
+      }))
+    );
+  };
+
+  const handleDeletePreset = (presetId: string) => {
+    persistPresets(savedPresets.filter((p) => p.id !== presetId));
+  };
+
   // Debounced preview regeneration when channels or overall adjustments change.
   useEffect(() => {
     if (debounceTimerRef.current) {
@@ -246,8 +474,14 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
       if (previewUrlRef.current) {
         URL.revokeObjectURL(previewUrlRef.current);
       }
+      if (beforePreviewUrlRef.current && beforePreviewUrlRef.current !== previewUrlRef.current) {
+        URL.revokeObjectURL(beforePreviewUrlRef.current);
+      }
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
+      }
+      if (analyzeControllerRef.current) {
+        analyzeControllerRef.current.abort();
       }
       if (timerRef.current) {
         clearTimeout(timerRef.current);
@@ -283,7 +517,8 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         !isDefaultSaturation(saturation) ? saturation : undefined
       );
 
-      if (previewUrlRef.current) {
+      // Revoke the old preview URL, but not if it's being held as the "before" snapshot
+      if (previewUrlRef.current && previewUrlRef.current !== beforePreviewUrl) {
         URL.revokeObjectURL(previewUrlRef.current);
       }
 
@@ -509,7 +744,23 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
             </div>
           )}
           {previewUrl && !previewLoading && (
-            <img src={previewUrl} alt="Final composite preview" className="preview-image" />
+            <>
+              <img
+                src={showBefore && beforePreviewUrl ? beforePreviewUrl : previewUrl}
+                alt={showBefore ? 'Before auto-stretch' : 'Final composite preview'}
+                className="preview-image"
+              />
+              {beforePreviewUrl && (
+                <button
+                  type="button"
+                  className={`btn-base before-after-toggle ${showBefore ? 'showing-before' : ''}`}
+                  onClick={() => setShowBefore((prev) => !prev)}
+                  title={showBefore ? 'Show current (after)' : 'Show previous (before)'}
+                >
+                  {showBefore ? 'Before' : 'After'}
+                </button>
+              )}
+            </>
           )}
         </div>
 
@@ -589,6 +840,35 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
                 {preset.label}
               </button>
             ))}
+            {savedPresets.map((preset) => (
+              <span key={preset.id} className="saved-preset-wrapper">
+                <button
+                  type="button"
+                  className="btn-base btn-compact preset-btn saved-preset-btn"
+                  onClick={() => handleLoadPreset(preset)}
+                  title={`Saved ${new Date(preset.createdAt).toLocaleDateString()}`}
+                >
+                  {preset.name}
+                </button>
+                <button
+                  type="button"
+                  className="saved-preset-delete"
+                  onClick={() => handleDeletePreset(preset.id)}
+                  title="Delete saved preset"
+                  aria-label={`Delete preset ${preset.name}`}
+                >
+                  &times;
+                </button>
+              </span>
+            ))}
+            <button
+              type="button"
+              className="btn-base btn-compact preset-btn save-preset-btn"
+              onClick={handleSavePreset}
+              title="Save current settings as a named preset"
+            >
+              + Save
+            </button>
           </div>
           {activePreset && (
             <span className="preset-hint">
@@ -838,9 +1118,10 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
               max="2.0"
               step="0.05"
               value={saturation.saturation}
-              onChange={(e) =>
-                setSaturation((prev) => ({ ...prev, saturation: parseFloat(e.target.value) }))
-              }
+              onChange={(e) => {
+                setActivePreset(null);
+                setSaturation((prev) => ({ ...prev, saturation: parseFloat(e.target.value) }));
+              }}
               className="quality-slider"
               aria-label="Saturation"
             />
@@ -859,9 +1140,10 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
               max="1.0"
               step="0.05"
               value={saturation.vibrancy}
-              onChange={(e) =>
-                setSaturation((prev) => ({ ...prev, vibrancy: parseFloat(e.target.value) }))
-              }
+              onChange={(e) => {
+                setActivePreset(null);
+                setSaturation((prev) => ({ ...prev, vibrancy: parseFloat(e.target.value) }));
+              }}
               className="quality-slider"
               aria-label="Vibrancy"
             />
@@ -880,9 +1162,10 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
               max="30"
               step="1"
               value={saturation.hueRotation}
-              onChange={(e) =>
-                setSaturation((prev) => ({ ...prev, hueRotation: parseFloat(e.target.value) }))
-              }
+              onChange={(e) => {
+                setActivePreset(null);
+                setSaturation((prev) => ({ ...prev, hueRotation: parseFloat(e.target.value) }));
+              }}
               className="quality-slider"
               aria-label="Hue rotation"
             />
@@ -895,30 +1178,65 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
 
         {/* Per-channel adjustments */}
         <div className="option-group per-channel-group">
-          <button
-            className={`btn-base per-channel-toggle ${perChannelExpanded ? 'expanded' : ''}`}
-            onClick={() => setPerChannelExpanded(!perChannelExpanded)}
-            type="button"
-          >
-            <span className="per-channel-toggle-label">Per-Channel Adjustments</span>
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              className={`per-channel-chevron ${perChannelExpanded ? 'expanded' : ''}`}
+          <div className="per-channel-header">
+            <button
+              className={`btn-base per-channel-toggle ${perChannelExpanded ? 'expanded' : ''}`}
+              onClick={() => setPerChannelExpanded(!perChannelExpanded)}
+              type="button"
             >
-              <polyline points="6 9 12 15 18 9" />
-            </svg>
-          </button>
+              <span className="per-channel-toggle-label">Per-Channel Adjustments</span>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                className={`per-channel-chevron ${perChannelExpanded ? 'expanded' : ''}`}
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              className="btn-base btn-compact auto-all-btn"
+              onClick={handleAutoAll}
+              disabled={analyzing}
+              title="Auto-detect optimal stretch for all channels"
+            >
+              {analyzing ? (
+                <span className="analyzing-spinner" />
+              ) : (
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M19 8l-4 4h3c0 3.31-2.69 6-6 6a5.87 5.87 0 0 1-2.8-.7l-1.46 1.46A7.93 7.93 0 0 0 12 20c4.42 0 8-3.58 8-8h3l-4-4zM6 12c0-3.31 2.69-6 6-6 1.01 0 1.97.25 2.8.7l1.46-1.46A7.93 7.93 0 0 0 12 4c-4.42 0-8 3.58-8 8H1l4 4 4-4H6z" />
+                </svg>
+              )}
+              Auto All
+            </button>
+          </div>
           {perChannelExpanded && (
             <div className="per-channel-controls">
               {channels.map((ch) => {
                 const images = getImagesForChannel(ch);
                 if (images.length === 0) return null;
                 const color = channelColorToHex(ch.color);
+                const analysis = ch.analysis;
+                const histData: HistogramData | null = analysis
+                  ? {
+                      counts: analysis.histogram.counts,
+                      bin_centers: analysis.histogram.binCenters,
+                      bin_edges: analysis.histogram.binEdges,
+                      n_bins: analysis.histogram.nBins,
+                    }
+                  : null;
+                const histStats: HistogramStats | null = analysis
+                  ? {
+                      min: analysis.stats.min,
+                      max: analysis.stats.max,
+                      mean: analysis.stats.mean,
+                      std: analysis.stats.std,
+                    }
+                  : null;
                 return (
                   <div
                     key={ch.id}
@@ -931,6 +1249,16 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
                       <span className="per-channel-filter">
                         {images.map((img) => getFilterLabel(img)).join(', ')}
                       </span>
+                      <button
+                        type="button"
+                        className="btn-base btn-compact auto-btn"
+                        onClick={() => handleAutoChannel(ch.id)}
+                        disabled={analyzing}
+                        title="Auto-detect optimal stretch for this channel"
+                      >
+                        {analyzing ? <span className="analyzing-spinner" /> : null}
+                        Auto
+                      </button>
                     </div>
                     <StretchControls
                       params={ch.params || DEFAULT_CHANNEL_PARAMS}
@@ -938,6 +1266,105 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
                       collapsed={channelCollapsed[ch.id] ?? true}
                       onToggleCollapse={() => toggleChannelCollapsed(ch.id)}
                     />
+                    {analysis && (
+                      <>
+                        <HistogramPanel
+                          histogram={histData}
+                          stats={histStats}
+                          blackPoint={ch.params.blackPoint}
+                          whitePoint={ch.params.whitePoint}
+                          onBlackPointChange={(v) =>
+                            handleChannelParamChange(ch.id, { ...ch.params, blackPoint: v })
+                          }
+                          onWhitePointChange={(v) =>
+                            handleChannelParamChange(ch.id, { ...ch.params, whitePoint: v })
+                          }
+                          collapsed={histogramCollapsed[ch.id] ?? true}
+                          onToggleCollapse={() =>
+                            setHistogramCollapsed((prev) => ({
+                              ...prev,
+                              [ch.id]: !(prev[ch.id] ?? true),
+                            }))
+                          }
+                          title={`${ch.label || 'Channel'} Histogram`}
+                          barColor={color}
+                        />
+                        <div
+                          className={`analysis-card ${analysisCardCollapsed[ch.id] !== false ? 'collapsed' : ''}`}
+                        >
+                          <button
+                            type="button"
+                            className="analysis-card-toggle"
+                            onClick={() =>
+                              setAnalysisCardCollapsed((prev) => ({
+                                ...prev,
+                                [ch.id]: prev[ch.id] === false,
+                              }))
+                            }
+                          >
+                            <span className="analysis-card-title">
+                              Auto-Stretch Details
+                              {analysis.meta.hdrDetected && (
+                                <span
+                                  className="analysis-badge-hdr"
+                                  title="High dynamic range detected"
+                                >
+                                  HDR
+                                </span>
+                              )}
+                              {analysis.meta.instrumentAdjusted && (
+                                <span
+                                  className="analysis-badge-instrument"
+                                  title="Instrument-specific adjustment applied"
+                                >
+                                  MIRI
+                                </span>
+                              )}
+                            </span>
+                            <svg
+                              width="12"
+                              height="12"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                            >
+                              <polyline points="6 9 12 15 18 9" />
+                            </svg>
+                          </button>
+                          {analysisCardCollapsed[ch.id] === false && (
+                            <div className="analysis-card-body">
+                              <div className="analysis-row">
+                                <span>Dynamic Range</span>
+                                <span>{analysis.meta.dynamicRange.toFixed(0)}:1</span>
+                              </div>
+                              <div className="analysis-row">
+                                <span>SNR</span>
+                                <span>{analysis.meta.snr.toFixed(1)}</span>
+                              </div>
+                              <div className="analysis-row">
+                                <span>Noise Floor</span>
+                                <span>{analysis.meta.noise.toExponential(2)}</span>
+                              </div>
+                              <div className="analysis-row">
+                                <span>Valid Pixels</span>
+                                <span>{analysis.meta.validPixels.toLocaleString()}</span>
+                              </div>
+                              <div className="analysis-row">
+                                <span>Coverage</span>
+                                <span>
+                                  {((1 - analysis.meta.zeroCoverageFrac) * 100).toFixed(1)}%
+                                </span>
+                              </div>
+                              <div className="analysis-row">
+                                <span>Curve</span>
+                                <span>{analysis.meta.curveReason.replace(/_/g, ' ')}</span>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      </>
+                    )}
                   </div>
                 );
               })}

--- a/frontend/jwst-frontend/src/services/compositeService.test.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.test.ts
@@ -32,6 +32,7 @@ import {
   generateNChannelPreview,
   exportNChannelComposite,
   exportNChannelCompositeAsync,
+  analyzeChannels,
   downloadComposite,
   generateFilename,
 } from './compositeService';
@@ -252,6 +253,54 @@ describe('compositeService', () => {
           sharpening: { radius: 1.0, amount: 0.4, threshold: 0.005 },
         })
       );
+    });
+  });
+
+  describe('analyzeChannels', () => {
+    it('should call apiClient.post with correct endpoint and request body', async () => {
+      const mockResponse = {
+        channels: [
+          {
+            channel_name: 'ch0_F444W',
+            label: 'F444W',
+            params: { stretch: 'asinh', asinh_a: 0.02 },
+            histogram: { counts: [1, 2], bin_centers: [0.5, 1.5], bin_edges: [0, 1, 2], n_bins: 2 },
+            meta: { dynamic_range: 500, snr: 80, hdr_detected: false },
+            stats: { min: 0, max: 100, mean: 50, std: 20 },
+          },
+        ],
+      };
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse);
+
+      const channels = [{ dataIds: ['abc'], color: { hue: 0 } }];
+      const result = await analyzeChannels(channels as never, true);
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/composite/analyze-channels',
+        { channels, backgroundNeutralization: true },
+        { signal: undefined }
+      );
+      expect(result.channels).toHaveLength(1);
+      expect(result.channels[0].channel_name).toBe('ch0_F444W');
+    });
+
+    it('should pass abort signal', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ channels: [] });
+      const controller = new AbortController();
+
+      await analyzeChannels([] as never, false, controller.signal);
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/composite/analyze-channels',
+        { channels: [], backgroundNeutralization: false },
+        { signal: controller.signal }
+      );
+    });
+
+    it('should propagate errors from apiClient', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('Analysis Failed'));
+
+      await expect(analyzeChannels([] as never)).rejects.toThrow('Analysis Failed');
     });
   });
 

--- a/frontend/jwst-frontend/src/services/compositeService.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.ts
@@ -12,6 +12,7 @@ import {
   NChannelConfigPayload,
   SaturationConfig,
   SharpeningConfig,
+  AnalyzeChannelsResponse,
 } from '../types/CompositeTypes';
 
 /**
@@ -165,6 +166,30 @@ export async function exportNChannelCompositeAsync(
   };
 
   return apiClient.post<{ jobId: string }>('/api/composite/export-nchannel', request);
+}
+
+/**
+ * Analyze channels — compute auto-stretch params, histograms, and detection metadata.
+ *
+ * Calls a lightweight endpoint that loads channels at low resolution,
+ * computes per-channel histogram + optimal stretch params, and returns JSON.
+ * Used by the "Auto" button UI to populate stretch controls.
+ *
+ * @param channels - Channel config payloads
+ * @param backgroundNeutralization - Whether to subtract sky background before analysis
+ * @param abortSignal - Optional AbortSignal for cancellation
+ * @returns Per-channel stretch params, histogram, and detection metadata
+ */
+export async function analyzeChannels(
+  channels: NChannelConfigPayload[],
+  backgroundNeutralization: boolean = true,
+  abortSignal?: AbortSignal
+): Promise<AnalyzeChannelsResponse> {
+  return apiClient.post<AnalyzeChannelsResponse>(
+    '/api/composite/analyze-channels',
+    { channels, backgroundNeutralization },
+    { signal: abortSignal }
+  );
 }
 
 /**

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -88,6 +88,81 @@ export interface ChannelColorSpec {
   luminance?: boolean; // true = luminance (detail) channel for LRGB
 }
 
+// --- Channel Analysis Types (from POST /composite/analyze-channels) ---
+
+/**
+ * Detection metadata from auto-stretch analysis.
+ */
+export interface AutoStretchMeta {
+  dynamicRange: number;
+  noise: number;
+  snr: number;
+  hdrDetected: boolean;
+  curveReason: string;
+  instrumentAdjusted: boolean;
+  validPixels: number;
+  zeroCoverageFrac: number;
+}
+
+/**
+ * Histogram data for a single channel's valid pixels.
+ */
+export interface ChannelHistogram {
+  counts: number[];
+  binCenters: number[];
+  binEdges: number[];
+  nBins: number;
+}
+
+/**
+ * Basic statistics for a channel's valid pixels.
+ */
+export interface ChannelAnalysisStats {
+  min: number;
+  max: number;
+  mean: number;
+  std: number;
+}
+
+/**
+ * Full analysis result for a single channel — params, histogram, and metadata.
+ */
+export interface ChannelAnalysis {
+  channelName: string;
+  label: string | null;
+  params: ChannelStretchParams;
+  histogram: ChannelHistogram;
+  meta: AutoStretchMeta;
+  stats: ChannelAnalysisStats;
+}
+
+/**
+ * Raw response from POST /composite/analyze-channels (snake_case from backend).
+ * Use mapAnalysisResult() in the component to convert to ChannelAnalysis.
+ */
+export interface AnalyzeChannelsResponse {
+  channels: Record<string, unknown>[];
+}
+
+// --- Saved Stretch Presets (localStorage) ---
+
+/**
+ * A user-saved stretch preset stored in localStorage.
+ */
+export interface SavedStretchPreset {
+  id: string;
+  name: string;
+  createdAt: string;
+  channelParams: ChannelStretchParams;
+  overall: OverallAdjustments;
+  sharpening?: SharpeningConfig;
+  saturation?: SaturationConfig;
+  backgroundNeutralization: boolean;
+}
+
+/** localStorage key for saved presets — versioned to handle schema changes. */
+export const SAVED_PRESETS_STORAGE_KEY = 'jwst_stretch_presets_v1';
+
 /**
  * State for a single N-channel in the wizard
  */
@@ -98,6 +173,7 @@ export interface NChannelState {
   label?: string;
   wavelengthUm?: number;
   params: ChannelStretchParams;
+  analysis?: ChannelAnalysis;
 }
 
 /**

--- a/processing-engine/app/composite/auto_stretch.py
+++ b/processing-engine/app/composite/auto_stretch.py
@@ -54,7 +54,18 @@ def auto_stretch_params(data: np.ndarray, instrument: str | None = None) -> dict
     # Edge case: not enough valid pixels for meaningful statistics
     if n_valid < 100:
         logger.warning(f"auto_stretch: only {n_valid} valid pixels, using safe defaults")
-        return dict(SAFE_DEFAULTS)
+        defaults = dict(SAFE_DEFAULTS)
+        defaults["_meta"] = {
+            "dynamic_range": 0.0,
+            "noise": 0.0,
+            "snr": 0.0,
+            "hdr_detected": False,
+            "curve_reason": "insufficient_data",
+            "instrument_adjusted": False,
+            "valid_pixels": int(n_valid),
+            "zero_coverage_frac": round(float(1.0 - n_valid / max(data.size, 1)), 4),
+        }
+        return defaults
 
     # Compute noise (1σ after sigma clipping)
     _, _, noise = sigma_clipped_stats(valid, sigma=3.0)
@@ -67,7 +78,18 @@ def auto_stretch_params(data: np.ndarray, instrument: str | None = None) -> dict
     # Edge case: constant data or zero range
     if signal_range < 1e-10 or noise < 1e-15:
         logger.warning("auto_stretch: constant/zero-range data, using safe defaults")
-        return dict(SAFE_DEFAULTS)
+        defaults = dict(SAFE_DEFAULTS)
+        defaults["_meta"] = {
+            "dynamic_range": 0.0,
+            "noise": round(float(noise), 6),
+            "snr": 0.0,
+            "hdr_detected": False,
+            "curve_reason": "constant_data",
+            "instrument_adjusted": False,
+            "valid_pixels": int(n_valid),
+            "zero_coverage_frac": round(float(1.0 - n_valid / max(data.size, 1)), 4),
+        }
+        return defaults
 
     # --- asinh_a: transition from linear → log at ~2× noise level ---
     # Small a = more compression (good for clean data with huge dynamic range)
@@ -144,6 +166,16 @@ def auto_stretch_params(data: np.ndarray, instrument: str | None = None) -> dict
     else:
         curve = "linear"  # Noisy — no curve (would amplify noise)
 
+    # Determine curve reasoning for metadata
+    if is_hdr:
+        curve_reason = "hdr"
+    elif snr > 100:
+        curve_reason = "high_snr"
+    elif snr > 10:
+        curve_reason = "medium_snr"
+    else:
+        curve_reason = "noisy"
+
     result = {
         "stretch": "asinh",
         "asinh_a": round(float(asinh_a), 4),
@@ -151,18 +183,31 @@ def auto_stretch_params(data: np.ndarray, instrument: str | None = None) -> dict
         "white_point": round(float(white_point), 4),
         "gamma": round(float(gamma), 2),
         "curve": curve,
+        "_meta": {
+            "dynamic_range": round(float(dynamic_range_ratio), 1),
+            "noise": round(float(noise), 6),
+            "snr": round(float(snr), 1),
+            "hdr_detected": bool(is_hdr),
+            "curve_reason": curve_reason,
+            "valid_pixels": int(n_valid),
+            "zero_coverage_frac": round(float(1.0 - coverage_frac), 4),
+        },
     }
 
     # Instrument-specific adjustments — MIRI has higher thermal background
     # and wider dynamic range than NIRCAM, needing more aggressive compression.
+    instrument_adjusted = False
     if instrument is not None:
         inst = instrument.upper()
         if inst == "MIRI":
             result["asinh_a"] = round(min(result["asinh_a"], 0.015), 4)
             result["gamma"] = round(min(result["gamma"] * 1.15, 2.5), 2)
+            instrument_adjusted = True
             logger.info(
                 f"auto_stretch: MIRI adjustment -> a={result['asinh_a']} gamma={result['gamma']}"
             )
+
+    result["_meta"]["instrument_adjusted"] = instrument_adjusted
 
     logger.info(
         f"auto_stretch: noise={noise:.2e} range={signal_range:.2e} "

--- a/processing-engine/app/composite/models.py
+++ b/processing-engine/app/composite/models.py
@@ -221,3 +221,71 @@ class NChannelCompositeRequest(BaseModel):
         default=False,
         description="Return per-channel coverage/feather masks instead of the composite image",
     )
+
+
+# --- Channel Analysis Models ---
+
+
+class AnalyzeChannelsRequest(BaseModel):
+    """Request to analyze channels and compute auto-stretch parameters + histograms."""
+
+    channels: list[NChannelConfig] = Field(
+        ..., min_length=1, description="Channel configurations to analyze"
+    )
+    background_neutralization: bool = Field(
+        default=True,
+        description="Subtract per-channel sky background before analysis",
+    )
+
+
+class AutoStretchMeta(BaseModel):
+    """Detection metadata from auto-stretch analysis."""
+
+    dynamic_range: float = Field(description="Ratio of max signal to noise floor")
+    noise: float = Field(description="1-sigma noise estimate from sigma-clipped stats")
+    snr: float = Field(description="Signal-to-noise ratio (99.9th percentile / noise)")
+    hdr_detected: bool = Field(description="Whether extreme dynamic range was detected (>5000)")
+    curve_reason: str = Field(
+        description="Why this tone curve was chosen: hdr, high_snr, medium_snr, noisy, "
+        "insufficient_data, constant_data"
+    )
+    instrument_adjusted: bool = Field(
+        description="Whether instrument-specific adjustments were applied"
+    )
+    valid_pixels: int = Field(description="Number of valid (>0) pixels in the channel")
+    zero_coverage_frac: float = Field(description="Fraction of pixels with no coverage (value=0)")
+
+
+class ChannelHistogram(BaseModel):
+    """Histogram data for a single channel's valid pixels."""
+
+    counts: list[int] = Field(description="Bin counts")
+    bin_centers: list[float] = Field(description="Center value of each bin")
+    bin_edges: list[float] = Field(description="Edge values (len = n_bins + 1)")
+    n_bins: int = Field(description="Number of bins")
+
+
+class ChannelStats(BaseModel):
+    """Basic statistics for a channel's valid pixels."""
+
+    min: float
+    max: float
+    mean: float
+    std: float
+
+
+class ChannelAnalysisResult(BaseModel):
+    """Analysis result for a single channel."""
+
+    channel_name: str = Field(description="Channel identifier (e.g. 'ch0_F444W')")
+    label: str | None = Field(default=None, description="Filter label")
+    params: dict = Field(description="Computed stretch parameters (stretch, asinh_a, etc.)")
+    histogram: ChannelHistogram
+    meta: AutoStretchMeta
+    stats: ChannelStats
+
+
+class AnalyzeChannelsResponse(BaseModel):
+    """Response from the analyze-channels endpoint."""
+
+    channels: list[ChannelAnalysisResult]

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -51,8 +51,14 @@ from .color_mapping import (
     linear_to_srgb,
 )
 from .models import (
+    AnalyzeChannelsRequest,
+    AnalyzeChannelsResponse,
+    AutoStretchMeta,
+    ChannelAnalysisResult,
     ChannelColor,
     ChannelConfig,
+    ChannelHistogram,
+    ChannelStats,
     NChannelCompositeRequest,
     NChannelConfig,
     OverallAdjustments,
@@ -1190,3 +1196,110 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
     if request.saturation is not None:
         rgb = apply_saturation_vibrancy(rgb, request.saturation)
     return _encode_and_respond(rgb, request, auto_feathered, feather)
+
+
+# ---------------------------------------------------------------------------
+# Analyze channels — lightweight endpoint for auto-stretch params + histograms
+# ---------------------------------------------------------------------------
+
+# Fixed low-resolution budget for fast analysis (512x512 = 262,144 px).
+# Full-quality reprojection is unnecessary — we only need pixel statistics.
+_ANALYZE_INPUT_BUDGET = 262_144
+
+
+@router.post("/analyze-channels", response_model=AnalyzeChannelsResponse)
+def analyze_channels(request: AnalyzeChannelsRequest):
+    """Analyze channel data and return auto-stretch params, histograms, and metadata.
+
+    Loads channels at low resolution for speed, computes per-channel histogram
+    and optimal stretch parameters. Used by the frontend to populate the
+    "Auto" stretch UI without rendering an image.
+
+    Returns:
+        JSON with per-channel stretch params, histogram, and detection metadata.
+    """
+    log_memory("analyze-start")
+    logger.info(f"Analyzing {len(request.channels)} channels")
+
+    # Build a lightweight NChannelCompositeRequest for reuse of existing helpers.
+    # Only the channel configs and a small output size matter — we won't render.
+    composite_request = NChannelCompositeRequest(
+        channels=request.channels,
+        output_format="png",
+        quality=85,
+        width=512,
+        height=512,
+    )
+
+    instruments = _detect_channel_instruments(request.channels)
+    reprojected = _load_reprojected_channels(composite_request, instruments, _ANALYZE_INPUT_BUDGET)
+
+    if request.background_neutralization:
+        analysis_input = neutralize_raw_backgrounds(reprojected)
+    else:
+        analysis_input = reprojected
+
+    ch_names = list(analysis_input.keys())
+    results: list[ChannelAnalysisResult] = []
+
+    for idx, ch_config in enumerate(request.channels):
+        ch_name = ch_names[idx]
+        data = analysis_input[ch_name]
+        valid = data[data > 0]
+
+        # Compute histogram on valid pixels
+        n_bins = 100
+        if valid.size > 0:
+            counts_arr, edges_arr = np.histogram(valid, bins=n_bins)
+            centers = ((edges_arr[:-1] + edges_arr[1:]) / 2).tolist()
+            histogram = ChannelHistogram(
+                counts=counts_arr.tolist(),
+                bin_centers=centers,
+                bin_edges=edges_arr.tolist(),
+                n_bins=n_bins,
+            )
+            stats = ChannelStats(
+                min=float(np.nanmin(valid)),
+                max=float(np.nanmax(valid)),
+                mean=float(np.nanmean(valid)),
+                std=float(np.nanstd(valid)),
+            )
+        else:
+            histogram = ChannelHistogram(
+                counts=[0] * n_bins,
+                bin_centers=[0.0] * n_bins,
+                bin_edges=[0.0] * (n_bins + 1),
+                n_bins=n_bins,
+            )
+            stats = ChannelStats(min=0.0, max=0.0, mean=0.0, std=0.0)
+
+        # Compute auto-stretch params with detection metadata
+        instrument = instruments[idx] if idx < len(instruments) else None
+        computed = auto_stretch_params(data, instrument=instrument)
+
+        meta_dict = computed.pop("_meta", {})
+        meta = AutoStretchMeta(
+            dynamic_range=meta_dict.get("dynamic_range", 0.0),
+            noise=meta_dict.get("noise", 0.0),
+            snr=meta_dict.get("snr", 0.0),
+            hdr_detected=meta_dict.get("hdr_detected", False),
+            curve_reason=meta_dict.get("curve_reason", "unknown"),
+            instrument_adjusted=meta_dict.get("instrument_adjusted", False),
+            valid_pixels=meta_dict.get("valid_pixels", 0),
+            zero_coverage_frac=meta_dict.get("zero_coverage_frac", 0.0),
+        )
+
+        results.append(
+            ChannelAnalysisResult(
+                channel_name=ch_name,
+                label=ch_config.label,
+                params=computed,
+                histogram=histogram,
+                meta=meta,
+                stats=stats,
+            )
+        )
+
+    log_memory("analyze-done")
+    logger.info(f"Channel analysis complete: {len(results)} channels")
+    return AnalyzeChannelsResponse(channels=results)

--- a/processing-engine/tests/test_analyze_channels.py
+++ b/processing-engine/tests/test_analyze_channels.py
@@ -1,0 +1,175 @@
+"""Tests for the POST /composite/analyze-channels endpoint."""
+
+from collections import OrderedDict
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    from main import app
+
+    return TestClient(app)
+
+
+# Deterministic test data: a synthetic 64x64 image with known statistics
+_RNG = np.random.default_rng(42)
+_SYNTHETIC_DATA = np.abs(_RNG.normal(loc=1000.0, scale=50.0, size=(64, 64))).astype(np.float32)
+
+# Minimal valid channel payload
+_CHANNEL_PAYLOAD = {
+    "file_paths": ["/fake/test_i2d.fits"],
+    "color": {"hue": 0},
+    "label": "F444W",
+    "stretch": "asinh",
+    "black_point": 0.0,
+    "white_point": 1.0,
+    "gamma": 1.0,
+    "asinh_a": 0.05,
+    "curve": "linear",
+    "weight": 1.0,
+}
+
+
+def _mock_reprojected(*_args, **_kwargs):
+    """Return a dict simulating reprojected channel data."""
+    return OrderedDict({"ch0_F444W": _SYNTHETIC_DATA.copy()})
+
+
+def _mock_instruments(*_args, **_kwargs):
+    """Return instrument list for one channel."""
+    return [None]
+
+
+def _mock_reprojected_two(*_args, **_kwargs):
+    """Return two channels of reprojected data."""
+    return OrderedDict(
+        {
+            "ch0_F444W": _SYNTHETIC_DATA.copy(),
+            "ch1_F200W": (_SYNTHETIC_DATA * 0.5).copy(),
+        }
+    )
+
+
+def _mock_instruments_two(*_args, **_kwargs):
+    return [None, None]
+
+
+_ROUTES_PREFIX = "app.composite.routes"
+
+
+class TestAnalyzeChannels:
+    """Tests for the analyze-channels endpoint."""
+
+    @patch(f"{_ROUTES_PREFIX}._load_reprojected_channels", side_effect=_mock_reprojected)
+    @patch(f"{_ROUTES_PREFIX}._detect_channel_instruments", side_effect=_mock_instruments)
+    def test_single_channel_returns_analysis(self, _mock_instr, _mock_load, client):
+        response = client.post(
+            "/composite/analyze-channels",
+            json={"channels": [_CHANNEL_PAYLOAD], "background_neutralization": False},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["channels"]) == 1
+
+        ch = body["channels"][0]
+        assert ch["channel_name"] == "ch0_F444W"
+        assert ch["label"] == "F444W"
+
+    @patch(f"{_ROUTES_PREFIX}._load_reprojected_channels", side_effect=_mock_reprojected)
+    @patch(f"{_ROUTES_PREFIX}._detect_channel_instruments", side_effect=_mock_instruments)
+    def test_response_contains_params(self, _mock_instr, _mock_load, client):
+        response = client.post(
+            "/composite/analyze-channels",
+            json={"channels": [_CHANNEL_PAYLOAD], "background_neutralization": False},
+        )
+        ch = response.json()["channels"][0]
+        params = ch["params"]
+        assert "stretch" in params
+        assert "asinh_a" in params
+        assert "black_point" in params
+        assert "white_point" in params
+        assert "gamma" in params
+
+    @patch(f"{_ROUTES_PREFIX}._load_reprojected_channels", side_effect=_mock_reprojected)
+    @patch(f"{_ROUTES_PREFIX}._detect_channel_instruments", side_effect=_mock_instruments)
+    def test_response_contains_histogram(self, _mock_instr, _mock_load, client):
+        response = client.post(
+            "/composite/analyze-channels",
+            json={"channels": [_CHANNEL_PAYLOAD], "background_neutralization": False},
+        )
+        ch = response.json()["channels"][0]
+        hist = ch["histogram"]
+        assert len(hist["counts"]) == 100
+        assert len(hist["bin_centers"]) == 100
+        assert len(hist["bin_edges"]) == 101
+        assert hist["n_bins"] == 100
+
+    @patch(f"{_ROUTES_PREFIX}._load_reprojected_channels", side_effect=_mock_reprojected)
+    @patch(f"{_ROUTES_PREFIX}._detect_channel_instruments", side_effect=_mock_instruments)
+    def test_response_contains_meta(self, _mock_instr, _mock_load, client):
+        response = client.post(
+            "/composite/analyze-channels",
+            json={"channels": [_CHANNEL_PAYLOAD], "background_neutralization": False},
+        )
+        ch = response.json()["channels"][0]
+        meta = ch["meta"]
+        assert "dynamic_range" in meta
+        assert "snr" in meta
+        assert "hdr_detected" in meta
+        assert "curve_reason" in meta
+        assert "instrument_adjusted" in meta
+        assert "valid_pixels" in meta
+        assert "zero_coverage_frac" in meta
+
+    @patch(f"{_ROUTES_PREFIX}._load_reprojected_channels", side_effect=_mock_reprojected)
+    @patch(f"{_ROUTES_PREFIX}._detect_channel_instruments", side_effect=_mock_instruments)
+    def test_response_contains_stats(self, _mock_instr, _mock_load, client):
+        response = client.post(
+            "/composite/analyze-channels",
+            json={"channels": [_CHANNEL_PAYLOAD], "background_neutralization": False},
+        )
+        ch = response.json()["channels"][0]
+        stats = ch["stats"]
+        assert stats["min"] > 0
+        assert stats["max"] > stats["min"]
+        assert stats["mean"] > 0
+        assert stats["std"] > 0
+
+    @patch(f"{_ROUTES_PREFIX}._load_reprojected_channels", side_effect=_mock_reprojected_two)
+    @patch(f"{_ROUTES_PREFIX}._detect_channel_instruments", side_effect=_mock_instruments_two)
+    def test_two_channels(self, _mock_instr, _mock_load, client):
+        ch2 = dict(_CHANNEL_PAYLOAD)
+        ch2["label"] = "F200W"
+        ch2["color"] = {"hue": 200}
+        response = client.post(
+            "/composite/analyze-channels",
+            json={"channels": [_CHANNEL_PAYLOAD, ch2], "background_neutralization": False},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["channels"]) == 2
+        assert body["channels"][0]["channel_name"] == "ch0_F444W"
+        assert body["channels"][1]["channel_name"] == "ch1_F200W"
+
+    def test_empty_channels_rejected(self, client):
+        response = client.post(
+            "/composite/analyze-channels",
+            json={"channels": [], "background_neutralization": False},
+        )
+        assert response.status_code == 422  # Pydantic validation error
+
+    @patch(f"{_ROUTES_PREFIX}._load_reprojected_channels", side_effect=_mock_reprojected)
+    @patch(f"{_ROUTES_PREFIX}._detect_channel_instruments", side_effect=_mock_instruments)
+    def test_histogram_counts_are_nonnegative(self, _mock_instr, _mock_load, client):
+        response = client.post(
+            "/composite/analyze-channels",
+            json={"channels": [_CHANNEL_PAYLOAD], "background_neutralization": False},
+        )
+        counts = response.json()["channels"][0]["histogram"]["counts"]
+        assert all(c >= 0 for c in counts)
+        assert sum(counts) > 0  # at least some data was binned

--- a/processing-engine/tests/test_auto_stretch.py
+++ b/processing-engine/tests/test_auto_stretch.py
@@ -9,7 +9,7 @@ class TestAutoStretchParams:
     """Test auto-stretch parameter derivation for various data profiles."""
 
     def test_returns_all_required_keys(self):
-        """Output dict must contain all stretch parameter keys."""
+        """Output dict must contain all stretch parameter keys plus _meta."""
         rng = np.random.default_rng(42)
         data = rng.exponential(scale=100, size=(200, 200))
         result = auto_stretch_params(data)
@@ -20,6 +20,7 @@ class TestAutoStretchParams:
             "white_point",
             "gamma",
             "curve",
+            "_meta",
         }
 
     def test_stretch_always_asinh(self):
@@ -76,24 +77,34 @@ class TestAutoStretchParams:
         assert result["curve"] in ("shadows", "linear")
 
     def test_all_zeros_returns_safe_defaults(self):
-        """All-zero data (no coverage) should return safe defaults."""
+        """All-zero data (no coverage) should return safe defaults with _meta."""
         data = np.zeros((200, 200))
         result = auto_stretch_params(data)
-        assert result == SAFE_DEFAULTS
+        # Stretch params match safe defaults; _meta is additional
+        for key in SAFE_DEFAULTS:
+            assert result[key] == SAFE_DEFAULTS[key]
+        assert "_meta" in result
+        assert result["_meta"]["curve_reason"] == "insufficient_data"
+        assert result["_meta"]["valid_pixels"] == 0
 
     def test_too_few_valid_pixels_returns_safe_defaults(self):
-        """Fewer than 100 valid pixels should return safe defaults."""
+        """Fewer than 100 valid pixels should return safe defaults with _meta."""
         data = np.zeros((200, 200))
         # Sprinkle 50 non-zero pixels (< 100 threshold)
         data.flat[:50] = 1.0
         result = auto_stretch_params(data)
-        assert result == SAFE_DEFAULTS
+        for key in SAFE_DEFAULTS:
+            assert result[key] == SAFE_DEFAULTS[key]
+        assert result["_meta"]["curve_reason"] == "insufficient_data"
+        assert result["_meta"]["valid_pixels"] == 50
 
     def test_constant_nonzero_data_returns_safe_defaults(self):
-        """Constant (non-zero) data has zero range — should return safe defaults."""
+        """Constant (non-zero) data has zero range — should return safe defaults with _meta."""
         data = np.full((200, 200), 42.0)
         result = auto_stretch_params(data)
-        assert result == SAFE_DEFAULTS
+        for key in SAFE_DEFAULTS:
+            assert result[key] == SAFE_DEFAULTS[key]
+        assert result["_meta"]["curve_reason"] == "constant_data"
 
     def test_parameter_bounds(self):
         """All computed parameters should be within their valid ranges."""
@@ -233,3 +244,119 @@ class TestInstrumentAwareStretch:
         data = self._make_typical_data()
         result = auto_stretch_params(data, instrument="MIRI")
         assert result["gamma"] <= 2.5
+
+
+class TestAutoStretchMeta:
+    """Tests for the _meta detection metadata returned by auto_stretch_params."""
+
+    def test_meta_has_all_keys(self):
+        """_meta must contain all expected detection metadata keys."""
+        rng = np.random.default_rng(42)
+        data = rng.exponential(scale=100, size=(200, 200))
+        result = auto_stretch_params(data)
+        meta = result["_meta"]
+        expected_keys = {
+            "dynamic_range",
+            "noise",
+            "snr",
+            "hdr_detected",
+            "curve_reason",
+            "instrument_adjusted",
+            "valid_pixels",
+            "zero_coverage_frac",
+        }
+        assert set(meta.keys()) == expected_keys
+
+    def test_meta_types(self):
+        """_meta values must have correct types."""
+        rng = np.random.default_rng(42)
+        data = rng.exponential(scale=100, size=(200, 200))
+        result = auto_stretch_params(data)
+        meta = result["_meta"]
+        assert isinstance(meta["dynamic_range"], float)
+        assert isinstance(meta["noise"], float)
+        assert isinstance(meta["snr"], float)
+        assert isinstance(meta["hdr_detected"], bool)
+        assert isinstance(meta["curve_reason"], str)
+        assert isinstance(meta["instrument_adjusted"], bool)
+        assert isinstance(meta["valid_pixels"], int)
+        assert isinstance(meta["zero_coverage_frac"], float)
+
+    def test_hdr_detected_true_for_extreme_range(self):
+        """HDR flag must be True when dynamic range ratio exceeds 5000."""
+        rng = np.random.default_rng(42)
+        data = rng.normal(loc=1.0, scale=0.5, size=(500, 500))
+        data = np.clip(data, 0, None)
+        y, x = np.mgrid[-250:250, -250:250]
+        data += 50000 * np.exp(-(x**2 + y**2) / (2 * 5**2))
+        result = auto_stretch_params(data)
+        assert result["_meta"]["hdr_detected"] is True
+        assert result["_meta"]["curve_reason"] == "hdr"
+
+    def test_hdr_detected_false_for_normal_data(self):
+        """HDR flag must be False for typical nebula data."""
+        rng = np.random.default_rng(42)
+        data = rng.exponential(scale=100, size=(300, 300))
+        result = auto_stretch_params(data)
+        assert result["_meta"]["hdr_detected"] is False
+        assert result["_meta"]["curve_reason"] != "hdr"
+
+    def test_curve_reason_matches_curve(self):
+        """curve_reason must be consistent with the chosen curve."""
+        rng = np.random.default_rng(42)
+        # High SNR data → s_curve + high_snr reason
+        data = rng.normal(loc=0.001, scale=0.001, size=(500, 500))
+        data = np.clip(data, 0, None)
+        y, x = np.mgrid[-250:250, -250:250]
+        data += 500 * np.exp(-(x**2 + y**2) / (2 * 50**2))
+        result = auto_stretch_params(data)
+        if result["curve"] == "s_curve":
+            assert result["_meta"]["curve_reason"] == "high_snr"
+        elif result["curve"] == "shadows":
+            assert result["_meta"]["curve_reason"] in ("medium_snr", "hdr")
+
+    def test_instrument_adjusted_true_for_miri(self):
+        """instrument_adjusted must be True when MIRI adjustments are applied."""
+        rng = np.random.default_rng(42)
+        data = rng.exponential(scale=100, size=(200, 200))
+        result = auto_stretch_params(data, instrument="MIRI")
+        assert result["_meta"]["instrument_adjusted"] is True
+
+    def test_instrument_adjusted_false_for_no_instrument(self):
+        """instrument_adjusted must be False when no instrument is provided."""
+        rng = np.random.default_rng(42)
+        data = rng.exponential(scale=100, size=(200, 200))
+        result = auto_stretch_params(data)
+        assert result["_meta"]["instrument_adjusted"] is False
+
+    def test_valid_pixels_count_accurate(self):
+        """valid_pixels must count only pixels > 0."""
+        data = np.zeros((100, 100))
+        data[:50, :] = 1.0  # 5000 valid pixels
+        result = auto_stretch_params(data)
+        assert result["_meta"]["valid_pixels"] == 5000
+
+    def test_zero_coverage_frac_with_gaps(self):
+        """zero_coverage_frac must reflect the proportion of zero pixels."""
+        rng = np.random.default_rng(42)
+        data = rng.exponential(scale=50, size=(500, 500))
+        # Set exactly 40% to zero
+        flat = data.flatten()
+        n_zero = int(0.4 * flat.size)
+        flat[:n_zero] = 0.0
+        data = flat.reshape(500, 500)
+        result = auto_stretch_params(data)
+        assert abs(result["_meta"]["zero_coverage_frac"] - 0.4) < 0.01
+
+    def test_safe_defaults_meta_insufficient_data(self):
+        """Safe defaults path should set curve_reason to 'insufficient_data'."""
+        data = np.zeros((200, 200))
+        data.flat[:10] = 1.0  # Only 10 valid pixels
+        result = auto_stretch_params(data)
+        assert result["_meta"]["curve_reason"] == "insufficient_data"
+
+    def test_safe_defaults_meta_constant_data(self):
+        """Constant data path should set curve_reason to 'constant_data'."""
+        data = np.full((200, 200), 42.0)
+        result = auto_stretch_params(data)
+        assert result["_meta"]["curve_reason"] == "constant_data"


### PR DESCRIPTION
Closes #688

## Summary
Add full-stack smart auto-stretch pipeline: per-channel histogram analysis, detection metadata (HDR, MIRI, SNR), and auto-computed stretch parameters. New `POST /composite/analyze-channels` endpoint through all three layers (Python -> .NET proxy -> Frontend). Frontend gains per-channel Auto buttons, Auto All, before/after comparison, saved preset library (localStorage), histogram panels, and explanation cards with HDR/MIRI badges.

## Why
Users currently have to manually tune 5+ stretch parameters per channel with no guidance. The auto-stretch algorithm already exists in the Python backend but wasn't exposed to the frontend. This bridges the gap with a lock-and-refine workflow: Auto computes optimal params, populates sliders, and users can tweak from an informed starting point.

## Changes Made

### Backend (Python processing engine)
- `auto_stretch_params()` returns `_meta` detection metadata: dynamic_range, SNR, HDR detection, curve reasoning, instrument adjustments, pixel coverage
- New `POST /composite/analyze-channels` endpoint: low-res channel loading (512x512 budget), per-channel histogram (100 bins), auto-stretch params, basic stats
- Pydantic models: `AnalyzeChannelsRequest/Response`, `ChannelAnalysisResult`, `AutoStretchMeta`, `ChannelHistogram`, `ChannelStats`

### Backend (.NET API proxy)
- `AnalyzeChannelsRequestDto` + `ProcessingAnalyzeChannelsRequest` DTOs
- `ICompositeService.AnalyzeChannelsAsync`: resolves DataIds to file paths, proxies JSON to Python
- `CompositeController.AnalyzeChannels`: `[AllowAnonymous]` with per-record service-level access checks
- Extracted shared `ValidateChannelConfigs` method (used by generate, export, and analyze endpoints)

### Frontend
- `analyzeChannels()` service function with proper camelCase request body
- Per-channel Auto buttons with lock-and-refine workflow (computed params populate sliders)
- Auto All button: analyzes all channels, captures before-preview for comparison
- Before/after comparison toggle with proper Object URL lifecycle management
- Saved stretch preset library (localStorage with versioned key `jwst_stretch_presets_v1`)
- Per-channel histogram panels (HistogramPanel integration)
- Auto-stretch explanation cards with HDR/MIRI detection badges
- Analysis errors shown in UI (not just console.error)
- Saturation/vibrancy/hue sliders clear active preset on change

### Docs
- Security model updated with new `POST /analyze-channels` endpoint
- `key-files.md` updated with `auto_stretch.py` and analyze-channels endpoint
- `development-plan.md` updated (#688 in progress)
- Plan saved to `docs/plans/features/688-smart-auto-stretch.md`

## Test Plan
- [x] **Python tests**: 32 `test_auto_stretch.py` tests pass (11 new for `_meta` metadata) + 8 `test_analyze_channels.py` endpoint tests (mocked reprojection)
- [x] **Frontend tests**: 18 `compositeService.test.ts` tests pass (3 new for `analyzeChannels`)
- [x] **Backend tests**: 1070 .NET tests pass, zero warnings
- [x] **TypeScript**: Compiles clean with `tsc --noEmit`
- [ ] **Manual**: Open Composite Wizard with loaded data -> click "Auto All" -> verify params populate sliders, histogram panels appear, explanation cards show HDR/MIRI badges -> click "Before/After" toggle -> verify before image shown -> save preset -> reload page -> verify preset persists -> load preset -> verify params restored

## Documentation Checklist
- [x] `docs/key-files.md` (new files/services)
- [x] `docs/architecture/security-model.md` (new endpoint auth posture)
- [x] `docs/development-plan.md` (milestone/phase changes)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: Medium — new endpoint + significant frontend additions, but follows established proxy pattern. Self-reviewed through 2 rounds (all findings fixed).
- Rollback: Revert single commit. No data model or storage changes.
