### PR TITLE
chore(hooks): pre-commit check for missing __init__.py in nested test dirs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -260,6 +260,48 @@ if has_staged_files_in "processing-engine/"; then
     fi
 
     cd "$REPO_ROOT"
+
+    # Catch the pytest import gotcha that bit PR #1352: a new test file under
+    # processing-engine/tests/<subdir>/ without __init__.py makes pytest's
+    # rootdir walk stop at <subdir>/ instead of processing-engine/, breaking
+    # `from app.* import ...`. Local Docker `docker exec ... pytest` masks this
+    # because the container has app on PYTHONPATH globally; raw `pytest` (CI)
+    # surfaces it as `ModuleNotFoundError: No module named 'app'`.
+    echo "  → Checking test package init files..."
+    NEW_TEST_FILES=$(git diff --cached --name-only --diff-filter=A | grep -E '^processing-engine/tests/.+/.+\.py$' || true)
+    if [ -n "$NEW_TEST_FILES" ]; then
+        STAGED_ALL=$(git diff --cached --name-only --diff-filter=A)
+        MISSING_INITS_FILE=$(mktemp)
+        echo "$NEW_TEST_FILES" | while IFS= read -r test_file; do
+            [ -z "$test_file" ] && continue
+            dir=$(dirname "$test_file")
+            while [ "$dir" != "processing-engine/tests" ] && [ "$dir" != "." ]; do
+                init_file="$dir/__init__.py"
+                if [ ! -f "$REPO_ROOT/$init_file" ] && ! echo "$STAGED_ALL" | grep -qFx "$init_file"; then
+                    echo "$init_file" >> "$MISSING_INITS_FILE"
+                fi
+                dir=$(dirname "$dir")
+            done
+        done
+        if [ -s "$MISSING_INITS_FILE" ]; then
+            echo -e "${RED}  ❌ Missing __init__.py in new test subdirectories:${NC}"
+            sort -u "$MISSING_INITS_FILE" | while IFS= read -r f; do
+                echo -e "${YELLOW}     $f${NC}"
+            done
+            echo -e "${YELLOW}     Without these, raw 'pytest' (CI) fails with ModuleNotFoundError: No module named 'app'.${NC}"
+            echo -e "${YELLOW}     Fix: create the missing files (empty is fine), e.g.:${NC}"
+            sort -u "$MISSING_INITS_FILE" | while IFS= read -r f; do
+                echo -e "${YELLOW}       touch $f && git add $f${NC}"
+            done
+            FAILED=1
+        else
+            echo -e "${GREEN}  ✓ Test package init files OK${NC}"
+        fi
+        rm -f "$MISSING_INITS_FILE"
+    else
+        echo -e "${GREEN}  ✓ No new nested test files — init check skipped${NC}"
+    fi
+
     echo ""
 fi
 


### PR DESCRIPTION
No linked issue
<!-- Surfaced from PR #1352 — meta-fix to prevent the gotcha from recurring. -->

## Summary

Add a pre-commit check that catches missing `__init__.py` in new nested `processing-engine/tests/<subdir>/` test files — the exact gotcha that broke CI on PR #1352.

## Why

PR #1352 (filename sanitizer security fix, closes #1095) added `processing-engine/tests/mast/test_download_utils.py` without `processing-engine/tests/mast/__init__.py`. Local Docker tests (`docker exec jwst-processing python -m pytest`) passed because the container has `app` on PYTHONPATH globally. CI runs raw `pytest` from `processing-engine/`, where pytest's rootdir walk stops at the first directory WITHOUT `__init__.py` — which became `tests/mast/` itself. Result: `ModuleNotFoundError: No module named 'app'`.

This hook catches the next occurrence at commit time, before the PR-CI cycle.

## Changes Made

- `.githooks/pre-commit` — Inside the existing Processing Engine Checks block (only runs when Python files changed), added a check that scans staged-added files for `processing-engine/tests/<subdir>/.../*.py`, walks each test file's parent directories up to `processing-engine/tests`, and flags any intermediate dir whose `__init__.py` is neither on disk nor staged. Errors with exact `touch` commands to fix.

## Test Plan

- [x] `bash -n .githooks/pre-commit` syntax check passes.
- [x] Self-test on this commit: hook ran (this PR's commit), Processing Engine block was skipped because no Python files changed (correct gating). Commit succeeded with `✅ All pre-commit checks passed!`.
- [ ] Future PR with a new nested test file will exercise the check end-to-end.

## Documentation Checklist

- [x] No documentation updates needed (hook self-documenting; error message tells operator how to fix)
- [ ] `docs/key-files.md`
- [ ] `docs/standards/backend-development.md`
- [ ] `docs/quick-reference.md`
- [ ] `docs/architecture/`
- [ ] `docs/development-plan.md`

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback

- Risk: Very low. Hook addition is additive; the new block only runs when Python files are staged AND only inspects newly-added test files. Worst case false-positive: developer is forced to create an empty file before the commit lands.
- Rollback: `git revert <commit>` removes the block cleanly. The hook continues to function; just loses the new check.

## Deployment Note

Operators must re-run `./scripts/setup-hooks.sh` to pick up the new check on existing clones (their local `.git/hooks/pre-commit` is a copy, not a symlink). New clones get it automatically.
