### PR TITLE
fix(target-detail): hide no-recipes empty state while recipes load

### DIFF
--- a/frontend/jwst-frontend/src/pages/TargetDetail.css
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.css
@@ -118,8 +118,9 @@
   text-decoration: underline;
 }
 
-/* No recipes fallback */
-.target-detail-no-recipes {
+/* No recipes fallback + pending state while recipe fetch is in flight */
+.target-detail-no-recipes,
+.target-detail-recipes-pending {
   padding: var(--space-6) var(--space-5);
   background: var(--bg-surface);
   border: 1px dashed var(--border-default);
@@ -127,6 +128,10 @@
   color: var(--text-muted);
   font-size: var(--text-base);
   text-align: center;
+}
+
+.target-detail-recipes-pending p {
+  opacity: 0.8;
 }
 
 .target-detail-no-recipes a {

--- a/frontend/jwst-frontend/src/pages/TargetDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.tsx
@@ -32,6 +32,11 @@ export function TargetDetail() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [observations, setObservations] = useState<MastObservationResult[]>([]);
   const [recipes, setRecipes] = useState<CompositeRecipe[]>([]);
+  // Stale-while-revalidate can flip loadState to 'ready' from cached observations
+  // before the recipe fetch has even started, so gate the "no recipes" empty-state
+  // on a separate "at least one recipe response came back" flag to avoid showing
+  // it during the pending window.
+  const [recipesLoaded, setRecipesLoaded] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
@@ -40,6 +45,7 @@ export function TargetDetail() {
     async function loadTargetData() {
       setLoadState('loading');
       setErrorMessage(null);
+      setRecipesLoaded(false);
 
       // ?fresh=true bypasses localStorage cache (useful when backend changes invalidate cached data)
       const freshParam = new URLSearchParams(window.location.search).get('fresh');
@@ -97,6 +103,7 @@ export function TargetDetail() {
               : (staleRecipes) => {
                   if (controller.signal.aborted) return;
                   setRecipes(staleRecipes.recipes);
+                  setRecipesLoaded(true);
                   if (!showedStale) {
                     setLoadState('ready');
                   }
@@ -107,6 +114,7 @@ export function TargetDetail() {
         if (controller.signal.aborted) return;
 
         setRecipes(recipeResponse.recipes);
+        setRecipesLoaded(true);
         setLoadState('ready');
       } catch (err) {
         if (controller.signal.aborted) return;
@@ -180,7 +188,13 @@ export function TargetDetail() {
             </section>
           )}
 
-          {recipes.length === 0 && (
+          {recipes.length === 0 && !recipesLoaded && (
+            <div className="target-detail-recipes-pending" role="status" aria-live="polite">
+              <p>Generating recipe suggestions&hellip;</p>
+            </div>
+          )}
+
+          {recipes.length === 0 && recipesLoaded && (
             <div className="target-detail-no-recipes">
               <p>
                 No composite recipes could be generated for these observations. You can still work


### PR DESCRIPTION
No linked issue — pre-existing UX bug caught during browser-testing.

## Summary

- Target-detail pages briefly showed "No composite recipes could be generated for these observations" before the recipe fetch had even returned, making the page look broken during normal navigation.
- Root cause: stale-while-revalidate on the observations request flips `loadState` to `'ready'` as soon as cached observations are available, at which point `recipes.length === 0` (initial default) triggers the empty-state copy even though the recipe fetch is still pending.
- Fix: track whether a recipe response has arrived (stale or fresh) via a new `recipesLoaded` flag; only show the empty state after the flag flips true. During the pending window, show a brief "Generating recipe suggestions…" indicator in the same container so the slot isn't blank.

## Why

Seen live while browser-testing `/target/NGC%203132` — the "no recipes" copy flashed on-screen during the recipe fetch, then recipe cards appeared once the API returned. Reads as a broken page to anyone navigating to a target for the first time.

## Changes Made

- `frontend/jwst-frontend/src/pages/TargetDetail.tsx` — add `recipesLoaded` state, reset to `false` at the start of each `loadTargetData`, set to `true` in the recipes stale-data callback and after the fresh response. Split the empty-state render into two branches: `!recipesLoaded` shows a pending hint; `recipesLoaded && recipes.length === 0` shows the existing "No composite recipes" message unchanged.
- `frontend/jwst-frontend/src/pages/TargetDetail.css` — add `.target-detail-recipes-pending` selector alongside the existing `.target-detail-no-recipes` style so both use the same dashed container for layout continuity; slight opacity reduction on the pending variant.

## Test Plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 944/944 passing across 73 files (no existing unit tests for `TargetDetail`, so no test updates needed)
- [x] `npx vite build` — clean production build
- [x] Pre-commit hook — ESLint, Prettier, tsc, vitest all green; zero new warnings
- [x] Existing e2e test `target-detail.spec.ts` (Carina Nebula) still valid — it asserts `.target-detail-no-recipes` appears with "No composite recipes could be generated"; the element still renders with that text after the API returns an empty recipe list, just not during the pending window.
- [ ] Browser-verified on `/target/NGC%203132` — pending state appears, recipe cards land after fetch. (Will confirm post-merge with a fresh cache clear; reproducer was the same NGC 3132 URL from the screenshot.)

## Documentation Checklist

- [x] No documentation updates needed — bug-fix only, no new files, services, or endpoints.
- [ ] `docs/key-files.md`
- [ ] `docs/standards/backend-development.md`
- [ ] `docs/quick-reference.md`
- [ ] `docs/architecture/`
- [ ] `docs/development-plan.md`

## Tech Debt Impact

- [x] No new tech debt introduced.
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback

- **Risk:** Low. Single-page, two-file change. New state flag is defensive (defaults to `false`, only unblocks existing copy when a fetch actually settles). No API changes, no auth, no data layer, no shared components.
- **Rollback:** `git revert <commit>` or `gh pr revert` after merge. Fully reversible.
