### PR TITLE
fix: migrate to photutils 3.0.0

### DIFF
--- a/docs/plans/features/quick/photutils-3-migration.md
+++ b/docs/plans/features/quick/photutils-3-migration.md
@@ -1,0 +1,46 @@
+# Plan: Migrate to photutils 3.0.0
+
+**Complexity**: Quick (normalization + test updates + version bump)
+
+## Problem
+
+`processing-engine/requirements.txt` pins `photutils>=1.10.0` with no upper bound. photutils 3.0.0 (released 2026-04) renamed centroid columns from `xcentroid`/`ycentroid` to `x_centroid`/`y_centroid`, which breaks:
+
+- `tests/test_detection.py::TestDetectPointSources::test_table_has_expected_columns` (asserts `xcentroid` in raw Table colnames)
+- `tests/test_detection.py::TestSourcesToDict::test_converts_table` (asserts `xcentroid` in normalized dict)
+
+The `Python Tests` CI job fresh-installs `photutils>=1.10.0` and now gets 3.0.0, so main's Python CI lane is broken for every new PR. Affects dependabot PRs #1303, #1305, #1307 and any new Python work.
+
+## Fix
+
+External API contract stays stable: `DetectedSource` Pydantic model and the frontend `SourceDetectionOverlay` both continue to receive `xcentroid`/`ycentroid`.
+
+1. `sources_to_dict()` in `app/processing/detection.py` normalizes photutils' new column names back to the legacy `xcentroid`/`ycentroid` via a module-level rename map. Everything downstream (`analysis/routes.py`, `SourceInfo`, frontend) is unaffected.
+2. `tests/test_detection.py::test_table_has_expected_columns` asserts on the raw photutils Table, so it now checks for either spelling (covers photutils 2.x if anyone still runs it, plus the new 3.x naming).
+3. `requirements.txt` bumps `photutils>=1.10.0` → `photutils>=3.0.0` — explicit commitment to 3.x and unblocks the deferred bumps below.
+
+Deferred (tracked by photutils deprecation warnings, not breakage): `npixels` → `n_pixels` keyword rename. Still works with a `DeprecationWarning` in 3.x and will break in photutils 4.x. Handle in a follow-up when 4.x lands.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `processing-engine/app/processing/detection.py` | Add `_PHOTUTILS_COLUMN_RENAMES` map; `sources_to_dict` applies it so `xcentroid`/`ycentroid` are always present in the output dicts |
+| `processing-engine/tests/test_detection.py` | `test_table_has_expected_columns` accepts either `xcentroid`/`ycentroid` or `x_centroid`/`y_centroid` on the raw photutils Table |
+| `processing-engine/requirements.txt` | `photutils>=1.10.0` → `photutils>=3.0.0` |
+
+## Verification
+
+- `docker exec -u root jwst-processing pip install --upgrade "photutils>=3.0.0"`
+- `docker cp` modified files into container (since compose doesn't bind-mount processing-engine)
+- `docker exec jwst-processing python -m pytest` → 1214 passed, 0 failed (vs. 2 failed before the fix)
+
+Downstream (unchanged):
+- `app/analysis/routes.py` still reads `s.get("xcentroid", 0.0)` and gets the normalized value
+- `SourceInfo` model exposes `xcentroid: float` / `ycentroid: float`
+- Frontend `AnalysisTypes.ts` types and `SourceDetectionOverlay` continue to consume `xcentroid`/`ycentroid`
+
+## Risk
+
+- Risk: Low. The normalization only translates known renamed columns; unknown columns pass through unchanged. Behavior under photutils 2.x is preserved (map is a no-op because the legacy names are already present). Frontend contract unchanged.
+- Rollback: `git revert` the commit; also pin `photutils>=1.10.0,<3.0.0` if the revert re-introduces the column break in CI. No data migration or coordinated rollback required.

--- a/processing-engine/app/processing/detection.py
+++ b/processing-engine/app/processing/detection.py
@@ -302,6 +302,16 @@ def detect_sources(
     return result
 
 
+# photutils 3.0 renamed several centroid columns to use underscores
+# (x_centroid vs xcentroid). We normalize back to the legacy names so the
+# rest of the pipeline and the public SourceInfo API stay stable across
+# photutils 2.x and 3.x.
+_PHOTUTILS_COLUMN_RENAMES: dict[str, str] = {
+    "x_centroid": "xcentroid",
+    "y_centroid": "ycentroid",
+}
+
+
 def sources_to_dict(sources: Table | None) -> list[dict[str, Any]]:
     """
     Convert source table to list of dictionaries for JSON serialization.
@@ -323,7 +333,7 @@ def sources_to_dict(sources: Table | None) -> list[dict[str, Any]]:
             # Convert numpy types to Python types
             if hasattr(val, "item"):
                 val = val.item()
-            source_dict[col] = val
+            source_dict[_PHOTUTILS_COLUMN_RENAMES.get(col, col)] = val
         result.append(source_dict)
 
     return result

--- a/processing-engine/requirements.txt
+++ b/processing-engine/requirements.txt
@@ -12,7 +12,7 @@ pandas==2.3.3
 # Astronomy libraries
 astropy==6.1.7
 astroquery==0.4.11
-photutils>=1.10.0
+photutils>=3.0.0
 reproject>=0.13.0
 
 # Image processing

--- a/processing-engine/tests/test_detection.py
+++ b/processing-engine/tests/test_detection.py
@@ -75,8 +75,10 @@ class TestDetectPointSources:
     def test_table_has_expected_columns(self, starfield):
         bg_subtracted = starfield - 100.0
         sources = detect_point_sources(bg_subtracted, threshold=25.0, fwhm=3.0)
-        assert "xcentroid" in sources.colnames
-        assert "ycentroid" in sources.colnames
+        # photutils 3.0 renamed centroid columns; sources_to_dict() normalizes
+        # back to the legacy names, but here we assert on the raw Table.
+        assert {"xcentroid", "x_centroid"} & set(sources.colnames)
+        assert {"ycentroid", "y_centroid"} & set(sources.colnames)
         assert "flux" in sources.colnames
 
     def test_invalid_method_raises(self, starfield):


### PR DESCRIPTION
No linked issue — surfaced during dependabot CI triage (#1303/#1305/#1307 were all blocked by the same root cause).

## Summary

Unbreaks the `Python Tests` CI lane by migrating to **photutils 3.0.0**. photutils 3.0 renamed centroid columns (`xcentroid` → `x_centroid`), which has been failing two detection tests on every Python PR since the release landed — including all in-flight Python dependabot bumps.

## Why

`processing-engine/requirements.txt` pinned `photutils>=1.10.0` with no upper bound. CI fresh-installs the latest, got `3.0.0`, and the two tests below began failing for every Python-touching PR (including main itself, whenever a job installs fresh).

- `tests/test_detection.py::TestDetectPointSources::test_table_has_expected_columns` — asserted `xcentroid` in raw photutils Table columns.
- `tests/test_detection.py::TestSourcesToDict::test_converts_table` — asserted `xcentroid` in the normalized dict output.

Production code in `app/analysis/routes.py` was also silently drifting — `s.get("xcentroid", 0.0)` returned the `0.0` default because the new column was named `x_centroid`, so detected sources would have all been placed at the origin in photutils 3.0.0 environments.

Fix normalizes at the boundary so the external API contract (`DetectedSource` model, frontend `SourceDetectionOverlay`, `AnalysisTypes.ts`) stays on the legacy spelling while the codebase commits to photutils 3.x going forward.

No linked issue.

## Changes Made

- `processing-engine/app/processing/detection.py` — new `_PHOTUTILS_COLUMN_RENAMES` map; `sources_to_dict()` now rewrites `x_centroid`/`y_centroid` back to `xcentroid`/`ycentroid` before returning dicts. Unknown columns pass through unchanged. Behavior under photutils 2.x is unchanged (map is a no-op when legacy names are already present).
- `processing-engine/tests/test_detection.py` — `test_table_has_expected_columns` now asserts on either spelling of the centroid columns (raw photutils Table). The `test_converts_table` test keeps asserting on the canonical `xcentroid` key because `sources_to_dict` now guarantees it.
- `processing-engine/requirements.txt` — `photutils>=1.10.0` → `photutils>=3.0.0`. Documents the migration and forces local dev envs to use the version CI is already pinning.
- `docs/plans/features/quick/photutils-3-migration.md` — plan file.

## Test Plan

- [x] Upgraded container (`docker exec -u root jwst-processing pip install --upgrade "photutils>=3.0.0"` → photutils 3.0.0)
- [x] `docker cp` modified files into container (compose doesn't bind-mount processing-engine)
- [x] `docker exec jwst-processing python -m pytest` — **1214 passed, 0 failed** (vs. 2 failed before the fix). 70% coverage maintained.
- [x] `docker exec jwst-processing python -m ruff check .` + `ruff format --check .` — pre-commit hook passed both.
- [ ] CI: `Python Tests` green on this PR (required).
- [ ] After merge: re-trigger CI on dependabot Python PRs #1303/#1305/#1307; they should go green without further changes because rebase pulls this fix.

## Documentation Checklist

- [x] No documentation updates needed — the change is internal (column-name normalization); the public `DetectedSource` API, OpenAPI schema, and frontend types are unchanged.

## Tech Debt Impact

- [x] Existing tech debt reduced — unblocks the `Python Tests` lane for every new Python PR. Eliminates a silent data corruption risk in `analysis/routes.py` that would have shipped to any user running against photutils 3.0.0 (all detected source centroids would have been zeroed out).
- Deferred follow-up: photutils also deprecated `npixels` → `n_pixels` in 3.0. Still works with a `DeprecationWarning` and will break in 4.x. 98 warnings remain from this. Not filed as an issue yet — will be trivially batched when photutils 4.x lands.

## Risk & Rollback

- Risk: Low. The rename map is additive; unknown columns pass through unchanged. External API (`SourceInfo` JSON response + frontend consumers) is unchanged. All 1214 tests pass locally under photutils 3.0.0.
- Rollback: `git revert` the commit; if a CI fresh-install has moved on, also pin `photutils>=1.10.0,<3.0.0` in the revert commit to restore the prior behavior.
