### PR TITLE
fix: set Docker service-name defaults in appsettings.Production.json

### DIFF
--- a/backend/JwstDataAnalysis.API/appsettings.Production.json
+++ b/backend/JwstDataAnalysis.API/appsettings.Production.json
@@ -1,5 +1,14 @@
 {
   "Seeding": {
     "Enabled": false
+  },
+  "ProcessingEngine": {
+    "BaseUrl": "http://processing-engine:8000"
+  },
+  "MastProxy": {
+    "BaseUrl": "http://mast-proxy:8000"
+  },
+  "MongoDB": {
+    "ConnectionString": "mongodb://mongodb:27017"
   }
 }

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -25,7 +25,17 @@ MONGO_DATABASE=jwst_data_analysis
 # Backend Configuration
 # =============================================================================
 # ASP.NET Core environment (Development, Staging, Production)
+#   Development → appsettings.json defaults (localhost URLs for `dotnet run` on host)
+#   Production  → appsettings.Production.json defaults (Docker service names:
+#                 processing-engine, mast-proxy, mongodb) — suitable for Docker
+#                 Compose deploys out of the box. Override below if services run
+#                 at different addresses (e.g. Kubernetes, external MongoDB).
 ASPNETCORE_ENVIRONMENT=Development
+
+# Backend service endpoints — only required when service names differ from the
+# Docker Compose defaults set in appsettings.Production.json. Uncomment to override.
+#   ProcessingEngine__BaseUrl=http://processing-engine:8000
+#   MastProxy__BaseUrl=http://mast-proxy:8000
 
 # JWT signing key — MUST be changed for production deployments.
 # Minimum 32 characters. The app refuses to start in Production with the placeholder.

--- a/docs/plans/features/quick/1339-docker-friendly-production-defaults.md
+++ b/docs/plans/features/quick/1339-docker-friendly-production-defaults.md
@@ -1,0 +1,42 @@
+# Plan: Docker-friendly defaults in appsettings.Production.json
+
+**Issue**: #1339
+**Complexity**: Quick (config files + env doc)
+
+## Problem
+
+`appsettings.json` hardcodes `ProcessingEngine.BaseUrl=http://localhost:8000` and `MastProxy.BaseUrl=http://localhost:8000`. These defaults work for `dotnet run` on a dev host but not for containerised deploys where services reach each other via service names.
+
+Today, `docker/docker-compose.yml` injects `ProcessingEngine__BaseUrl` and `MastProxy__BaseUrl` env vars to override the defaults. That works for the Compose path but:
+
+- `appsettings.Production.json` is an empty `Seeding.Enabled=false` and inherits the localhost defaults from `appsettings.json`.
+- A Kubernetes / bare-Docker / non-Compose deploy has no override source and silently targets localhost.
+- `.env.example` documents `ASPNETCORE_ENVIRONMENT` but not the service URL override vars.
+
+Blocks the CE deploy plan (VPS + Docker Compose) because the setup invites silent misconfiguration on first deploy.
+
+## Fix
+
+Two small config changes — no .NET code change required.
+
+1. `appsettings.Production.json`: set `ProcessingEngine.BaseUrl`, `MastProxy.BaseUrl`, and `MongoDB.ConnectionString` to the Docker service names (`processing-engine`, `mast-proxy`, `mongodb`). Production deployments become self-sufficient — set `ASPNETCORE_ENVIRONMENT=Production` and the API wires itself to the neighbouring containers without additional env vars.
+2. `docker/.env.example`: annotate `ASPNETCORE_ENVIRONMENT` with what each mode selects and document the `ProcessingEngine__BaseUrl` / `MastProxy__BaseUrl` override syntax for deploys that need different addresses (e.g. Kubernetes with custom service names).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/JwstDataAnalysis.API/appsettings.Production.json` | Add `ProcessingEngine`, `MastProxy`, `MongoDB` sections with Docker service name defaults |
+| `docker/.env.example` | Annotate `ASPNETCORE_ENVIRONMENT` modes; document `ProcessingEngine__BaseUrl` / `MastProxy__BaseUrl` override vars |
+
+## Verification
+
+- `dotnet build` — Production.json parses as valid JSON.
+- Unit tests pass (no code changed; this is config-only).
+- Local `docker compose up -d` still works because Compose env vars keep overriding — env var precedence is unchanged.
+- Production-mode verification: `ASPNETCORE_ENVIRONMENT=Production` with no `ProcessingEngine__BaseUrl` override — app logs should show `Processing engine at http://processing-engine:8000` on first outbound call.
+
+## Risk
+
+- Risk: Low. Config-only, only affects Production environment. Development remains on localhost defaults. Env-var overrides still take precedence (ASP.NET config priority: env vars > appsettings.{Env}.json > appsettings.json), so existing Compose deploys are unaffected.
+- Rollback: `git revert`. Services revert to inheriting localhost from `appsettings.json`, which is the current state.


### PR DESCRIPTION
Closes #1339

## Summary

Sets Docker service-name defaults in `appsettings.Production.json` so containerised deployments work out of the box with just `ASPNETCORE_ENVIRONMENT=Production`. Documents the override env vars in `docker/.env.example`.

## Why

`appsettings.Production.json` was a one-liner (`Seeding.Enabled=false`) that fell back to `appsettings.json`'s localhost URLs for `ProcessingEngine.BaseUrl` and `MastProxy.BaseUrl`. Today the local Compose stack works only because `docker/docker-compose.yml` injects env-var overrides — strip those away (Kubernetes deploy, bare Docker, VPS without the exact Compose file) and the API silently targets localhost.

This blocks the Community Edition deploy plan (VPS + Docker Compose) because the out-of-the-box defaults invite silent misconfiguration. Fixing it is a prerequisite for #688's output to actually ship to real users on a VPS.

Closes #1339.

## Changes Made

- `backend/JwstDataAnalysis.API/appsettings.Production.json` — adds `ProcessingEngine.BaseUrl`, `MastProxy.BaseUrl`, and `MongoDB.ConnectionString` with Docker Compose service names (`processing-engine`, `mast-proxy`, `mongodb`). Production deployments now self-wire when `ASPNETCORE_ENVIRONMENT=Production` is set.
- `docker/.env.example` — annotates `ASPNETCORE_ENVIRONMENT` with what each mode selects (Development → localhost defaults, Production → Docker service names). Documents the `ProcessingEngine__BaseUrl` / `MastProxy__BaseUrl` env-var override syntax for Kubernetes or non-Compose deploys.
- `docs/plans/features/quick/1339-docker-friendly-production-defaults.md` — plan file.

No .NET code changes. ASP.NET Core config precedence is unchanged: env vars > `appsettings.{Environment}.json` > `appsettings.json`, so existing Compose deploys that inject overrides continue to behave identically.

## Test Plan

- [x] `dotnet build` succeeds — `appsettings.Production.json` parses as valid JSON.
- [x] Pre-commit hook passed: 1072/1072 backend tests + secrets scan.
- [x] Local `docker compose up -d --build` with `ASPNETCORE_ENVIRONMENT=Development` — unchanged behaviour (Compose env vars still override).
- [ ] CI: `CI Gate` + `Validate PR Standards` green on this PR.
- [ ] Post-merge verification (CE deploy rehearsal):
  - [ ] `docker compose -f docker/docker-compose.yml -f docker/docker-compose.prod.yml up -d` with a minimal `.env` (only `MONGO_ROOT_PASSWORD`, `JWT_SECRET_KEY`, `ASPNETCORE_ENVIRONMENT=Production`)
  - [ ] Backend logs show processing-engine calls going to `http://processing-engine:8000` (not localhost)
  - [ ] Frontend successfully generates a composite (end-to-end through containerised stack)

## Documentation Checklist

- [x] `docs/plans/features/quick/1339-docker-friendly-production-defaults.md` captures the plan.
- [ ] No other doc updates needed — `appsettings.Production.json` is self-documenting via the new defaults; `.env.example` carries the override syntax inline. README / setup-guide updates can come with the CE deploy PR that actually uses these defaults.

## Tech Debt Impact

- [x] Existing tech debt reduced — closes #1339 and unblocks the CE deploy sequence (#1339 → #650 → #652 → #1040 → CE launch). Next steps in that sequence are still open (`#650` production env, `#652` deploy workflow review, `#1040` remove `window.jwst` debug helpers).

## Risk & Rollback

- Risk: Low. Config-only, scoped to Production environment. Development mode is untouched. ASP.NET Core env-var precedence keeps existing Compose deploys identical. `dotnet run` on a host with `ASPNETCORE_ENVIRONMENT=Production` would now try `http://processing-engine:8000` — but anyone running Production locally is already aware they need infrastructure for that, and the old localhost default would have failed too (no processing-engine listening there).
- Rollback: `git revert`. Services revert to inheriting localhost from `appsettings.json`, matching current behaviour. No data migration or coordinated rollback required.
