### PR TITLE
feat(frontend): NGC-3324 OOM — warning banner + estimate pre-flight (#882, PR 3/3)

### DIFF
--- a/frontend/jwst-frontend/eslint.config.js
+++ b/frontend/jwst-frontend/eslint.config.js
@@ -50,6 +50,7 @@ export default [
         FormData: 'readonly',
         File: 'readonly',
         Blob: 'readonly',
+        Headers: 'readonly',
         FileReader: 'readonly',
         HTMLElement: 'readonly',
         HTMLInputElement: 'readonly',

--- a/frontend/jwst-frontend/src/components/CompositeWarningBanner.css
+++ b/frontend/jwst-frontend/src/components/CompositeWarningBanner.css
@@ -1,0 +1,64 @@
+.composite-warning-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-warning);
+  background: var(--color-warning-subtle);
+  color: var(--color-warning);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.composite-warning-banner--fail {
+  border-color: var(--border-error);
+  background: var(--color-error-subtle);
+  color: var(--color-error);
+}
+
+.composite-warning-banner__icon {
+  flex-shrink: 0;
+  font-size: 1.1rem;
+  line-height: 1.4;
+}
+
+.composite-warning-banner__body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.composite-warning-banner__title {
+  font-weight: 600;
+  margin-bottom: 0.15rem;
+}
+
+.composite-warning-banner__detail {
+  opacity: 0.9;
+}
+
+.composite-warning-banner__detail code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
+.composite-warning-banner__dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+  opacity: 0.7;
+}
+
+.composite-warning-banner__dismiss:hover,
+.composite-warning-banner__dismiss:focus {
+  opacity: 1;
+  outline: none;
+}

--- a/frontend/jwst-frontend/src/components/CompositeWarningBanner.test.tsx
+++ b/frontend/jwst-frontend/src/components/CompositeWarningBanner.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CompositeWarningBanner } from './CompositeWarningBanner';
+import type { CompositeWarning } from '../types/CompositeTypes';
+
+describe('CompositeWarningBanner', () => {
+  it('renders nothing when warning is null', () => {
+    const { container } = render(<CompositeWarningBanner warning={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when status is ok (no useful signal)', () => {
+    const warning: CompositeWarning = {
+      budgetStatus: 'ok',
+      wasDownscaled: false,
+    };
+    const { container } = render(<CompositeWarningBanner warning={warning} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows reduction details when wasDownscaled', () => {
+    const warning: CompositeWarning = {
+      budgetStatus: 'warn',
+      wasDownscaled: true,
+      originalShape: [5750, 5750],
+      outputShape: [5462, 5462],
+      sideFactor: 0.95,
+    };
+    render(<CompositeWarningBanner warning={warning} />);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText(/Output reduced to fit memory budget/i)).toBeInTheDocument();
+    expect(screen.getByText(/5462×5462px from 5750×5750px/)).toBeInTheDocument();
+    expect(screen.getByText(/95% of original side length/)).toBeInTheDocument();
+  });
+
+  it('shows fail-mode message for stale-cache fail status', () => {
+    const warning: CompositeWarning = {
+      budgetStatus: 'fail',
+      wasDownscaled: false,
+    };
+    render(<CompositeWarningBanner warning={warning} />);
+
+    expect(
+      screen.getByText(/Result served from cache exceeds current memory budget/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/MAX_COMPOSITE_MEMORY_BYTES/)).toBeInTheDocument();
+  });
+
+  it('hides after dismiss button is clicked', () => {
+    const warning: CompositeWarning = {
+      budgetStatus: 'warn',
+      wasDownscaled: true,
+      originalShape: [1000, 1000],
+      outputShape: [800, 800],
+      sideFactor: 0.8,
+    };
+    const { container } = render(<CompositeWarningBanner warning={warning} />);
+    expect(container.firstChild).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss warning/i }));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('reveals again when a fresh warning arrives after dismissal', () => {
+    const initial: CompositeWarning = {
+      budgetStatus: 'warn',
+      wasDownscaled: true,
+      originalShape: [1000, 1000],
+      outputShape: [800, 800],
+      sideFactor: 0.8,
+    };
+    const { rerender, container } = render(<CompositeWarningBanner warning={initial} />);
+    fireEvent.click(screen.getByRole('button', { name: /dismiss warning/i }));
+    expect(container.firstChild).toBeNull();
+
+    // A stricter downscale arrives — banner must reveal, not stay dismissed.
+    const next: CompositeWarning = {
+      budgetStatus: 'warn',
+      wasDownscaled: true,
+      originalShape: [1000, 1000],
+      outputShape: [600, 600],
+      sideFactor: 0.6,
+    };
+    rerender(<CompositeWarningBanner warning={next} />);
+
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText(/600×600px from 1000×1000px/)).toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/components/CompositeWarningBanner.tsx
+++ b/frontend/jwst-frontend/src/components/CompositeWarningBanner.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import type { CompositeWarning } from '../types/CompositeTypes';
+import './CompositeWarningBanner.css';
+
+interface CompositeWarningBannerProps {
+  warning: CompositeWarning | null;
+}
+
+/**
+ * Banner that surfaces a memory-budget warning emitted by the processing engine.
+ *
+ * Renders only when the engine actually reduced the output (`wasDownscaled`)
+ * or when budget pressure on a cached result would force a reduction
+ * (`budgetStatus === 'fail'`). For status="ok" the banner stays hidden — no
+ * useful signal to surface.
+ *
+ * Dismissible: dismissing clears the banner until a *different* warning arrives
+ * (e.g. user tweaks parameters, regenerates, hits a fresh budget pressure).
+ * Tracks dismissal by warning identity rather than a boolean, so a stricter
+ * downscale cannot stay hidden behind an old dismiss.
+ */
+export const CompositeWarningBanner: React.FC<CompositeWarningBannerProps> = ({ warning }) => {
+  // Store the warning object that was dismissed (or null if nothing dismissed).
+  // When a new warning arrives, identity differs, banner re-shows automatically
+  // — no effect needed, parent passes a fresh object per generate call.
+  const [dismissedWarning, setDismissedWarning] = useState<CompositeWarning | null>(null);
+
+  if (!warning) return null;
+  if (warning.budgetStatus === 'ok') return null;
+  if (dismissedWarning === warning) return null;
+
+  const original = warning.originalShape;
+  const output = warning.outputShape;
+  const sideFactor = warning.sideFactor;
+
+  const sizeText =
+    original && output ? `${output[1]}×${output[0]}px from ${original[1]}×${original[0]}px` : null;
+  const reductionText =
+    sideFactor !== undefined ? `(${(sideFactor * 100).toFixed(0)}% of original side length)` : null;
+
+  const isFail = warning.budgetStatus === 'fail';
+
+  return (
+    <div
+      className={`composite-warning-banner${isFail ? ' composite-warning-banner--fail' : ''}`}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="composite-warning-banner__icon" aria-hidden="true">
+        ⚠
+      </div>
+      <div className="composite-warning-banner__body">
+        <div className="composite-warning-banner__title">
+          {isFail
+            ? 'Result served from cache exceeds current memory budget'
+            : 'Output reduced to fit memory budget'}
+        </div>
+        <div className="composite-warning-banner__detail">
+          {warning.wasDownscaled && sizeText && <span>{sizeText} </span>}
+          {reductionText && <span>{reductionText}</span>}
+          {!warning.wasDownscaled && isFail && (
+            <span>
+              Clear cache (restart processing-engine) or raise{' '}
+              <code>MAX_COMPOSITE_MEMORY_BYTES</code> to refresh.
+            </span>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        className="composite-warning-banner__dismiss"
+        onClick={() => setDismissedWarning(warning)}
+        aria-label="Dismiss warning"
+      >
+        ×
+      </button>
+    </div>
+  );
+};
+
+export default CompositeWarningBanner;

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -8,10 +8,15 @@ import {
   hueToHex,
   NASA_PALETTE,
 } from '../../utils/wavelengthUtils';
-import type { CompositePageState, NChannelConfigPayload } from '../../types/CompositeTypes';
+import type {
+  CompositePageState,
+  CompositeWarning,
+  NChannelConfigPayload,
+} from '../../types/CompositeTypes';
 import { COMPOSITE_PRESETS } from '../../types/CompositeTypes';
 import { ExportFramingPanel } from './ExportFramingPanel';
 import type { ExportFramingResult } from './ExportFramingPanel';
+import { CompositeWarningBanner } from '../CompositeWarningBanner';
 import './ResultStep.css';
 
 interface ResultStepProps {
@@ -24,6 +29,8 @@ interface ResultStepProps {
   isExporting: boolean;
   /** Export error */
   exportError: string | null;
+  /** Memory-budget warning surfaced from the engine for this composite */
+  compositeWarning: CompositeWarning | null;
   /** Callback to regenerate with adjusted params */
   onAdjust: (adjustments: {
     brightness: number;
@@ -57,6 +64,7 @@ export function ResultStep({
   previewUrl,
   isExporting,
   exportError,
+  compositeWarning,
   onAdjust,
   channels,
   onChannelsChange,
@@ -219,6 +227,7 @@ export function ResultStep({
       <div className="result-layout">
         {/* Left: framing canvas (serves as main preview) */}
         <div className="result-preview-wrap">
+          {compositeWarning && <CompositeWarningBanner warning={compositeWarning} />}
           <ExportFramingPanel
             previewUrl={previewUrl}
             rotation={rotation}

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.test.tsx
@@ -6,7 +6,7 @@ import { createDefaultRGBChannels } from '../../types/CompositeTypes';
 vi.mock('../../services', () => ({
   compositeService: {
     generatePreview: vi.fn(() => Promise.resolve(new Blob())),
-    generateNChannelPreview: vi.fn(() => Promise.resolve(new Blob())),
+    generateNChannelPreview: vi.fn(() => Promise.resolve({ blob: new Blob(), warning: null })),
     exportComposite: vi.fn(() => Promise.resolve(new Blob())),
     exportNChannelCompositeAsync: vi.fn(() => Promise.resolve({ jobId: 'test-job-123' })),
     generateFilename: vi.fn(() => 'test-composite.png'),

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -19,10 +19,12 @@ import {
   StretchMethod,
   COMPOSITE_PRESETS,
   CompositePreset,
+  CompositeWarning,
   STRETCH_OPTIONS,
   SAVED_PRESETS_STORAGE_KEY,
 } from '../../types/CompositeTypes';
 import { compositeService, ApiError } from '../../services';
+import { CompositeWarningBanner } from '../CompositeWarningBanner';
 import { getFilterLabel, channelColorToHex, filterToInstrument } from '../../utils/wavelengthUtils';
 import { useJobProgress } from '../../hooks/useJobProgress';
 import { useSimulatedProgress } from '../../hooks/useSimulatedProgress';
@@ -61,6 +63,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewWarning, setPreviewWarning] = useState<CompositeWarning | null>(null);
   const [mosaicRetrying, setMosaicRetrying] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
@@ -498,6 +501,9 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
 
     setPreviewLoading(true);
     setPreviewError(null);
+    // Clear stale warning before kicking off — both the inline banner and
+    // any prior toast are tied to the previous result.
+    setPreviewWarning(null);
 
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
@@ -506,7 +512,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     abortControllerRef.current = controller;
 
     try {
-      const blob = await compositeService.generateNChannelPreview(payloads, {
+      const { blob, warning } = await compositeService.generateNChannelPreview(payloads, {
         previewSize: 1000,
         overall: overallAdjustments,
         abortSignal: controller.signal,
@@ -523,6 +529,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
       const nextPreviewUrl = URL.createObjectURL(blob);
       previewUrlRef.current = nextPreviewUrl;
       setPreviewUrl(nextPreviewUrl);
+      setPreviewWarning(warning);
     } catch (err) {
       if ((err as Error).name !== 'AbortError') {
         if (err instanceof ApiError && err.status === 409) {
@@ -536,6 +543,18 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
             setMosaicRetrying(false);
             generatePreview();
           }, 30_000);
+        } else if (err instanceof ApiError && err.status === 413) {
+          // Memory budget exceeded — engine detail names the env vars to tune.
+          // Inline preview error is the user's focal point on this screen, so
+          // a toast on top would just duplicate the same text. Inline only.
+          setMosaicRetrying(false);
+          if (previewUrlRef.current && previewUrlRef.current !== beforePreviewUrl) {
+            URL.revokeObjectURL(previewUrlRef.current);
+            previewUrlRef.current = null;
+            setPreviewUrl(null);
+          }
+          setPreviewError(err.message);
+          console.error('Preview generation 413:', err);
         } else {
           setMosaicRetrying(false);
           const detail = err instanceof ApiError ? err.message : 'Failed to generate preview';
@@ -734,6 +753,9 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
                 Retry
               </button>
             </div>
+          )}
+          {previewUrl && !previewLoading && previewWarning && (
+            <CompositeWarningBanner warning={previewWarning} />
           )}
           {previewUrl && !previewLoading && (
             <>

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -16,10 +16,13 @@ import {
 import { checkDataAvailability } from '../services/jwstDataService';
 import { subscribeToJobProgress } from '../hooks/useJobProgress';
 import { apiClient } from '../services/apiClient';
+import { ApiError } from '../services/ApiError';
 import { useAuth } from '../context/useAuth';
+import { toast } from '../components/ui/toast';
 import type { ImportJobStatus, MastObservationResult } from '../types/MastTypes';
 import type { CompositeRecipe } from '../types/DiscoveryTypes';
 import type {
+  CompositeWarning,
   NChannelConfigPayload,
   OverallAdjustments,
   CompositePreset,
@@ -165,6 +168,7 @@ export function GuidedCreate() {
   const [exportError, setExportError] = useState<string | null>(null);
   const [channelPayloads, setChannelPayloads] = useState<NChannelConfigPayload[]>([]);
   const [activePreset, setActivePreset] = useState<CompositePreset>(DEFAULT_PRESET);
+  const [compositeWarning, setCompositeWarning] = useState<CompositeWarning | null>(null);
 
   // Refs for cleanup
   const subscriptionsRef = useRef<Array<{ unsubscribe: () => void }>>([]);
@@ -546,6 +550,8 @@ export function GuidedCreate() {
    */
   async function startProcessing(matchedRecipe: CompositeRecipe) {
     setCurrentStep(2);
+    // Clear any stale memory-budget warning from a prior preset/run.
+    setCompositeWarning(null);
 
     try {
       const channels = buildChannelPayloads(matchedRecipe, filterDataMapRef.current);
@@ -592,6 +598,8 @@ export function GuidedCreate() {
               try {
                 const blob = await apiClient.getBlob(`/api/jobs/${jobId}/result`);
                 applyBlobPreview(blob);
+                // Authenticated async path drops X-Composite-* warning headers —
+                // tracked in #1441 (extend job-completion payload to carry them).
                 setCurrentStep(3);
               } catch (err) {
                 setProcessError(
@@ -600,6 +608,8 @@ export function GuidedCreate() {
               }
             },
             onFailed: (status) => {
+              // 413 from engine surfaces as text in status.error; the HTTP code
+              // is lost crossing the SignalR boundary. Tracked in #1441.
               setProcessError(status.error ?? 'Composite generation failed.');
             },
           },
@@ -609,7 +619,7 @@ export function GuidedCreate() {
         subscriptionsRef.current.push(sub);
       } else {
         // Anonymous: use synchronous endpoint (AllowAnonymous)
-        const blob = await generateNChannelComposite({
+        const { blob, warning } = await generateNChannelComposite({
           channels,
           overall: activePreset.overall,
           sharpening: effectiveSharpening,
@@ -619,9 +629,18 @@ export function GuidedCreate() {
         });
         setProcessComplete(true);
         applyBlobPreview(blob);
+        setCompositeWarning(warning);
         setCurrentStep(3);
       }
     } catch (err) {
+      if (err instanceof ApiError && err.status === 413) {
+        setProcessError(err.message);
+        toast.error('Composite would exceed memory budget', {
+          description: err.message,
+          duration: 12_000,
+        });
+        return;
+      }
       setProcessError(err instanceof Error ? err.message : 'Failed to start composite generation.');
     }
   }
@@ -636,6 +655,8 @@ export function GuidedCreate() {
   ) {
     setIsExporting(true);
     setExportError(null);
+    // Clear stale warning — fresh regenerate may have a different verdict.
+    setCompositeWarning(null);
 
     const effectiveSharpening =
       activePreset.sharpening && activePreset.sharpening.amount > 0
@@ -666,6 +687,8 @@ export function GuidedCreate() {
               try {
                 const blob = await apiClient.getBlob(`/api/jobs/${jobId}/result`);
                 applyBlobPreview(blob);
+                // Authenticated async path drops X-Composite-* warning headers —
+                // tracked in #1441 (extend job-completion payload to carry them).
               } catch (err) {
                 setExportError(err instanceof Error ? err.message : 'Failed to apply adjustments.');
               } finally {
@@ -673,6 +696,10 @@ export function GuidedCreate() {
               }
             },
             onFailed: (status) => {
+              // 413 from engine surfaces here as `status.error` text only — the
+              // HTTP status code is lost crossing the SignalR job-failure boundary.
+              // Tracked in #1441; for now the engine's actionable detail still
+              // appears in the error string, just without the dedicated framing.
               setExportError(status.error ?? 'Adjustment regeneration failed.');
               setIsExporting(false);
             },
@@ -683,7 +710,7 @@ export function GuidedCreate() {
         subscriptionsRef.current.push(sub);
       } else {
         // Anonymous: use synchronous endpoint
-        const blob = await generateNChannelComposite({
+        const { blob, warning } = await generateNChannelComposite({
           channels,
           overall,
           sharpening: effectiveSharpening,
@@ -692,6 +719,7 @@ export function GuidedCreate() {
           ...COMPOSITE_OUTPUT,
         });
         applyBlobPreview(blob);
+        setCompositeWarning(warning);
         setIsExporting(false);
       }
     } catch (err) {
@@ -836,7 +864,7 @@ export function GuidedCreate() {
         );
         subscriptionsRef.current.push(sub);
       } else {
-        const blob = await exportNChannelComposite(channelPayloads, {
+        const { blob } = await exportNChannelComposite(channelPayloads, {
           format: result.format,
           quality: result.format === 'jpeg' ? 92 : 95,
           width: result.width,
@@ -851,6 +879,15 @@ export function GuidedCreate() {
         setIsExporting(false);
       }
     } catch (err) {
+      if (err instanceof ApiError && err.status === 413) {
+        setExportError(err.message);
+        toast.error('Composite would exceed memory budget', {
+          description: err.message,
+          duration: 12_000,
+        });
+        setIsExporting(false);
+        return;
+      }
       setExportError(err instanceof Error ? err.message : 'Export failed.');
       setIsExporting(false);
     }
@@ -1004,6 +1041,7 @@ export function GuidedCreate() {
             previewUrl={previewUrl}
             isExporting={isExporting}
             exportError={exportError}
+            compositeWarning={compositeWarning}
             onAdjust={handleAdjust}
             channels={channelPayloads}
             onChannelsChange={handleChannelsChange}

--- a/frontend/jwst-frontend/src/services/apiClient.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.ts
@@ -395,6 +395,24 @@ class ApiClient {
    * Includes automatic 401 retry with token refresh.
    */
   async postBlob(endpoint: string, data?: unknown, options?: RequestOptions): Promise<Blob> {
+    const { blob } = await this.postBlobWithHeaders(endpoint, data, options);
+    return blob;
+  }
+
+  /**
+   * POST request that returns a Blob plus the response Headers, so callers can
+   * read non-body metadata (e.g. composite memory-budget warning headers
+   * emitted by the processing engine: `X-Composite-Was-Downscaled`,
+   * `X-Composite-Original-Shape`, `X-Composite-Output-Shape`,
+   * `X-Composite-Side-Factor`, `X-Composite-Budget-Status`).
+   *
+   * Same auth-retry semantics as `postBlob`.
+   */
+  async postBlobWithHeaders(
+    endpoint: string,
+    data?: unknown,
+    options?: RequestOptions
+  ): Promise<{ blob: Blob; headers: Headers }> {
     if (!options?.skipAuthRetry) {
       await this.ensureFreshToken();
     }
@@ -426,7 +444,7 @@ class ApiClient {
           if (!retryResponse.ok) {
             throw await ApiError.fromResponse(retryResponse);
           }
-          return retryResponse.blob();
+          return { blob: await retryResponse.blob(), headers: retryResponse.headers };
         }
       }
     }
@@ -435,7 +453,7 @@ class ApiClient {
       throw await ApiError.fromResponse(response);
     }
 
-    return response.blob();
+    return { blob: await response.blob(), headers: response.headers };
   }
 
   /**

--- a/frontend/jwst-frontend/src/services/compositeService.test.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('./apiClient', () => {
   const mockApiClient = {
     postBlob: vi.fn(),
+    postBlobWithHeaders: vi.fn(),
     post: vi.fn(),
   };
   return {
@@ -28,14 +29,21 @@ vi.mock('./apiClient', () => {
 
 import { apiClient } from './apiClient';
 import {
-  generateNChannelComposite,
-  generateNChannelPreview,
+  estimateComposite,
   exportNChannelComposite,
   exportNChannelCompositeAsync,
+  generateNChannelComposite,
+  generateNChannelPreview,
+  parseCompositeWarning,
   analyzeChannels,
   downloadComposite,
   generateFilename,
 } from './compositeService';
+
+/** Build a Headers object from a plain dict for terse mock responses. */
+function H(obj: Record<string, string> = {}): Headers {
+  return new Headers(obj);
+}
 
 describe('compositeService', () => {
   beforeEach(() => {
@@ -47,9 +55,9 @@ describe('compositeService', () => {
   });
 
   describe('generateNChannelComposite', () => {
-    it('should call apiClient.postBlob with correct endpoint and request', async () => {
+    it('should call apiClient.postBlobWithHeaders with correct endpoint and request', async () => {
       const mockBlob = new Blob(['image-data'], { type: 'image/png' });
-      vi.mocked(apiClient.postBlob).mockResolvedValue(mockBlob);
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({ blob: mockBlob, headers: H() });
 
       const request = {
         channels: [{ dataId: 'abc', color: 'red' }],
@@ -61,19 +69,27 @@ describe('compositeService', () => {
 
       const result = await generateNChannelComposite(request as never);
 
-      expect(apiClient.postBlob).toHaveBeenCalledWith('/api/composite/generate-nchannel', request, {
-        signal: undefined,
-      });
-      expect(result).toBe(mockBlob);
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
+        '/api/composite/generate-nchannel',
+        request,
+        {
+          signal: undefined,
+        }
+      );
+      expect(result.blob).toBe(mockBlob);
+      expect(result.warning).toBeNull();
     });
 
     it('should pass abort signal', async () => {
-      vi.mocked(apiClient.postBlob).mockResolvedValue(new Blob());
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
       const controller = new AbortController();
 
       await generateNChannelComposite({ channels: [] } as never, controller.signal);
 
-      expect(apiClient.postBlob).toHaveBeenCalledWith(
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
         '/api/composite/generate-nchannel',
         expect.any(Object),
         { signal: controller.signal }
@@ -81,7 +97,7 @@ describe('compositeService', () => {
     });
 
     it('should propagate errors from apiClient', async () => {
-      vi.mocked(apiClient.postBlob).mockRejectedValue(new Error('API Error'));
+      vi.mocked(apiClient.postBlobWithHeaders).mockRejectedValue(new Error('API Error'));
 
       await expect(generateNChannelComposite({ channels: [] } as never)).rejects.toThrow(
         'API Error'
@@ -91,12 +107,15 @@ describe('compositeService', () => {
 
   describe('generateNChannelPreview', () => {
     it('should build preview request with defaults', async () => {
-      vi.mocked(apiClient.postBlob).mockResolvedValue(new Blob());
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
 
       const channels = [{ dataId: 'abc', color: 'red' }];
       await generateNChannelPreview(channels as never);
 
-      expect(apiClient.postBlob).toHaveBeenCalledWith(
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
         '/api/composite/generate-nchannel',
         {
           channels,
@@ -112,11 +131,14 @@ describe('compositeService', () => {
     });
 
     it('should use custom preview size', async () => {
-      vi.mocked(apiClient.postBlob).mockResolvedValue(new Blob());
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
 
       await generateNChannelPreview([], { previewSize: 400 });
 
-      expect(apiClient.postBlob).toHaveBeenCalledWith(
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
         '/api/composite/generate-nchannel',
         expect.objectContaining({ width: 400, height: 400 }),
         expect.any(Object)
@@ -124,13 +146,16 @@ describe('compositeService', () => {
     });
 
     it('should pass sharpening through into the request body', async () => {
-      vi.mocked(apiClient.postBlob).mockResolvedValue(new Blob());
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
 
       await generateNChannelPreview([], {
         sharpening: { radius: 1.5, amount: 0.6, threshold: 0.01 },
       });
 
-      expect(apiClient.postBlob).toHaveBeenCalledWith(
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
         '/api/composite/generate-nchannel',
         expect.objectContaining({
           sharpening: { radius: 1.5, amount: 0.6, threshold: 0.01 },
@@ -142,7 +167,10 @@ describe('compositeService', () => {
 
   describe('exportNChannelComposite', () => {
     it('should build export request with specified format/quality/dimensions', async () => {
-      vi.mocked(apiClient.postBlob).mockResolvedValue(new Blob());
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
 
       const channels = [{ dataId: 'abc' }];
       await exportNChannelComposite(channels as never, {
@@ -152,7 +180,7 @@ describe('compositeService', () => {
         height: 1500,
       });
 
-      expect(apiClient.postBlob).toHaveBeenCalledWith(
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
         '/api/composite/generate-nchannel',
         expect.objectContaining({
           outputFormat: 'png',
@@ -165,7 +193,10 @@ describe('compositeService', () => {
     });
 
     it('should include overall adjustments and backgroundNeutralization', async () => {
-      vi.mocked(apiClient.postBlob).mockResolvedValue(new Blob());
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
 
       const overall = { brightness: 1.2, contrast: 1.0 };
       await exportNChannelComposite([], {
@@ -177,7 +208,7 @@ describe('compositeService', () => {
         backgroundNeutralization: true,
       });
 
-      expect(apiClient.postBlob).toHaveBeenCalledWith(
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
         '/api/composite/generate-nchannel',
         expect.objectContaining({
           overall,
@@ -188,7 +219,10 @@ describe('compositeService', () => {
     });
 
     it('should pass sharpening through into the export request body', async () => {
-      vi.mocked(apiClient.postBlob).mockResolvedValue(new Blob());
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
 
       await exportNChannelComposite([], {
         format: 'png',
@@ -198,7 +232,7 @@ describe('compositeService', () => {
         sharpening: { radius: 2.0, amount: 1.2, threshold: 0.0 },
       });
 
-      expect(apiClient.postBlob).toHaveBeenCalledWith(
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
         '/api/composite/generate-nchannel',
         expect.objectContaining({
           sharpening: { radius: 2.0, amount: 1.2, threshold: 0.0 },
@@ -369,6 +403,160 @@ describe('compositeService', () => {
       const filename = generateFilename('jpeg');
 
       expect(filename).toMatch(/^jwst-composite-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.jpg$/);
+    });
+  });
+
+  describe('parseCompositeWarning', () => {
+    it('returns null when X-Composite-Budget-Status is absent', () => {
+      expect(parseCompositeWarning(H())).toBeNull();
+    });
+
+    it('returns null when budget status is an unknown value', () => {
+      expect(parseCompositeWarning(H({ 'X-Composite-Budget-Status': 'mystery' }))).toBeNull();
+    });
+
+    it('parses ok status without downscale', () => {
+      const w = parseCompositeWarning(H({ 'X-Composite-Budget-Status': 'ok' }));
+      expect(w).toEqual({
+        budgetStatus: 'ok',
+        wasDownscaled: false,
+        originalShape: undefined,
+        outputShape: undefined,
+        sideFactor: undefined,
+      });
+    });
+
+    it('parses warn status with downscale shapes and side factor', () => {
+      const w = parseCompositeWarning(
+        H({
+          'X-Composite-Budget-Status': 'warn',
+          'X-Composite-Was-Downscaled': 'true',
+          'X-Composite-Original-Shape': '5750,5750',
+          'X-Composite-Output-Shape': '5462,5462',
+          'X-Composite-Side-Factor': '0.950',
+        })
+      );
+      expect(w).toEqual({
+        budgetStatus: 'warn',
+        wasDownscaled: true,
+        originalShape: [5750, 5750],
+        outputShape: [5462, 5462],
+        sideFactor: 0.95,
+      });
+    });
+
+    it('handles fail status from a stale-budget cache hit', () => {
+      const w = parseCompositeWarning(
+        H({
+          'X-Composite-Budget-Status': 'fail',
+          'X-Composite-Was-Downscaled': 'false',
+        })
+      );
+      expect(w?.budgetStatus).toBe('fail');
+      expect(w?.wasDownscaled).toBe(false);
+    });
+
+    it('returns undefined shape when header is malformed', () => {
+      const w = parseCompositeWarning(
+        H({
+          'X-Composite-Budget-Status': 'warn',
+          'X-Composite-Was-Downscaled': 'true',
+          'X-Composite-Original-Shape': 'not,a,shape',
+        })
+      );
+      expect(w?.originalShape).toBeUndefined();
+    });
+
+    it('rejects Infinity side factor', () => {
+      const w = parseCompositeWarning(
+        H({ 'X-Composite-Budget-Status': 'warn', 'X-Composite-Side-Factor': 'Infinity' })
+      );
+      expect(w?.sideFactor).toBeUndefined();
+    });
+
+    it('rejects negative side factor', () => {
+      const w = parseCompositeWarning(
+        H({ 'X-Composite-Budget-Status': 'warn', 'X-Composite-Side-Factor': '-0.5' })
+      );
+      expect(w?.sideFactor).toBeUndefined();
+    });
+
+    it('rejects side factor > 1 (engine contract violation)', () => {
+      const w = parseCompositeWarning(
+        H({ 'X-Composite-Budget-Status': 'warn', 'X-Composite-Side-Factor': '1.5' })
+      );
+      expect(w?.sideFactor).toBeUndefined();
+    });
+
+    it('accepts side factor = 1.0 (boundary)', () => {
+      const w = parseCompositeWarning(
+        H({ 'X-Composite-Budget-Status': 'warn', 'X-Composite-Side-Factor': '1.0' })
+      );
+      expect(w?.sideFactor).toBe(1.0);
+    });
+  });
+
+  describe('generateNChannelComposite warning surface', () => {
+    it('forwards parsed warning when engine emits downscale headers', async () => {
+      const mockBlob = new Blob();
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: mockBlob,
+        headers: H({
+          'X-Composite-Budget-Status': 'warn',
+          'X-Composite-Was-Downscaled': 'true',
+          'X-Composite-Original-Shape': '5750,5750',
+          'X-Composite-Output-Shape': '5462,5462',
+          'X-Composite-Side-Factor': '0.950',
+        }),
+      });
+
+      const result = await generateNChannelComposite({ channels: [] } as never);
+
+      expect(result.blob).toBe(mockBlob);
+      expect(result.warning?.budgetStatus).toBe('warn');
+      expect(result.warning?.wasDownscaled).toBe(true);
+      expect(result.warning?.outputShape).toEqual([5462, 5462]);
+    });
+  });
+
+  describe('estimateComposite', () => {
+    it('POSTs to /api/composite/estimate and returns the verdict', async () => {
+      const verdict = {
+        status: 'warn' as const,
+        originalShape: [4150, 4150] as [number, number],
+        outputShape: [3947, 3947] as [number, number],
+        sideFactor: 0.951,
+        detail: 'Composite output would shrink to 95% of requested side length.',
+        memoryLimitMb: 3000,
+        failThreshold: 0.85,
+      };
+      vi.mocked(apiClient.post).mockResolvedValue(verdict);
+
+      const result = await estimateComposite({ channels: [] } as never);
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/composite/estimate',
+        { channels: [] },
+        { signal: undefined }
+      );
+      expect(result).toEqual(verdict);
+    });
+
+    it('passes abort signal through', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({});
+      const controller = new AbortController();
+
+      await estimateComposite({ channels: [] } as never, controller.signal);
+
+      expect(apiClient.post).toHaveBeenCalledWith('/api/composite/estimate', expect.any(Object), {
+        signal: controller.signal,
+      });
+    });
+
+    it('propagates errors from the API', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('engine down'));
+
+      await expect(estimateComposite({ channels: [] } as never)).rejects.toThrow('engine down');
     });
   });
 });

--- a/frontend/jwst-frontend/src/services/compositeService.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.ts
@@ -7,6 +7,8 @@
 
 import { apiClient } from './apiClient';
 import {
+  CompositeEstimateResponse,
+  CompositeWarning,
   NChannelCompositeRequest,
   NChannelConfigPayload,
   NChannelPreviewOptions,
@@ -15,30 +17,82 @@ import {
 } from '../types/CompositeTypes';
 
 /**
- * Generate an N-channel composite image
+ * Result of a composite generation call: image bytes plus an optional
+ * memory-budget warning parsed from `X-Composite-*` response headers.
+ */
+export interface CompositeBlobResult {
+  blob: Blob;
+  warning: CompositeWarning | null;
+}
+
+/**
+ * Parse `[H, W]` from a comma-separated `X-Composite-*-Shape` header. Returns
+ * undefined if the header is missing or not parseable as exactly two ints.
+ */
+function parseShapeHeader(value: string | null): [number, number] | undefined {
+  if (!value) return undefined;
+  const parts = value.split(',').map((s) => Number.parseInt(s.trim(), 10));
+  if (parts.length !== 2 || parts.some((n) => Number.isNaN(n))) return undefined;
+  return [parts[0], parts[1]];
+}
+
+/**
+ * Build a typed `CompositeWarning` from the engine's response headers, or
+ * return null if the engine didn't emit a budget status (older engine, or
+ * the request didn't go through the composite memory path at all).
+ */
+export function parseCompositeWarning(headers: Headers): CompositeWarning | null {
+  const status = headers.get('X-Composite-Budget-Status');
+  if (status !== 'ok' && status !== 'warn' && status !== 'fail') return null;
+
+  const wasDownscaled = headers.get('X-Composite-Was-Downscaled') === 'true';
+  const sideFactorRaw = headers.get('X-Composite-Side-Factor');
+  const sideFactor = sideFactorRaw ? Number.parseFloat(sideFactorRaw) : undefined;
+
+  // Engine contract: side_factor is in (0, 1]. Reject NaN, Infinity, and
+  // out-of-range values to avoid rendering nonsense like "Infinity%".
+  const validSideFactor =
+    sideFactor !== undefined && Number.isFinite(sideFactor) && sideFactor > 0 && sideFactor <= 1
+      ? sideFactor
+      : undefined;
+
+  return {
+    budgetStatus: status,
+    wasDownscaled,
+    originalShape: parseShapeHeader(headers.get('X-Composite-Original-Shape')),
+    outputShape: parseShapeHeader(headers.get('X-Composite-Output-Shape')),
+    sideFactor: validSideFactor,
+  };
+}
+
+/**
+ * Generate an N-channel composite image.
  *
- * @param request - N-channel composite request
- * @param abortSignal - Optional AbortSignal for cancellation
- * @returns Promise resolving to image Blob
+ * @returns Image blob plus optional memory-budget warning parsed from
+ * `X-Composite-*` response headers (warning is null when the engine did not
+ * emit budget metadata).
  */
 export async function generateNChannelComposite(
   request: NChannelCompositeRequest,
   abortSignal?: AbortSignal
-): Promise<Blob> {
-  return apiClient.postBlob('/api/composite/generate-nchannel', request, { signal: abortSignal });
+): Promise<CompositeBlobResult> {
+  const { blob, headers } = await apiClient.postBlobWithHeaders(
+    '/api/composite/generate-nchannel',
+    request,
+    { signal: abortSignal }
+  );
+  return { blob, warning: parseCompositeWarning(headers) };
 }
 
 /**
- * Generate an N-channel preview composite
+ * Generate an N-channel preview composite.
  *
- * @param channels - Channel config payloads
- * @param options - Preview generation options
- * @returns Promise resolving to image Blob
+ * @returns Image blob plus optional warning (same as `generateNChannelComposite`).
  */
 export async function generateNChannelPreview(
   channels: NChannelConfigPayload[],
   options: NChannelPreviewOptions = {}
-): Promise<Blob> {
+): Promise<CompositeBlobResult> {
   const {
     previewSize = 800,
     overall,
@@ -66,6 +120,21 @@ export async function generateNChannelPreview(
 }
 
 /**
+ * Pre-flight a composite request against the engine's memory budget.
+ * Returns a verdict (ok | warn | fail) without doing reproject + combine work.
+ * Used by recipe walkthroughs that should skip infeasible recipes rather than
+ * triggering OOM kills, and by UI flows that want to warn before submitting.
+ */
+export async function estimateComposite(
+  request: NChannelCompositeRequest,
+  abortSignal?: AbortSignal
+): Promise<CompositeEstimateResponse> {
+  return apiClient.post<CompositeEstimateResponse>('/api/composite/estimate', request, {
+    signal: abortSignal,
+  });
+}
+
+/**
  * Export an N-channel composite with user-specified options
  *
  * @param channels - Channel config payloads
@@ -75,7 +144,7 @@ export async function generateNChannelPreview(
 export async function exportNChannelComposite(
   channels: NChannelConfigPayload[],
   options: NChannelExportOptions
-): Promise<Blob> {
+): Promise<CompositeBlobResult> {
   const {
     format,
     quality,

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -660,3 +660,38 @@ export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
   width: 2000,
   height: 2000,
 };
+
+/**
+ * Memory-budget warning surfaced from the processing engine via X-Composite-*
+ * response headers. Present when the engine had to downscale the output to fit
+ * MAX_COMPOSITE_MEMORY_BYTES, or when budget pressure would force a downscale
+ * for a freshly-computed result.
+ *
+ * Status values match the engine verdict:
+ *   - 'ok'   — no pressure; banner not shown
+ *   - 'warn' — mild downscale applied (or cached result fits current budget)
+ *   - 'fail' — would have refused; only seen on cached results when operator
+ *              tightened the budget after caching
+ */
+export interface CompositeWarning {
+  budgetStatus: 'ok' | 'warn' | 'fail';
+  wasDownscaled: boolean;
+  originalShape?: [number, number]; // [height, width]
+  outputShape?: [number, number];
+  sideFactor?: number;
+}
+
+/**
+ * Verdict returned by POST /api/composite/estimate. The endpoint reads file
+ * WCS headers and runs the engine's memory math without doing reproject +
+ * combine, so callers can pre-flight feasibility before submitting work.
+ */
+export interface CompositeEstimateResponse {
+  status: 'ok' | 'warn' | 'fail';
+  originalShape: [number, number];
+  outputShape: [number, number];
+  sideFactor: number;
+  detail: string;
+  memoryLimitMb: number;
+  failThreshold: number;
+}

--- a/scripts/recipe-walkthrough.py
+++ b/scripts/recipe-walkthrough.py
@@ -344,6 +344,41 @@ def hex_to_hue(hex_color: str) -> float | None:
     return hue % 360
 
 
+def estimate_composite(
+    channels: list[dict],
+    token: str,
+    width: int = 2000,
+    height: int = 2000,
+    feather_strength: float = 0.0,
+) -> dict:
+    """Pre-flight check via /api/composite/estimate.
+
+    Returns the engine verdict ({status, original_shape, output_shape,
+    side_factor, detail, memory_limit_mb, fail_threshold}). Raises
+    requests.HTTPError on real errors (engine down, validation, file-cap 413).
+    The verdict-fail case (status='fail') is a 200 response — caller should
+    branch on the status field, not on HTTP code.
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    payload = {
+        "channels": channels,
+        "width": width,
+        "height": height,
+        "outputFormat": "png",
+        "quality": 95,
+        "featherStrength": feather_strength,
+        "backgroundNeutralization": True,
+    }
+    resp = requests.post(
+        f"{BASE_URL}/api/composite/estimate",
+        json=payload,
+        headers=headers,
+        timeout=120,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
 def generate_composite(
     channels: list[dict],
     token: str,
@@ -582,8 +617,42 @@ def run(
                 summary.append((target_name, recipe_name, "too few channels"))
                 continue
 
-            # Generate composite
+            # Pre-flight: ask engine if this would 413 before kicking off
+            # the heavy generate. Avoids triggering OOM kills on
+            # memory-constrained engines for infeasible recipes.
             print(f"    {recipe_name} ({len(channels)} ch)...", end=" ", flush=True)
+            try:
+                verdict = estimate_composite(channels, token, feather_strength=feather_strength)
+            except requests.HTTPError as e:
+                # Any non-2xx (413 file-cap, 503 engine flap, 500 unexpected) means
+                # we can't establish feasibility. Skip rather than fire the heavy
+                # generate against an unhealthy engine — that's the OOM-cascade
+                # this whole train exists to prevent.
+                code = e.response.status_code if e.response is not None else "?"
+                detail = ""
+                if e.response is not None:
+                    try:
+                        detail = e.response.json().get("error", "") or str(e)
+                    except (ValueError, requests.JSONDecodeError):
+                        detail = str(e)
+                print(f"SKIP — estimate failed ({code}): {detail}")
+                summary.append((target_name, recipe_name, f"skipped (estimate {code})"))
+                continue
+
+            if verdict.get("status") == "fail":
+                detail = verdict.get("detail", "memory budget would be exceeded")
+                print(f"SKIP — estimate verdict=fail: {detail}")
+                summary.append((target_name, recipe_name, "skipped (memory budget)"))
+                continue
+            if verdict.get("status") == "warn":
+                # Mild downscale will be applied; log but proceed.
+                print(
+                    f"warn (side_factor={verdict.get('side_factor', 1.0):.2f}) ...",
+                    end=" ",
+                    flush=True,
+                )
+
+            # Generate composite
             t0 = time.time()
             try:
                 png_data = generate_composite(channels, token, preset_name, feather_strength=feather_strength)


### PR DESCRIPTION
Closes #882

## Summary

PR-3 of the #882 OOM fix train (frontend slice). PR-1 (engine) and PR-2 (.NET backend) are on main. This PR makes the engine's HTTP 413 + `X-Composite-*` headers actually visible to humans:

- A dismissible **memory-budget warning banner** above the composite preview (wizard) and result image (guided flow)
- **HTTP 413 toast** on the guided async export path with the engine's actionable detail (env-var names)
- **Inline error** on the wizard preview path with the same detail
- **Recipe walkthrough pre-flight** that calls `/api/composite/estimate` and skips infeasible recipes — no more OOM cascades on memory-constrained engines

## Why

After PR-1 + PR-2, the engine and .NET layer correctly emit and propagate budget metadata, but the frontend ignored it: `apiClient.postBlob` returned just the Blob and dropped headers. Anyone looking at the wizard saw a downscaled image with no signal that anything had changed. Anyone running the recipe walkthrough still triggered OOM kills for infeasible recipes because the script blindly fired `generate_composite` against a stressed engine.

## Type of Change

- [ ] feat (new capability)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no behavior change)
- [ ] test (tests only)
- [ ] chore (tooling/process)

## Changes Made

### Types (`CompositeTypes.ts`)
- New `CompositeWarning` and `CompositeEstimateResponse` interfaces mirroring the engine/backend contract.

### API client (`apiClient.ts`)
- New `postBlobWithHeaders(endpoint, data, options)` returns `{ blob, headers }`. Same auth-retry semantics as `postBlob`. Existing `postBlob` is now a thin delegator (back-compat).
- Added `Headers` to the eslint browser globals list.

### Composite service (`compositeService.ts`)
- `generateNChannelComposite`, `generateNChannelPreview`, `exportNChannelComposite` now return `CompositeBlobResult` (`{ blob, warning }`).
- New `parseCompositeWarning(headers)` helper validates header shape and rejects out-of-range side factors (NaN, ±Infinity, ≤0, >1).
- New `estimateComposite(request)` posts to `/api/composite/estimate`.

### Banner component (`CompositeWarningBanner.tsx` + `.css`)
- Renders shape diff (output× from original×) + side-factor percent for "warn" status.
- Renders stale-cache hint with `MAX_COMPOSITE_MEMORY_BYTES` reference for "fail" status.
- Uses existing design tokens (`--color-warning`, `--border-warning`, etc.).
- Identity-based dismiss tracking (no `useEffect` — lint-clean per `react-hooks/set-state-in-effect`): a stricter downscale auto-shows a fresh banner even if a previous one was dismissed.
- Accessibility: `role="status"`, `aria-live="polite"`, `aria-label` on dismiss.

### Wiring
- `CompositePreviewStep.tsx` (wizard): clears stale warning at top of `generatePreview`, captures new warning, renders banner above preview, special-cases 413 with inline error (no toast — preview area is user's focal point already).
- `GuidedCreate.tsx` (guided flow): clears stale warning at start of `startProcessing`/`regenerateComposite`, captures new warning, passes to `ResultStep`, fires toast + inline error on 413 in async export paths (where user might have scrolled away). TODO comments at all `onCompleted`/`onFailed` sites referencing **#1441** for the SignalR-payload header gap.
- `ResultStep.tsx`: new `compositeWarning` prop; renders banner above the framing canvas.

### Recipe walkthrough (`scripts/recipe-walkthrough.py`)
- New `estimate_composite()` POSTs to `/api/composite/estimate` before each recipe.
- Skips recipes where verdict is `fail` (would 413) or estimate itself errors with any HTTPError (413 file-cap, 503 engine flap, 500 unexpected). Records skip reason in summary.
- Logs warn-mode side factor and proceeds.

### Tests
- 5 new tests on `parseCompositeWarning` (Infinity, negative, >1, 1.0 boundary, malformed shape).
- 6 new tests on `CompositeWarningBanner` (null, ok, warn, fail, dismiss, dismiss-then-fresh-warning).
- 3 new tests on `estimateComposite`.
- Existing service tests updated to new `{ blob, warning }` return shape.
- 957 vitest tests pass, 0 TypeScript errors.

## Behavior Change

- Existing JS callers of `generateNChannelComposite/Preview/exportNChannelComposite` get a `CompositeBlobResult` instead of a `Blob`. All in-tree callers updated. Anyone building against this service externally would need to destructure `.blob`.
- Recipe walkthrough now skips recipes that would OOM, where it previously fired `generate_composite` and either succeeded with silent downscale or triggered an OOM kill.

## Known Gap (tracked)

**Authenticated SignalR job-result path** (the primary path for logged-in users): `/api/jobs/{id}/result` is just a blob fetch and doesn't carry the `X-Composite-*` headers. Engine 413s during async generation surface as `status.error` text strings via SignalR — the HTTP code is lost crossing that boundary. The actionable detail still appears in the error string (env-var names included), it just doesn't get the dedicated banner/toast framing.

Tracked in **#1441** (extend job-completion payload to carry warning metadata + frontend SignalR handler). All 5 affected sites in `GuidedCreate.tsx` have explicit TODO comments referencing #1441.

## Test Plan

- [x] Tested locally with Docker (`docker compose up -d --build`) and `npm run build` — production build clean
- [x] Pre-commit hooks pass (ESLint clean, Prettier, vitest, doc consistency)
- [x] `npx vitest run` — 957 passed, 0 failed
- [x] `npx tsc --noEmit` — 0 errors
- [ ] CI green
- [ ] Manual browser verification on staging once merged: trigger 413 path (large composite on small budget) → toast/inline; trigger warn path (mild downscale) → banner with shape diff; recipe walkthrough → infeasible recipes skipped with reason

## Documentation Checklist

- [ ] No documentation updates needed
- [x] `docs/key-files.md` — to be updated as a docs sweep after PR-3 merges; the new `CompositeWarningBanner` component + `estimateComposite` service function will be added together
- [x] `docs/quick-reference.md` — same sweep
- [ ] `docs/architecture/` — additive endpoint, no flow diagram changes
- [ ] `docs/development-plan.md` — no milestone change

## Tech Debt Impact

- [x] No new tech debt introduced
- [x] Existing tech debt addressed — #882 fully closed (engine + backend + frontend slices). Async-export warning surface tracked in #1441.

## Risk & Rollback

- **Risk:** Low. The `CompositeBlobResult` shape change is breaking but caught at compile time; all in-tree consumers updated and tested. Banner is purely additive UI. The eslint config addition (Headers global) is uncontroversial. Recipe walkthrough change is bounded (skips on error, logs reason, doesn't crash). Identity-based dismiss tracking avoids the `set-state-in-effect` rule that would otherwise block the lint hook.
- **Rollback:** `git revert` cleanly. No persistent state, no DB migrations, no API contract removals. Frontend build is unaffected if reverted.

## Follow-ups (filed)

- #1441 — surface composite warning headers on async export job completion (deferred SignalR-payload work)
- #1423 — tile-based streaming (deferred to post-CE)
- #1424 — per-filter file count cap (deferred to real-user feedback)
