### PR TITLE
docs: rename block-pr-merge hook references to warn-pr-merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Quality is enforced structurally, not by memory:
 | Pre-commit (git) | At commit | Blocks main, runs ESLint, Prettier, tsc, vitest, dotnet build+test, ruff |
 | Pre-push (git) | At push | Blocks pushes to main |
 | validate-before-pr-create | Before `gh pr create` | Validates PR body sections and branch prefix |
-| block-pr-merge | Before `gh pr merge` | Warns — get user approval |
+| warn-pr-merge | Before `gh pr merge` | Warns — get user approval |
 | block-push-merged-branch | Before `git push` | Blocks pushes to branches with merged PRs |
 | post-edit-typecheck | After Edit/Write | Per-file tsc on .ts/.tsx files |
 | post-edit-lint | After Edit/Write | Anti-pattern scan (inline styles, `any`, unexplained suppressions, debug logging) |

--- a/docs/architecture/build-pipeline.md
+++ b/docs/architecture/build-pipeline.md
@@ -213,7 +213,7 @@ In addition to git hooks, Claude Code hooks run during development:
 | `post-edit-lint` | After Edit/Write | Anti-pattern scan (inline styles, `any`, debug logging) |
 | `post-edit-doc-drift` | After Edit/Write | Warns when docs may need updating |
 | `validate-before-pr-create` | Before `gh pr create` | Validates PR body and branch prefix |
-| `block-pr-merge` | Before `gh pr merge` | Warns for merge approval |
+| `warn-pr-merge` | Before `gh pr merge` | Warns for merge approval |
 | `block-push-merged-branch` | Before `git push` | Blocks pushes to already-merged branches |
 
 ## Build Matrix

--- a/docs/plans/exploration/claude-code-agents-evaluation.md
+++ b/docs/plans/exploration/claude-code-agents-evaluation.md
@@ -35,7 +35,7 @@ Before evaluating new agents, inventory of what we already have:
 | Command | `browser-debug` — Playwright debugging | `~/.claude/commands/browser-debug.md` |
 | Command | `start-application` — Docker stack startup | `~/.claude/commands/start-application.md` |
 | Command | `view-docs` — MkDocs viewer | `~/.claude/commands/view-docs.md` |
-| Hook | `block-pr-merge.sh` — merge approval warning | `.claude/hooks/` |
+| Hook | `warn-pr-merge.sh` — merge approval warning | `.claude/hooks/` |
 | Hook | `block-push-merged-branch.sh` — prevent stale pushes | `.claude/hooks/` |
 | Hook | `validate-before-pr-create.sh` — PR body validation | `.claude/hooks/` |
 | Script | `agent-stack.sh` — isolated Docker stacks per agent | `scripts/` |


### PR DESCRIPTION
No linked issue — cosmetic rename only.

## Summary

Rename documentation references from `block-pr-merge` to `warn-pr-merge` so the name matches the hook's actual behavior (exit 0 = warn-only, not block). Tiered merge policy (auto/skim/full review) remains a judgment call documented in CLAUDE.md — the hook is just a reminder prompt. Local `.claude/hooks/block-pr-merge.sh` renamed alongside `settings.local.json` update; both are gitignored.

## Why

The hook's name implied a hard block, but the implementation always exited 0 with a soft warning. New agents reading `AGENTS.md` were getting a misleading signal about the enforcement model.

## Changes Made

- `AGENTS.md` — Hook Enforcement table row updated (`block-pr-merge` → `warn-pr-merge`).
- `docs/architecture/build-pipeline.md` — Hook Reference table row updated.
- `docs/plans/exploration/claude-code-agents-evaluation.md` — tooling inventory row updated.

## Test Plan

- [x] Grep confirms no remaining `block-pr-merge` references in tracked files.
- [x] Smoke-tested renamed hook locally: piping a fake `gh pr merge 999 --squash` JSON payload prints the WARNING line and exits 0.
- [x] Pre-commit checks passed (sensitive patterns, gitleaks, doc consistency).

## Documentation Checklist

- [x] No documentation updates needed beyond the three touched files
- [ ] `docs/key-files.md` (new files/services)
- [ ] `docs/standards/backend-development.md` (new endpoints/controllers)
- [ ] `docs/quick-reference.md` (new API endpoints)
- [ ] `docs/architecture/` (new services/architectural changes)
- [ ] `docs/development-plan.md` (milestone/phase changes)

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback

- Risk: Zero. Docs-only change to tracked files; hook behavior is identical (soft warn). Local rename affects only this machine's gitignored `.claude/` setup.
- Rollback: `git revert` this commit to restore doc references; locally rename `warn-pr-merge.sh` back to `block-pr-merge.sh` and revert `settings.local.json`.
