### PR TITLE
chore(skills): one question per AskUserQuestion in plan-{ceo,eng}-review

### DIFF
--- a/.claude/skills/plan-ceo-review/SKILL.md
+++ b/.claude/skills/plan-ceo-review/SKILL.md
@@ -16,6 +16,13 @@ allowed-tools:
 
 You are not here to rubber-stamp this plan. You are here to make it extraordinary, catch every landmine before it explodes, and ensure that when this ships, it ships right.
 
+> **Hard rule for AskUserQuestion calls in this skill**:
+> Every `AskUserQuestion` call MUST contain exactly ONE question — i.e. the
+> `questions` array has length 1. Wait for the user's answer before issuing
+> the next AskUserQuestion. Even when two questions are about the same
+> feature, ask them sequentially so the user can give each one full
+> consideration. Batching is the failure mode this rule exists to prevent.
+
 **First: detect the base branch.**
 ```bash
 git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"
@@ -62,13 +69,12 @@ Regardless of mode, ask these questions internally before proceeding (do not ski
 
 ### Mode A — Scope Expansion
 - Identify 3-5 scope expansions that would make this significantly better
-- For EACH expansion, use AskUserQuestion: state what it adds, estimated effort (S/M/L), risk level
-- Never batch expansions into one question
+- For EACH expansion, issue a separate AskUserQuestion call (1 question per call). State what it adds, estimated effort (S/M/L), risk level. **Wait for the user's answer before asking the next.**
 - Accepted expansions become part of the scope; rejected ones go to "NOT in scope" list
 
 ### Mode B — Selective Expansion
 - First: make the current scope bulletproof (same as Mode C)
-- Then: surface expansion opportunities one at a time via AskUserQuestion
+- Then: surface expansion opportunities one at a time via AskUserQuestion (1 question per call, wait for answer between)
 - Neutral posture — present the option, state effort + risk, let the user decide
 
 ### Mode C — Hold Scope
@@ -139,6 +145,8 @@ When the recommendation is **"proceed as-is"** or **"proceed with changes"**:
 ## Formatting Rules
 
 - Use AskUserQuestion for every scope opt-in/opt-out — never make scope decisions silently
-- One issue per AskUserQuestion — never batch unrelated decisions
+- **Exactly ONE question per AskUserQuestion call.** The `questions` array has length 1. Wait for the user's answer before issuing the next AskUserQuestion. This applies even when questions are about the same feature — batching robs the user of focused consideration.
+  - ✅ Do: ask EXPANSION-1, wait for answer, ask EXPANSION-2, wait, ask EXPANSION-3.
+  - ❌ Don't: pack EXPANSION-1, EXPANSION-2, EXPANSION-3 into one call.
 - Label questions: "EXPANSION-1", "RISK-1", "DECISION-1" etc. for reference
 - Be direct. No rubber-stamping. If the plan has a flaw, say so.

--- a/.claude/skills/plan-eng-review/SKILL.md
+++ b/.claude/skills/plan-eng-review/SKILL.md
@@ -18,6 +18,14 @@ Engineering preferences that guide this review:
 - **Explicit > clever** — readable code beats clever code
 - **Minimal diff** — solve the problem, don't refactor the neighborhood
 
+> **Hard rule for AskUserQuestion calls in this skill**:
+> Every `AskUserQuestion` call MUST contain exactly ONE question — i.e. the
+> `questions` array has length 1. Wait for the user's answer before issuing
+> the next AskUserQuestion. Even when decisions are about the same feature
+> (e.g. multiple ARCH/RISK/DECISION items in one review), ask them
+> sequentially. The user evaluates each one alone and gives it full
+> consideration. Batching is the failure mode this rule exists to prevent.
+
 **Detect base branch:**
 ```bash
 git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"
@@ -123,7 +131,17 @@ Manual Verification:
 
 ## Step 5: AskUserQuestion Loop
 
-For each significant architectural decision or risk found, ask one question at a time:
+For each significant architectural decision or risk found, issue a SEPARATE
+AskUserQuestion call (1 question per call). Wait for the user's answer
+before issuing the next AskUserQuestion. **Even when decisions are about
+the same feature or PR, ask them sequentially** — the user evaluates each
+one alone and gives it full consideration. This rule exists because batched
+questions force shallow consideration of each decision.
+
+- ✅ Do: ask DECISION-1, wait for answer, ask DECISION-2, wait for answer, ask DECISION-3.
+- ❌ Don't: pack DECISION-1, DECISION-2, DECISION-3 (and their related/same-feature framing) into one AskUserQuestion call.
+
+For each question:
 
 - Label: "ARCH-1", "RISK-1", "DECISION-1"
 - State the issue clearly
@@ -131,7 +149,6 @@ For each significant architectural decision or risk found, ask one question at a
   - **Pros:** concrete benefits (performance, simplicity, correctness, future-proofing)
   - **Cons:** concrete costs (complexity, coupling, migration burden, maintenance)
 - State your recommendation and why, but present all options fairly
-- Never batch unrelated decisions into one question
 - If a decision is load-bearing (auth, data model, storage, API contract) — recommend EnterPlanMode before proceeding
 
 ---


### PR DESCRIPTION
No linked issue
<!-- Surfaced from session #650 review — too many questions at once. -->

## Summary

Tighten `plan-ceo-review` and `plan-eng-review` skills so AskUserQuestion calls always contain exactly one question, with the next question waiting for the previous answer.

## Why

Both skills already said "ask one at a time" and "never batch unrelated decisions" — but the rule was easy to misread when decisions were related to the same feature. During the #650 eng review I batched four architectural decisions (mongo-tools, setup-script refactor, certbot, PR-split) into one AskUserQuestion. The user surfaced this as friction: batched questions force shallow consideration of each option, which is exactly the failure mode the original wording was trying to prevent.

The fix isn't new policy — it's tightening the wording so the same agent can't talk itself into "these are related, batching is fine."

## Changes Made

- `.claude/skills/plan-ceo-review/SKILL.md` — added a top-of-file "Hard rule" banner. Updated Mode A and Mode B steps to spell out that each expansion is its own AskUserQuestion call with a wait-for-answer between. Strengthened the Formatting Rules section with ✅/❌ pattern examples.
- `.claude/skills/plan-eng-review/SKILL.md` — added the same top-of-file "Hard rule" banner. Rewrote Step 5 (AskUserQuestion Loop) to lead with the one-at-a-time directive, explicit ✅/❌ pattern examples, and an explicit note that the rule applies even when decisions are about the same feature/PR.

## Test Plan

- [x] Visual diff of both files — wording is unambiguous and the patterns are concrete.
- [x] Pre-commit hook passed (no secrets, docs consistency check OK).
- [ ] Behavioral test: confirm in next plan-eng-review session that AskUserQuestion is called once-per-question.

## Documentation Checklist

- [x] No documentation updates needed (the skill files ARE the documentation)
- [ ] `docs/key-files.md`
- [ ] `docs/standards/backend-development.md`
- [ ] `docs/quick-reference.md`
- [ ] `docs/architecture/`
- [ ] `docs/development-plan.md`

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback

- Risk: Very low. Wording-only changes to two skill files. No code, no CI tooling, no runtime behavior of the app. The skills are read by Claude at invocation time; the next invocation picks up the new wording. Worst case: agent overcorrects and pads short reviews with too many sequential prompts (still better than batching).
- Rollback: `git revert <commit>` restores both files cleanly.
