### PR TITLE
chore: remove window.jwst debug helpers (#1040)

### DIFF
--- a/frontend/jwst-frontend/src/index.tsx
+++ b/frontend/jwst-frontend/src/index.tsx
@@ -4,25 +4,6 @@ import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
 import { AuthProvider } from './context/AuthContext';
-import { clearAllCache, getCacheStats } from './utils/cacheUtils';
-
-// Expose cache utilities on window for debugging in development only.
-// Gated behind import.meta.env.DEV so they are tree-shaken from production builds.
-if (import.meta.env.DEV) {
-  (window as unknown as Record<string, unknown>).jwst = {
-    clearCache: () => {
-      const count = clearAllCache();
-      console.log(`Cleared ${count} cached entries. Reload the page to fetch fresh data.`); // eslint-disable-line no-console -- debug utility output
-      return count;
-    },
-    cacheStats: () => {
-      const stats = getCacheStats();
-      console.table(stats.entries); // eslint-disable-line no-console -- debug utility output
-      console.log(`Total: ${stats.entryCount} entries, ${(stats.totalBytes / 1024).toFixed(1)} KB`); // eslint-disable-line no-console -- debug utility output
-      return stats;
-    },
-  };
-}
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(

--- a/frontend/jwst-frontend/src/services/apiClient.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.ts
@@ -41,7 +41,7 @@ function authLog(message: string, data?: unknown): void {
 }
 
 /**
- * Get stored auth debug logs (call from browser console in dev: getAuthLogs())
+ * Get stored auth debug logs.
  */
 export function getAuthLogs(): string[] {
   try {
@@ -53,21 +53,13 @@ export function getAuthLogs(): string[] {
 }
 
 /**
- * Print auth logs to console (call from browser console in dev: printAuthLogs())
+ * Print auth logs to console.
  */
 export function printAuthLogs(): void {
   const logs = getAuthLogs();
   console.warn('=== Auth Debug Logs ===');
   logs.forEach((log) => console.warn(log));
   console.warn(`=== ${logs.length} entries ===`);
-}
-
-// Expose to window for easy console access — development only
-if (import.meta.env.DEV && typeof window !== 'undefined') {
-  (
-    window as unknown as { getAuthLogs: typeof getAuthLogs; printAuthLogs: typeof printAuthLogs }
-  ).getAuthLogs = getAuthLogs;
-  (window as unknown as { printAuthLogs: typeof printAuthLogs }).printAuthLogs = printAuthLogs;
 }
 
 type RequestOptions = {


### PR DESCRIPTION
Closes #1040

## Summary
Fully remove the `window.jwst` and `window.getAuthLogs` / `window.printAuthLogs` debug helpers from the frontend. Previously these were DEV-gated and tree-shaken from production, but the guard was load-bearing and left ambiguity for the Community Edition release. Now they are just gone.

## Why
Issue #1040 (CE deploy blocker) flagged the `window.jwst` debug surface as an implementation-leak risk. PR #1086 mitigated with a DEV gate; this PR closes out the issue by removing the helpers entirely — cleaner, no reliance on tree-shaking, no debug surface in any build mode.

The underlying functions (`clearAllCache`, `getCacheStats`, `getAuthLogs`, `printAuthLogs`) stay exported from `cacheUtils.ts` / `apiClient.ts` so the unit tests keep working and a future admin panel can still consume them.

## Changes Made
- `frontend/jwst-frontend/src/index.tsx` — removed the DEV-gated `window.jwst` assignment block and the now-unused `clearAllCache`/`getCacheStats` imports.
- `frontend/jwst-frontend/src/services/apiClient.ts` — removed the DEV-gated `window.getAuthLogs` / `window.printAuthLogs` assignments. Cleaned up the doc comments on the two exported functions (dropped stale "call from browser console" hints).

## Test Plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 937/937 pass (72 files)
- [x] `npm run build` — production bundle built successfully
- [x] `grep -E "window\.jwst|getAuthLogs|printAuthLogs|cacheStats|clearCache" dist/assets/*.js` — zero matches, confirming the helpers and their identifiers are not shipped
- [x] `grep -rn "window\.jwst\|window\.getAuthLogs\|window\.printAuthLogs" frontend/jwst-frontend/src` — zero references remain
- [x] Pre-commit hook passed (ESLint, Prettier, tsc, 937 unit tests)

## Documentation Checklist
- [x] No documentation updates needed — these helpers were undocumented runtime conveniences

## Tech Debt Impact
- [x] Existing tech debt reduced — closes #1040 (CE deploy blocker)

## Risk & Rollback
- **Risk**: Low. Debug helpers only, previously DEV-only. No production behavior change; tests and types unaffected.
- **Rollback**: Revert the single commit. Helper functions are still exported, so re-exposing them on `window` is a few lines if ever needed.
