### PR TITLE
fix: harden filename sanitizer against URL-encoded and mid-name traversal (#1095)

### DIFF
--- a/docs/plans/features/quick/1095-filename-sanitization-fix.md
+++ b/docs/plans/features/quick/1095-filename-sanitization-fix.md
@@ -1,0 +1,181 @@
+# Plan: Fix Filename Sanitization Bypasses in S3 and Chunked Downloaders
+
+**Issue:** #1095
+**Labels:** backend, security, priority: high
+**Complexity:** Quick (single module, pure Python, no schema/API changes)
+
+---
+
+## CEO Review
+
+### Right problem?
+Yes. Both `_sanitize_filename` implementations have the same two concrete gaps:
+
+1. **URL-encoded traversal** (`%2e%2e/etc/passwd`): neither function calls
+   `urllib.parse.unquote` before checking for `..`, so percent-encoded variants
+   slip through the `..` check and past `os.path.basename`.
+
+2. **Mid-name double-dot in chunked_downloader**: the `..` strip runs before the
+   `SAFE_FILENAME_PATTERN` regex. The regex `[A-Za-z0-9_\-.]+` does **not** block
+   `..` in the middle of a name (e.g. `"file..name"`). After `os.path.basename`
+   that name contains no slash, so the strip doesn't fire, and it passes validation.
+
+The existing `_is_path_within_directory` defense-in-depth catch is the last
+safety net but shouldn't be relied on as the primary sanitizer.
+
+### Already implemented?
+No. Test coverage for both files is missing the URL-encoded and mid-name
+double-dot cases. No shared utility module exists.
+
+### Reversal cost
+Low — internal Python helper, no public API or DB schema touched. Could be
+reverted in under 30 minutes.
+
+### Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Valid FITS filenames containing `..` mid-name (e.g. `jw02733..001.fits`) | Low | MAST filenames follow strict STScI naming; none use `..` legitimately |
+| Switching to `raise ValueError` at utility level breaks call-site loop | Medium | Keep `None`-return API at the wrapper layer; raise only in the new shared helper if desired, or keep None-return throughout — see decision below |
+| `PurePosixPath` on Windows paths | Negligible | Runs in Docker/Linux only |
+
+**Decision on raise vs None:** Keep `None`-return API to avoid touching all call
+sites. The shared helper returns `None` for invalid names; callers already handle
+this with `continue`/`skipped` counters.
+
+### NOT in scope
+- `obs_id` validation (already covered in `mast_service.py`)
+- C# backend, frontend, MongoDB schema
+- Changes to `_is_path_within_directory` (it's correct as-is)
+
+---
+
+## Engineering Plan
+
+### Approach
+Extract a single hardened `sanitize_filename` into a new shared module
+`processing-engine/app/mast/download_utils.py`. Both downloaders import from it.
+Remove the duplicate `SAFE_FILENAME_PATTERN` and `_sanitize_filename` definitions.
+
+### Corrected algorithm
+
+```python
+# processing-engine/app/mast/download_utils.py
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath
+from urllib.parse import unquote
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Whitelist: alphanumeric, underscore, hyphen, single dots only
+# Note: this blocks ".." at any position because the fullmatch catches it via
+# the post-check below; the regex itself allows dots so FITS names like
+# "jw02733001001_02101_00001_nircam_cal.fits" pass cleanly.
+SAFE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9_\-.]+$")
+
+
+def sanitize_filename(raw: str) -> str | None:
+    """
+    Sanitize a filename to prevent path traversal attacks.
+
+    Steps:
+    1. URL-decode to catch %2e%2e variants.
+    2. Strip all directory components using PurePosixPath.name (handles both
+       / and \\ separators after replace).
+    3. Null-byte removal.
+    4. Whitespace strip.
+    5. Explicit ".." rejection (catches mid-name patterns like "file..name").
+    6. Whitelist regex fullmatch.
+
+    Returns the sanitized filename, or None if it is invalid/dangerous.
+    """
+    if not raw:
+        return None
+
+    # Step 1: URL-decode (%2e%2e, %2f, etc.)
+    decoded = unquote(raw)
+
+    # Step 2: Strip all directory components (handles / and \)
+    name = PurePosixPath(decoded.replace("\\", "/")).name
+
+    # Step 3: Remove null bytes
+    name = name.replace("\x00", "")
+
+    # Step 4: Strip whitespace
+    name = name.strip()
+
+    if not name:
+        return None
+
+    # Step 5: Reject any ".." anywhere in the name
+    if ".." in name:
+        logger.warning("Filename contains parent-directory reference: %.50s", raw)
+        return None
+
+    # Step 6: Whitelist check
+    if not SAFE_FILENAME_PATTERN.fullmatch(name):
+        logger.warning("Filename contains invalid characters: %.50s", name)
+        return None
+
+    return name
+```
+
+### Files changed
+
+| File | Change |
+|---|---|
+| `processing-engine/app/mast/download_utils.py` | **New** — shared `sanitize_filename` + `SAFE_FILENAME_PATTERN` |
+| `processing-engine/app/mast/s3_downloader.py` | Remove `_sanitize_filename` + local `SAFE_FILENAME_PATTERN`; import `sanitize_filename` from `download_utils`; update call sites |
+| `processing-engine/app/mast/chunked_downloader.py` | Same removals; import from `download_utils`; update call sites |
+| `processing-engine/tests/mast/test_download_utils.py` | **New** — exhaustive tests for `sanitize_filename` |
+| `processing-engine/tests/test_s3_downloader.py` | Update traversal test expectations if needed (current `passwd` test may now return `None` for `%2e` forms) |
+
+### Failure modes to test
+
+- `"../../../etc/passwd"` → `None`
+- `"%2e%2e/%2e%2e/etc/passwd"` → `None`
+- `"file\\..\\other"` (Windows backslash) → `None`
+- `"file..name"` → `None` (mid-name double-dot)
+- `"\x00evil"` → `None`
+- `"  "` → `None`
+- `""` → `None`
+- `"jw02733001001_02101_00001_nircam_cal.fits"` → passes (valid FITS name)
+- `"test-image_1.2.fits"` → passes (single dots OK)
+- `"bad<file>.fits"` → `None` (invalid char)
+
+### Call-site wiring
+
+Both downloaders call `_sanitize_filename(raw_filename)` today. After the change,
+both call `sanitize_filename(raw_filename)` (no underscore prefix — it's now a
+public utility). The existing `if filename is None: ... continue` guard remains
+unchanged.
+
+### Test plan
+
+**TDD order:**
+1. Write `tests/mast/test_download_utils.py` covering all failure modes above → RED
+2. Implement `download_utils.py` → GREEN
+3. Refactor `s3_downloader.py` and `chunked_downloader.py` to import and use it
+4. Run full pytest suite inside Docker: `docker exec jwst-processing python -m pytest`
+5. Verify existing `test_s3_downloader.py::test_sanitizes_traversal_filenames` still passes (the `"../../../etc/passwd"` traversal case was already handled — only the URL-encoded variant was new)
+
+**Manual smoke test:**
+Not applicable — no UI change. Docker unit test run is sufficient.
+
+### Docs update checklist
+- No public endpoints changed, no controller added → doc update not required.
+
+---
+
+## Implementation sequence
+
+1. Branch: `feature/1095-filename-sanitization`
+2. Write failing tests in `tests/mast/test_download_utils.py`
+3. Create `app/mast/download_utils.py` with `sanitize_filename`
+4. Refactor both downloader files to import from `download_utils`
+5. Run pytest, confirm all green
+6. PR → `Closes #1095`

--- a/processing-engine/app/mast/chunked_downloader.py
+++ b/processing-engine/app/mast/chunked_downloader.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -18,12 +17,10 @@ from typing import Any
 import aiofiles
 import aiohttp
 
+from .download_utils import sanitize_filename
+
 
 logger = logging.getLogger(__name__)
-
-# Security: Valid filename pattern for FITS files
-# Allows alphanumeric, underscores, hyphens, dots - no path separators or special chars
-SAFE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9_\-.]+$")
 
 # Configuration
 CHUNK_SIZE = 5 * 1024 * 1024  # 5MB chunks
@@ -79,42 +76,6 @@ class DownloadJobState:
 
 # Progress callback type
 ProgressCallback = Callable[[DownloadJobState], None]
-
-
-def _sanitize_filename(filename: str) -> str | None:
-    """
-    Sanitize a filename to prevent path traversal attacks.
-
-    Security: Removes path separators and validates against safe pattern.
-
-    Args:
-        filename: The filename to sanitize
-
-    Returns:
-        Sanitized filename, or None if the filename is invalid/dangerous
-    """
-    if not filename:
-        return None
-
-    # Remove any path components - take only the basename
-    # This handles both Unix (/) and Windows (\) separators
-    sanitized = os.path.basename(filename.replace("\\", "/"))
-
-    # Remove any remaining dangerous sequences
-    sanitized = sanitized.replace("..", "").replace("\x00", "")
-
-    # Strip whitespace
-    sanitized = sanitized.strip()
-
-    if not sanitized:
-        return None
-
-    # Validate against safe pattern
-    if not SAFE_FILENAME_PATTERN.match(sanitized):
-        logger.warning(f"Filename contains invalid characters after sanitization: {sanitized[:50]}")
-        return None
-
-    return sanitized
 
 
 def _is_path_within_directory(filepath: str, directory: str) -> bool:
@@ -408,7 +369,7 @@ class ChunkedDownloader:
             raw_filename = file_info.get("filename", os.path.basename(url))
 
             # Security: Sanitize filename to prevent path traversal
-            filename = _sanitize_filename(raw_filename)
+            filename = sanitize_filename(raw_filename)
             if filename is None:
                 logger.warning(
                     f"Path traversal attempt blocked - invalid filename: {raw_filename[:100]}"

--- a/processing-engine/app/mast/download_utils.py
+++ b/processing-engine/app/mast/download_utils.py
@@ -18,6 +18,15 @@ logger = logging.getLogger(__name__)
 
 SAFE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9_\-.]+$")
 
+# Windows reserved device names. Runtime is Linux-only today, but rejecting
+# these protects contributors on Windows and any downstream sync to a
+# Windows share.
+_WINDOWS_RESERVED_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{i}" for i in range(1, 10)}
+    | {f"LPT{i}" for i in range(1, 10)}
+)
+
 
 def sanitize_filename(raw: str) -> str | None:
     """Return a sanitized filename, or ``None`` if the input is unsafe.
@@ -67,6 +76,18 @@ def sanitize_filename(raw: str) -> str | None:
 
     if not SAFE_FILENAME_PATTERN.fullmatch(name):
         logger.warning("Filename contains invalid characters: %.50s", name)
+        return None
+
+    # Reject leading '-' so a downstream subprocess call can't mistake the
+    # filename for a CLI flag (e.g. `-rf`, `-oProxyCommand=...`).
+    if name.startswith("-"):
+        logger.warning("Filename starts with dash (flag-injection risk): %.50s", name)
+        return None
+
+    # Reject Windows reserved device names (case-insensitive, any extension).
+    stem = name.split(".", 1)[0].upper()
+    if stem in _WINDOWS_RESERVED_NAMES:
+        logger.warning("Filename uses Windows reserved name: %.50s", name)
         return None
 
     return name

--- a/processing-engine/app/mast/download_utils.py
+++ b/processing-engine/app/mast/download_utils.py
@@ -22,19 +22,39 @@ SAFE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9_\-.]+$")
 def sanitize_filename(raw: str) -> str | None:
     """Return a sanitized filename, or ``None`` if the input is unsafe.
 
-    Rejects anything with a ``..`` sequence (decoded), null bytes, path
-    separators that survive basename extraction, or characters outside the
-    whitelist. Call sites must still apply a containment check
-    (``_is_path_within_directory``) as defense-in-depth.
+    Rejects anything with a ``..`` sequence (decoded), null bytes (raw or
+    percent-encoded), path separators that survive basename extraction, or
+    characters outside the whitelist. Call sites must still apply a
+    containment check (``_is_path_within_directory``) as defense-in-depth.
+
+    Accepts URL-encoded inputs by design so encoded traversal (``%2e%2e``)
+    is decoded and rejected; MAST filenames themselves are plain ASCII,
+    not URLs, so decoding here hardens against bypass rather than inviting
+    callers to pass URLs.
     """
     if not raw:
         return None
 
-    if "\x00" in raw:
+    # Bounded unquote loop: catches multi-level encodings like `%252e%252e`
+    # that would otherwise survive a single `unquote` pass as `%2e%2e` and
+    # slip past the `..` check once the directory portion is stripped off.
+    decoded = raw
+    for _ in range(4):
+        nxt = unquote(decoded)
+        if nxt == decoded:
+            break
+        decoded = nxt
+
+    if "\x00" in raw or "\x00" in decoded:
         logger.warning("Filename contains null byte: rejected")
         return None
 
-    decoded = unquote(raw)
+    # Reject non-ASCII to block Unicode lookalikes (fullwidth `．．` U+FF0E,
+    # one-dot leader U+2024, etc.) and overlong UTF-8 that decodes to U+FFFD.
+    # MAST filenames are plain ASCII — non-ASCII input is never legitimate here.
+    if not decoded.isascii():
+        logger.warning("Filename contains non-ASCII characters: %.50s", raw)
+        return None
 
     if ".." in decoded:
         logger.warning("Filename contains parent-directory reference: %.50s", raw)

--- a/processing-engine/app/mast/download_utils.py
+++ b/processing-engine/app/mast/download_utils.py
@@ -1,0 +1,52 @@
+"""Shared filename sanitizer for MAST downloaders.
+
+Closes #1095: consolidates two duplicate ``_sanitize_filename`` implementations
+in ``s3_downloader`` and ``chunked_downloader`` into one hardened helper that
+closes URL-encoded (``%2e%2e``) and mid-name (``file..name``) double-dot
+bypasses.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import PurePosixPath
+from urllib.parse import unquote
+
+
+logger = logging.getLogger(__name__)
+
+SAFE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9_\-.]+$")
+
+
+def sanitize_filename(raw: str) -> str | None:
+    """Return a sanitized filename, or ``None`` if the input is unsafe.
+
+    Rejects anything with a ``..`` sequence (decoded), null bytes, path
+    separators that survive basename extraction, or characters outside the
+    whitelist. Call sites must still apply a containment check
+    (``_is_path_within_directory``) as defense-in-depth.
+    """
+    if not raw:
+        return None
+
+    if "\x00" in raw:
+        logger.warning("Filename contains null byte: rejected")
+        return None
+
+    decoded = unquote(raw)
+
+    if ".." in decoded:
+        logger.warning("Filename contains parent-directory reference: %.50s", raw)
+        return None
+
+    name = PurePosixPath(decoded.replace("\\", "/")).name.strip()
+
+    if not name:
+        return None
+
+    if not SAFE_FILENAME_PATTERN.fullmatch(name):
+        logger.warning("Filename contains invalid characters: %.50s", name)
+        return None
+
+    return name

--- a/processing-engine/app/mast/s3_downloader.py
+++ b/processing-engine/app/mast/s3_downloader.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -19,13 +18,11 @@ from boto3.s3.transfer import TransferConfig
 from botocore.exceptions import ClientError
 
 from .chunked_downloader import DownloadJobState, FileDownloadProgress
+from .download_utils import sanitize_filename
 from .s3_client import S3Client
 
 
 logger = logging.getLogger(__name__)
-
-# Security: Valid filename pattern for FITS files (reuse from chunked_downloader)
-SAFE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9_\-.]+$")
 
 # Transfer configuration for multipart downloads
 S3_TRANSFER_CONFIG = TransferConfig(
@@ -36,21 +33,6 @@ S3_TRANSFER_CONFIG = TransferConfig(
 
 # Progress callback type matching chunked_downloader
 ProgressCallback = Callable[[DownloadJobState], None]
-
-
-def _sanitize_filename(filename: str) -> str | None:
-    """Sanitize a filename to prevent path traversal."""
-    if not filename:
-        return None
-    sanitized = os.path.basename(filename.replace("\\", "/"))
-    sanitized = sanitized.replace("..", "").replace("\x00", "")
-    sanitized = sanitized.strip()
-    if not sanitized:
-        return None
-    if not SAFE_FILENAME_PATTERN.match(sanitized):
-        logger.warning("Filename contains invalid characters: %s", sanitized[:50])
-        return None
-    return sanitized
 
 
 def _is_path_within_directory(filepath: str, directory: str) -> bool:
@@ -102,7 +84,7 @@ class S3Downloader:
         skipped = 0
         for info in files_info:
             raw_filename = info.get("filename", "")
-            filename = _sanitize_filename(raw_filename)
+            filename = sanitize_filename(raw_filename)
             if filename is None:
                 logger.warning("Skipping invalid filename: %s", raw_filename[:100])
                 skipped += 1

--- a/processing-engine/tests/mast/test_download_utils.py
+++ b/processing-engine/tests/mast/test_download_utils.py
@@ -1,0 +1,92 @@
+"""Tests for the shared filename sanitizer in app.mast.download_utils."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mast.download_utils import sanitize_filename
+
+
+class TestSanitizeFilenameRejects:
+    """Cases that must return None."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            # Classic path traversal
+            "../../../etc/passwd",
+            "..",
+            "../",
+            # URL-encoded traversal — the bug #1095 closes
+            "%2e%2e/%2e%2e/etc/passwd",
+            "%2E%2E%2F%2E%2E%2Fetc%2Fpasswd",
+            "%2e%2e",
+            # Windows-style traversal
+            "file\\..\\other",
+            "..\\..\\windows\\system32",
+            # Mid-name double-dot — the other bug #1095 closes
+            "file..name",
+            "jw02733..001.fits",
+            "foo...bar",
+            # Null byte
+            "\x00evil",
+            "evil\x00.fits",
+            # Empty / whitespace-only
+            "",
+            "   ",
+            "\t\n",
+            # Disallowed characters
+            "file`whoami`.fits",
+            "file$(id).fits",
+            "file|cat.fits",
+            "file with spaces.fits",
+            "file<evil>.fits",
+        ],
+    )
+    def test_rejects(self, raw: str):
+        assert sanitize_filename(raw) is None
+
+
+class TestSanitizeFilenameAccepts:
+    """Cases that must return a sanitized basename."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # Valid FITS names pass through untouched
+            (
+                "jw02733001001_02101_00001_nircam_cal.fits",
+                "jw02733001001_02101_00001_nircam_cal.fits",
+            ),
+            ("test-image_1.2.fits", "test-image_1.2.fits"),
+            ("simple_file.fits", "simple_file.fits"),
+            ("file-with-dashes.fits", "file-with-dashes.fits"),
+            ("file.with.dots.fits", "file.with.dots.fits"),
+            # Basename extraction from a clean posix path (no traversal in raw)
+            ("path/to/file.fits", "file.fits"),
+            ("/tmp/file.fits", "file.fits"),
+            # Basename extraction from a windows path
+            ("C:\\Windows\\file.fits", "file.fits"),
+            ("dir\\sub\\file.fits", "file.fits"),
+            # URL-encoded path separators that decode to a clean basename
+            ("path%2Fto%2Ffile.fits", "file.fits"),
+            # URL-encoded single dots are fine (%2E == '.')
+            ("foo%2Ebar.fits", "foo.bar.fits"),
+        ],
+    )
+    def test_accepts(self, raw: str, expected: str):
+        assert sanitize_filename(raw) == expected
+
+
+class TestSanitizeFilenameLogging:
+    """Confirm we log a warning on rejection (helps ops diagnose bad inputs)."""
+
+    def test_logs_on_traversal(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level("WARNING", logger="app.mast.download_utils"):
+            sanitize_filename("../../etc/passwd")
+        assert any("parent-directory" in r.message for r in caplog.records)
+
+    def test_logs_on_invalid_chars(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level("WARNING", logger="app.mast.download_utils"):
+            sanitize_filename("file|pipe.fits")
+        assert any("invalid characters" in r.message for r in caplog.records)

--- a/processing-engine/tests/mast/test_download_utils.py
+++ b/processing-engine/tests/mast/test_download_utils.py
@@ -44,6 +44,18 @@ class TestSanitizeFilenameRejects:
             # CR / LF injection
             "file\r\n.fits",
             "file\r.fits",
+            # Leading-dash — flag-injection defense
+            "-rf",
+            "--help",
+            "-oProxyCommand=evil",
+            # Windows reserved device names (case-insensitive, any extension)
+            "CON",
+            "con.fits",
+            "PRN.txt",
+            "aux",
+            "NUL",
+            "COM1.fits",
+            "lpt9.dat",
             # Empty / whitespace-only
             "",
             "   ",

--- a/processing-engine/tests/mast/test_download_utils.py
+++ b/processing-engine/tests/mast/test_download_utils.py
@@ -21,6 +21,14 @@ class TestSanitizeFilenameRejects:
             "%2e%2e/%2e%2e/etc/passwd",
             "%2E%2E%2F%2E%2E%2Fetc%2Fpasswd",
             "%2e%2e",
+            # Double-URL-encoded (%25 is literal '%') — unquote runs once,
+            # leaving "%2e%2e" which fails the whitelist
+            "%252e%252e%2fetc%2fpasswd",
+            # Overlong UTF-8 dots — decode to replacement chars and fail whitelist
+            "%c0%ae%c0%ae%2fpasswd",
+            # Unicode lookalikes — ASCII-only whitelist rejects them
+            "\uff0e\uff0e/etc/passwd",  # fullwidth dots
+            "\u2024\u2024/etc/passwd",  # one-dot leader
             # Windows-style traversal
             "file\\..\\other",
             "..\\..\\windows\\system32",
@@ -28,9 +36,14 @@ class TestSanitizeFilenameRejects:
             "file..name",
             "jw02733..001.fits",
             "foo...bar",
-            # Null byte
+            # Null byte — raw and percent-encoded
             "\x00evil",
             "evil\x00.fits",
+            "%00evil",
+            "evil%00.fits",
+            # CR / LF injection
+            "file\r\n.fits",
+            "file\r.fits",
             # Empty / whitespace-only
             "",
             "   ",
@@ -90,3 +103,8 @@ class TestSanitizeFilenameLogging:
         with caplog.at_level("WARNING", logger="app.mast.download_utils"):
             sanitize_filename("file|pipe.fits")
         assert any("invalid characters" in r.message for r in caplog.records)
+
+    def test_logs_on_encoded_null_byte(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level("WARNING", logger="app.mast.download_utils"):
+            sanitize_filename("evil%00.fits")
+        assert any("null byte" in r.message for r in caplog.records)

--- a/processing-engine/tests/test_mast_service_security.py
+++ b/processing-engine/tests/test_mast_service_security.py
@@ -203,13 +203,12 @@ class TestChunkedDownloaderFilenameValidation:
             ("simple_file.fits", "simple_file.fits"),
             ("file-with-dashes.fits", "file-with-dashes.fits"),
             ("file.with.dots.fits", "file.with.dots.fits"),
-            # Path traversal attempts - basename extracted, which may be valid or not
-            # These extract the basename and check against pattern
-            ("../../../etc/passwd", "passwd"),  # basename is 'passwd', valid pattern
-            ("/etc/passwd", "passwd"),  # basename is 'passwd', valid pattern
+            # Path traversal attempts — '..' anywhere now rejected (#1095)
+            ("../../../etc/passwd", None),
+            ("/etc/passwd", "passwd"),  # no '..' in raw, basename extracted
             ("path/to/file.fits", "file.fits"),  # basename extracted
-            # Windows paths - basename extracted
-            ("C:\\Windows\\file.fits", "file.fits"),  # backslash converted, basename extracted
+            # Windows paths — basename extracted when no '..' present
+            ("C:\\Windows\\file.fits", "file.fits"),
             # Special characters in filename should be rejected (not in path)
             ("file`whoami`.fits", None),  # backtick not in pattern
             ("file$(id).fits", None),  # $ and () not in pattern
@@ -223,32 +222,28 @@ class TestChunkedDownloaderFilenameValidation:
     )
     def test_sanitize_filename(self, filename: str, expected: str | None):
         """Test filename sanitization extracts basename and validates pattern."""
-        from app.mast.chunked_downloader import _sanitize_filename
+        from app.mast.download_utils import sanitize_filename
 
-        result = _sanitize_filename(filename)
+        result = sanitize_filename(filename)
         assert result == expected, f"Sanitize '{filename}' expected '{expected}', got '{result}'"
 
     def test_sanitize_filename_empty_string(self):
         """Empty string should return None."""
-        from app.mast.chunked_downloader import _sanitize_filename
+        from app.mast.download_utils import sanitize_filename
 
-        assert _sanitize_filename("") is None
+        assert sanitize_filename("") is None
 
-    def test_sanitize_filename_removes_null_bytes(self):
-        """Null bytes should be stripped from filename."""
-        from app.mast.chunked_downloader import _sanitize_filename
+    def test_sanitize_filename_rejects_null_bytes(self):
+        """Null bytes are rejected outright (#1095)."""
+        from app.mast.download_utils import sanitize_filename
 
-        # Null byte is removed, resulting in valid filename
-        result = _sanitize_filename("file\x00.fits")
-        assert result == "file.fits"
+        assert sanitize_filename("file\x00.fits") is None
 
-    def test_sanitize_filename_double_dot_removed(self):
-        """Double dots should be removed from the basename."""
-        from app.mast.chunked_downloader import _sanitize_filename
+    def test_sanitize_filename_rejects_double_dot(self):
+        """Mid-name double dots are rejected, not stripped (#1095)."""
+        from app.mast.download_utils import sanitize_filename
 
-        # After basename extraction and .. removal
-        result = _sanitize_filename("file..name.fits")
-        assert result == "filename.fits"  # .. removed
+        assert sanitize_filename("file..name.fits") is None
 
     @pytest.mark.parametrize(
         "filepath,directory,expected",

--- a/processing-engine/tests/test_s3_downloader.py
+++ b/processing-engine/tests/test_s3_downloader.py
@@ -79,7 +79,7 @@ class TestS3Downloader:
         assert result.status == "complete"
 
     def test_sanitizes_traversal_filenames(self, downloader, mock_s3_client, tmp_path):
-        """Test that path traversal filenames are sanitized to safe basenames."""
+        """Path traversal filenames are rejected outright (#1095)."""
         download_dir = str(tmp_path / "downloads")
         files_info = [
             {
@@ -102,14 +102,10 @@ class TestS3Downloader:
         mock_s3_client.download_file.side_effect = fake_download
 
         result = downloader.download_files(files_info, download_dir, job_state)
-        # Traversal path is sanitized to basename "passwd" — safe within download_dir
-        assert len(result.files) == 2
-        filenames = [f.filename for f in result.files]
-        assert "passwd" in filenames
-        assert "good.fits" in filenames
-        # Verify the sanitized file stays within the download directory
-        for f in result.files:
-            assert os.path.abspath(f.local_path).startswith(os.path.abspath(download_dir))
+        # Traversal filename is rejected; only good.fits survives.
+        assert len(result.files) == 1
+        assert result.files[0].filename == "good.fits"
+        assert os.path.abspath(result.files[0].local_path).startswith(os.path.abspath(download_dir))
 
     def test_skips_truly_invalid_filenames(self, downloader, mock_s3_client, tmp_path):
         """Test that filenames with invalid characters are skipped entirely."""


### PR DESCRIPTION
<!-- Closes #1095 -->

## Summary

Closes filename-sanitizer bypasses in `s3_downloader._sanitize_filename` and `chunked_downloader._sanitize_filename` by consolidating them into one hardened helper. The two documented bypasses (URL-encoded `%2e%2e`, mid-name `file..name`) are closed, plus three additional classes that self-review surfaced: double-URL-encoded (`%252e%252e`), Unicode lookalikes (U+FF0E / U+2024 / overlong UTF-8), and two defense-in-depth gaps (leading-dash flag injection, Windows reserved device names).

## Why

Both downloaders carried duplicate sanitizers with identical gaps: no `urllib.parse.unquote` before the `..` check, and a whitelist regex that permits `..` mid-name. Fixing in one place closes all bypasses and removes duplication. Two rounds of code-reviewer self-review uncovered four additional bypass/hardening classes beyond the original #1095 scope.

## Changes Made

- **New** `processing-engine/app/mast/download_utils.py` exposing `sanitize_filename`, which:
  - URL-decodes in a bounded loop (handles multi-level encoding like `%252e%252e`)
  - Rejects null bytes (raw or percent-encoded)
  - Requires `decoded.isascii()` (blocks Unicode lookalikes, overlong UTF-8)
  - Rejects any `..` in the decoded input (not strip)
  - Extracts basename via `PurePosixPath` (handles `\` and `/`)
  - Whitelist-matches the basename
  - Rejects leading `-` (flag-injection defense)
  - Rejects Windows reserved device names (`CON`, `PRN`, `COM1`-`9`, etc.)
- `s3_downloader.py` and `chunked_downloader.py` now import the shared helper; duplicate `_sanitize_filename` and `SAFE_FILENAME_PATTERN` removed.
- `_is_path_within_directory` defense-in-depth check unchanged.

### Tests

- **New** `processing-engine/tests/mast/test_download_utils.py` covers: URL-encoded, double-URL-encoded, Unicode fullwidth dots, one-dot leader, overlong UTF-8, null byte (raw + encoded), CR/LF injection, leading-dash, Windows reserved names, Windows-backslash traversal, mid-name `..`, and valid FITS filenames.
- Updated `test_mast_service_security.py`: `../../../etc/passwd` now returns `None` (was `"passwd"`); null bytes and `..` are **rejected**, not stripped.
- Updated `test_s3_downloader.py::test_sanitizes_traversal_filenames` to expect the traversal entry to be rejected.

### Commits

1. `d6af034` — docs: add plan
2. `3bd7719` — fix: harden sanitizer (original #1095 scope)
3. `892376d` — fix: close multi-encoding and Unicode bypasses (self-review round 1)
4. `69606eb` — fix: reject leading-dash and Windows reserved names (self-review round 2)

## Test Plan

- [x] `docker exec jwst-processing python -m pytest` — **1311 passed, 0 failed**
- [x] New tests cover all bypass classes: URL-encoded `..`, double-encoded `..`, mid-name `..`, Unicode lookalikes, overlong UTF-8, null bytes (raw + encoded), CR/LF, leading-dash, Windows reserved names, Windows backslash.
- [x] Existing `_is_path_within_directory` containment tests still pass.
- [x] Ruff lint + format clean.
- [x] Two rounds of code-reviewer agent self-review completed.

## Documentation Checklist

- [x] No public endpoints/controllers added — doc update not required per doc-update skill.

## Tech Debt Impact

- [x] Existing tech debt reduced — closes #1095. Removes duplicate `SAFE_FILENAME_PATTERN` and `_sanitize_filename` across two modules.

## Risk & Rollback

- **Risk: Low-Medium.** Behavior change: inputs that previously yielded a sanitized basename (e.g. `../../../etc/passwd` → `"passwd"`) now return `None` and the caller skips them. The existing `_is_path_within_directory` check already blocked the resulting paths from escaping the download dir, so this is a defense-in-depth tightening rather than a user-visible change. Legitimate STScI/MAST filenames never contain `..`, non-ASCII characters, leading `-`, or match Windows reserved names.
- **Rollback:** Revert the branch; prior sanitizers return, bypasses reopen.
