### PR TITLE
fix(backend): NGC-3324 OOM — 413 + composite headers + estimate endpoint (#882, PR 2/3)

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/CompositeControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/CompositeControllerTests.cs
@@ -268,8 +268,8 @@ public class CompositeControllerTests
         var request = CreateValidNChannelRequest();
         var imageBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
         mockCompositeService.Setup(s => s.GenerateNChannelCompositeAsync(
-                request, TestUserId, true, false))
-            .ReturnsAsync(imageBytes);
+                request, TestUserId, true, false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompositeResult(imageBytes, new Dictionary<string, string>()));
 
         // Act
         var result = await sut.GenerateNChannelComposite(request);
@@ -292,8 +292,8 @@ public class CompositeControllerTests
         request.OutputFormat = "jpeg";
         var imageBytes = new byte[] { 0xFF, 0xD8, 0xFF };
         mockCompositeService.Setup(s => s.GenerateNChannelCompositeAsync(
-                request, TestUserId, true, false))
-            .ReturnsAsync(imageBytes);
+                request, TestUserId, true, false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompositeResult(imageBytes, new Dictionary<string, string>()));
 
         // Act
         var result = await sut.GenerateNChannelComposite(request);
@@ -549,8 +549,8 @@ public class CompositeControllerTests
         var request = CreateValidNChannelRequest();
         var imageBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
         mockCompositeService.Setup(s => s.GenerateNChannelCompositeAsync(
-                request, TestUserId, true, false))
-            .ReturnsAsync(imageBytes);
+                request, TestUserId, true, false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompositeResult(imageBytes, new Dictionary<string, string>()));
 
         // Act
         var result = await sut.GenerateNChannelComposite(request);
@@ -558,6 +558,137 @@ public class CompositeControllerTests
         // Assert — sync endpoint still returns file directly
         var fileResult = Assert.IsType<FileContentResult>(result);
         fileResult.ContentType.Should().Be("image/png");
+    }
+
+    // PR-2 of #882 train — 413 propagation, header forwarding, /api/composite/estimate
+    [Fact]
+    public async Task GenerateNChannelComposite_BudgetExceeded_Returns413WithDetail()
+    {
+        var request = CreateValidNChannelRequest();
+        const string detail = "Composite output would shrink to 65%. Lower COMPOSITE_DOWNSCALE_FAIL_THRESHOLD or raise MAX_COMPOSITE_MEMORY_BYTES.";
+        mockCompositeService
+            .Setup(s => s.GenerateNChannelCompositeAsync(request, TestUserId, true, false, false, null, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new CompositeBudgetExceededException(detail));
+
+        var result = await sut.GenerateNChannelComposite(request);
+
+        var status = Assert.IsType<ObjectResult>(result);
+        status.StatusCode.Should().Be(StatusCodes.Status413PayloadTooLarge);
+
+        // Detail must reach the caller — it names the actionable env vars.
+        status.Value!.ToString().Should().Contain("MAX_COMPOSITE_MEMORY_BYTES");
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_Success_CopiesCompositeHeadersToResponse()
+    {
+        var request = CreateValidNChannelRequest();
+        var bytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+        var headers = new Dictionary<string, string>
+        {
+            ["X-Composite-Budget-Status"] = "warn",
+            ["X-Composite-Was-Downscaled"] = "true",
+            ["X-Composite-Original-Shape"] = "5750,5750",
+            ["X-Composite-Output-Shape"] = "5462,5462",
+            ["X-Composite-Side-Factor"] = "0.950",
+            ["X-Quality-Score"] = "0.87",
+        };
+        mockCompositeService
+            .Setup(s => s.GenerateNChannelCompositeAsync(request, TestUserId, true, false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompositeResult(bytes, headers));
+
+        var result = await sut.GenerateNChannelComposite(request);
+
+        Assert.IsType<FileContentResult>(result);
+        sut.Response.Headers.Should().ContainKey("X-Composite-Budget-Status");
+        sut.Response.Headers["X-Composite-Budget-Status"].ToString().Should().Be("warn");
+        sut.Response.Headers["X-Composite-Was-Downscaled"].ToString().Should().Be("true");
+        sut.Response.Headers["X-Composite-Original-Shape"].ToString().Should().Be("5750,5750");
+        sut.Response.Headers["X-Composite-Side-Factor"].ToString().Should().Be("0.950");
+    }
+
+    [Fact]
+    public async Task Estimate_Success_Returns200WithVerdict()
+    {
+        var request = CreateValidNChannelRequest();
+        var verdict = new CompositeEstimateResponseDto
+        {
+            Status = "warn",
+            OriginalShape = [4150, 4150],
+            OutputShape = [3947, 3947],
+            SideFactor = 0.951,
+            Detail = "...",
+            MemoryLimitMb = 3000,
+            FailThreshold = 0.85,
+        };
+        mockCompositeService
+            .Setup(s => s.EstimateCompositeAsync(request, TestUserId, true, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(verdict);
+
+        var result = await sut.Estimate(request);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        ok.Value.Should().BeSameAs(verdict);
+    }
+
+    [Fact]
+    public async Task Estimate_ReturnsBadRequest_WhenChannelsEmpty()
+    {
+        var request = new NChannelCompositeRequestDto { Channels = [] };
+
+        var result = await sut.Estimate(request);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Estimate_HttpRequestException_Returns503()
+    {
+        var request = CreateValidNChannelRequest();
+        mockCompositeService
+            .Setup(s => s.EstimateCompositeAsync(request, TestUserId, true, false, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("engine down"));
+
+        var result = await sut.Estimate(request);
+
+        var status = Assert.IsType<ObjectResult>(result);
+        status.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_BudgetExceededDetail_DoesNotLeakInternalPaths()
+    {
+        // Regression guard: the engine's 413 detail names env vars by design,
+        // but must never include /app/, /data/, FITS file paths, or other
+        // internal location strings the operator might want kept private.
+        var request = CreateValidNChannelRequest();
+        const string detail = "Composite output would shrink to 65% of requested side length. Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB; COMPOSITE_DOWNSCALE_FAIL_THRESHOLD = 0.85.";
+        mockCompositeService
+            .Setup(s => s.GenerateNChannelCompositeAsync(request, TestUserId, true, false, false, null, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new CompositeBudgetExceededException(detail));
+
+        var result = await sut.GenerateNChannelComposite(request);
+
+        var status = Assert.IsType<ObjectResult>(result);
+        var body = status.Value!.ToString()!;
+        body.Should().NotContain("/app/");
+        body.Should().NotContain("/data/");
+        body.Should().NotContain(".fits");
+        body.Should().NotContain("http://");
+        body.Should().Contain("MAX_COMPOSITE_MEMORY_BYTES");
+    }
+
+    [Fact]
+    public async Task Estimate_DataNotFound_Returns404()
+    {
+        var request = CreateValidNChannelRequest();
+        mockCompositeService
+            .Setup(s => s.EstimateCompositeAsync(request, TestUserId, true, false, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException("data missing"));
+
+        var result = await sut.Estimate(request);
+
+        Assert.IsType<NotFoundObjectResult>(result);
     }
 
     // ===== Helpers =====

--- a/backend/JwstDataAnalysis.API.Tests/Services/CompositeBackgroundServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/CompositeBackgroundServiceTests.cs
@@ -62,7 +62,7 @@ public class CompositeBackgroundServiceTests : IDisposable
                 true,
                 It.IsAny<Func<int, string, string, Task>?>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(imageBytes);
+            .ReturnsAsync(new CompositeResult(imageBytes, new Dictionary<string, string>()));
         mockJobTracker.Setup(j => j.CompleteBlobJobAsync(
                 "job-1", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null))
             .Callback(() => completed.TrySetResult(true))
@@ -177,7 +177,7 @@ public class CompositeBackgroundServiceTests : IDisposable
                 true,
                 It.IsAny<Func<int, string, string, Task>?>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new byte[] { 1, 2, 3 });
+            .ReturnsAsync(new CompositeResult(new byte[] { 1, 2, 3 }, new Dictionary<string, string>()));
         mockJobTracker.Setup(j => j.FailJobAsync("job-cancel-after", "Cancelled"))
             .Callback(() => completed.TrySetResult(true))
             .Returns(Task.CompletedTask);

--- a/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
@@ -83,7 +83,7 @@ public class CompositeServiceTests
             request, "user-1", isAuthenticated: true, isAdmin: false);
 
         // Assert
-        result.Should().BeEquivalentTo(expectedBytes);
+        result.Bytes.Should().BeEquivalentTo(expectedBytes);
     }
 
     [Fact]
@@ -258,7 +258,7 @@ public class CompositeServiceTests
             CreateRequest(), "admin-user", isAuthenticated: true, isAdmin: true);
 
         // Assert
-        result.Should().NotBeEmpty();
+        result.Bytes.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -280,7 +280,7 @@ public class CompositeServiceTests
             CreateRequest(), "owner-user", isAuthenticated: true, isAdmin: false);
 
         // Assert
-        result.Should().NotBeEmpty();
+        result.Bytes.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -302,7 +302,7 @@ public class CompositeServiceTests
             CreateRequest(), "shared-user", isAuthenticated: true, isAdmin: false);
 
         // Assert
-        result.Should().NotBeEmpty();
+        result.Bytes.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -323,7 +323,7 @@ public class CompositeServiceTests
             CreateRequest(), null, isAuthenticated: false, isAdmin: false);
 
         // Assert
-        result.Should().NotBeEmpty();
+        result.Bytes.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -639,4 +639,140 @@ public class CompositeServiceTests
             return Task.FromResult(response);
         }
     }
+
+    // PR-2 of #882 train — engine 413 propagation + header forwarding + estimate proxy.
+    // Tests appended after FakeHttpMessageHandler to keep PR-2 changes localized in one block;
+    // SA1201 (method should not follow a class) is suppressed for the same reason.
+#pragma warning disable SA1201
+    [Fact]
+    public async Task GenerateNChannelComposite_413_ThrowsCompositeBudgetExceededExceptionWithDetail()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        const string detail = "Composite output would shrink to 65% of requested side length. Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB; COMPOSITE_DOWNSCALE_FAIL_THRESHOLD = 0.85.";
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.RequestEntityTooLarge)
+        {
+            Content = new StringContent($"{{\"detail\":\"{detail}\"}}", System.Text.Encoding.UTF8, "application/json"),
+        });
+        var sut = CreateService(new HttpClient(handler));
+
+        var act = () => sut.GenerateNChannelCompositeAsync(
+            CreateRequest(), "user-1", isAuthenticated: true, isAdmin: false);
+
+        await act.Should().ThrowAsync<CompositeBudgetExceededException>()
+            .Where(ex => ex.Message.Contains("MAX_COMPOSITE_MEMORY_BYTES")
+                      && ex.Message.Contains("COMPOSITE_DOWNSCALE_FAIL_THRESHOLD"));
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_Success_ReturnsCompositeResultWithBytesAndCompositeHeaders()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        var expectedBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+        var resp = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(expectedBytes),
+        };
+        resp.Headers.Add("X-Composite-Budget-Status", "warn");
+        resp.Headers.Add("X-Composite-Was-Downscaled", "true");
+        resp.Headers.Add("X-Composite-Original-Shape", "5750,5750");
+        resp.Headers.Add("X-Composite-Output-Shape", "5462,5462");
+        resp.Headers.Add("X-Composite-Side-Factor", "0.950");
+        resp.Headers.Add("X-Quality-Score", "0.87");
+        resp.Headers.Add("X-Unrelated-Header", "should-be-filtered");
+        var handler = new FakeHttpMessageHandler(resp);
+        var sut = CreateService(new HttpClient(handler));
+
+        var result = await sut.GenerateNChannelCompositeAsync(
+            CreateRequest(), "user-1", isAuthenticated: true, isAdmin: false);
+
+        result.Bytes.Should().BeEquivalentTo(expectedBytes);
+        result.Headers.Should().ContainKey("X-Composite-Budget-Status").WhoseValue.Should().Be("warn");
+        result.Headers.Should().ContainKey("X-Composite-Was-Downscaled").WhoseValue.Should().Be("true");
+        result.Headers.Should().ContainKey("X-Composite-Original-Shape").WhoseValue.Should().Be("5750,5750");
+        result.Headers.Should().ContainKey("X-Composite-Output-Shape").WhoseValue.Should().Be("5462,5462");
+        result.Headers.Should().ContainKey("X-Composite-Side-Factor").WhoseValue.Should().Be("0.950");
+        result.Headers.Should().ContainKey("X-Quality-Score").WhoseValue.Should().Be("0.87");
+        result.Headers.Should().NotContainKey("X-Unrelated-Header");
+    }
+
+    [Fact]
+    public async Task EstimateComposite_Success_DeserializesVerdict()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        const string verdictJson = """
+            {
+                "status": "warn",
+                "original_shape": [4150, 4150],
+                "output_shape": [3947, 3947],
+                "side_factor": 0.951,
+                "detail": "Composite output would shrink to 95% of requested side length.",
+                "memory_limit_mb": 3000,
+                "fail_threshold": 0.85
+            }
+            """;
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(verdictJson, System.Text.Encoding.UTF8, "application/json"),
+        });
+        var sut = CreateService(new HttpClient(handler));
+
+        var verdict = await sut.EstimateCompositeAsync(
+            CreateRequest(), "user-1", isAuthenticated: true, isAdmin: false);
+
+        verdict.Status.Should().Be("warn");
+        verdict.OriginalShape.Should().Equal(4150, 4150);
+        verdict.OutputShape.Should().Equal(3947, 3947);
+        verdict.SideFactor.Should().BeApproximately(0.951, 0.001);
+        verdict.MemoryLimitMb.Should().Be(3000);
+        verdict.FailThreshold.Should().BeApproximately(0.85, 0.001);
+    }
+
+    [Fact]
+    public async Task EstimateComposite_PostsToEstimateEndpointWithSnakeCasePayload()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        HttpRequestMessage? captured = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"status":"ok","original_shape":[100,100],"output_shape":[100,100],"side_factor":1.0,"detail":"","memory_limit_mb":3000,"fail_threshold":0.85}""",
+                    System.Text.Encoding.UTF8,
+                    "application/json"),
+            },
+            req => captured = req);
+        var sut = CreateService(new HttpClient(handler));
+
+        await sut.EstimateCompositeAsync(
+            CreateRequest(), "user-1", isAuthenticated: true, isAdmin: false);
+
+        captured.Should().NotBeNull();
+        captured!.RequestUri!.AbsolutePath.Should().EndWith("/composite/estimate");
+        var body = await captured.Content!.ReadAsStringAsync();
+        body.Should().Contain("\"file_paths\"");
+        body.Should().Contain("\"channels\"");
+    }
+
+    [Fact]
+    public async Task EstimateComposite_DataNotFound_ThrowsKeyNotFoundException()
+    {
+        // Same auth resolution path as Generate — missing data raises KeyNotFoundException.
+        mockMongo.Setup(m => m.GetAsync("missing")).ReturnsAsync((JwstDataModel?)null);
+        var sut = CreateService();
+
+        var act = () => sut.EstimateCompositeAsync(
+            CreateRequest(dataIds: ["missing"]), "user-1", isAuthenticated: true, isAdmin: false);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>()
+            .WithMessage("*missing*not found*");
+    }
+#pragma warning restore SA1201
 }

--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.Log.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.Log.cs
@@ -55,5 +55,17 @@ namespace JwstDataAnalysis.API.Controllers
             Level = LogLevel.Information,
             Message = "Analyzing channels: {ChannelCount} channel(s)")]
         private partial void LogAnalyzingChannels(int channelCount);
+
+        [LoggerMessage(
+            EventId = 10,
+            Level = LogLevel.Information,
+            Message = "Composite budget exceeded (413): {Detail}")]
+        private partial void LogBudgetExceeded(string detail);
+
+        [LoggerMessage(
+            EventId = 11,
+            Level = LogLevel.Information,
+            Message = "Composite estimate requested: {ChannelCount} channel(s)")]
+        private partial void LogEstimateRequested(int channelCount);
     }
 }

--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
@@ -33,6 +33,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// <response code="200">Returns the generated composite image.</response>
         /// <response code="400">Invalid request parameters.</response>
         /// <response code="404">One or more data IDs not found.</response>
+        /// <response code="413">Composite would shrink below COMPOSITE_DOWNSCALE_FAIL_THRESHOLD; tune env vars or reduce inputs.</response>
         /// <response code="503">Processing engine unavailable.</response>
         [HttpPost("generate-nchannel")]
         [AllowAnonymous]
@@ -40,6 +41,7 @@ namespace JwstDataAnalysis.API.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status413PayloadTooLarge)]
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         public async Task<IActionResult> GenerateNChannelComposite([FromBody] NChannelCompositeRequestDto request)
         {
@@ -57,11 +59,17 @@ namespace JwstDataAnalysis.API.Controllers
                 var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
                 var isAdmin = IsCurrentUserAdmin();
 
-                var imageBytes = await compositeService.GenerateNChannelCompositeAsync(
+                var compositeResult = await compositeService.GenerateNChannelCompositeAsync(
                     request,
                     userId,
                     isAuthenticated,
-                    isAdmin);
+                    isAdmin,
+                    cancellationToken: HttpContext.RequestAborted);
+
+                foreach (var (name, value) in compositeResult.Headers)
+                {
+                    Response.Headers[name] = value;
+                }
 
                 var contentType = request.OutputFormat.Equals("jpeg", StringComparison.OrdinalIgnoreCase)
                     ? "image/jpeg"
@@ -69,7 +77,12 @@ namespace JwstDataAnalysis.API.Controllers
 
                 var fileName = $"composite-nchannel.{request.OutputFormat.ToLowerInvariant()}";
 
-                return File(imageBytes, contentType, fileName);
+                return File(compositeResult.Bytes, contentType, fileName);
+            }
+            catch (CompositeBudgetExceededException ex)
+            {
+                LogBudgetExceeded(ex.Message);
+                return StatusCode(StatusCodes.Status413PayloadTooLarge, new { error = ex.Message });
             }
             catch (ObservationMosaicInProgressException ex)
             {
@@ -110,6 +123,86 @@ namespace JwstDataAnalysis.API.Controllers
             {
                 LogUnexpectedError(ex);
                 return StatusCode(500, new { error = "Composite generation failed. Please retry." });
+            }
+        }
+
+        /// <summary>
+        /// Pre-flight memory feasibility check. Calls the engine's
+        /// /composite/estimate endpoint, which reads file WCS headers but
+        /// skips reproject + combine. Returns a verdict (ok | warn | fail)
+        /// so callers (recipe walkthroughs, UI flows) can avoid submitting
+        /// requests that would HTTP 413.
+        /// </summary>
+        /// <param name="request">N-channel composite request to evaluate.</param>
+        /// <response code="200">Verdict (ok | warn | fail).</response>
+        /// <response code="400">Invalid request parameters.</response>
+        /// <response code="404">One or more data IDs not found.</response>
+        /// <response code="413">Total input file count exceeds the engine's soft cap.</response>
+        /// <response code="503">Processing engine unavailable.</response>
+        [HttpPost("estimate")]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(CompositeEstimateResponseDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status413PayloadTooLarge)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public async Task<IActionResult> Estimate([FromBody] NChannelCompositeRequestDto request)
+        {
+            try
+            {
+                var validationResult = ValidateNChannelRequest(request);
+                if (validationResult is not null)
+                {
+                    return validationResult;
+                }
+
+                LogEstimateRequested(request.Channels.Count);
+
+                var userId = GetCurrentUserId();
+                var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+                var isAdmin = IsCurrentUserAdmin();
+
+                var verdict = await compositeService.EstimateCompositeAsync(
+                    request, userId, isAuthenticated, isAdmin, HttpContext.RequestAborted);
+
+                return Ok(verdict);
+            }
+            catch (CompositeBudgetExceededException ex)
+            {
+                // Engine returns 413 on /composite/estimate when the soft file-count
+                // cap is exceeded (MAX_COMPOSITE_ESTIMATE_FILES). Surface verbatim.
+                LogBudgetExceeded(ex.Message);
+                return StatusCode(StatusCodes.Status413PayloadTooLarge, new { error = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                LogDataNotFound(ex.Message);
+                return NotFound(new { error = "The requested data was not found." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                LogInvalidOperation(ex.Message);
+                return BadRequest(new { error = "The request could not be processed." });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LogInvalidOperation(ex.Message);
+                var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
+                return isAuthenticated ? Forbid() : NotFound(new { error = "The requested data was not found." });
+            }
+            catch (HttpRequestException ex)
+            {
+                LogProcessingEngineError(ex);
+                return StatusCode(503, new { error = "Processing engine is temporarily unavailable. Please retry." });
+            }
+            catch (TaskCanceledException)
+            {
+                return StatusCode(504, new { error = "Estimate timed out." });
+            }
+            catch (Exception ex)
+            {
+                LogUnexpectedError(ex);
+                return StatusCode(500, new { error = "Composite estimate failed. Please retry." });
             }
         }
 
@@ -203,7 +296,8 @@ namespace JwstDataAnalysis.API.Controllers
                     request,
                     userId,
                     isAuthenticated,
-                    isAdmin);
+                    isAdmin,
+                    HttpContext.RequestAborted);
 
                 return Ok(result);
             }

--- a/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
@@ -460,4 +460,45 @@ namespace JwstDataAnalysis.API.Models
         [JsonPropertyName("height")]
         public int Height { get; set; } = 1000;
     }
+
+    /// <summary>
+    /// Wraps the bytes returned by the processing engine alongside the
+    /// `X-Composite-*` and `X-Quality-*` response headers so the controller
+    /// can forward them to the HTTP client.
+    /// </summary>
+    /// <remarks>
+    /// Record equality compares <c>Bytes</c> and <c>Headers</c> by reference
+    /// (not deep). Treat instances as transient; do not use as dictionary keys
+    /// or in equality-based assertions.
+    /// </remarks>
+    public sealed record CompositeResult(byte[] Bytes, IReadOnlyDictionary<string, string> Headers);
+
+    /// <summary>
+    /// Verdict from the processing engine's POST /composite/estimate endpoint.
+    /// status carries "ok" | "warn" | "fail"; shapes are encoded as
+    /// JSON arrays [height, width].
+    /// </summary>
+    public sealed class CompositeEstimateResponseDto
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; set; } = "ok";
+
+        [JsonPropertyName("original_shape")]
+        public int[] OriginalShape { get; set; } = [0, 0];
+
+        [JsonPropertyName("output_shape")]
+        public int[] OutputShape { get; set; } = [0, 0];
+
+        [JsonPropertyName("side_factor")]
+        public double SideFactor { get; set; } = 1.0;
+
+        [JsonPropertyName("detail")]
+        public string Detail { get; set; } = string.Empty;
+
+        [JsonPropertyName("memory_limit_mb")]
+        public int MemoryLimitMb { get; set; }
+
+        [JsonPropertyName("fail_threshold")]
+        public double FailThreshold { get; set; }
+    }
 }

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -286,13 +286,34 @@ builder.Services.AddCors(options => options.AddPolicy(
                 ? corsEnvVar.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 : builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>();
 
+            // Headers the engine adds to /composite responses that the
+            // frontend needs to read off `Response.headers.get(...)`.
+            // Browsers won't expose non-simple response headers without
+            // an explicit Access-Control-Expose-Headers entry.
+            string[] exposedHeaders =
+            [
+                "X-Composite-Budget-Status",
+                "X-Composite-Was-Downscaled",
+                "X-Composite-Original-Shape",
+                "X-Composite-Output-Shape",
+                "X-Composite-Side-Factor",
+                "X-Composite-Auto-Feather",
+                "X-Composite-Feather-Strength",
+                "X-Quality-Score",
+                "X-Quality-SNR",
+                "X-Quality-Balance",
+                "X-Quality-Spread",
+                "X-Quality-Coverage",
+            ];
+
             // Use configured origins, or default to localhost for development
             if (allowedOrigins != null && allowedOrigins.Length > 0)
             {
                 policy.WithOrigins(allowedOrigins)
                       .AllowAnyHeader()
                       .AllowAnyMethod()
-                      .AllowCredentials();
+                      .AllowCredentials()
+                      .WithExposedHeaders(exposedHeaders);
             }
             else if (builder.Environment.IsDevelopment())
             {
@@ -304,14 +325,18 @@ builder.Services.AddCors(options => options.AddPolicy(
                         "http://127.0.0.1:5173")
                       .AllowAnyHeader()
                       .AllowAnyMethod()
-                      .AllowCredentials();
+                      .AllowCredentials()
+                      .WithExposedHeaders(exposedHeaders);
             }
             else
             {
-                // Production with no configured origins - deny all cross-origin requests
+                // Production with no configured origins - deny all cross-origin requests.
+                // Still expose headers for defense in depth: if a future operator softens
+                // this fallback, headers should propagate without a separate config change.
                 policy.WithOrigins("https://example.com") // Placeholder that won't match
                       .AllowAnyHeader()
-                      .AllowAnyMethod();
+                      .AllowAnyMethod()
+                      .WithExposedHeaders(exposedHeaders);
             }
         }));
 

--- a/backend/JwstDataAnalysis.API/Services/CompositeBackgroundService.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeBackgroundService.cs
@@ -30,7 +30,7 @@ namespace JwstDataAnalysis.API.Services
                     await jobTracker.UpdateProgressAsync(item.JobId, 10, "generating", "Generating composite image...");
 
                     var jobId = item.JobId;
-                    var imageBytes = await compositeService.GenerateNChannelCompositeAsync(
+                    var compositeResult = await compositeService.GenerateNChannelCompositeAsync(
                         item.Request,
                         item.UserId,
                         item.IsAuthenticated,
@@ -52,7 +52,9 @@ namespace JwstDataAnalysis.API.Services
                     var filename = $"composite-nchannel.{format}";
                     var storageKey = $"tmp/jobs/{item.JobId}/composite.{format}";
 
-                    using var stream = new MemoryStream(imageBytes);
+                    // Async export path drops X-Composite-* warning headers — surfacing them via
+                    // SignalR job completion would need a different shape. Tracked as follow-up.
+                    using var stream = new MemoryStream(compositeResult.Bytes);
                     await storageProvider.WriteAsync(storageKey, stream, stoppingToken);
 
                     await jobTracker.CompleteBlobJobAsync(item.JobId, storageKey, contentType, filename);

--- a/backend/JwstDataAnalysis.API/Services/CompositeBudgetExceededException.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeBudgetExceededException.cs
@@ -1,0 +1,19 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+namespace JwstDataAnalysis.API.Services
+{
+    /// <summary>
+    /// Thrown when the processing engine refuses a composite request because
+    /// the projected output would shrink below the configured fail threshold
+    /// (HTTP 413). Detail string is propagated verbatim from the engine and
+    /// names the env vars an operator can tune to allow the request.
+    /// </summary>
+    public sealed class CompositeBudgetExceededException : Exception
+    {
+        public CompositeBudgetExceededException(string detail)
+            : base(detail)
+        {
+        }
+    }
+}

--- a/backend/JwstDataAnalysis.API/Services/CompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.cs
@@ -15,6 +15,12 @@ namespace JwstDataAnalysis.API.Services
     /// <inheritdoc/>
     public partial class CompositeService : ICompositeService
     {
+        /// <summary>
+        /// Header name prefixes that the controller forwards from the engine
+        /// to the HTTP client. Anything not matching one of these is dropped.
+        /// </summary>
+        private static readonly string[] ForwardableHeaderPrefixes = ["X-Composite-", "X-Quality-"];
+
         private readonly HttpClient httpClient;
         private readonly IMongoDBService mongoDBService;
         private readonly IStorageProvider storageProvider;
@@ -53,7 +59,7 @@ namespace JwstDataAnalysis.API.Services
         }
 
         /// <inheritdoc/>
-        public async Task<byte[]> GenerateNChannelCompositeAsync(
+        public async Task<CompositeResult> GenerateNChannelCompositeAsync(
             NChannelCompositeRequestDto request,
             string? userId,
             bool isAuthenticated,
@@ -64,58 +70,8 @@ namespace JwstDataAnalysis.API.Services
         {
             LogGeneratingNChannelComposite(request.Channels.Count);
 
-            var processingChannels = new List<ProcessingNChannelConfig>();
-
-            foreach (var channel in request.Channels)
-            {
-                var filePaths = await ResolveDataIdsToFilePathsAsync(
-                    channel.DataIds,
-                    userId,
-                    isAuthenticated,
-                    isAdmin,
-                    allowInlineMosaic,
-                    onProgress,
-                    cancellationToken);
-
-                processingChannels.Add(new ProcessingNChannelConfig
-                {
-                    FilePaths = filePaths,
-                    Stretch = channel.Stretch,
-                    BlackPoint = channel.BlackPoint,
-                    WhitePoint = channel.WhitePoint,
-                    Gamma = channel.Gamma,
-                    AsinhA = channel.AsinhA,
-                    Curve = channel.Curve,
-                    Weight = channel.Weight,
-                    Color = new ProcessingChannelColor
-                    {
-                        Hue = channel.Color.Hue,
-                        Rgb = channel.Color.Rgb,
-                        Luminance = channel.Color.Luminance,
-                    },
-                    Label = channel.Label,
-                    WavelengthUm = channel.WavelengthUm,
-                    AutoStretch = channel.AutoStretch,
-                });
-            }
-
-            var processingRequest = new ProcessingNChannelCompositeRequest
-            {
-                Channels = processingChannels,
-                Overall = CreateProcessingOverallAdjustments(request.Overall),
-                Sharpening = CreateProcessingSharpening(request.Sharpening),
-                Saturation = CreateProcessingSaturation(request.Saturation),
-                BackgroundNeutralization = request.BackgroundNeutralization,
-                FeatherStrength = request.FeatherStrength,
-                RotationDegrees = request.RotationDegrees,
-                CropCenterX = request.CropCenterX,
-                CropCenterY = request.CropCenterY,
-                CropZoom = request.CropZoom,
-                OutputFormat = request.OutputFormat,
-                Quality = request.Quality,
-                Width = request.Width,
-                Height = request.Height,
-            };
+            var processingRequest = await BuildProcessingRequestAsync(
+                request, userId, isAuthenticated, isAdmin, allowInlineMosaic, onProgress, cancellationToken);
 
             var json = JsonSerializer.Serialize(processingRequest, jsonOptions);
             LogCallingProcessingEngine(json);
@@ -125,6 +81,13 @@ namespace JwstDataAnalysis.API.Services
                 $"{processingEngineUrl}/composite/generate-nchannel",
                 content,
                 cancellationToken);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.RequestEntityTooLarge)
+            {
+                var detail = await ReadEngineDetailAsync(response, cancellationToken);
+                LogProcessingEngineError(response.StatusCode, detail);
+                throw new CompositeBudgetExceededException(detail);
+            }
 
             if (!response.IsSuccessStatusCode)
             {
@@ -139,7 +102,52 @@ namespace JwstDataAnalysis.API.Services
             var imageBytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
             LogCompositeGenerated(imageBytes.Length, request.OutputFormat);
 
-            return imageBytes;
+            return new CompositeResult(imageBytes, ExtractForwardableHeaders(response));
+        }
+
+        /// <inheritdoc/>
+        public async Task<CompositeEstimateResponseDto> EstimateCompositeAsync(
+            NChannelCompositeRequestDto request,
+            string? userId,
+            bool isAuthenticated,
+            bool isAdmin,
+            CancellationToken cancellationToken = default)
+        {
+            var processingRequest = await BuildProcessingRequestAsync(
+                request, userId, isAuthenticated, isAdmin, allowInlineMosaic: false, onProgress: null, cancellationToken);
+
+            var json = JsonSerializer.Serialize(processingRequest, jsonOptions);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await httpClient.PostAsync(
+                $"{processingEngineUrl}/composite/estimate",
+                content,
+                cancellationToken);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.RequestEntityTooLarge)
+            {
+                // /composite/estimate returns 413 only when the input file count
+                // exceeds MAX_COMPOSITE_ESTIMATE_FILES. The verdict-fail path
+                // (status="fail") returns 200; this branch is the soft-cap.
+                var detail = await ReadEngineDetailAsync(response, cancellationToken);
+                LogProcessingEngineError(response.StatusCode, detail);
+                throw new CompositeBudgetExceededException(detail);
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                LogProcessingEngineError(response.StatusCode, errorBody);
+                throw new HttpRequestException(
+                    $"Processing engine error: {response.StatusCode} - {errorBody}",
+                    null,
+                    response.StatusCode);
+            }
+
+            var verdictJson = await response.Content.ReadAsStringAsync(cancellationToken);
+            var verdict = JsonSerializer.Deserialize<CompositeEstimateResponseDto>(verdictJson, jsonOptions)
+                ?? throw new HttpRequestException("Empty verdict from processing engine /composite/estimate");
+
+            return verdict;
         }
 
         /// <inheritdoc/>
@@ -152,38 +160,14 @@ namespace JwstDataAnalysis.API.Services
         {
             LogAnalyzingChannels(request.Channels.Count);
 
-            var processingChannels = new List<ProcessingNChannelConfig>();
-
-            foreach (var channel in request.Channels)
-            {
-                var filePaths = await ResolveDataIdsToFilePathsAsync(
-                    channel.DataIds,
-                    userId,
-                    isAuthenticated,
-                    isAdmin,
-                    cancellationToken: cancellationToken);
-
-                processingChannels.Add(new ProcessingNChannelConfig
-                {
-                    FilePaths = filePaths,
-                    Stretch = channel.Stretch,
-                    BlackPoint = channel.BlackPoint,
-                    WhitePoint = channel.WhitePoint,
-                    Gamma = channel.Gamma,
-                    AsinhA = channel.AsinhA,
-                    Curve = channel.Curve,
-                    Weight = channel.Weight,
-                    Color = new ProcessingChannelColor
-                    {
-                        Hue = channel.Color.Hue,
-                        Rgb = channel.Color.Rgb,
-                        Luminance = channel.Color.Luminance,
-                    },
-                    Label = channel.Label,
-                    WavelengthUm = channel.WavelengthUm,
-                    AutoStretch = channel.AutoStretch,
-                });
-            }
+            var processingChannels = await ResolveAndMapChannelsAsync(
+                request.Channels,
+                userId,
+                isAuthenticated,
+                isAdmin,
+                allowInlineMosaic: false,
+                onProgress: null,
+                cancellationToken);
 
             var processingRequest = new ProcessingAnalyzeChannelsRequest
             {
@@ -216,6 +200,148 @@ namespace JwstDataAnalysis.API.Services
             return JsonSerializer.Deserialize<JsonElement>(responseBody);
         }
 
+        /// <summary>
+        /// Pull the engine's `{"detail": "..."}` body off a 413 response.
+        /// Falls back to the raw body if JSON parse fails.
+        /// </summary>
+        private static async Task<string> ReadEngineDetailAsync(
+            HttpResponseMessage response,
+            CancellationToken cancellationToken)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                if (doc.RootElement.TryGetProperty("detail", out var detail) && detail.ValueKind == JsonValueKind.String)
+                {
+                    return detail.GetString() ?? body;
+                }
+            }
+            catch (JsonException)
+            {
+                // Not JSON — fall through
+            }
+
+            return body;
+        }
+
+        /// <summary>
+        /// Capture only the X-Composite-* and X-Quality-* response headers
+        /// from the processing-engine response. Other headers (Content-Type,
+        /// Server, etc.) are framework concerns and stay with the bytes.
+        /// </summary>
+        private static Dictionary<string, string> ExtractForwardableHeaders(HttpResponseMessage response)
+        {
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (name, values) in response.Headers)
+            {
+                if (ForwardableHeaderPrefixes.Any(p => name.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+                {
+                    headers[name] = string.Join(", ", values);
+                }
+            }
+
+            return headers;
+        }
+
+        /// <summary>
+        /// Build the processing-engine request payload — DTO mapping plus
+        /// data-ID → file-path resolution. Shared by Generate and Estimate so
+        /// auth and inline-mosaic semantics are identical.
+        /// </summary>
+        private async Task<ProcessingNChannelCompositeRequest> BuildProcessingRequestAsync(
+            NChannelCompositeRequestDto request,
+            string? userId,
+            bool isAuthenticated,
+            bool isAdmin,
+            bool allowInlineMosaic,
+            Func<int, string, string, Task>? onProgress,
+            CancellationToken cancellationToken)
+        {
+            var processingChannels = await ResolveAndMapChannelsAsync(
+                request.Channels,
+                userId,
+                isAuthenticated,
+                isAdmin,
+                allowInlineMosaic,
+                onProgress,
+                cancellationToken);
+
+            return new ProcessingNChannelCompositeRequest
+            {
+                Channels = processingChannels,
+                Overall = CreateProcessingOverallAdjustments(request.Overall),
+                Sharpening = CreateProcessingSharpening(request.Sharpening),
+                Saturation = CreateProcessingSaturation(request.Saturation),
+                BackgroundNeutralization = request.BackgroundNeutralization,
+                FeatherStrength = request.FeatherStrength,
+                RotationDegrees = request.RotationDegrees,
+                CropCenterX = request.CropCenterX,
+                CropCenterY = request.CropCenterY,
+                CropZoom = request.CropZoom,
+                OutputFormat = request.OutputFormat,
+                Quality = request.Quality,
+                Width = request.Width,
+                Height = request.Height,
+            };
+        }
+
+        /// <summary>
+        /// Resolve data IDs to file paths and map DTO fields to processing
+        /// channel configs. Shared by Generate, Estimate, and Analyze paths
+        /// so a new field on NChannelConfigDto can't drift between callers.
+        /// </summary>
+        private async Task<List<ProcessingNChannelConfig>> ResolveAndMapChannelsAsync(
+            List<NChannelConfigDto> channels,
+            string? userId,
+            bool isAuthenticated,
+            bool isAdmin,
+            bool allowInlineMosaic,
+            Func<int, string, string, Task>? onProgress,
+            CancellationToken cancellationToken)
+        {
+            var processingChannels = new List<ProcessingNChannelConfig>(channels.Count);
+
+            foreach (var channel in channels)
+            {
+                var filePaths = await ResolveDataIdsToFilePathsAsync(
+                    channel.DataIds,
+                    userId,
+                    isAuthenticated,
+                    isAdmin,
+                    allowInlineMosaic,
+                    onProgress,
+                    cancellationToken);
+
+                processingChannels.Add(new ProcessingNChannelConfig
+                {
+                    FilePaths = filePaths,
+                    Stretch = channel.Stretch,
+                    BlackPoint = channel.BlackPoint,
+                    WhitePoint = channel.WhitePoint,
+                    Gamma = channel.Gamma,
+                    AsinhA = channel.AsinhA,
+                    Curve = channel.Curve,
+                    Weight = channel.Weight,
+                    Color = new ProcessingChannelColor
+                    {
+                        Hue = channel.Color.Hue,
+                        Rgb = channel.Color.Rgb,
+                        Luminance = channel.Color.Luminance,
+                    },
+                    Label = channel.Label,
+                    WavelengthUm = channel.WavelengthUm,
+                    AutoStretch = channel.AutoStretch,
+                });
+            }
+
+            return processingChannels;
+        }
+
+        // Static helpers below intentionally interleave with the instance
+        // BuildProcessingRequestAsync above — the helpers are grouped by
+        // purpose (DTO mapping) rather than by static vs instance.
+#pragma warning disable SA1204
         private static ProcessingOverallAdjustments? CreateProcessingOverallAdjustments(
             OverallAdjustmentsDto? overall)
         {
@@ -507,5 +633,6 @@ namespace JwstDataAnalysis.API.Services
 
             return result;
         }
+#pragma warning restore SA1204
     }
 }

--- a/backend/JwstDataAnalysis.API/Services/ICompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/ICompositeService.cs
@@ -22,14 +22,36 @@ namespace JwstDataAnalysis.API.Services
         /// <param name="allowInlineMosaic">When true (async export path), generate missing observation mosaics inline.</param>
         /// <param name="onProgress">Optional async callback for progress updates (percent, stage, message).</param>
         /// <param name="cancellationToken">Cancellation token for graceful shutdown.</param>
-        /// <returns>Binary image data (PNG or JPEG).</returns>
-        Task<byte[]> GenerateNChannelCompositeAsync(
+        /// <returns>
+        /// Composite result with binary image data and the X-Composite-* /
+        /// X-Quality-* headers that the engine emitted, so the controller can
+        /// forward them to the HTTP client.
+        /// </returns>
+        Task<CompositeResult> GenerateNChannelCompositeAsync(
             NChannelCompositeRequestDto request,
             string? userId,
             bool isAuthenticated,
             bool isAdmin,
             bool allowInlineMosaic = false,
             Func<int, string, string, Task>? onProgress = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Pre-flight memory feasibility check for a composite request.
+        /// Calls the engine's POST /composite/estimate (which reads file WCS
+        /// headers but skips reproject + combine) and returns a verdict.
+        /// </summary>
+        /// <param name="request">Composite request to evaluate.</param>
+        /// <param name="userId">Current user ID when authenticated, otherwise null.</param>
+        /// <param name="isAuthenticated">Whether the request is authenticated.</param>
+        /// <param name="isAdmin">Whether the current user has Admin role.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Verdict with status (ok | warn | fail), shape info, and limits.</returns>
+        Task<CompositeEstimateResponseDto> EstimateCompositeAsync(
+            NChannelCompositeRequestDto request,
+            string? userId,
+            bool isAuthenticated,
+            bool isAdmin,
             CancellationToken cancellationToken = default);
 
         /// <summary>


### PR DESCRIPTION
Closes #882

## Summary

PR-2 of the #882 OOM fix train (.NET backend slice). PR-1 (processing-engine) is already on main. This PR plumbs the engine's HTTP 413 + `X-Composite-*` response headers through the .NET API to the HTTP client and adds the matching `POST /api/composite/estimate` proxy.

PR-3 (frontend toast + recipe walkthrough pre-flight) follows.

## Why

- After PR-1, browsers couldn't read the engine's new headers because the CORS policy didn't list them in `Access-Control-Expose-Headers`. Frontend reads silently returned undefined.
- The service mapped engine 413 to a generic 503 via the `HttpRequestException` catch, hiding the actionable env-var-name detail from operators.
- Recipe walkthroughs and UI flows had no .NET endpoint to call for pre-flight feasibility checks.

## Type of Change

- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made

- **CORS** (`Program.cs`): expose all 12 forwardable headers (`X-Composite-Budget-Status`, `X-Composite-Was-Downscaled`, `X-Composite-Original-Shape`, `X-Composite-Output-Shape`, `X-Composite-Side-Factor`, `X-Composite-Auto-Feather`, `X-Composite-Feather-Strength`, `X-Quality-Score`, `X-Quality-SNR`, `X-Quality-Balance`, `X-Quality-Spread`, `X-Quality-Coverage`) in all three CORS branches (configured origins, dev fallback, production-no-config fallback).
- **DTOs** (`CompositeModels.cs`): new `CompositeResult` record (bytes + headers) and `CompositeEstimateResponseDto` (snake_case JSON via `[JsonPropertyName(...)]`, shapes as `int[]`).
- **Exception** (`CompositeBudgetExceededException.cs`): typed exception carrying engine's 413 detail.
- **Service** (`CompositeService.cs`):
  - `GenerateNChannelCompositeAsync` returns `CompositeResult`; 413 → typed exception.
  - New `EstimateCompositeAsync` posts to `/composite/estimate`, deserializes verdict, surfaces engine 413 (file-cap) as the same typed exception.
  - Shared `ResolveAndMapChannelsAsync` helper used by Generate, Estimate, and Analyze paths so DTO field additions can't drift.
- **Controller** (`CompositeController.cs`):
  - Generate copies forwardable headers onto response; new 413 catch returns engine detail verbatim.
  - New `[HttpPost("estimate")] [AllowAnonymous]` action mirroring Generate's auth/error mapping; same 413 catch.
  - All three actions thread `HttpContext.RequestAborted` to the service.
- **Background service** (`CompositeBackgroundService.cs`): caller updated to `compositeResult.Bytes`. Async export drops warning headers — filed as #1441 for follow-up.
- **Logging** (`CompositeController.Log.cs`): `LogBudgetExceeded(detail)` and `LogEstimateRequested(channelCount)`.
- **Tests**: 8 new tests in service + controller; 1 regression test asserting 413 body contains `MAX_COMPOSITE_MEMORY_BYTES` but not `/app/`, `/data/`, `.fits`, or `http://` substrings. Existing mock setups updated to `It.IsAny<CancellationToken>()` for resilience.

## Test Plan

- [x] Tested locally with Docker (`docker compose up -d --build backend`)
- [x] Pre-commit hooks pass (Backend tests, lint, format, gitleaks, doc consistency)
- [x] `dotnet test` — 1084 passed, 0 failed
- [x] Manual `OPTIONS /api/composite/estimate` from `Origin: http://localhost:3000` → 204 with full `Access-Control-Allow-*` set
- [x] Manual `POST /api/composite/estimate` with valid ObjectId for missing data → 404 (correct path)
- [x] `Access-Control-Expose-Headers` response header lists all 12 expected headers (verified end-to-end on running backend)
- [ ] CI green
- [ ] Manual verification on staging once PR-3 lands

## Documentation Checklist

- [ ] No documentation updates needed
- [x] `docs/key-files.md` — adding `/api/composite/estimate` belongs in this PR's docs scope; deferred to PR-3 with the rest of the user-visible doc surface
- [x] `docs/quick-reference.md` — same as above; defer to PR-3
- [x] `docs/standards/backend-development.md` — 413+headers pattern; will note in PR-3 docs sweep
- [ ] `docs/architecture/` — additive endpoint, no flow diagram changes
- [ ] `docs/development-plan.md` — no milestone change

## Tech Debt Impact

- [x] No new tech debt introduced
- [x] Existing tech debt addressed — #882 backend slice complete; #1441 filed for the deferred async-export warning surface.

## Risk & Rollback

- **Risk:** Low. Additive endpoint. The `CompositeResult` return-type change is internal — only `CompositeController` and `CompositeBackgroundService` consume it; both updated. CORS additions are additive (no removed headers, no policy tightening). 413 catch comes before the existing 503 catch in the controller; precedence is correct.
- **Rollback:** `git revert` cleanly reverts. No persistent state changes (no DB migrations, no cache poisoning, no public DTO contract removals — `CompositeEstimateResponseDto` is new). If a regression hits production, frontend-side reads of `X-Composite-*` headers fall back to "header not present" gracefully (PR-3 will guard against undefined).

## Follow-ups (filed)

- #1441 — surface composite warning headers on async export job completion (deferred; needs IJobTracker payload extension + frontend SignalR handler)
- #1423 — tile-based streaming (deferred to post-CE)
- #1424 — per-filter file count cap (deferred to real-user feedback)
