### PR TITLE
chore: remove duplicate scope from Dependabot PR titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
-      include: "scope"
     labels:
       - "dependencies"
       - "frontend"
@@ -45,7 +44,6 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     labels:
       - "dependencies"
       - "backend"
@@ -59,7 +57,6 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
-      include: "scope"
     labels:
       - "dependencies"
       - "processing-engine"
@@ -71,7 +68,6 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     labels:
       - "dependencies"
       - "docker"
@@ -83,7 +79,6 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     labels:
       - "dependencies"
       - "ci"

--- a/docs/plans/features/quick/dependabot-dedupe-scope.md
+++ b/docs/plans/features/quick/dependabot-dedupe-scope.md
@@ -1,0 +1,38 @@
+# Plan: Remove duplicate scope from Dependabot PR titles
+
+**Complexity**: Quick (single-file YAML change)
+
+## Problem
+
+`Validate PR Standards` has been rejecting dependabot PRs because titles arrive as `chore(deps)(deps): bump ...` (double scope). The title regex expects a single conventional-commit scope, so all 9 open dependabot PRs in the 2026-04-18 batch had to be manually retitled to merge.
+
+Root cause in `.github/dependabot.yml`: every ecosystem sets both
+
+```yaml
+commit-message:
+  prefix: "chore(deps)"
+  include: "scope"
+```
+
+Dependabot treats `prefix` as a literal string and still appends its own inferred scope (`deps` / `deps-dev`) when `include: scope` is set, producing `chore(deps)(deps):`.
+
+## Fix
+
+Remove `include: "scope"` from the `commit-message` block of every ecosystem (npm, nuget, pip, docker, github-actions). The literal `(deps)` already inside the prefix is sufficient and was the original design intent (see top-of-file comment).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.github/dependabot.yml` | Drop `include: "scope"` from all 5 `commit-message` blocks |
+
+## Verification
+
+- No immediate CI effect (config is read by dependabot, not CI).
+- Next scheduled run (weekly) should produce titles like `chore(deps): bump X from A to B` — single scope, passes `Validate PR Standards`.
+- Manual verification: trigger a dependabot recreate on an existing PR (`@dependabot recreate`) after merge; the new title should have single scope.
+
+## Risk
+
+- Risk: Minimal. Single YAML edit; only affects future dependabot PR titles. No effect on production code or CI pipelines.
+- Rollback: `git revert` the commit; titles return to doubled-scope (but currently unblocked manually).


### PR DESCRIPTION
No linked issue.

## Summary

Removes `include: "scope"` from every ecosystem's `commit-message` block in `.github/dependabot.yml` so Dependabot stops producing PR titles with doubled scope like `chore(deps)(deps): bump ...`.

## Why

`Validate PR Standards` has been rejecting Dependabot PRs whose titles arrive with doubled scope. The 2026-04-18 weekly batch produced 9 PRs in this state, each requiring manual retitling before merge. Root cause: every ecosystem set `prefix: "chore(deps)"` **and** `include: "scope"`, so Dependabot appended its inferred scope on top of the literal scope already in the prefix. Dropping `include: "scope"` leaves the conventional `chore(deps):` prefix intact (matching the original intent at the top of the file) and lets future Dependabot PRs pass `Validate PR Standards` without manual intervention.

## Changes Made

- `.github/dependabot.yml` — removed `include: "scope"` from the `commit-message` block of every ecosystem (npm, nuget, pip, docker, github-actions). Prefix `"chore(deps)"` (and `prefix-development: "chore(deps-dev)"` where applicable) already encodes the conventional-commit scope.
- `docs/plans/features/quick/dependabot-dedupe-scope.md` — implementation plan.

## Test Plan

- [x] Before: any of the doubled-scope open PRs (#1302, #1303, #1305, #1306, #1307, #1310) fails `Validate PR Standards` with `PR title must use conventional format`.
- [x] After (future verification): next scheduled Dependabot run produces titles like `chore(deps): bump X from A to B` — single scope — and passes `Validate PR Standards` without manual retitling.
- [ ] CI: `CI Gate` + `Validate PR Standards` green on this PR.
- [ ] After merge, manually `@dependabot recreate` one existing open PR to confirm the new title format.

## Documentation Checklist

- [x] No documentation updates needed — `.github/dependabot.yml` is self-documenting; the restored single-scope behavior matches the comment already at the top of the file.

## Tech Debt Impact

- [x] Existing tech debt reduced — eliminates the recurring manual-retitle step that has been blocking every weekly Dependabot batch since `include: "scope"` was added.

## Risk & Rollback

- Risk: Minimal. Config-only change; affects Dependabot PR titles from the next scheduled run onward. No effect on production code, CI pipelines, or the validator itself.
- Rollback: `git revert` the commit restores doubled-scope behavior; blocked PRs would once again need manual retitling but nothing else breaks.

