### PR TITLE
feat: surface composite warning headers on async export (#1441)

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/JobsControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/JobsControllerTests.cs
@@ -200,6 +200,79 @@ public class JobsControllerTests
     }
 
     [Fact]
+    public async Task GetResult_ForwardsWarningHeaders_OnBlobResponse()
+    {
+        var warningHeaders = new Dictionary<string, string>
+        {
+            ["X-Composite-Budget-Status"] = "warn",
+            ["X-Composite-Was-Downscaled"] = "true",
+            ["X-Composite-Side-Factor"] = "0.950",
+        };
+        var job = new JobStatus
+        {
+            JobId = "job-warn",
+            OwnerUserId = TestUserId,
+            State = JobStates.Completed,
+            ResultKind = ResultKinds.Blob,
+            ResultStorageKey = "results/composite.png",
+            ResultContentType = "image/png",
+            ResultFilename = "composite.png",
+            ResultWarningHeaders = warningHeaders,
+        };
+        mockJobTracker
+            .Setup(t => t.GetJobAsync("job-warn", TestUserId))
+            .ReturnsAsync(job);
+        mockJobTracker
+            .Setup(t => t.RecordResultAccessAsync("job-warn"))
+            .Returns(Task.CompletedTask);
+        mockStorage
+            .Setup(s => s.ExistsAsync("results/composite.png", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        mockStorage
+            .Setup(s => s.ReadStreamAsync("results/composite.png", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream([0x89, 0x50, 0x4E, 0x47]));
+
+        var result = await sut.GetResult("job-warn");
+
+        result.Should().BeOfType<FileStreamResult>();
+        sut.Response.Headers["X-Composite-Budget-Status"].ToString().Should().Be("warn");
+        sut.Response.Headers["X-Composite-Was-Downscaled"].ToString().Should().Be("true");
+        sut.Response.Headers["X-Composite-Side-Factor"].ToString().Should().Be("0.950");
+    }
+
+    [Fact]
+    public async Task GetResult_OmitsWarningHeaders_WhenJobHasNone()
+    {
+        var job = new JobStatus
+        {
+            JobId = "job-1",
+            OwnerUserId = TestUserId,
+            State = JobStates.Completed,
+            ResultKind = ResultKinds.Blob,
+            ResultStorageKey = "results/composite.png",
+            ResultContentType = "image/png",
+            ResultFilename = "composite.png",
+            ResultWarningHeaders = null,
+        };
+        mockJobTracker
+            .Setup(t => t.GetJobAsync("job-1", TestUserId))
+            .ReturnsAsync(job);
+        mockJobTracker
+            .Setup(t => t.RecordResultAccessAsync("job-1"))
+            .Returns(Task.CompletedTask);
+        mockStorage
+            .Setup(s => s.ExistsAsync("results/composite.png", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        mockStorage
+            .Setup(s => s.ReadStreamAsync("results/composite.png", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream([0x89]));
+
+        await sut.GetResult("job-1");
+
+        sut.Response.Headers.Should().NotContainKey("X-Composite-Budget-Status");
+    }
+
+    [Fact]
     public async Task GetResult_ReturnsDataId_ForDataIdResult()
     {
         var job = new JobStatus

--- a/backend/JwstDataAnalysis.API.Tests/Services/CompositeBackgroundServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/CompositeBackgroundServiceTests.cs
@@ -64,7 +64,12 @@ public class CompositeBackgroundServiceTests : IDisposable
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CompositeResult(imageBytes, new Dictionary<string, string>()));
         mockJobTracker.Setup(j => j.CompleteBlobJobAsync(
-                "job-1", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null))
+                "job-1",
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                null,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
             .Callback(() => completed.TrySetResult(true))
             .Returns(Task.CompletedTask);
 
@@ -111,7 +116,74 @@ public class CompositeBackgroundServiceTests : IDisposable
                 It.Is<string>(k => k.StartsWith("tmp/jobs/job-1/")),
                 "image/png",
                 "composite-nchannel.png",
-                null),
+                null,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DequeuesAndForwardsWarningHeaders()
+    {
+        // Arrange — engine returned X-Composite-* headers; we expect them
+        // plumbed through to CompleteBlobJobAsync so the result download
+        // response can re-emit them.
+        var imageBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+        var item = CreateItem("job-warn");
+        var engineHeaders = new Dictionary<string, string>
+        {
+            ["X-Composite-Budget-Status"] = "warn",
+            ["X-Composite-Was-Downscaled"] = "true",
+            ["X-Composite-Side-Factor"] = "0.950",
+        };
+        var completed = new TaskCompletionSource<bool>();
+        mockCompositeService.Setup(s => s.GenerateNChannelCompositeAsync(
+                item.Request,
+                item.UserId,
+                item.IsAuthenticated,
+                item.IsAdmin,
+                true,
+                It.IsAny<Func<int, string, string, Task>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CompositeResult(imageBytes, engineHeaders));
+        mockJobTracker.Setup(j => j.CompleteBlobJobAsync(
+                "job-warn",
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                null,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+            .Callback(() => completed.TrySetResult(true))
+            .Returns(Task.CompletedTask);
+
+        queue.TryEnqueue(item);
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        var serviceTask = sut.StartAsync(cts.Token);
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+
+        try
+        {
+            await sut.StopAsync(CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        // Assert
+        mockJobTracker.Verify(
+            j => j.CompleteBlobJobAsync(
+                "job-warn",
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                null,
+                It.Is<IReadOnlyDictionary<string, string>?>(h =>
+                    h != null
+                    && h["X-Composite-Budget-Status"] == "warn"
+                    && h["X-Composite-Was-Downscaled"] == "true"
+                    && h["X-Composite-Side-Factor"] == "0.950")),
             Times.Once);
     }
 

--- a/backend/JwstDataAnalysis.API.Tests/Services/JobTrackerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/JobTrackerTests.cs
@@ -338,6 +338,55 @@ public class JobTrackerTests
         updated!.Message.Should().Be("Completed");
     }
 
+    [Fact]
+    public async Task CompleteBlobJobAsync_PersistsWarningHeaders()
+    {
+        var job = await sut.CreateJobAsync(JobTypes.Composite, "Composite", TestUserId);
+        var warningHeaders = new Dictionary<string, string>
+        {
+            ["X-Composite-Budget-Status"] = "warn",
+            ["X-Composite-Was-Downscaled"] = "true",
+            ["X-Composite-Side-Factor"] = "0.950",
+        };
+
+        await sut.CompleteBlobJobAsync(
+            job.JobId,
+            "results/composite.png",
+            "image/png",
+            "composite.png",
+            warningHeaders: warningHeaders);
+
+        var updated = await sut.GetJobAsync(job.JobId, TestUserId);
+        updated!.ResultWarningHeaders.Should().BeEquivalentTo(warningHeaders);
+    }
+
+    [Fact]
+    public async Task CompleteBlobJobAsync_NullWarningHeaders_LeavesFieldNull()
+    {
+        var job = await sut.CreateJobAsync(JobTypes.Composite, "Composite", TestUserId);
+
+        await sut.CompleteBlobJobAsync(job.JobId, "key", "type", "file");
+
+        var updated = await sut.GetJobAsync(job.JobId, TestUserId);
+        updated!.ResultWarningHeaders.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CompleteBlobJobAsync_EmptyWarningHeaders_LeavesFieldNull()
+    {
+        var job = await sut.CreateJobAsync(JobTypes.Composite, "Composite", TestUserId);
+
+        await sut.CompleteBlobJobAsync(
+            job.JobId,
+            "key",
+            "type",
+            "file",
+            warningHeaders: new Dictionary<string, string>());
+
+        var updated = await sut.GetJobAsync(job.JobId, TestUserId);
+        updated!.ResultWarningHeaders.Should().BeNull();
+    }
+
     // ===== CompleteDataIdJobAsync =====
     [Fact]
     public async Task CompleteDataIdJobAsync_SetsDataIdResultFields()

--- a/backend/JwstDataAnalysis.API/Controllers/JobsController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JobsController.cs
@@ -144,6 +144,17 @@ namespace JwstDataAnalysis.API.Controllers
                 return NotFound(new { error = "Result file has expired or been cleaned up" });
             }
 
+            // Re-emit engine warning headers (e.g. X-Composite-*) so async-export
+            // consumers can surface the same memory-budget banner as the sync path.
+            // CORS exposure is configured in Program.cs.
+            if (job.ResultWarningHeaders is { Count: > 0 } warningHeaders)
+            {
+                foreach (var (key, value) in warningHeaders)
+                {
+                    Response.Headers[key] = value;
+                }
+            }
+
             var stream = await storageProvider.ReadStreamAsync(job.ResultStorageKey);
             return File(stream, job.ResultContentType ?? "application/octet-stream", job.ResultFilename);
         }

--- a/backend/JwstDataAnalysis.API/Models/JobStatus.cs
+++ b/backend/JwstDataAnalysis.API/Models/JobStatus.cs
@@ -112,6 +112,15 @@ namespace JwstDataAnalysis.API.Models
         public string? ResultDataId { get; set; }
 
         /// <summary>
+        /// Gets or sets engine warning headers forwarded with a blob result (e.g.
+        /// composite memory-budget metadata: <c>X-Composite-Was-Downscaled</c>,
+        /// <c>X-Composite-Budget-Status</c>, <c>X-Composite-Side-Factor</c>, ...).
+        /// Re-emitted on the result download response so the async export path
+        /// matches the sync wizard's transparency.
+        /// </summary>
+        public Dictionary<string, string>? ResultWarningHeaders { get; set; }
+
+        /// <summary>
         /// Gets or sets type-specific metadata (e.g., byte-level progress for imports).
         /// </summary>
         [BsonExtraElements]

--- a/backend/JwstDataAnalysis.API/Services/CompositeBackgroundService.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeBackgroundService.cs
@@ -52,12 +52,15 @@ namespace JwstDataAnalysis.API.Services
                     var filename = $"composite-nchannel.{format}";
                     var storageKey = $"tmp/jobs/{item.JobId}/composite.{format}";
 
-                    // Async export path drops X-Composite-* warning headers — surfacing them via
-                    // SignalR job completion would need a different shape. Tracked as follow-up.
                     using var stream = new MemoryStream(compositeResult.Bytes);
                     await storageProvider.WriteAsync(storageKey, stream, stoppingToken);
 
-                    await jobTracker.CompleteBlobJobAsync(item.JobId, storageKey, contentType, filename);
+                    await jobTracker.CompleteBlobJobAsync(
+                        item.JobId,
+                        storageKey,
+                        contentType,
+                        filename,
+                        warningHeaders: compositeResult.Headers);
                     LogJobCompleted(item.JobId);
                 }
                 catch (Exception ex)

--- a/backend/JwstDataAnalysis.API/Services/IJobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/IJobTracker.cs
@@ -44,14 +44,17 @@ namespace JwstDataAnalysis.API.Services
         Task StartJobAsync(string jobId);
 
         /// <summary>
-        /// Mark a job as completed with a blob result.
+        /// Mark a job as completed with a blob result. Optional <paramref name="warningHeaders"/>
+        /// (e.g. composite <c>X-Composite-*</c>) are persisted on the job and re-emitted
+        /// on the result download response.
         /// </summary>
         Task CompleteBlobJobAsync(
             string jobId,
             string storageKey,
             string contentType,
             string filename,
-            string? message = null);
+            string? message = null,
+            IReadOnlyDictionary<string, string>? warningHeaders = null);
 
         /// <summary>
         /// Mark a job as completed with a data ID result.

--- a/backend/JwstDataAnalysis.API/Services/JobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/JobTracker.cs
@@ -161,7 +161,8 @@ namespace JwstDataAnalysis.API.Services
             string storageKey,
             string contentType,
             string filename,
-            string? message = null)
+            string? message = null,
+            IReadOnlyDictionary<string, string>? warningHeaders = null)
         {
             var job = await GetFromCacheOrDb(jobId);
             if (job is null)
@@ -181,6 +182,9 @@ namespace JwstDataAnalysis.API.Services
             job.ResultStorageKey = storageKey;
             job.ResultContentType = contentType;
             job.ResultFilename = filename;
+            job.ResultWarningHeaders = warningHeaders is { Count: > 0 }
+                ? warningHeaders.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+                : null;
 
             await PersistJob(job);
             await NotifyCompleted(job);

--- a/docs/plans/features/quick/1441-composite-async-warning-headers.md
+++ b/docs/plans/features/quick/1441-composite-async-warning-headers.md
@@ -1,0 +1,58 @@
+# Plan: Surface composite warning headers on async export
+
+**Issue**: #1441
+**Complexity**: Quick-medium (plumbing through 3 layers, no new logic)
+
+## Problem
+
+The sync composite path (`/api/composite/generate-nchannel`) forwards engine `X-Composite-*` memory-budget headers, so wizard users see the "downscaled" warning banner once #882 PR-3 shipped.
+
+The async export path (`CompositeBackgroundService` → `/api/composite/export-nchannel`) drops the headers when persisting bytes to storage. Users get the same downscaled output with no warning. Same data, different transparency.
+
+Three call sites in `pages/GuidedCreate.tsx` and one in `components/wizard/CompositePreviewStep.tsx` already have explicit `// tracked in #1441` TODO comments next to `apiClient.getBlob('/api/jobs/{id}/result')` calls.
+
+## Fix
+
+Persist the engine's forwarded headers on the `JobStatus` record at completion, then re-emit them on the result download response (`GET /api/jobs/{id}/result`). Frontend reads headers via a new `apiClient.getBlobWithHeaders` and reuses the existing `parseCompositeWarning(headers)` and `<CompositeWarningBanner>`.
+
+The HTTP `/result` response is the carrier of choice — it mirrors the sync wizard's pattern (where the engine's headers ride the same response that delivers the bytes), keeps a single source of truth, and avoids fan-out to a SignalR-shaped second copy that the frontend would never read because the bytes still need to be fetched.
+
+## Files Changed
+
+### Backend
+
+| File | Change |
+|------|--------|
+| `Models/JobStatus.cs` | Add `Dictionary<string, string>? ResultWarningHeaders` |
+| `Services/IJobTracker.cs` | Extend `CompleteBlobJobAsync` with optional `IReadOnlyDictionary<string, string>? warningHeaders = null` |
+| `Services/JobTracker.cs` | Persist headers on completion |
+| `Services/CompositeBackgroundService.cs` | Pass `compositeResult.Headers` (drops `// Tracked as follow-up.`) |
+| `Controllers/JobsController.cs` | Re-emit X-Composite-* headers on `GET /api/jobs/{id}/result` |
+
+### Frontend
+
+| File | Change |
+|------|--------|
+| `services/apiClient.ts` | Add `getBlobWithHeaders` (mirror of `postBlobWithHeaders`) |
+| `components/wizard/CompositePreviewStep.tsx` | Switch download to `getBlobWithHeaders`, parse warning, render `<CompositeWarningBanner />` |
+| `pages/GuidedCreate.tsx` | Three async-path `apiClient.getBlob` call sites switch to `getBlobWithHeaders`; feed into existing `setCompositeWarning` (drops three `// Tracked in #1441` comments). Adds a `cancelled` flag around each `subscribeToJobProgress.onCompleted` body so a unmount mid-fetch doesn't apply the result on a torn-down component |
+
+### Tests
+
+| File | Change |
+|------|--------|
+| `Services/CompositeBackgroundServiceTests.cs` | Verify `compositeResult.Headers` propagated to `CompleteBlobJobAsync` |
+| `Services/JobTrackerTests.cs` | Verify stored on `JobStatus` + emitted on `NotifyCompleted` |
+| `Controllers/JobsControllerTests.cs` | Verify `/result` response carries X-Composite-* headers |
+
+## Verification
+
+- `dotnet build` clean; new + existing unit tests pass
+- `vitest run` clean for frontend
+- E2E: trigger an async export of a known-large composite (NGC 3324 superset), confirm warning banner shows on download with the same shapes as the sync path
+- Backwards compat: mosaic + embedding background services pass `null` for `warningHeaders` (default), no behavior change
+
+## Risk
+
+- **Risk**: Low-medium. Touches `IJobTracker` (used by import, composite, mosaic, embedding background services), but the new parameter is optional with a `null` default — existing call sites unchanged. Adds an optional field to `JobStatus` (nullable Bson serialization handles missing field on existing documents). SignalR payload gets a new optional field.
+- **Rollback**: `git revert`. Headers continue to be dropped exactly as before.

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -24,6 +24,7 @@ import {
   SAVED_PRESETS_STORAGE_KEY,
 } from '../../types/CompositeTypes';
 import { compositeService, ApiError } from '../../services';
+import { parseCompositeWarning } from '../../services/compositeService';
 import { CompositeWarningBanner } from '../CompositeWarningBanner';
 import { getFilterLabel, channelColorToHex, filterToInstrument } from '../../utils/wavelengthUtils';
 import { useJobProgress } from '../../hooks/useJobProgress';
@@ -73,6 +74,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
   // force-downscale, the user adjusts sliders and exports, and the export
   // re-hits 413 with no path forward.
   const [allowForceDownscale, setAllowForceDownscale] = useState(false);
+  const [exportWarning, setExportWarning] = useState<CompositeWarning | null>(null);
   const exportFormatRef = useRef<'png' | 'jpeg'>('png');
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const {
@@ -606,10 +608,11 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     // Job completed — fetch the result blob and trigger download
     const downloadResult = async () => {
       try {
-        const blob = await apiClient.getBlob(`/api/jobs/${jobId}/result`);
+        const { blob, headers } = await apiClient.getBlobWithHeaders(`/api/jobs/${jobId}/result`);
         if (cancelled) return;
         const filename = compositeService.generateFilename(format);
         compositeService.downloadComposite(blob, filename);
+        setExportWarning(parseCompositeWarning(headers));
 
         const completeCb = onExportCompleteRef.current;
         if (completeCb) {
@@ -645,6 +648,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
 
     setExporting(true);
     setExportError(null);
+    setExportWarning(null);
     exportFormatRef.current = exportOptions.format;
 
     try {
@@ -1547,6 +1551,8 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
             )}
           </div>
         )}
+
+        {exportWarning && !exporting && <CompositeWarningBanner warning={exportWarning} />}
 
         {/* Export button — fills as progress bar during export */}
         <button

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -12,6 +12,7 @@ import {
   generateNChannelComposite,
   downloadComposite,
   generateFilename,
+  parseCompositeWarning,
 } from '../services/compositeService';
 import { checkDataAvailability } from '../services/jwstDataService';
 import { subscribeToJobProgress } from '../hooks/useJobProgress';
@@ -612,37 +613,50 @@ export function GuidedCreate() {
           allowForceDownscale: forceDownscale,
         });
 
+        let cancelled = false;
         const sub = subscribeToJobProgress(
           jobId,
           {
             onProgress: (status) => {
+              if (cancelled) return;
               setProcessProgress(status);
             },
             onCompleted: async () => {
+              if (cancelled) return;
               setProcessComplete(true);
 
               try {
-                const blob = await apiClient.getBlob(`/api/jobs/${jobId}/result`);
+                const { blob, headers } = await apiClient.getBlobWithHeaders(
+                  `/api/jobs/${jobId}/result`
+                );
+                if (cancelled) return;
                 applyBlobPreview(blob);
-                // Authenticated async path drops X-Composite-* warning headers —
-                // tracked in #1441 (extend job-completion payload to carry them).
+                setCompositeWarning(parseCompositeWarning(headers));
                 setCurrentStep(3);
               } catch (err) {
+                if (cancelled) return;
                 setProcessError(
                   err instanceof Error ? err.message : 'Failed to fetch composite result.'
                 );
               }
             },
             onFailed: (status) => {
+              if (cancelled) return;
               // 413 from engine surfaces as text in status.error; the HTTP code
-              // is lost crossing the SignalR boundary. Tracked in #1441.
+              // is lost crossing the SignalR boundary. Engine detail still
+              // appears in the error string.
               setProcessError(status.error ?? 'Composite generation failed.');
             },
           },
           { signalROnly: true }
         );
 
-        subscriptionsRef.current.push(sub);
+        subscriptionsRef.current.push({
+          unsubscribe: () => {
+            cancelled = true;
+            sub.unsubscribe();
+          },
+        });
       } else {
         // Anonymous: use synchronous endpoint (AllowAnonymous)
         const { blob, warning } = await generateNChannelComposite({
@@ -717,6 +731,7 @@ export function GuidedCreate() {
           allowForceDownscale,
         });
 
+        let cancelled = false;
         const sub = subscribeToJobProgress(
           jobId,
           {
@@ -724,22 +739,26 @@ export function GuidedCreate() {
               /* wait for completion */
             },
             onCompleted: async () => {
+              if (cancelled) return;
               try {
-                const blob = await apiClient.getBlob(`/api/jobs/${jobId}/result`);
+                const { blob, headers } = await apiClient.getBlobWithHeaders(
+                  `/api/jobs/${jobId}/result`
+                );
+                if (cancelled) return;
                 applyBlobPreview(blob);
-                // Authenticated async path drops X-Composite-* warning headers —
-                // tracked in #1441 (extend job-completion payload to carry them).
+                setCompositeWarning(parseCompositeWarning(headers));
               } catch (err) {
+                if (cancelled) return;
                 setExportError(err instanceof Error ? err.message : 'Failed to apply adjustments.');
               } finally {
-                setIsExporting(false);
+                if (!cancelled) setIsExporting(false);
               }
             },
             onFailed: (status) => {
+              if (cancelled) return;
               // 413 from engine surfaces here as `status.error` text only — the
               // HTTP status code is lost crossing the SignalR job-failure boundary.
-              // Tracked in #1441; for now the engine's actionable detail still
-              // appears in the error string, just without the dedicated framing.
+              // Engine detail still appears in the error string.
               setExportError(status.error ?? 'Adjustment regeneration failed.');
               setIsExporting(false);
             },
@@ -747,7 +766,12 @@ export function GuidedCreate() {
           { signalROnly: true }
         );
 
-        subscriptionsRef.current.push(sub);
+        subscriptionsRef.current.push({
+          unsubscribe: () => {
+            cancelled = true;
+            sub.unsubscribe();
+          },
+        });
       } else {
         // Anonymous: use synchronous endpoint
         const { blob, warning } = await generateNChannelComposite({
@@ -856,6 +880,8 @@ export function GuidedCreate() {
     lastExportResultRef.current = result;
     setIsExporting(true);
     setExportError(null);
+    // Clear stale warning — fresh export may have a different verdict.
+    setCompositeWarning(null);
     // The state setter is async; use the override directly when the caller
     // explicitly opted in, otherwise read from sticky state.
     const useForceDownscale = forceDownscaleOverride || allowForceDownscale;
@@ -888,29 +914,42 @@ export function GuidedCreate() {
           allowForceDownscale: useForceDownscale,
         });
 
+        let cancelled = false;
         const sub = subscribeToJobProgress(
           jobId,
           {
             onProgress: () => {},
             onCompleted: async () => {
+              if (cancelled) return;
               try {
-                const blob = await apiClient.getBlob(`/api/jobs/${jobId}/result`);
+                const { blob, headers } = await apiClient.getBlobWithHeaders(
+                  `/api/jobs/${jobId}/result`
+                );
+                if (cancelled) return;
                 downloadComposite(blob, generateFilename(result.format));
                 lastExportResultRef.current = null;
+                setCompositeWarning(parseCompositeWarning(headers));
               } catch (err) {
+                if (cancelled) return;
                 setExportError(err instanceof Error ? err.message : 'Failed to download export.');
               } finally {
-                setIsExporting(false);
+                if (!cancelled) setIsExporting(false);
               }
             },
             onFailed: (status) => {
+              if (cancelled) return;
               setExportError(status.error ?? 'Export failed.');
               setIsExporting(false);
             },
           },
           { signalROnly: true }
         );
-        subscriptionsRef.current.push(sub);
+        subscriptionsRef.current.push({
+          unsubscribe: () => {
+            cancelled = true;
+            sub.unsubscribe();
+          },
+        });
       } else {
         const { blob } = await exportNChannelComposite(channelPayloads, {
           format: result.format,

--- a/frontend/jwst-frontend/src/services/apiClient.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.ts
@@ -482,6 +482,22 @@ class ApiClient {
    * Includes automatic 401 retry with token refresh.
    */
   async getBlob(endpoint: string, options?: RequestOptions): Promise<Blob> {
+    const { blob } = await this.getBlobWithHeaders(endpoint, options);
+    return blob;
+  }
+
+  /**
+   * GET request that returns a Blob plus the response Headers, so callers can
+   * read non-body metadata (e.g. composite memory-budget warning headers
+   * re-emitted by the API on `/api/jobs/{id}/result` for async exports —
+   * mirroring the sync `/api/composite/generate-nchannel` behavior).
+   *
+   * Same auth-retry semantics as `getBlob`.
+   */
+  async getBlobWithHeaders(
+    endpoint: string,
+    options?: RequestOptions
+  ): Promise<{ blob: Blob; headers: Headers }> {
     await this.ensureFreshToken();
     const makeRequest = () =>
       fetch(this.buildUrl(endpoint), {
@@ -509,7 +525,7 @@ class ApiClient {
           if (!retryResponse.ok) {
             throw await ApiError.fromResponse(retryResponse);
           }
-          return retryResponse.blob();
+          return { blob: await retryResponse.blob(), headers: retryResponse.headers };
         }
       }
     }
@@ -518,7 +534,7 @@ class ApiClient {
       throw await ApiError.fromResponse(response);
     }
 
-    return response.blob();
+    return { blob: await response.blob(), headers: response.headers };
   }
 
   /**


### PR DESCRIPTION
Closes #1441

## Summary

The async composite-export path (`CompositeBackgroundService` → `/api/composite/export-nchannel`) was dropping the engine's `X-Composite-*` memory-budget warning headers when persisting the generated bytes to storage. The sync wizard path (`/api/composite/generate-nchannel`) forwards those headers and shows a "downscaled" banner; the async export silently produced the same downscaled output. This PR closes that transparency gap.

## Why

Same data, different transparency. Users on the wizard saw "your composite was downscaled to fit in memory"; users on the async export got the same downscaled output without knowing. Tracked in #1441 (follow-up to #882 PR-2). Three `// Tracked in #1441` TODO comments in the codebase pinpointed the exact integration sites.

## Changes Made

### Backend
- `Models/JobStatus.cs` — add `Dictionary<string, string>? ResultWarningHeaders`
- `Services/IJobTracker.cs` — extend `CompleteBlobJobAsync` with optional `IReadOnlyDictionary<string, string>? warningHeaders = null` (default-null keeps mosaic + embedding background services unchanged)
- `Services/JobTracker.cs` — persist headers on completion
- `Services/CompositeBackgroundService.cs` — pass `compositeResult.Headers`
- `Controllers/JobsController.cs` — re-emit `X-Composite-*` headers on `GET /api/jobs/{id}/result` (CORS exposure already configured in `Program.cs`)

### Frontend
- `services/apiClient.ts` — add `getBlobWithHeaders` (mirror of existing `postBlobWithHeaders`); existing `getBlob` delegates to it for back-compat
- `components/wizard/CompositePreviewStep.tsx` — switch async download to `getBlobWithHeaders`, parse warning, render `<CompositeWarningBanner />` near the export button
- `pages/GuidedCreate.tsx` — three async-path `apiClient.getBlob` call sites switch to `getBlobWithHeaders`; warning fed into existing `setCompositeWarning` (drops three `// Tracked in #1441` comments). Adds a `cancelled` flag around each `subscribeToJobProgress.onCompleted` body so a mid-fetch unmount doesn't apply the result on a torn-down component (caught in self-review). `handleExport` now clears stale `setCompositeWarning(null)` upfront, matching `regenerateComposite`

### Tests
- `JobTrackerTests.CompleteBlobJobAsync_PersistsWarningHeaders` — round-trip persistence
- `JobTrackerTests.CompleteBlobJobAsync_NullWarningHeaders_LeavesFieldNull` + `..._EmptyWarningHeaders_LeavesFieldNull` — null/empty contract
- `CompositeBackgroundServiceTests.DequeuesAndForwardsWarningHeaders` — engine headers propagate to `CompleteBlobJobAsync`
- `JobsControllerTests.GetResult_ForwardsWarningHeaders_OnBlobResponse` + `_OmitsWarningHeaders_WhenJobHasNone`

### Plan
- [docs/plans/features/quick/1441-composite-async-warning-headers.md](docs/plans/features/quick/1441-composite-async-warning-headers.md)

## Test Plan

- [x] Backend test suite: 1090/1090 passing (`dotnet test`)
- [x] Frontend test suite: 957/957 passing (`vitest run`)
- [x] Frontend typecheck clean (`tsc --noEmit`)
- [x] Frontend lint: no new warnings on changed files (only pre-existing react-hooks deps warnings)
- [x] Backend build clean (`dotnet build` — 0 warnings, 0 errors)
- [x] Self-review with `code-reviewer` agent: round 1 (3 SHOULD FIX + 1 NIT all addressed: dropped dead SignalR field, added cancelled flags in `GuidedCreate`, cleared stale warning on `handleExport`); round 2 (3 SHOULD FIX stale doc comments fixed; verdict clean)
- [x] Docker compose up -d --build (full stack rebuilt + healthy)
- [ ] **E2E (run before merge)**: trigger an authenticated async export against a known-large composite (NGC 3324 superset), confirm the warning banner renders on download with shapes matching the sync path
- [ ] **E2E (run before merge)**: trigger a non-warning composite export, confirm no banner appears
- [ ] **E2E (run before merge)**: in GuidedCreate, click two presets in rapid succession to validate the cancelled-flag wrapper prevents stale results

## Documentation Checklist
- [x] No documentation updates needed (no new endpoints, controllers, services, or architectural changes — extends an existing endpoint's response shape with optional headers)

## Tech Debt Impact
- [x] Existing tech debt reduced — closes #1441 (drops three `// Tracked in #1441` TODO comments in `GuidedCreate.tsx` and one in `CompositeBackgroundService.cs`)

Reviewer flagged one pre-existing race in `regenerateComposite` (rapid back-to-back preset clicks spawn parallel SignalR jobs whose finish order determines the displayed preview). Out of scope here — file as a follow-up issue if it ever surfaces in practice. The cancelled-flag pattern this PR introduces makes that future fix trivial.

## Risk & Rollback
- **Risk**: Low-medium. Touches `IJobTracker` (used by import, composite, mosaic, embedding background services), but the new parameter is optional with a `null` default — existing call sites unchanged. Adds an optional nullable field to `JobStatus` (BSON serialization handles missing field on existing documents, deserializing it as `null`). No SignalR contract change. Mosaic + embedding background services pass `null` (default), no behavior change.
- **Rollback**: `git revert`. Headers continue to be dropped exactly as before; existing `JobStatus` documents with `ResultWarningHeaders` populated remain readable but the field becomes orphaned data (cleaned up by the existing job reaper TTL).
