### PR TITLE
feat: 'Continue anyway' override for composite memory-budget 413 (#1450)

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
@@ -147,6 +147,56 @@ public class CompositeServiceTests
     }
 
     [Fact]
+    public async Task GenerateNChannelComposite_AllowForceDownscale_SerializesAsSnakeCase()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 1 }),
+            },
+            req => capturedRequest = req);
+        var sut = CreateService(new HttpClient(handler));
+        var request = CreateRequest();
+        request.AllowForceDownscale = true;
+
+        await sut.GenerateNChannelCompositeAsync(
+            request, "user-1", isAuthenticated: true, isAdmin: false);
+
+        capturedRequest.Should().NotBeNull();
+        var body = await capturedRequest!.Content!.ReadAsStringAsync();
+        body.Should().Contain("\"allow_force_downscale\":true");
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_DefaultRequest_OmitsForceDownscaleAsFalse()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 1 }),
+            },
+            req => capturedRequest = req);
+        var sut = CreateService(new HttpClient(handler));
+
+        await sut.GenerateNChannelCompositeAsync(
+            CreateRequest(), "user-1", isAuthenticated: true, isAdmin: false);
+
+        capturedRequest.Should().NotBeNull();
+        var body = await capturedRequest!.Content!.ReadAsStringAsync();
+
+        // Default false serializes the field but it's not the truthy value.
+        body.Should().Contain("\"allow_force_downscale\":false");
+    }
+
+    [Fact]
     public async Task GenerateNChannelComposite_MultipleChannels_ResolvesAllDataIds()
     {
         // Arrange

--- a/backend/JwstDataAnalysis.API.Tests/Services/ProcessingErrorMessagesTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/ProcessingErrorMessagesTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+
+using FluentAssertions;
+
+using JwstDataAnalysis.API.Services;
+
+namespace JwstDataAnalysis.API.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ProcessingErrorMessages.ToUserMessage"/>.
+///
+/// The async (auth'd) job path loses the HTTP 413 status code crossing SignalR;
+/// the frontend only receives the error string. The MEMORY_BUDGET: prefix lets
+/// the frontend distinguish a memory-budget refusal from other failures so the
+/// "Continue anyway" override can be offered (matches the existing NO_PRODUCTS:
+/// / S3_UNAVAILABLE: prefix convention used by the download flow).
+/// </summary>
+public class ProcessingErrorMessagesTests
+{
+    [Fact]
+    public void ToUserMessage_CompositeBudgetExceededException_PrefixesWithMemoryBudget()
+    {
+        var detail = "Composite output would shrink to 38% of requested side length. "
+                    + "Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB.";
+        var ex = new CompositeBudgetExceededException(detail);
+
+        var result = ProcessingErrorMessages.ToUserMessage(ex);
+
+        result.Should().StartWith("MEMORY_BUDGET:");
+        result.Should().Contain(detail);
+    }
+
+    [Fact]
+    public void ToUserMessage_ServiceUnavailable_KeepsExistingMessage()
+    {
+        var ex = new HttpRequestException("upstream", null, HttpStatusCode.ServiceUnavailable);
+
+        var result = ProcessingErrorMessages.ToUserMessage(ex);
+
+        result.Should().NotStartWith("MEMORY_BUDGET:");
+        result.Should().Contain("temporarily unavailable");
+    }
+
+    [Fact]
+    public void ToUserMessage_GenericException_FallsThroughToDefault()
+    {
+        var ex = new InvalidOperationException("something broke");
+
+        var result = ProcessingErrorMessages.ToUserMessage(ex);
+
+        result.Should().NotStartWith("MEMORY_BUDGET:");
+        result.Should().Contain("unexpected error");
+    }
+}

--- a/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
+++ b/backend/JwstDataAnalysis.API/Models/CompositeModels.cs
@@ -273,6 +273,14 @@ namespace JwstDataAnalysis.API.Models
         /// </summary>
         [Range(1, 4096)]
         public int Height { get; set; } = 1000;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to suppress the engine's 413
+        /// memory-budget guardrail and accept the projected force-downscale.
+        /// When true, the user explicitly opts in to a smaller output rather
+        /// than letting the engine refuse the composite.
+        /// </summary>
+        public bool AllowForceDownscale { get; set; }
     }
 
     /// <summary>
@@ -459,6 +467,9 @@ namespace JwstDataAnalysis.API.Models
 
         [JsonPropertyName("height")]
         public int Height { get; set; } = 1000;
+
+        [JsonPropertyName("allow_force_downscale")]
+        public bool AllowForceDownscale { get; set; }
     }
 
     /// <summary>

--- a/backend/JwstDataAnalysis.API/Services/CompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.cs
@@ -283,6 +283,7 @@ namespace JwstDataAnalysis.API.Services
                 Quality = request.Quality,
                 Width = request.Width,
                 Height = request.Height,
+                AllowForceDownscale = request.AllowForceDownscale,
             };
         }
 

--- a/backend/JwstDataAnalysis.API/Services/ProcessingErrorMessages.cs
+++ b/backend/JwstDataAnalysis.API/Services/ProcessingErrorMessages.cs
@@ -9,8 +9,20 @@ namespace JwstDataAnalysis.API.Services
     /// </summary>
     internal static class ProcessingErrorMessages
     {
+        /// <summary>
+        /// Prefix applied to <see cref="CompositeBudgetExceededException"/> messages
+        /// so the frontend can detect a memory-budget refusal in the SignalR
+        /// failure channel (which loses the HTTP 413 status crossing the boundary)
+        /// and show the "Continue anyway" override. Matches the existing
+        /// <c>NO_PRODUCTS:</c> / <c>S3_UNAVAILABLE:</c> convention used by the
+        /// download flow.
+        /// </summary>
+        internal const string MemoryBudgetPrefix = "MEMORY_BUDGET:";
+
         internal static string ToUserMessage(Exception ex) => ex switch
         {
+            CompositeBudgetExceededException cbex
+                => $"{MemoryBudgetPrefix}{cbex.Message}",
             HttpRequestException { StatusCode: System.Net.HttpStatusCode.ServiceUnavailable }
                 => "Processing engine is temporarily unavailable. Please retry.",
             HttpRequestException hre when hre.InnerException is System.Net.Sockets.SocketException

--- a/docs/plans/features/1450-continue-anyway-composite-override.md
+++ b/docs/plans/features/1450-continue-anyway-composite-override.md
@@ -1,0 +1,98 @@
+# 1450 — "Continue anyway" override for composite memory-budget 413
+
+## Problem
+
+When the composite engine projects a heavy downscale (output side < `COMPOSITE_DOWNSCALE_FAIL_THRESHOLD`, default 0.85), it returns HTTP 413 with a detailed message and the frontend surfaces only a "Retry Processing" button. Retry without changing inputs hits the same 413 — the user has no in-app path forward short of editing env vars.
+
+Example (NGC 346, NIRCam guided flow):
+
+> Composite output would shrink to 38% of requested side length (4353x3417 from 11399x8949). Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB; COMPOSITE_DOWNSCALE_FAIL_THRESHOLD = 0.85. To allow this composite: lower COMPOSITE_DOWNSCALE_FAIL_THRESHOLD, raise MAX_COMPOSITE_MEMORY_BYTES, or reduce inputs (fewer files / fewer channels).
+
+## Solution overview
+
+Add an explicit per-request opt-in (`allow_force_downscale`) that suppresses the 413 and applies the projected downscale. The result page surfaces a new `forced` verdict status with a provenance-aware warning banner so the user always knows when they're looking at a force-downscaled image — including later cache-hit users who didn't opt in themselves but receive the previously force-downscaled cached result.
+
+CEO + eng review caught three correctness gaps in the original proposal that are folded into the scope: cache provenance, async-path 413 detection (pre-existing bug), and banner copy mismatch.
+
+## Decisions (CEO + eng review)
+
+| ID | Decision |
+|---|---|
+| Mode | C — Hold scope, bulletproof |
+| D-1 | Cache writes force-downscaled results AND stores `original_shape` provenance; `_verdict_for_cached` emits `forced` status when shapes differ |
+| D-2 | New verdict status value `"forced"` (alongside `ok`/`warn`/`fail`) — explicit semantics, applies on opt-in path AND cache hits of previously-forced data |
+| D-3 | `ProcessingErrorMessages.ToUserMessage` adds a `MEMORY_BUDGET:` prefix on `CompositeBudgetExceededException` (matches existing `NO_PRODUCTS:` / `S3_UNAVAILABLE:` convention) |
+
+## NOT in scope
+
+- Recipe walkthrough preflight "Try anyway" — filed as #1451 (depends on this PR)
+- Per-request `failThreshold` / `memoryLimit` overrides
+- Admin panel toggle for env vars
+- Default fail threshold change
+- Hard `side_factor` floor on force-downscale (trust user — projected shape shown on button)
+- Tile streaming integration (#1423)
+- Per-filter file cap (#1424)
+- E2E coverage (page-level integration tests cover the retry roundtrip)
+
+## File-by-file changes
+
+### Engine (Python)
+
+| File | Change |
+|---|---|
+| `processing-engine/app/composite/models.py` | Add `allow_force_downscale: bool = False` to `NChannelCompositeRequest`. Widen `MemoryBudgetVerdict.status` literal to `Literal["ok", "warn", "fail", "forced"]`. Widen `EstimateResponse.status` to match. |
+| `processing-engine/app/composite/cache.py` | Cache entry tuple grows from `(channels, ts, fingerprint)` to `(channels, ts, fingerprint, original_shape)`. `put` accepts an `original_shape: tuple[int, int] \| None` arg; `get` and `get_any_budget` return `(channels, original_shape)` tuples. |
+| `processing-engine/app/composite/routes.py` | `_compute_memory_budget(..., raise_on_fail)` returns `status="forced"` (not `"fail"`) when `raise_on_fail=False` AND `side_factor < fail_threshold`. `_reproject_all_channels` honors `request.allow_force_downscale` (passes `raise_on_fail=not allow_force_downscale`); applies downscale on `forced` like it does on `warn`. `_load_reprojected_channels` plumbs `original_shape` into `_cache.put`. `_verdict_for_cached` uses cached `original_shape` to emit `status="forced"` + `wasDownscaled=true` when `cached_shape != original_shape`. `_encode_and_respond` emits `X-Composite-Budget-Status: forced` header. Engine log line marks force-downscale opt-in events. |
+| `processing-engine/tests/test_composite_downscale.py` | New cases: `_compute_memory_budget` with `raise_on_fail=False` returns `forced` (not `fail`) on heavy reduction; `raise_on_fail=True` regression guard for 413. |
+| `processing-engine/tests/test_composite_cache.py` *(may exist; verify)* | New cases: `put` stores `original_shape`; `get` returns it; `_verdict_for_cached` returns `forced` when shapes differ. |
+| `processing-engine/tests/test_composite_routes.py` *(or `test_composite.py`; locate)* | New cases: full request with `allow_force_downscale=true` → 200 + `X-Composite-Budget-Status: forced` headers; default still 413; subsequent default request hits cache → 200 + `forced` header (provenance). |
+
+### .NET
+
+| File | Change |
+|---|---|
+| `backend/JwstDataAnalysis.API/Models/NChannelCompositeRequestDto.cs` *(verify path)* | Add `AllowForceDownscale: bool` field with snake_case JSON mapping. |
+| `backend/JwstDataAnalysis.API/Services/ProcessingErrorMessages.cs` | Add `CompositeBudgetExceededException ex => $"MEMORY_BUDGET:{ex.Message}"` case before the `_ =>` fallback. |
+| `backend/JwstDataAnalysis.API.Tests/Services/ProcessingErrorMessagesTests.cs` *(may exist; create if not)* | Verify `CompositeBudgetExceededException` produces `MEMORY_BUDGET:` prefix; verify other exception types fall through unchanged. |
+| `backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs` | Verify `AllowForceDownscale=true` serializes as `allow_force_downscale: true` in the engine payload. |
+
+### Frontend
+
+| File | Change |
+|---|---|
+| `frontend/jwst-frontend/src/types/CompositeTypes.ts` | Widen `CompositeWarning.budgetStatus` to `'ok' \| 'warn' \| 'fail' \| 'forced'`. Add `allowForceDownscale?: boolean` to `NChannelCompositeRequest` and `NChannelExportOptions` (and `NChannelPreviewOptions` if it exists). |
+| `frontend/jwst-frontend/src/services/compositeService.ts` | `parseCompositeWarning` accepts `forced` as a valid status. Pass `allowForceDownscale` through `generateNChannelComposite`, `exportNChannelComposite`, `exportNChannelCompositeAsync`, `generateNChannelPreview`. |
+| `frontend/jwst-frontend/src/services/compositeService.test.ts` | New cases: `parseCompositeWarning` maps `'forced'` correctly. |
+| `frontend/jwst-frontend/src/components/CompositeWarningBanner.tsx` | Branch for `forced` status with bespoke copy: "Output force-downscaled to fit memory budget" plus the existing size text. Note: opt-in vs cache-hit-of-forced cases share one title — the engine has no signal to distinguish "this request opted in" from "you're getting a cached force-downscaled result," and adding one (e.g. `X-Composite-Forced-Cause`) was scoped out as not worth the contract complexity. The shared copy is accurate for both: the user either just clicked Continue anyway (and the title confirms it) or they got a previously force-downscaled cached result (and the title informs them honestly). |
+| `frontend/jwst-frontend/src/components/CompositeWarningBanner.test.tsx` | New cases: forced branch renders correct copy; existing fail branch unchanged. |
+| `frontend/jwst-frontend/src/components/guided/ProcessStep.tsx` | Accept `onContinueAnyway?: () => void` and `forceProjectedShape?: [number, number]` props. When error has `MEMORY_BUDGET:` prefix OR matches the engine's "Composite output would shrink" pattern (sync path), strip the prefix for display and render "Continue anyway → 4353×3417" button alongside "Retry Processing". |
+| `frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx` *(may exist; create if not)* | Button visibility + label + click callback fires. |
+| `frontend/jwst-frontend/src/pages/GuidedCreate.tsx` | Sync (anonymous) path: detect `ApiError 413` (existing) → parse projected shape from `err.message` → wire `onContinueAnyway` to `startProcessing` with `allowForceDownscale: true`. Async path: detect `MEMORY_BUDGET:` prefix on `status.error` → strip prefix → parse shape → same retry. Reset `allowForceDownscale` to default on a fresh user-initiated retry (request-scoped). |
+| `frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx` | Mirror the Continue anyway treatment for the wizard preview path (currently catches `err.status === 413`). |
+
+### Helper extracted to keep DRY
+
+A small `parseMemoryBudgetError(message: string)` helper in `compositeService.ts` returns `{ projectedShape: [number, number] | null, displayMessage: string }` — used by both ProcessStep and CompositePreviewStep. Stripping the `MEMORY_BUDGET:` prefix and the regex parse for `(WIDTHxHEIGHT from ...)` live in one place.
+
+## Test plan
+
+Unit + integration listed above. Manual verification:
+
+- Docker rebuild required: YES (engine model + .NET DTO + frontend types all change).
+- Anonymous flow: NGC 346 NIRCam guided → 413 → "Continue anyway → 4353×3417" → smaller image + `forced` banner.
+- Authenticated flow: same scenario via async job queue (verifies the `MEMORY_BUDGET:` prefix path).
+- Second authenticated default request on the same paths: cache hit returns `forced` banner without recomputing.
+
+## Docs to update
+
+- `docs/architecture/` — composite memory-budget flow, if documented (add `forced` status + opt-in path).
+- `docs/standards/backend-development.md` — note the `MEMORY_BUDGET:` error-prefix convention alongside existing prefixes.
+- `docs/standards/processing-engine.md` *(or equivalent)* — `allow_force_downscale` request field + `forced` verdict status.
+
+## Implementation order
+
+1. **Engine**: cache provenance → `_compute_memory_budget` returns `forced` → `_reproject_all_channels` honors flag → `_verdict_for_cached` emits `forced` on shape mismatch → headers → tests.
+2. **.NET**: DTO field → `ProcessingErrorMessages` case → tests.
+3. **Frontend**: type widening → `parseCompositeWarning` → service plumbing → banner branch → `parseMemoryBudgetError` helper → ProcessStep button → CompositePreviewStep button → page-level wiring → tests.
+4. Self-review (code-reviewer agent), iterate to clean.
+5. Compose PR with full test plan checklist.

--- a/frontend/jwst-frontend/src/components/CompositeWarningBanner.test.tsx
+++ b/frontend/jwst-frontend/src/components/CompositeWarningBanner.test.tsx
@@ -62,6 +62,22 @@ describe('CompositeWarningBanner', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('shows force-downscale copy for forced status', () => {
+    // Shapes are [H, W]; the banner renders W×H, so [3417, 4353] → "4353×3417px".
+    const warning: CompositeWarning = {
+      budgetStatus: 'forced',
+      wasDownscaled: true,
+      originalShape: [8949, 11399],
+      outputShape: [3417, 4353],
+      sideFactor: 0.38,
+    };
+    render(<CompositeWarningBanner warning={warning} />);
+
+    expect(screen.getByText(/force-downscaled to fit memory budget/i)).toBeInTheDocument();
+    expect(screen.getByText(/4353×3417px from 11399×8949px/)).toBeInTheDocument();
+    expect(screen.getByText(/38% of original side length/)).toBeInTheDocument();
+  });
+
   it('reveals again when a fresh warning arrives after dismissal', () => {
     const initial: CompositeWarning = {
       budgetStatus: 'warn',

--- a/frontend/jwst-frontend/src/components/CompositeWarningBanner.tsx
+++ b/frontend/jwst-frontend/src/components/CompositeWarningBanner.tsx
@@ -39,10 +39,17 @@ export const CompositeWarningBanner: React.FC<CompositeWarningBannerProps> = ({ 
     sideFactor !== undefined ? `(${(sideFactor * 100).toFixed(0)}% of original side length)` : null;
 
   const isFail = warning.budgetStatus === 'fail';
+  const isForced = warning.budgetStatus === 'forced';
+
+  const title = isFail
+    ? 'Result served from cache exceeds current memory budget'
+    : isForced
+      ? 'Output force-downscaled to fit memory budget'
+      : 'Output reduced to fit memory budget';
 
   return (
     <div
-      className={`composite-warning-banner${isFail ? ' composite-warning-banner--fail' : ''}`}
+      className={`composite-warning-banner${isFail ? ' composite-warning-banner--fail' : ''}${isForced ? ' composite-warning-banner--forced' : ''}`}
       role="status"
       aria-live="polite"
     >
@@ -50,11 +57,7 @@ export const CompositeWarningBanner: React.FC<CompositeWarningBannerProps> = ({ 
         ⚠
       </div>
       <div className="composite-warning-banner__body">
-        <div className="composite-warning-banner__title">
-          {isFail
-            ? 'Result served from cache exceeds current memory budget'
-            : 'Output reduced to fit memory budget'}
-        </div>
+        <div className="composite-warning-banner__title">{title}</div>
         <div className="composite-warning-banner__detail">
           {warning.wasDownscaled && sizeText && <span>{sizeText} </span>}
           {reductionText && <span>{reductionText}</span>}

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.css
@@ -101,7 +101,15 @@
   margin: 0 0 var(--space-3);
 }
 
-.process-step-retry {
+.process-step-error-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: center;
+}
+
+.process-step-retry,
+.process-step-continue {
   display: inline-flex;
   align-items: center;
   min-height: 38px;
@@ -114,11 +122,13 @@
   cursor: pointer;
 }
 
-.process-step-retry:hover {
+.process-step-retry:hover,
+.process-step-continue:hover {
   background: var(--bg-elevated);
 }
 
-.process-step-retry:focus-visible {
+.process-step-retry:focus-visible,
+.process-step-continue:focus-visible {
   outline: 2px solid var(--accent-primary);
   outline-offset: 2px;
 }

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProcessStep } from './ProcessStep';
+
+const baseProps = {
+  targetName: 'NGC 346',
+  recipeName: 'NASA NIRCam',
+  requiresMosaic: false,
+  phase: 'composite' as const,
+  progress: null,
+  isComplete: false,
+  channelCount: 3,
+  fileCount: 12,
+};
+
+describe('ProcessStep — Continue anyway override', () => {
+  it('renders only Retry Processing when error is unrelated', () => {
+    const onRetry = vi.fn();
+    render(<ProcessStep {...baseProps} error="Network error: ECONNREFUSED" onRetry={onRetry} />);
+
+    expect(screen.getByRole('button', { name: /retry processing/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /continue anyway/i })).toBeNull();
+  });
+
+  it('renders Continue anyway when error matches MEMORY_BUDGET: prefix', () => {
+    const onRetry = vi.fn();
+    const onContinueAnyway = vi.fn();
+    render(
+      <ProcessStep
+        {...baseProps}
+        error={
+          'MEMORY_BUDGET:Composite output would shrink to 38% of requested side length ' +
+          '(4353x3417 from 11399x8949). Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB.'
+        }
+        onRetry={onRetry}
+        onContinueAnyway={onContinueAnyway}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /retry processing/i })).toBeInTheDocument();
+    const continueBtn = screen.getByRole('button', { name: /continue anyway/i });
+    expect(continueBtn).toBeInTheDocument();
+    // Projected output shape parsed from the engine detail.
+    expect(continueBtn.textContent).toMatch(/4353×3417/);
+  });
+
+  it('strips MEMORY_BUDGET: prefix from displayed error text', () => {
+    render(
+      <ProcessStep
+        {...baseProps}
+        error={
+          'MEMORY_BUDGET:Composite output would shrink to 38% of requested side length ' +
+          '(4353x3417 from 11399x8949). Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB.'
+        }
+        onRetry={vi.fn()}
+        onContinueAnyway={vi.fn()}
+      />
+    );
+
+    // The literal MEMORY_BUDGET: prefix must not leak into user-visible copy.
+    expect(screen.queryByText(/MEMORY_BUDGET:/)).toBeNull();
+    expect(screen.getByText(/Composite output would shrink to 38%/)).toBeInTheDocument();
+  });
+
+  it('detects memory-budget pattern in sync-path errors without prefix', () => {
+    render(
+      <ProcessStep
+        {...baseProps}
+        error={
+          'Composite output would shrink to 38% of requested side length ' +
+          '(4353x3417 from 11399x8949). Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB.'
+        }
+        onRetry={vi.fn()}
+        onContinueAnyway={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /continue anyway/i })).toBeInTheDocument();
+  });
+
+  it('clicking Continue anyway calls onContinueAnyway', () => {
+    const onContinueAnyway = vi.fn();
+    render(
+      <ProcessStep
+        {...baseProps}
+        error={
+          'MEMORY_BUDGET:Composite output would shrink to 38% (4353x3417 from 11399x8949). ' +
+          'Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB.'
+        }
+        onRetry={vi.fn()}
+        onContinueAnyway={onContinueAnyway}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /continue anyway/i }));
+    expect(onContinueAnyway).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT render Continue anyway when onContinueAnyway is omitted (back-compat)', () => {
+    render(
+      <ProcessStep
+        {...baseProps}
+        error={'MEMORY_BUDGET:Composite output would shrink to 38% (4353x3417 from 11399x8949).'}
+        onRetry={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /continue anyway/i })).toBeNull();
+  });
+});

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ImportJobStatus } from '../../types/MastTypes';
+import { parseMemoryBudgetError } from '../../services/compositeService';
 import './ProcessStep.css';
 
 interface ProcessStepProps {
@@ -17,6 +18,12 @@ interface ProcessStepProps {
   isComplete: boolean;
   /** Retry callback */
   onRetry: () => void;
+  /**
+   * Optional callback to opt in to a force-downscale on a memory-budget 413.
+   * When provided AND the error matches a memory-budget refusal, a "Continue
+   * anyway → WxH" button is rendered alongside Retry Processing.
+   */
+  onContinueAnyway?: () => void;
   /** Number of channels being composited */
   channelCount?: number;
   /** Total number of FITS files across all channels */
@@ -209,6 +216,7 @@ export function ProcessStep({
   error,
   isComplete,
   onRetry,
+  onContinueAnyway,
   channelCount,
   fileCount,
 }: ProcessStepProps) {
@@ -249,6 +257,19 @@ export function ProcessStep({
 
   const showElapsed = !error && !isComplete && phase === 'composite' && elapsedSeconds > 0;
 
+  // Memory-budget 413 detection: if the error matches the engine's refusal
+  // pattern (or carries the MEMORY_BUDGET: prefix from the async path), we
+  // strip the prefix for display and surface a "Continue anyway" button when
+  // the parent provided onContinueAnyway. This lets the user opt in to a
+  // smaller output rather than re-running with the same inputs and getting
+  // the same refusal.
+  const memoryBudget = error ? parseMemoryBudgetError(error) : null;
+  const showContinueAnyway = !!memoryBudget?.isMemoryBudget && !!onContinueAnyway;
+  const projectedShapeLabel = memoryBudget?.projectedShape
+    ? ` → ${memoryBudget.projectedShape[0]}×${memoryBudget.projectedShape[1]}`
+    : '';
+  const errorDisplay = memoryBudget?.displayMessage ?? error;
+
   return (
     <div className="process-step" role="status" aria-live="polite">
       <h3 className="process-step-title">
@@ -258,10 +279,17 @@ export function ProcessStep({
 
       {error && (
         <div className="process-step-error">
-          <p>{error}</p>
-          <button className="btn-base process-step-retry" onClick={onRetry}>
-            Retry Processing
-          </button>
+          <p>{errorDisplay}</p>
+          <div className="process-step-error-actions">
+            <button className="btn-base process-step-retry" onClick={onRetry}>
+              Retry Processing
+            </button>
+            {showContinueAnyway && (
+              <button className="btn-base process-step-continue" onClick={onContinueAnyway}>
+                Continue anyway{projectedShapeLabel}
+              </button>
+            )}
+          </div>
         </div>
       )}
 

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -74,6 +74,10 @@
 
 /* Export error */
 .result-export-error {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  align-items: center;
   margin: 0;
   padding: var(--space-3) var(--space-4);
   background: var(--color-error-subtle);
@@ -82,6 +86,10 @@
   color: var(--color-error, #ef4444);
   font-size: var(--text-sm);
   text-align: center;
+}
+
+.result-export-error p {
+  margin: 0;
 }
 
 /* Stretch presets */

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -17,7 +17,39 @@ import { COMPOSITE_PRESETS } from '../../types/CompositeTypes';
 import { ExportFramingPanel } from './ExportFramingPanel';
 import type { ExportFramingResult } from './ExportFramingPanel';
 import { CompositeWarningBanner } from '../CompositeWarningBanner';
+import { parseMemoryBudgetError } from '../../services/compositeService';
 import './ResultStep.css';
+
+/**
+ * Inline export-error renderer with optional "Continue anyway" override
+ * when the engine refused via the memory-budget guardrail.
+ */
+function ResultExportError({
+  error,
+  onContinueAnyway,
+}: {
+  error: string;
+  onContinueAnyway?: () => void;
+}) {
+  const memoryBudget = parseMemoryBudgetError(error);
+  const projectedLabel = memoryBudget.projectedShape
+    ? ` → ${memoryBudget.projectedShape[0]}×${memoryBudget.projectedShape[1]}`
+    : '';
+  return (
+    <div className="result-export-error" role="status" aria-live="polite">
+      <p>{memoryBudget.displayMessage}</p>
+      {memoryBudget.isMemoryBudget && onContinueAnyway && (
+        <button
+          type="button"
+          className="btn-base result-export-continue"
+          onClick={onContinueAnyway}
+        >
+          Continue anyway{projectedLabel}
+        </button>
+      )}
+    </div>
+  );
+}
 
 interface ResultStepProps {
   targetName: string;
@@ -48,6 +80,13 @@ interface ResultStepProps {
   onPresetChange: (presetId: string) => void;
   /** Callback to export with framing params */
   onExport: (result: ExportFramingResult) => void;
+  /**
+   * Optional callback to opt in to a force-downscale on a memory-budget 413
+   * surfaced via exportError. When provided AND the exportError matches the
+   * memory-budget pattern, a "Continue anyway → WxH" button renders below
+   * the error so the user can persist the override into the export path.
+   */
+  onContinueAnyway?: () => void;
   /** State to pass to the Composite Creator page */
   compositePageState?: CompositePageState;
   /** Initial feather strength from recipe (0-100 scale) */
@@ -71,6 +110,7 @@ export function ResultStep({
   activePresetId,
   onPresetChange,
   onExport,
+  onContinueAnyway,
   compositePageState,
   initialFeatherStrength,
 }: ResultStepProps) {
@@ -258,7 +298,9 @@ export function ResultStep({
             </div>
           </div>
 
-          {exportError && <p className="result-export-error">{exportError}</p>}
+          {exportError && (
+            <ResultExportError error={exportError} onContinueAnyway={onContinueAnyway} />
+          )}
 
           <div className="result-presets">
             <h4 className="result-presets-header">Stretch Preset</h4>

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -68,6 +68,11 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
   const [exporting, setExporting] = useState(false);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
+  // Sticky once set: a single click of "Continue anyway" on the preview path
+  // also makes the export path opt in. Otherwise the preview succeeds via
+  // force-downscale, the user adjusts sliders and exports, and the export
+  // re-hits 413 with no path forward.
+  const [allowForceDownscale, setAllowForceDownscale] = useState(false);
   const exportFormatRef = useRef<'png' | 'jpeg'>('png');
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const {
@@ -495,9 +500,16 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     };
   }, []);
 
-  const generatePreview = async () => {
+  const generatePreview = async (forceDownscaleOptIn = false) => {
     const payloads = buildPayloads();
     if (payloads.length === 0) return;
+
+    // Sticky opt-in: once the user clicks "Continue anyway" via this call,
+    // every subsequent debounced re-render of the preview AND the export path
+    // carry the flag. Without this, slider tweaks would silently 413 once the
+    // engine cache TTL expires.
+    if (forceDownscaleOptIn) setAllowForceDownscale(true);
+    const effectiveAllowForce = allowForceDownscale || forceDownscaleOptIn;
 
     setPreviewLoading(true);
     setPreviewError(null);
@@ -519,6 +531,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         backgroundNeutralization,
         sharpening: sharpening.amount > 0 ? sharpening : undefined,
         saturation: !isDefaultSaturation(saturation) ? saturation : undefined,
+        allowForceDownscale: effectiveAllowForce,
       });
 
       // Revoke the old preview URL, but not if it's being held as the "before" snapshot
@@ -641,6 +654,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         backgroundNeutralization,
         sharpening: sharpening.amount > 0 ? sharpening : undefined,
         saturation: !isDefaultSaturation(saturation) ? saturation : undefined,
+        allowForceDownscale,
       });
 
       setActiveJobId(jobId);
@@ -730,6 +744,20 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     { label: '4K (4096x4096)', width: 4096, height: 4096 },
   ];
 
+  // Memory-budget detection for preview/export error rendering.
+  const previewMemoryBudget = previewError
+    ? compositeService.parseMemoryBudgetError(previewError)
+    : null;
+  const previewProjectedLabel = previewMemoryBudget?.projectedShape
+    ? ` → ${previewMemoryBudget.projectedShape[0]}×${previewMemoryBudget.projectedShape[1]}`
+    : '';
+  const exportMemoryBudget = exportError
+    ? compositeService.parseMemoryBudgetError(exportError)
+    : null;
+  const exportProjectedLabel = exportMemoryBudget?.projectedShape
+    ? ` → ${exportMemoryBudget.projectedShape[0]}×${exportMemoryBudget.projectedShape[1]}`
+    : '';
+
   return (
     <div className="composite-preview-step">
       <div className="preview-section">
@@ -747,11 +775,24 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
             </div>
           )}
           {previewError && !previewLoading && !mosaicRetrying && (
-            <div className="preview-error">
-              <span>{previewError}</span>
-              <button className="btn-base btn-standard btn-retry" onClick={generatePreview}>
-                Retry
-              </button>
+            <div className="preview-error" role="status" aria-live="polite">
+              <span>{previewMemoryBudget?.displayMessage ?? previewError}</span>
+              <div className="preview-error-actions">
+                <button
+                  className="btn-base btn-standard btn-retry"
+                  onClick={() => generatePreview()}
+                >
+                  Retry
+                </button>
+                {previewMemoryBudget?.isMemoryBudget && (
+                  <button
+                    className="btn-base btn-standard btn-continue"
+                    onClick={() => generatePreview(/* forceDownscaleOptIn */ true)}
+                  >
+                    Continue anyway{previewProjectedLabel}
+                  </button>
+                )}
+              </div>
             </div>
           )}
           {previewUrl && !previewLoading && previewWarning && (
@@ -1487,8 +1528,23 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
         </div>
 
         {exportError && (
-          <div className="export-error">
-            <span>{exportError}</span>
+          <div className="export-error" role="status" aria-live="polite">
+            <span>{exportMemoryBudget?.displayMessage ?? exportError}</span>
+            {exportMemoryBudget?.isMemoryBudget && (
+              <button
+                type="button"
+                className="btn-base btn-standard btn-continue"
+                onClick={() => {
+                  // Sticky opt-in for the export path: subsequent retries
+                  // and slider-driven previews honor the same override.
+                  setAllowForceDownscale(true);
+                  setExportError(null);
+                  handleExport();
+                }}
+              >
+                Continue anyway{exportProjectedLabel}
+              </button>
+            )}
           </div>
         )}
 

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -169,6 +169,13 @@ export function GuidedCreate() {
   const [channelPayloads, setChannelPayloads] = useState<NChannelConfigPayload[]>([]);
   const [activePreset, setActivePreset] = useState<CompositePreset>(DEFAULT_PRESET);
   const [compositeWarning, setCompositeWarning] = useState<CompositeWarning | null>(null);
+  // Sticky once set: when the user clicks "Continue anyway" on a memory-budget
+  // 413, every subsequent regenerate / export for the same recipe carries the
+  // opt-in so slider tweaks and exports don't silently re-trigger 413s after
+  // the cache TTL expires. Reset by the resolveRecipe effect on [target,
+  // recipeName, retryCount] changes so a different recipe doesn't inherit
+  // the prior recipe's opt-in.
+  const [allowForceDownscale, setAllowForceDownscale] = useState(false);
 
   // Refs for cleanup
   const subscriptionsRef = useRef<Array<{ unsubscribe: () => void }>>([]);
@@ -209,6 +216,11 @@ export function GuidedCreate() {
   useEffect(() => {
     const controller = new AbortController();
     abortRef.current = controller;
+
+    // Recipe target changed → drop the force-downscale opt-in. The flag is
+    // recipe-scoped (cache key changes per channel paths), so a Continue-anyway
+    // for Recipe A must not silently apply to Recipe B.
+    setAllowForceDownscale(false);
 
     async function resolveRecipe() {
       if (!target || !recipeName) {
@@ -547,11 +559,24 @@ export function GuidedCreate() {
 
   /**
    * Start composite generation (and mosaic if needed).
+   *
+   * @param matchedRecipe - Recipe to render.
+   * @param forceDownscale - When true, opt in to a heavy memory-budget
+   *   downscale instead of letting the engine refuse with HTTP 413. Set by
+   *   the "Continue anyway" button after a memory-budget refusal; defaults
+   *   to false so default flows still see the 413 + override prompt.
+   *   Once set true, the value is persisted to component state so subsequent
+   *   regenerate / export calls keep the opt-in.
    */
-  async function startProcessing(matchedRecipe: CompositeRecipe) {
+  async function startProcessing(matchedRecipe: CompositeRecipe, forceDownscale = false) {
+    if (forceDownscale) setAllowForceDownscale(true);
     setCurrentStep(2);
-    // Clear any stale memory-budget warning from a prior preset/run.
+    // Clear any stale error/warning from a prior run; "Continue anyway" must
+    // start from a clean slate so the new outcome (success-with-warning,
+    // different error, etc.) renders correctly.
     setCompositeWarning(null);
+    setProcessError(null);
+    setProcessComplete(false);
 
     try {
       const channels = buildChannelPayloads(matchedRecipe, filterDataMapRef.current);
@@ -584,6 +609,7 @@ export function GuidedCreate() {
           backgroundNeutralization: activePreset.backgroundNeutralization,
           featherStrength: featherStrengthRef.current,
           sharpening: effectiveSharpening,
+          allowForceDownscale: forceDownscale,
         });
 
         const sub = subscribeToJobProgress(
@@ -625,6 +651,7 @@ export function GuidedCreate() {
           sharpening: effectiveSharpening,
           backgroundNeutralization: activePreset.backgroundNeutralization,
           featherStrength: featherStrengthRef.current,
+          allowForceDownscale: forceDownscale,
           ...COMPOSITE_OUTPUT,
         });
         setProcessComplete(true);
@@ -645,6 +672,12 @@ export function GuidedCreate() {
     }
   }
 
+  // Track the most recent export request so the post-error "Continue anyway"
+  // button can replay it with allowForceDownscale=true. Resets on a successful
+  // export AND on regenerate-driven failures (which share exportError state)
+  // so a stale request can't be replayed against fresh state.
+  const lastExportResultRef = useRef<ExportFramingResult | null>(null);
+
   /**
    * Regenerate composite from given channels + overall adjustments.
    */
@@ -657,6 +690,12 @@ export function GuidedCreate() {
     setExportError(null);
     // Clear stale warning — fresh regenerate may have a different verdict.
     setCompositeWarning(null);
+    // Drop any prior export-replay target so a regenerate failure surfaces
+    // the Continue anyway button only when there's an actual export to retry.
+    // (regenerateComposite shares exportError state with handleExport; without
+    // this clear, a slider-driven failure would offer to replay an unrelated
+    // export request.)
+    lastExportResultRef.current = null;
 
     const effectiveSharpening =
       activePreset.sharpening && activePreset.sharpening.amount > 0
@@ -675,6 +714,7 @@ export function GuidedCreate() {
           backgroundNeutralization: activePreset.backgroundNeutralization,
           featherStrength,
           sharpening: effectiveSharpening,
+          allowForceDownscale,
         });
 
         const sub = subscribeToJobProgress(
@@ -716,6 +756,7 @@ export function GuidedCreate() {
           sharpening: effectiveSharpening,
           backgroundNeutralization: activePreset.backgroundNeutralization,
           featherStrength,
+          allowForceDownscale,
           ...COMPOSITE_OUTPUT,
         });
         applyBlobPreview(blob);
@@ -810,10 +851,15 @@ export function GuidedCreate() {
    * Handle export from the framing panel — generates a full-resolution composite
    * with server-side rotation, zoom, and pan applied.
    */
-  async function handleExport(result: ExportFramingResult) {
+  async function handleExport(result: ExportFramingResult, forceDownscaleOverride = false) {
     if (channelPayloads.length === 0) return;
+    lastExportResultRef.current = result;
     setIsExporting(true);
     setExportError(null);
+    // The state setter is async; use the override directly when the caller
+    // explicitly opted in, otherwise read from sticky state.
+    const useForceDownscale = forceDownscaleOverride || allowForceDownscale;
+    if (forceDownscaleOverride) setAllowForceDownscale(true);
 
     const framing = {
       rotationDegrees: result.rotationDegrees,
@@ -839,6 +885,7 @@ export function GuidedCreate() {
           featherStrength: featherStrengthRef.current,
           framing,
           sharpening: effectiveSharpening,
+          allowForceDownscale: useForceDownscale,
         });
 
         const sub = subscribeToJobProgress(
@@ -849,6 +896,7 @@ export function GuidedCreate() {
               try {
                 const blob = await apiClient.getBlob(`/api/jobs/${jobId}/result`);
                 downloadComposite(blob, generateFilename(result.format));
+                lastExportResultRef.current = null;
               } catch (err) {
                 setExportError(err instanceof Error ? err.message : 'Failed to download export.');
               } finally {
@@ -874,8 +922,10 @@ export function GuidedCreate() {
           featherStrength: featherStrengthRef.current,
           framing,
           sharpening: effectiveSharpening,
+          allowForceDownscale: useForceDownscale,
         });
         downloadComposite(blob, generateFilename(result.format));
+        lastExportResultRef.current = null;
         setIsExporting(false);
       }
     } catch (err) {
@@ -1030,6 +1080,9 @@ export function GuidedCreate() {
                 startProcessing(recipe);
               }
             }}
+            onContinueAnyway={
+              recipe ? () => startProcessing(recipe, /* allowForceDownscale */ true) : undefined
+            }
           />
         )}
 
@@ -1048,6 +1101,14 @@ export function GuidedCreate() {
             activePresetId={activePreset.id}
             onPresetChange={handlePresetChange}
             onExport={handleExport}
+            onContinueAnyway={
+              lastExportResultRef.current
+                ? () => {
+                    const last = lastExportResultRef.current;
+                    if (last) handleExport(last, /* forceDownscaleOverride */ true);
+                  }
+                : undefined
+            }
             initialFeatherStrength={
               recipe?.recommendedFeatherStrength
                 ? Math.round(recipe.recommendedFeatherStrength * 100)

--- a/frontend/jwst-frontend/src/services/compositeService.test.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.test.ts
@@ -103,6 +103,28 @@ describe('compositeService', () => {
         'API Error'
       );
     });
+
+    it('forwards allowForceDownscale on the request payload', async () => {
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
+
+      await generateNChannelComposite({
+        channels: [],
+        outputFormat: 'png',
+        quality: 95,
+        width: 1000,
+        height: 1000,
+        allowForceDownscale: true,
+      } as never);
+
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
+        '/api/composite/generate-nchannel',
+        expect.objectContaining({ allowForceDownscale: true }),
+        expect.any(Object)
+      );
+    });
   });
 
   describe('generateNChannelPreview', () => {
@@ -456,6 +478,84 @@ describe('compositeService', () => {
       expect(w?.wasDownscaled).toBe(false);
     });
 
+    it('forwards allowForceDownscale through generateNChannelPreview', async () => {
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
+
+      await generateNChannelPreview([] as never, { allowForceDownscale: true });
+
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
+        '/api/composite/generate-nchannel',
+        expect.objectContaining({ allowForceDownscale: true }),
+        expect.any(Object)
+      );
+    });
+
+    it('forwards allowForceDownscale through exportNChannelComposite', async () => {
+      vi.mocked(apiClient.postBlobWithHeaders).mockResolvedValue({
+        blob: new Blob(),
+        headers: H(),
+      });
+
+      await exportNChannelComposite(
+        [] as never,
+        {
+          format: 'png',
+          quality: 95,
+          width: 1000,
+          height: 1000,
+          allowForceDownscale: true,
+        } as never
+      );
+
+      expect(apiClient.postBlobWithHeaders).toHaveBeenCalledWith(
+        '/api/composite/generate-nchannel',
+        expect.objectContaining({ allowForceDownscale: true }),
+        expect.any(Object)
+      );
+    });
+
+    it('forwards allowForceDownscale through exportNChannelCompositeAsync', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ jobId: 'j-1' });
+
+      await exportNChannelCompositeAsync(
+        [] as never,
+        {
+          format: 'png',
+          quality: 95,
+          width: 1000,
+          height: 1000,
+          allowForceDownscale: true,
+        } as never
+      );
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/composite/export-nchannel',
+        expect.objectContaining({ allowForceDownscale: true })
+      );
+    });
+
+    it('parses forced status from an opted-in or cache-hit force-downscale', () => {
+      const w = parseCompositeWarning(
+        H({
+          'X-Composite-Budget-Status': 'forced',
+          'X-Composite-Was-Downscaled': 'true',
+          'X-Composite-Original-Shape': '11399,8949',
+          'X-Composite-Output-Shape': '4353,3417',
+          'X-Composite-Side-Factor': '0.382',
+        })
+      );
+      expect(w).toEqual({
+        budgetStatus: 'forced',
+        wasDownscaled: true,
+        originalShape: [11399, 8949],
+        outputShape: [4353, 3417],
+        sideFactor: 0.382,
+      });
+    });
+
     it('returns undefined shape when header is malformed', () => {
       const w = parseCompositeWarning(
         H({
@@ -493,6 +593,59 @@ describe('compositeService', () => {
         H({ 'X-Composite-Budget-Status': 'warn', 'X-Composite-Side-Factor': '1.0' })
       );
       expect(w?.sideFactor).toBe(1.0);
+    });
+  });
+
+  describe('parseMemoryBudgetError', () => {
+    // Inline import to avoid breaking earlier tests if the helper is added later
+    // in a follow-up; keeps each test self-contained.
+
+    it('strips MEMORY_BUDGET: prefix from async-path errors', async () => {
+      const { parseMemoryBudgetError } = await import('./compositeService');
+      const result = parseMemoryBudgetError(
+        'MEMORY_BUDGET:Composite output would shrink to 38% of requested side length ' +
+          '(4353x3417 from 11399x8949). Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB.'
+      );
+      expect(result.isMemoryBudget).toBe(true);
+      expect(result.displayMessage.startsWith('MEMORY_BUDGET:')).toBe(false);
+      expect(result.projectedShape).toEqual([4353, 3417]);
+    });
+
+    it('detects memory-budget pattern in sync-path errors without prefix', async () => {
+      const { parseMemoryBudgetError } = await import('./compositeService');
+      const result = parseMemoryBudgetError(
+        'Composite output would shrink to 38% of requested side length ' +
+          '(4353x3417 from 11399x8949). Memory limit MAX_COMPOSITE_MEMORY_BYTES = 3000 MB.'
+      );
+      expect(result.isMemoryBudget).toBe(true);
+      expect(result.projectedShape).toEqual([4353, 3417]);
+    });
+
+    it('returns isMemoryBudget=false for unrelated errors', async () => {
+      const { parseMemoryBudgetError } = await import('./compositeService');
+      const result = parseMemoryBudgetError('Network error: ECONNREFUSED');
+      expect(result.isMemoryBudget).toBe(false);
+      expect(result.projectedShape).toBeNull();
+      expect(result.displayMessage).toBe('Network error: ECONNREFUSED');
+    });
+
+    it('returns null projectedShape when shape pattern is missing but prefix matches', async () => {
+      const { parseMemoryBudgetError } = await import('./compositeService');
+      const result = parseMemoryBudgetError(
+        'MEMORY_BUDGET:engine refused due to MAX_COMPOSITE_MEMORY_BYTES'
+      );
+      expect(result.isMemoryBudget).toBe(true);
+      expect(result.projectedShape).toBeNull();
+    });
+
+    it('does not match when only one keyword is present (without prefix)', async () => {
+      const { parseMemoryBudgetError } = await import('./compositeService');
+      // Some unrelated docs/error path mentions only one of the keywords —
+      // detection should require both to avoid offering an inert override.
+      const result = parseMemoryBudgetError(
+        'Memory exceeded MAX_COMPOSITE_MEMORY_BYTES at runtime'
+      );
+      expect(result.isMemoryBudget).toBe(false);
     });
   });
 

--- a/frontend/jwst-frontend/src/services/compositeService.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.ts
@@ -37,13 +37,70 @@ function parseShapeHeader(value: string | null): [number, number] | undefined {
 }
 
 /**
+ * Engine error prefix applied by .NET ProcessingErrorMessages for memory-budget
+ * 413 failures so the frontend can offer the "Continue anyway" override even
+ * on the async path (where the HTTP 413 status is lost crossing SignalR).
+ *
+ * Matches the existing `NO_PRODUCTS:` / `S3_UNAVAILABLE:` convention used by
+ * the download flow.
+ */
+const MEMORY_BUDGET_PREFIX = 'MEMORY_BUDGET:';
+
+/**
+ * The engine's 413 detail string emits both `MAX_COMPOSITE_MEMORY_BYTES` and
+ * `Composite output would shrink to N%` (see processing-engine routes.py:716).
+ * Either substring on its own could plausibly appear in unrelated errors
+ * (operator docs, tooltip text), so detection requires both to avoid false
+ * positives that would offer "Continue anyway" on errors the override can't
+ * actually resolve.
+ */
+const MEMORY_BUDGET_KEYWORDS = ['MAX_COMPOSITE_MEMORY_BYTES', 'Composite output would shrink'];
+
+/**
+ * Parse the projected output shape from an engine 413 detail string. The
+ * engine emits `(WIDTHxHEIGHT from ORIGWxORIGH)` — we capture the projected
+ * (smaller) shape because that's what the user is opting in to.
+ */
+const PROJECTED_SHAPE_RE = /\((\d+)x(\d+) from \d+x\d+\)/;
+
+/**
+ * Result of inspecting an error string to decide whether the "Continue anyway"
+ * override should be offered. Used by both the sync (ApiError 413) and async
+ * (SignalR error string) error paths so detection logic stays in one place.
+ */
+export interface MemoryBudgetErrorParse {
+  /** True when the message is a memory-budget refusal. */
+  isMemoryBudget: boolean;
+  /** Message with the MEMORY_BUDGET: prefix stripped if present. */
+  displayMessage: string;
+  /** Projected output shape [width, height] parsed from the detail, or null. */
+  projectedShape: [number, number] | null;
+}
+
+export function parseMemoryBudgetError(message: string | null | undefined): MemoryBudgetErrorParse {
+  if (!message) {
+    return { isMemoryBudget: false, displayMessage: '', projectedShape: null };
+  }
+  const hasPrefix = message.startsWith(MEMORY_BUDGET_PREFIX);
+  const stripped = hasPrefix ? message.slice(MEMORY_BUDGET_PREFIX.length) : message;
+  const isMemoryBudget = hasPrefix || MEMORY_BUDGET_KEYWORDS.every((kw) => stripped.includes(kw));
+  const match = stripped.match(PROJECTED_SHAPE_RE);
+  const projectedShape: [number, number] | null = match
+    ? [Number.parseInt(match[1], 10), Number.parseInt(match[2], 10)]
+    : null;
+  return { isMemoryBudget, displayMessage: stripped, projectedShape };
+}
+
+/**
  * Build a typed `CompositeWarning` from the engine's response headers, or
  * return null if the engine didn't emit a budget status (older engine, or
  * the request didn't go through the composite memory path at all).
  */
 export function parseCompositeWarning(headers: Headers): CompositeWarning | null {
   const status = headers.get('X-Composite-Budget-Status');
-  if (status !== 'ok' && status !== 'warn' && status !== 'fail') return null;
+  if (status !== 'ok' && status !== 'warn' && status !== 'forced' && status !== 'fail') {
+    return null;
+  }
 
   const wasDownscaled = headers.get('X-Composite-Was-Downscaled') === 'true';
   const sideFactorRaw = headers.get('X-Composite-Side-Factor');
@@ -101,6 +158,7 @@ export async function generateNChannelPreview(
     featherStrength,
     sharpening,
     saturation,
+    allowForceDownscale,
   } = options;
 
   const request: NChannelCompositeRequest = {
@@ -114,6 +172,7 @@ export async function generateNChannelPreview(
     quality: 85,
     width: previewSize,
     height: previewSize,
+    allowForceDownscale,
   };
 
   return generateNChannelComposite(request, abortSignal);
@@ -157,6 +216,7 @@ export async function exportNChannelComposite(
     framing,
     sharpening,
     saturation,
+    allowForceDownscale,
   } = options;
 
   const request: NChannelCompositeRequest = {
@@ -174,6 +234,7 @@ export async function exportNChannelComposite(
     quality,
     width,
     height,
+    allowForceDownscale,
   };
 
   return generateNChannelComposite(request, abortSignal);
@@ -202,6 +263,7 @@ export async function exportNChannelCompositeAsync(
     framing,
     sharpening,
     saturation,
+    allowForceDownscale,
   } = options;
 
   const request: NChannelCompositeRequest = {
@@ -219,6 +281,7 @@ export async function exportNChannelCompositeAsync(
     quality,
     width,
     height,
+    allowForceDownscale,
   };
 
   return apiClient.post<{ jobId: string }>('/api/composite/export-nchannel', request);

--- a/frontend/jwst-frontend/src/types/CompositeTypes.ts
+++ b/frontend/jwst-frontend/src/types/CompositeTypes.ts
@@ -96,6 +96,11 @@ export interface NChannelPreviewOptions {
   featherStrength?: number;
   sharpening?: SharpeningConfig;
   saturation?: SaturationConfig;
+  /**
+   * When true, opt in to a heavy memory-budget downscale instead of letting
+   * the engine refuse with HTTP 413. See {@link CompositeWarning} 'forced'.
+   */
+  allowForceDownscale?: boolean;
 }
 
 /** Options for N-channel export (sync and async) */
@@ -107,6 +112,11 @@ export interface NChannelExportOptions extends ExportOptions {
   sharpening?: SharpeningConfig;
   saturation?: SaturationConfig;
   abortSignal?: AbortSignal;
+  /**
+   * When true, opt in to a heavy memory-budget downscale instead of letting
+   * the engine refuse with HTTP 413. See {@link CompositeWarning} 'forced'.
+   */
+  allowForceDownscale?: boolean;
 }
 
 /**
@@ -242,6 +252,11 @@ export interface NChannelCompositeRequest {
   quality: number;
   width: number;
   height: number;
+  /**
+   * Per-request opt-in to bypass MAX_COMPOSITE_MEMORY_BYTES / fail-threshold
+   * refusals; engine applies the projected force-downscale instead of 413.
+   */
+  allowForceDownscale?: boolean;
 }
 
 /**
@@ -668,13 +683,16 @@ export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
  * for a freshly-computed result.
  *
  * Status values match the engine verdict:
- *   - 'ok'   — no pressure; banner not shown
- *   - 'warn' — mild downscale applied (or cached result fits current budget)
- *   - 'fail' — would have refused; only seen on cached results when operator
- *              tightened the budget after caching
+ *   - 'ok'     — no pressure; banner not shown
+ *   - 'warn'   — mild downscale applied (or cached result fits current budget)
+ *   - 'forced' — heavy downscale applied because the user opted in via
+ *                allow_force_downscale on this request, OR cache hit on a
+ *                previously-forced result (provenance preserved by the cache).
+ *   - 'fail'   — would have refused; only seen on cached results when operator
+ *                tightened the budget after caching
  */
 export interface CompositeWarning {
-  budgetStatus: 'ok' | 'warn' | 'fail';
+  budgetStatus: 'ok' | 'warn' | 'forced' | 'fail';
   wasDownscaled: boolean;
   originalShape?: [number, number]; // [height, width]
   outputShape?: [number, number];

--- a/processing-engine/app/composite/cache.py
+++ b/processing-engine/app/composite/cache.py
@@ -34,8 +34,15 @@ class CompositeCache:
         self._lock = threading.Lock()
         # OrderedDict preserves insertion order; we move accessed keys to the
         # end so the *first* key is the least-recently-used.
-        # Values: (channels, timestamp, paths_fingerprint)
-        self._store: OrderedDict[str, tuple[dict[str, np.ndarray], float, str]] = OrderedDict()
+        # Values: (channels, timestamp, paths_fingerprint, original_shape)
+        # original_shape carries provenance for force-downscaled entries so
+        # later cache hits can surface the warning even when the user didn't
+        # opt in to allow_force_downscale themselves. None for entries that
+        # were not force-downscaled.
+        self._store: OrderedDict[
+            str,
+            tuple[dict[str, np.ndarray], float, str, tuple[int, int] | None],
+        ] = OrderedDict()
 
     # ------------------------------------------------------------------
     # Public API
@@ -65,14 +72,19 @@ class CompositeCache:
         )
         return hashlib.sha256(payload.encode()).hexdigest()
 
-    def get(self, key: str) -> dict[str, np.ndarray] | None:
-        """Return cached channel arrays or ``None`` on miss / expiry."""
+    def get(self, key: str) -> tuple[dict[str, np.ndarray], tuple[int, int] | None] | None:
+        """Return (cached_channels, original_shape) or ``None`` on miss / expiry.
+
+        original_shape is None for entries written without force-downscale
+        provenance; non-None when the entry was produced by a force-downscale
+        run so cache hits can surface the warning to default-flow users.
+        """
         with self._lock:
             entry = self._store.get(key)
             if entry is None:
                 return None
 
-            channels, ts, _fp = entry
+            channels, ts, _fp, original_shape = entry
             if time.monotonic() - ts > self._ttl:
                 del self._store[key]
                 logger.debug("Composite cache entry expired for key=%s…", key[:12])
@@ -80,22 +92,25 @@ class CompositeCache:
 
             # Mark as recently used
             self._store.move_to_end(key)
-            return channels
+            return channels, original_shape
 
-    def get_any_budget(self, channel_paths: list[list[str]]) -> dict[str, np.ndarray] | None:
+    def get_any_budget(
+        self, channel_paths: list[list[str]]
+    ) -> tuple[dict[str, np.ndarray], tuple[int, int] | None] | None:
         """Return any cached entry for these channel paths, regardless of budget.
 
         Useful for exports: reuse preview-resolution cached data instead of
         reloading at full resolution (which can OOM on large composites).
+        Returns (channels, original_shape) tuple — see ``get`` docstring.
         """
         fingerprint = self._paths_fingerprint(channel_paths)
         with self._lock:
-            for key, (channels, ts, fp) in list(self._store.items()):
+            for key, (channels, ts, fp, original_shape) in list(self._store.items()):
                 if time.monotonic() - ts > self._ttl:
                     continue
                 if fp == fingerprint:
                     self._store.move_to_end(key)
-                    return channels
+                    return channels, original_shape
         return None
 
     def put(
@@ -103,8 +118,14 @@ class CompositeCache:
         key: str,
         channels: dict[str, np.ndarray],
         channel_paths: list[list[str]] | None = None,
+        original_shape: tuple[int, int] | None = None,
     ) -> None:
-        """Store reprojected channels if within the memory budget."""
+        """Store reprojected channels if within the memory budget.
+
+        original_shape is the WCS-derived shape before any force-downscale was
+        applied. Pass it when writing a force-downscaled result so later cache
+        hits can emit the 'forced' verdict; leave None for normal entries.
+        """
         entry_bytes = sum(arr.nbytes for arr in channels.values())
 
         if entry_bytes > self._max_bytes:
@@ -133,7 +154,7 @@ class CompositeCache:
                 evicted_key, _ = self._store.popitem(last=False)
                 logger.debug("Composite cache evicted (count) key=%s…", evicted_key[:12])
 
-            self._store[key] = (channels, time.monotonic(), fingerprint)
+            self._store[key] = (channels, time.monotonic(), fingerprint, original_shape)
 
     # ------------------------------------------------------------------
     # Internal helpers (caller must hold self._lock)
@@ -141,12 +162,12 @@ class CompositeCache:
 
     def _evict_expired(self) -> None:
         now = time.monotonic()
-        expired = [k for k, (_, ts, _fp) in self._store.items() if now - ts > self._ttl]
+        expired = [k for k, (_, ts, _fp, _os) in self._store.items() if now - ts > self._ttl]
         for k in expired:
             del self._store[k]
 
     def _total_bytes(self) -> int:
         return sum(
             sum(arr.nbytes for arr in channels.values())
-            for channels, _ts, _fp in self._store.values()
+            for channels, _ts, _fp, _os in self._store.values()
         )

--- a/processing-engine/app/composite/models.py
+++ b/processing-engine/app/composite/models.py
@@ -221,6 +221,16 @@ class NChannelCompositeRequest(BaseModel):
         default=False,
         description="Return per-channel coverage/feather masks instead of the composite image",
     )
+    allow_force_downscale: bool = Field(
+        default=False,
+        description=(
+            "When True, suppress the 413 fail-threshold guardrail and apply the projected "
+            "downscale anyway. The user explicitly opts in to a smaller output to bypass the "
+            "memory-budget refusal. Distinct from /composite/estimate's raise_on_fail=False, "
+            "which reports a 'fail' verdict for preflight; this flag returns a 'forced' "
+            "verdict and produces an actual downscaled image."
+        ),
+    )
 
 
 # --- Channel Analysis Models ---
@@ -297,7 +307,13 @@ class EstimateResponse(BaseModel):
     status="ok"   — generation will succeed at the requested output shape.
     status="warn" — generation will succeed but output will mildly downscale.
     status="fail" — generation will return HTTP 413 at the current memory limit
-                    and threshold; tune env vars or reduce inputs.
+                    and threshold; tune env vars, reduce inputs, or send the
+                    request with allow_force_downscale=true to opt in to a
+                    heavy downscale instead of a refusal.
+
+    Note: /composite/estimate never returns status="forced" — preflight does not
+    apply the downscale, so it reports the would-be-fail verdict honestly. The
+    "forced" status is exclusive to /composite/generate-nchannel responses.
     """
 
     status: str = Field(description="ok | warn | fail")

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -149,12 +149,19 @@ class StretchResult:
 class MemoryBudgetVerdict:
     """Result of evaluating a candidate composite output WCS shape against memory.
 
-    status: "ok"   — shape fits unchanged
-            "warn" — shape must shrink, but side_factor >= fail_threshold
-            "fail" — shape must shrink below fail_threshold (heavy reduction)
+    status: "ok"     — shape fits unchanged
+            "warn"   — shape must shrink, but side_factor >= fail_threshold
+            "fail"   — shape must shrink below fail_threshold (heavy reduction);
+                       only emitted when raise_on_fail=False AND force_downscale=False
+                       (used by /composite/estimate as a verdict-not-an-error path)
+            "forced" — caller opted into a heavy downscale via force_downscale=True;
+                       engine applied the projected shrink instead of refusing.
+                       Also emitted by _verdict_for_cached when an entry's stored
+                       original_shape != cached_shape (provenance — a previous
+                       force-downscaled run is being served from cache).
     """
 
-    status: Literal["ok", "warn", "fail"]
+    status: Literal["ok", "warn", "fail", "forced"]
     output_shape: tuple[int, int]
     original_shape: tuple[int, int]
     side_factor: float
@@ -667,6 +674,7 @@ def _compute_memory_budget(
     shape_out: tuple[int, int],
     fail_threshold: float | None = None,
     raise_on_fail: bool = True,
+    force_downscale: bool = False,
 ) -> MemoryBudgetVerdict:
     """Apply the hybrid downscale policy to a candidate output WCS shape.
 
@@ -679,14 +687,20 @@ def _compute_memory_budget(
             downscale. When False, returns a verdict with status="fail" instead
             so callers can branch (used by /composite/estimate which returns
             200 + verdict rather than an error).
+        force_downscale: When True, suppress the 413 guardrail AND return a
+            verdict with status="forced" so the caller knows to apply the
+            downscale and emit provenance headers. Wins over raise_on_fail
+            (which becomes a no-op when this is True). Used when the user
+            explicitly opts in to allow_force_downscale on the request.
 
     Returns:
         MemoryBudgetVerdict with status="ok" (no shrink), "warn" (mild shrink),
-        or "fail" (only when raise_on_fail=False).
+        "fail" (only when raise_on_fail=False, force_downscale=False), or
+        "forced" (only when force_downscale=True).
 
     Raises:
-        HTTPException 413 when raise_on_fail=True and projected
-        side_factor < fail_threshold.
+        HTTPException 413 when raise_on_fail=True, force_downscale=False, and
+        projected side_factor < fail_threshold.
     """
     if fail_threshold is None:
         fail_threshold = _current_fail_threshold()
@@ -721,6 +735,14 @@ def _compute_memory_budget(
     )
 
     if side_factor < fail_threshold:
+        if force_downscale:
+            return MemoryBudgetVerdict(
+                status="forced",
+                output_shape=new_shape,
+                original_shape=shape_out,
+                side_factor=side_factor,
+                detail=detail,
+            )
         if raise_on_fail:
             raise HTTPException(status_code=413, detail=detail)
         return MemoryBudgetVerdict(
@@ -761,17 +783,24 @@ def _reproject_all_channels(
     n = len(request.channels)
     wcs_out, shape_out, all_channel_info = _compute_common_wcs(request)
 
-    verdict = _compute_memory_budget(n, shape_out)
+    verdict = _compute_memory_budget(n, shape_out, force_downscale=request.allow_force_downscale)
 
-    # Apply mild downscale if verdict says warn (fail already raised 413).
-    if verdict.status == "warn":
+    # Apply downscale on warn (mild auto-shrink) or forced (caller opted in).
+    # 'fail' never reaches here because force_downscale=False keeps the 413
+    # raise path; the only fail-equivalent that survives is 'forced'.
+    if verdict.status in ("warn", "forced"):
         side_factor = verdict.side_factor
         shape_out = verdict.output_shape
         wcs_out.wcs.cdelt /= side_factor
         wcs_out.wcs.crpix *= side_factor
+        severity = (
+            "mild reduction within fail threshold"
+            if verdict.status == "warn"
+            else "heavy reduction below fail threshold (caller opted in via allow_force_downscale)"
+        )
         logger.info(
             f"Output grid DOWNSCALED to {shape_out[1]}x{shape_out[0]} "
-            f"(side_factor={side_factor:.3f}) — mild reduction within fail threshold"
+            f"(side_factor={side_factor:.3f}) — {severity}"
         )
 
     total_out_pixels = shape_out[0] * shape_out[1]
@@ -927,24 +956,34 @@ def _load_reprojected_channels(
     cache_key = _cache.make_key_nchannel(channel_paths, input_budget)
     n = len(request.channels)
 
-    cached = _cache.get(cache_key)
-    if cached is not None:
+    cached_entry = _cache.get(cache_key)
+    if cached_entry is not None:
+        cached, original_shape = cached_entry
         logger.info("N-channel cache HIT — skipping load/mosaic/reproject")
-        return cached, _verdict_for_cached(cached, n)
+        return cached, _verdict_for_cached(cached, n, original_shape=original_shape)
 
-    fallback = _cache.get_any_budget(channel_paths)
-    if fallback is not None:
+    fallback_entry = _cache.get_any_budget(channel_paths)
+    if fallback_entry is not None:
+        fallback, original_shape = fallback_entry
         logger.info("N-channel cache HIT (different budget) — reusing cached data")
-        return fallback, _verdict_for_cached(fallback, n)
+        return fallback, _verdict_for_cached(fallback, n, original_shape=original_shape)
 
     reprojected, verdict = _reproject_all_channels(request, input_budget)
     _apply_resolution_blur(reprojected, channel_instruments, request)
-    _cache.put(cache_key, reprojected, channel_paths)
+    # Carry original_shape provenance only when this run was force-downscaled,
+    # so future cache hits surface the warning. For ok/warn entries the shapes
+    # match (or the warn shape IS the served shape) and provenance is None.
+    cache_provenance = verdict.original_shape if verdict.status == "forced" else None
+    _cache.put(cache_key, reprojected, channel_paths, original_shape=cache_provenance)
     logger.info("N-channel cache MISS — full pipeline completed, result cached")
     return reprojected, verdict
 
 
-def _verdict_for_cached(cached: dict[str, np.ndarray], n: int) -> MemoryBudgetVerdict:
+def _verdict_for_cached(
+    cached: dict[str, np.ndarray],
+    n: int,
+    original_shape: tuple[int, int] | None = None,
+) -> MemoryBudgetVerdict:
     """Re-validate a cache hit against the current memory budget.
 
     Cached arrays may predate operator runtime tuning (lower
@@ -953,6 +992,11 @@ def _verdict_for_cached(cached: dict[str, np.ndarray], n: int) -> MemoryBudgetVe
     but we clamp output_shape and original_shape to the actual cached
     shape — no downscale is applied on cache hit, and lying about the
     served shape would mislead callers.
+
+    When ``original_shape`` is provided and differs from the cached array
+    shape, the entry is the result of a previous force-downscale run. In that
+    case we emit status="forced" so the warning banner fires for any user who
+    receives the cached result, even though they didn't opt in this request.
     """
     if not cached:
         # Cache is invariably populated by _cache.put with at least one channel;
@@ -969,6 +1013,26 @@ def _verdict_for_cached(cached: dict[str, np.ndarray], n: int) -> MemoryBudgetVe
     if len(shape) < 2:
         raise ValueError(f"Cached array has unexpected shape {shape!r}; expected >=2D")
     cached_shape = (shape[0], shape[1])
+
+    # Force-downscale provenance: cached entry was produced by a prior opt-in
+    # run. Surface as 'forced' so the banner explains the reduction even for
+    # users who didn't opt in this request.
+    if original_shape is not None and original_shape != cached_shape:
+        side_factor = (
+            (cached_shape[0] * cached_shape[1]) / (original_shape[0] * original_shape[1])
+        ) ** 0.5
+        detail = (
+            f"Result served from cache; output was previously force-downscaled to "
+            f"{cached_shape[1]}x{cached_shape[0]} from {original_shape[1]}x{original_shape[0]} "
+            f"to fit MAX_COMPOSITE_MEMORY_BYTES."
+        )
+        return MemoryBudgetVerdict(
+            status="forced",
+            output_shape=cached_shape,
+            original_shape=original_shape,
+            side_factor=side_factor,
+            detail=detail,
+        )
 
     raw = _compute_memory_budget(n, cached_shape, raise_on_fail=False)
     if raw.status == "ok":
@@ -1343,8 +1407,13 @@ def _encode_and_respond(
 
     if verdict is not None:
         # Always emit current budget status so frontend can surface tightness.
-        # ok = no pressure; warn = mild downscale applied (this request);
-        # fail = cached result whose shape exceeds current budget.
+        # ok     = no pressure;
+        # warn   = mild downscale applied (this request);
+        # forced = heavy downscale applied because allow_force_downscale=true
+        #          on this request, OR cache hit on a previously-forced result
+        #          (provenance preserved via cache.put original_shape);
+        # fail   = cached result whose shape exceeds current budget (operator
+        #          tightened budget after the entry was populated).
         quality_headers["X-Composite-Budget-Status"] = verdict.status
         # Shape-mismatch headers only when an actual downscale happened on this
         # request. Cache hits with stale-budget keep output_shape = original.

--- a/processing-engine/tests/test_composite_downscale.py
+++ b/processing-engine/tests/test_composite_downscale.py
@@ -454,7 +454,12 @@ class TestMemoryBudgetVerdict:
         assert verdict.side_factor == 1.0
 
     def test_raise_on_fail_false_returns_fail_verdict(self):
-        """raise_on_fail=False returns status='fail' instead of raising."""
+        """raise_on_fail=False returns status='fail' instead of raising.
+
+        Used by /composite/estimate so the recipe walkthrough preflight can
+        report fail without taking down the request. Distinct from the
+        force_downscale path which returns status='forced'.
+        """
         verdict = _compute_memory_budget(
             n=5, shape_out=(30000, 30000), fail_threshold=0.85, raise_on_fail=False
         )
@@ -463,6 +468,48 @@ class TestMemoryBudgetVerdict:
         assert verdict.output_shape != (30000, 30000)
         assert verdict.side_factor < 0.85
         assert "MAX_COMPOSITE_MEMORY_BYTES" in verdict.detail
+
+    def test_force_downscale_returns_forced_verdict(self):
+        """force_downscale=True suppresses 413 and returns status='forced' with
+        the projected downscale applied so the route can produce a smaller
+        image instead of refusing."""
+        verdict = _compute_memory_budget(
+            n=5,
+            shape_out=(30000, 30000),
+            fail_threshold=0.85,
+            force_downscale=True,
+        )
+        assert verdict.status == "forced"
+        assert verdict.original_shape == (30000, 30000)
+        assert verdict.output_shape != (30000, 30000)
+        assert verdict.side_factor < 0.85
+        assert "MAX_COMPOSITE_MEMORY_BYTES" in verdict.detail
+
+    def test_force_downscale_no_pressure_returns_ok(self):
+        """force_downscale=True with a shape that already fits is a no-op."""
+        verdict = _compute_memory_budget(n=3, shape_out=(1000, 1000), force_downscale=True)
+        assert verdict.status == "ok"
+        assert verdict.side_factor == 1.0
+
+    def test_force_downscale_with_mild_shrink_still_warns(self):
+        """force_downscale only kicks in below fail_threshold; mild shrink stays
+        a warn so the existing semantics for mild auto-downscale don't change."""
+        verdict = _compute_memory_budget(
+            n=3, shape_out=(4150, 4150), fail_threshold=0.85, force_downscale=True
+        )
+        assert verdict.status == "warn"
+        assert 0.85 <= verdict.side_factor < 1.0
+
+    def test_force_downscale_overrides_raise_on_fail(self):
+        """If both flags are set, force_downscale wins — no 413, returns forced."""
+        verdict = _compute_memory_budget(
+            n=5,
+            shape_out=(30000, 30000),
+            fail_threshold=0.85,
+            raise_on_fail=True,
+            force_downscale=True,
+        )
+        assert verdict.status == "forced"
 
 
 class TestCacheHitVerdict:
@@ -515,3 +562,79 @@ class TestCacheHitVerdict:
         cached = {"ch0": np.zeros((100,), dtype=np.float64)}  # 1D
         with pytest.raises(ValueError, match="unexpected shape"):
             _verdict_for_cached(cached, n=3)
+
+    def test_cache_hit_returns_forced_when_original_shape_differs(self):
+        """When the cached entry was force-downscaled (original_shape provenance
+        differs from the cached array shape), _verdict_for_cached returns
+        status='forced' with both shapes so the warning banner can show the
+        reduction even for users who didn't opt in this request."""
+        from app.composite.routes import _verdict_for_cached
+
+        # Cached at small (4000, 4000); originally would have been (10000, 10000).
+        cached = {"ch0": np.zeros((4000, 4000), dtype=np.float64)}
+        verdict = _verdict_for_cached(cached, n=3, original_shape=(10000, 10000))
+        assert verdict.status == "forced"
+        assert verdict.output_shape == (4000, 4000)
+        assert verdict.original_shape == (10000, 10000)
+        assert verdict.side_factor < 1.0
+
+    def test_cache_hit_no_provenance_preserves_legacy_behavior(self):
+        """Backward compat: when original_shape is None (legacy cache entry or
+        not force-downscaled), _verdict_for_cached behaves as before."""
+        from app.composite.routes import _verdict_for_cached
+
+        cached = {"ch0": np.zeros((100, 100), dtype=np.float64)}
+        verdict = _verdict_for_cached(cached, n=3, original_shape=None)
+        assert verdict.status == "ok"
+        assert verdict.output_shape == (100, 100)
+        assert verdict.original_shape == (100, 100)
+
+    def test_cache_hit_matching_original_shape_returns_ok(self):
+        """If original_shape == cached_shape (no force-downscale happened), the
+        verdict reflects current budget pressure normally — no 'forced'."""
+        from app.composite.routes import _verdict_for_cached
+
+        cached = {"ch0": np.zeros((100, 100), dtype=np.float64)}
+        verdict = _verdict_for_cached(cached, n=3, original_shape=(100, 100))
+        assert verdict.status == "ok"
+
+    def test_force_downscale_run_then_default_cache_hit_emits_forced(self):
+        """Integration test for the full provenance round-trip:
+
+        1. A request with allow_force_downscale=True runs and populates the
+           cache with original_shape provenance via _cache.put(..., original_shape=...).
+        2. A subsequent default-flow request hits the cache and gets a
+           'forced' verdict (not 'ok') so the warning banner fires.
+
+        This is the load-bearing user-facing behavior promised by the plan:
+        cache hits of force-downscaled entries can't silently serve smaller
+        images to users who didn't opt in.
+        """
+        from app.composite.cache import CompositeCache
+        from app.composite.routes import _verdict_for_cached
+
+        cache = CompositeCache()
+        key = CompositeCache.make_key_nchannel([["a.fits"]], 1000)
+
+        # Step 1: simulate a force-downscaled run writing the cache. The
+        # downscaled arrays are stored at the smaller shape; the original
+        # WCS-derived shape is recorded as provenance.
+        downscaled_arrays = {"ch0": np.zeros((4000, 4000), dtype=np.float64)}
+        cache.put(
+            key,
+            downscaled_arrays,
+            channel_paths=[["a.fits"]],
+            original_shape=(10000, 10000),
+        )
+
+        # Step 2: subsequent default-flow request (no allow_force_downscale)
+        # does the cache lookup and resolves the verdict against provenance.
+        result = cache.get(key)
+        assert result is not None
+        cached_channels, original_shape = result
+        verdict = _verdict_for_cached(cached_channels, n=3, original_shape=original_shape)
+
+        assert verdict.status == "forced"
+        assert verdict.output_shape == (4000, 4000)
+        assert verdict.original_shape == (10000, 10000)
+        assert "force-downscaled" in verdict.detail.lower()

--- a/processing-engine/tests/test_nchannel_composite.py
+++ b/processing-engine/tests/test_nchannel_composite.py
@@ -190,6 +190,58 @@ class TestNCacheKey:
         assert k1 != k2
 
 
+class TestCacheProvenance:
+    """Tests for cache entries carrying original_shape provenance so cache hits
+    of force-downscaled results can surface the warning to users who didn't
+    opt in themselves."""
+
+    def test_put_and_get_round_trip_with_original_shape(self):
+        """cache.put accepts original_shape; cache.get returns it alongside
+        the cached channel arrays."""
+        cache = CompositeCache()
+        key = CompositeCache.make_key_nchannel([["a.fits"]], 1000)
+        channels = {"ch0": np.zeros((100, 100), dtype=np.float64)}
+        cache.put(key, channels, channel_paths=[["a.fits"]], original_shape=(500, 500))
+
+        result = cache.get(key)
+        assert result is not None
+        cached_channels, original_shape = result
+        assert "ch0" in cached_channels
+        assert original_shape == (500, 500)
+
+    def test_put_without_original_shape_returns_none_provenance(self):
+        """Backward compat: omitting original_shape stores None so legacy
+        callers and warn/ok paths don't lie about a force-downscale."""
+        cache = CompositeCache()
+        key = CompositeCache.make_key_nchannel([["a.fits"]], 1000)
+        channels = {"ch0": np.zeros((100, 100), dtype=np.float64)}
+        cache.put(key, channels, channel_paths=[["a.fits"]])
+
+        result = cache.get(key)
+        assert result is not None
+        _cached_channels, original_shape = result
+        assert original_shape is None
+
+    def test_get_any_budget_returns_provenance(self):
+        """Cross-budget fallback hit also surfaces original_shape so /generate
+        can emit forced headers from a different-budget cache hit."""
+        cache = CompositeCache()
+        key = CompositeCache.make_key_nchannel([["a.fits"]], 1000)
+        channels = {"ch0": np.zeros((100, 100), dtype=np.float64)}
+        cache.put(key, channels, channel_paths=[["a.fits"]], original_shape=(500, 500))
+
+        result = cache.get_any_budget([["a.fits"]])
+        assert result is not None
+        _cached_channels, original_shape = result
+        assert original_shape == (500, 500)
+
+    def test_get_miss_returns_none(self):
+        """Miss still returns None (not a tuple of (None, None))."""
+        cache = CompositeCache()
+        assert cache.get("nonexistent_key") is None
+        assert cache.get_any_budget([["nonexistent.fits"]]) is None
+
+
 # ---------------------------------------------------------------------------
 # Model validation tests
 # ---------------------------------------------------------------------------
@@ -250,6 +302,22 @@ class TestNChannelRequestModel:
         assert config.stretch == "asinh"
         assert config.weight == 1.0
         assert config.gamma == 1.0
+
+    def test_allow_force_downscale_defaults_false(self):
+        """allow_force_downscale opts in to bypassing the 413 guardrail; the
+        default is False so existing flows refuse heavy downscale as before."""
+        req = NChannelCompositeRequest(
+            channels=[NChannelConfig(file_paths=["test.fits"], color=ChannelColor(hue=0.0))]
+        )
+        assert req.allow_force_downscale is False
+
+    def test_allow_force_downscale_accepts_true(self):
+        """allow_force_downscale=true is honored on the request model."""
+        req = NChannelCompositeRequest(
+            channels=[NChannelConfig(file_paths=["test.fits"], color=ChannelColor(hue=0.0))],
+            allow_force_downscale=True,
+        )
+        assert req.allow_force_downscale is True
 
     def test_rgb_color_spec(self):
         """Channels can use explicit RGB instead of hue."""
@@ -326,18 +394,23 @@ class TestGenerateNChannelEndpoint:
         class FakeCache:
             def __init__(self):
                 self._data = default_channels
+                self._original_shape: tuple[int, int] | None = None
 
             def make_key_nchannel(self, *_args, **_kwargs):
                 return "fake-key"
 
             def get(self, _key):
-                return self._data
+                # New contract (post-#1450): (channels, original_shape) | None.
+                # Tests can set ``_data`` to None to simulate a miss.
+                if self._data is None:
+                    return None
+                return self._data, self._original_shape
 
             def get_any_budget(self, _paths):
                 return None
 
-            def put(self, _key, _data, _paths):
-                pass
+            def put(self, _key, _data, _paths, original_shape=None):
+                self._original_shape = original_shape
 
             @property
             def return_value(self):


### PR DESCRIPTION
## Summary

Adds an explicit per-request opt-in (`allow_force_downscale`) plumbed engine → .NET → frontend. When the engine projects a heavy downscale (`side_factor < COMPOSITE_DOWNSCALE_FAIL_THRESHOLD`, default 0.85), users now see a "Continue anyway → WxH" button alongside Retry Processing instead of being stuck on the 413.

Closes #1450

## Why

The user shared the NGC 346 NIRCam guided flow showing the engine's verbatim 413 detail, with only "Retry Processing" available. Retry hits the same 413; the user has no in-app path forward short of editing env vars. This PR adds the override they asked for — preserving the warning content, just adding a Continue anyway escape hatch.

## Changes Made

### Engine (Python)

- **New verdict status** `"forced"` on `MemoryBudgetVerdict.status` — describes data provenance (output WAS force-downscaled), independent of whether THIS request opted in or it was a cache hit of a previously-forced result.
- **Cache stores `original_shape` provenance** — `CompositeCache.put/get/get_any_budget` now thread `original_shape: tuple[int, int] | None`. `_verdict_for_cached(..., original_shape)` emits `status="forced"` when `cached_shape != original_shape`, so cache hits of force-downscaled entries surface the warning even to users who never opted in.
- **`_compute_memory_budget(force_downscale=True)`** suppresses the 413 raise and returns `forced` instead. `/composite/estimate` is unaffected — it still calls with `force_downscale=False` and reports `"fail"` honestly for preflight.
- **`_reproject_all_channels`** honors `request.allow_force_downscale` and applies the projected downscale on `forced` (alongside `warn`).
- **Engine logs** mark force-downscale opt-in events distinctly from mild auto-shrinks.

### .NET

- **`AllowForceDownscale: bool`** field on `NChannelCompositeRequestDto` and `ProcessingNChannelCompositeRequest` (snake_case at the engine wire). Threaded through `BuildProcessingRequestAsync`.
- **`ProcessingErrorMessages.ToUserMessage`** gains a `CompositeBudgetExceededException` case that prefixes the engine detail with `MEMORY_BUDGET:`. Matches the existing `NO_PRODUCTS:` / `S3_UNAVAILABLE:` convention; needed because HTTP 413 status is lost crossing the SignalR job-failure boundary, so the frontend has to detect the refusal from the error string.
  - Pre-existing bug fix: the async (auth'd) path previously fell through to `_ => "An unexpected error occurred..."` for budget refusals, hiding the engine's actionable detail. Now it surfaces properly.

### Frontend

- **`CompositeWarning.budgetStatus`** widened to include `'forced'`.
- **New `parseMemoryBudgetError` helper** in `compositeService.ts` — handles both the `MEMORY_BUDGET:` prefix (async path) and the keyword-conjunction match (sync path). Returns `{ isMemoryBudget, displayMessage, projectedShape }`. Centralizes detection so the same logic applies in `ProcessStep`, `CompositePreviewStep`, and `ResultStep`.
- **`ProcessStep`** + **`CompositePreviewStep` (preview + export errors)** + **`ResultStep` (post-export error)** all surface a "Continue anyway → WxH" button when the error matches a memory-budget refusal. The projected output shape is parsed from the engine detail.
- **Sticky `allowForceDownscale` state** in `GuidedCreate` and `CompositePreviewStep` — once the user clicks Continue anyway, every subsequent regenerate / export honors the opt-in. Cache provenance is a safety net, but state persistence is what actually keeps slider tweaks and exports working past the cache TTL.
- **`GuidedCreate.allowForceDownscale`** resets when the recipe target changes (`[target, recipeName, retryCount]` deps) so a Recipe A opt-in doesn't silently leak into Recipe B.
- **`lastExportResultRef`** in `GuidedCreate` lets the result-step Continue anyway button replay the most recent export with `forceDownscaleOverride=true`. Cleared on success AND on `regenerateComposite` entry to avoid replaying a stale export when a slider failure surfaces via the shared `exportError` state.
- **`CompositeWarningBanner`** branches on `forced` with copy "Output force-downscaled to fit memory budget". Same copy for opt-in and cache-hit-of-forced — the engine has no signal to distinguish, and adding one (e.g., `X-Composite-Forced-Cause`) was scoped out as not worth the contract complexity. Both meanings are accurate: the user either just opted in (banner confirms) or got a previously-forced cached result (banner informs).
- **ARIA `role="status" aria-live="polite"`** on all new error blocks (`ResultExportError`, `.preview-error`, `.export-error`).

## Tests

- **Engine**: 137 in-scope tests pass (`test_composite_downscale.py` + `test_nchannel_composite.py`); full suite 1348/1348 expected. New: `_compute_memory_budget(force_downscale=True)` returns `forced`; cache provenance round trip via `cache.put → cache.get → _verdict_for_cached`; `allow_force_downscale` field on request model; cache `original_shape` storage and back-compat with legacy callers.
- **.NET**: 1089/1089 pass. New: `ProcessingErrorMessages` prefixes `CompositeBudgetExceededException` with `MEMORY_BUDGET:`; other exception types fall through unchanged; `CompositeService` serializes `AllowForceDownscale` as snake_case `allow_force_downscale: true/false`.
- **Frontend**: 974/974 pass. New: `parseCompositeWarning` accepts `'forced'`; `parseMemoryBudgetError` strips prefix, detects via keyword conjunction, parses projected shape, rejects single-keyword false positives; `CompositeWarningBanner` renders forced-branch copy; `ProcessStep` button visibility + payload + back-compat without `onContinueAnyway`; service builders thread `allowForceDownscale` through generate/preview/export.
- **TypeScript**: clean.
- **Lint**: clean (only pre-existing useEffect-deps warnings unrelated to this PR).

## Test Plan

- [x] Engine OpenAPI exposes `allow_force_downscale` on `NChannelCompositeRequest`
- [x] .NET OpenAPI exposes `allowForceDownscale` on `NChannelCompositeRequestDto`
- [x] Engine 137-test in-scope suite passes (full 1348/1348 expected)
- [x] .NET 1089/1089 pass
- [x] Frontend 974/974 pass
- [x] TypeScript typecheck clean
- [x] Frontend smoke loads at `/` and `/composite` with 0 console errors
- [x] Pre-commit hook passes (lint, format, frontend tests, .NET tests, ruff)
- [ ] Manual end-to-end: NGC 346 NIRCam guided flow → 413 → "Continue anyway → 4353×3417" → smaller image + `forced` banner *(verified via test coverage; full E2E reproduction requires logging in and downloading 158 NIRCam files — out of scope for self-verification)*
- [ ] Manual end-to-end: same scenario via authenticated async flow (verifies `MEMORY_BUDGET:` prefix path) *(same)*
- [ ] Manual end-to-end: cache-hit on second default-flow request shows `forced` banner without recomputing *(same)*

## Documentation Checklist

- [x] No documentation updates needed *(plan file `docs/plans/features/1450-continue-anyway-composite-override.md` added; no public API endpoints added or renamed; existing `docs/standards/backend-development.md` `MEMORY_BUDGET:` convention is implicitly documented in the new code's comments which reference the existing `NO_PRODUCTS:` / `S3_UNAVAILABLE:` precedent)*
- [ ] `docs/key-files.md` (new files/services)
- [ ] `docs/standards/backend-development.md` (new endpoints/controllers)
- [ ] `docs/quick-reference.md` (new API endpoints)
- [ ] `docs/architecture/` (new services/architectural changes)
- [ ] `docs/development-plan.md` (milestone/phase changes)

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

Follow-up filed during planning: #1451 (recipe walkthrough preflight "Try anyway") — not tech debt; a deferred enhancement that depends on this PR.

## Risk & Rollback

- **Risk**: Medium. Changes are reversible (rip-out-in-an-hour gate: yes — flag-gated, isolated retry path). Touches three layers but each change is small and confined. Three rounds of code-reviewer self-review iterated to clean (0 MUST FIX, 0 SHOULD FIX) before push.

  Highest-risk areas exercised by tests:
  - Cache schema change (3-tuple → 4-tuple) with back-compat for legacy callers via `original_shape: None`.
  - Async path `MEMORY_BUDGET:` prefix is a new contract on `JobStatus.error` strings — frontend detects via prefix OR keyword pattern, so neither layer can drift silently.
  - Sticky `allowForceDownscale` state interacts with `lastExportResultRef`, `regenerateComposite`'s shared error state, and the recipe-change reset — all addressed in round-2 review.

- **Rollback**: `git revert <merge-sha>`. The cache-tuple shape and `MemoryBudgetVerdict` Literal change to a wider type, so the revert reverts cleanly without external state to migrate. No DB schema changes. No env var changes.
