### PR TITLE
docs: document post-edit-ruff and require-plan-file hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Quality is enforced structurally, not by memory:
 | Pre-commit (git) | At commit | Blocks main, runs ESLint, Prettier, tsc, vitest, dotnet build+test, ruff |
 | Pre-push (git) | At push | Blocks pushes to main |
 | validate-before-pr-create | Before `gh pr create` | Validates PR body sections and branch prefix |
+| require-plan-file | Before Edit/Write | Warns if no `docs/plans/features/` plan matches current `feature/`, `fix/`, `refactor/`, `perf/`, or `ci/` branch |
 | warn-pr-merge | Before `gh pr merge` | Warns — get user approval |
 | block-push-merged-branch | Before `git push` | Blocks pushes to branches with merged PRs |
 | post-edit-typecheck | After Edit/Write | Per-file tsc on .ts/.tsx files |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Quality is enforced structurally, not by memory:
 | block-push-merged-branch | Before `git push` | Blocks pushes to branches with merged PRs |
 | post-edit-typecheck | After Edit/Write | Per-file tsc on .ts/.tsx files |
 | post-edit-lint | After Edit/Write | Anti-pattern scan (inline styles, `any`, unexplained suppressions, debug logging) |
+| post-edit-ruff | After Edit/Write | Per-file `ruff check` on `.py` files under `processing-engine/` |
 | post-edit-doc-drift | After Edit/Write | Scores changes, warns when docs may need updating |
 
 Don't manually run checks the hooks already enforce.

--- a/docs/architecture/build-pipeline.md
+++ b/docs/architecture/build-pipeline.md
@@ -211,6 +211,7 @@ In addition to git hooks, Claude Code hooks run during development:
 |------|---------|---------|
 | `post-edit-typecheck` | After Edit/Write on .ts/.tsx | Per-file `tsc` check |
 | `post-edit-lint` | After Edit/Write | Anti-pattern scan (inline styles, `any`, debug logging) |
+| `post-edit-ruff` | After Edit/Write on `.py` | Per-file `ruff check` on processing-engine files |
 | `post-edit-doc-drift` | After Edit/Write | Warns when docs may need updating |
 | `validate-before-pr-create` | Before `gh pr create` | Validates PR body and branch prefix |
 | `warn-pr-merge` | Before `gh pr merge` | Warns for merge approval |

--- a/docs/architecture/build-pipeline.md
+++ b/docs/architecture/build-pipeline.md
@@ -214,6 +214,7 @@ In addition to git hooks, Claude Code hooks run during development:
 | `post-edit-ruff` | After Edit/Write on `.py` | Per-file `ruff check` on processing-engine files |
 | `post-edit-doc-drift` | After Edit/Write | Warns when docs may need updating |
 | `validate-before-pr-create` | Before `gh pr create` | Validates PR body and branch prefix |
+| `require-plan-file` | Before Edit/Write | Warns if no plan file in `docs/plans/features/` matches the current implementation branch |
 | `warn-pr-merge` | Before `gh pr merge` | Warns for merge approval |
 | `block-push-merged-branch` | Before `git push` | Blocks pushes to already-merged branches |
 


### PR DESCRIPTION
No linked issue — new local hook documentation.

## Summary

Documents two new Claude Code hooks added to the local `.claude/hooks/` setup (gitignored). Both hooks tighten the feedback loop on common workflow violations.

- **`post-edit-ruff`** — PostToolUse Edit/Write. Runs `ruff check` on `.py` files under `processing-engine/`. Catches lint issues at edit time instead of at commit time. ~38 ms per file, non-blocking.
- **`require-plan-file`** — PreToolUse Edit/Write. Warns when editing source on an implementation-prefix branch (`feature/`, `fix/`, `refactor/`, `perf/`, `ci/`) with no matching plan file under `docs/plans/features/` or `docs/plans/features/quick/`. Enforces workflow rule 1 (plan before implementation).

## Why

**post-edit-ruff**: Backend `.cs` edits and Python `.py` edits previously relied on the pre-commit hook alone — which fires many edits late. Frontend already has `post-edit-typecheck` for per-file tsc. Adding ruff parity for Python catches issues earlier. C# per-file `dotnet build` was evaluated but rejected (~6.7 s incremental latency too high).

**require-plan-file**: Workflow rule 1 (issue → CEO review → eng review → outline → branch → implement) was enforced only by memory + session-start reminder — both easily overlooked. Skipping the plan step has been the biggest single workflow failure mode. This hook makes the plan-first discipline structural: an fs existence check against the current branch name. Warn-only for now so carve-outs can be tuned based on real false positives; consider upgrading to block later.

Replaced the previous Stop-hook Haiku judge (which only enforced the narrower "asked question but kept working" rule) with a deterministic PreToolUse check that covers the higher-value workflow rule. Stop hook removed locally.

## Changes Made

- `AGENTS.md` — Hook Enforcement table gains `post-edit-ruff` and `require-plan-file` rows.
- `docs/architecture/build-pipeline.md` — Claude Code Hooks table gains the same two rows.

## Test Plan

- [x] Verified `ruff 0.15.1` is installed on host.
- [x] `post-edit-ruff` smoke test: passthrough for non-processing-engine files; warnings for E401/F401/I001 violations inside `processing-engine/`; 38 ms total latency on a clean real file.
- [x] `require-plan-file` smoke test (10 cases): passthrough for `chore/`, `docs/`, `main`, non-source `.md`, `/tmp/*`, feature branches with matching numeric and non-numeric plans; warn for feature/fix branches with no matching plan (numeric and non-numeric slugs).
- [x] Both hooks use `${CLAUDE_PROJECT_DIR:-}` fallback, safe under `set -u` without env.
- [x] Pre-commit checks passed (sensitive patterns, gitleaks, doc consistency).

## Documentation Checklist

- [x] No documentation updates needed beyond the two touched files
- [ ] `docs/key-files.md` (new files/services)
- [ ] `docs/standards/backend-development.md` (new endpoints/controllers)
- [ ] `docs/quick-reference.md` (new API endpoints)
- [ ] `docs/architecture/` (new services/architectural changes)
- [ ] `docs/development-plan.md` (milestone/phase changes)

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback

- Risk: Zero for tracked files. Docs-only change — adds two rows to existing tables. Both hooks are local, gitignored, non-blocking (exit 0 always). No impact on CI, build, or runtime.
- Rollback: `git revert` this commit on the feature branch to remove the documentation rows. Hook scripts can stay or be deleted locally with no side effects.
