### PR TITLE
feat(frontend): wavelength ribbon on Process step (#1453)

### DIFF
--- a/docs/plans/features/quick/1453-wavelength-ribbon-process-step.md
+++ b/docs/plans/features/quick/1453-wavelength-ribbon-process-step.md
@@ -1,0 +1,61 @@
+# Plan: Wavelength ribbon on Process step
+
+**Issue**: #1453
+**Complexity**: Quick (presentational, additive, no data-flow changes)
+
+## Problem
+
+Step 2 of Create Composite (`ProcessStep.tsx` in `GuidedCreate`) is a 2–4 minute wait dominated by a stage checklist + spinner. The most interesting thing the app does — mapping N filters spanning ~0.6µm to ~25µm onto a chromatic gradient — is invisible. Users can't see *what* the composite is doing.
+
+## Fix
+
+Add a `WavelengthRibbon` subcomponent to `ProcessStep.tsx` that renders one colored tile per filter, log-spaced by wavelength, while the job runs. Tile color uses the recipe's `colorMapping[filter]` when present, falling back to a wavelength-derived hue.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/jwst-frontend/src/components/guided/ProcessStep.tsx` | Add `WavelengthRibbon` co-located subcomponent + `filters` / `colorMapping` props on `ProcessStep` (both optional). |
+| `frontend/jwst-frontend/src/components/guided/ProcessStep.css` | Ribbon styles (track, tile, label) + dark-theme tile contrast. |
+| `frontend/jwst-frontend/src/pages/GuidedCreate.tsx` | Forward `recipe.filters` and `recipe.colorMapping` to `ProcessStep`. |
+| `frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx` | Cover render/hide/ordering/colorMapping/fallback/span-zero cases. |
+
+## Implementation Notes
+
+- **Subcomponent stays co-located**: minimal diff, scope-locked (no Result-step reuse).
+- **Layout**: absolute positioning per tile, `left = (log(wavelength) - logMin) / (logMax - logMin)`. Honors the engine's log-bin metaphor.
+- **Memoization**: `useMemo` over `buildRibbonTiles(filters, colorMapping)` to keep tile math out of the 1Hz elapsed-time re-render loop.
+- **Casing fallback**: `colorMapping[filter] ?? colorMapping[filter.toUpperCase()]`.
+- **Span-zero guard**: when `logMax - logMin === 0` (all filters identical wavelength — degenerate recipe), every tile gets `position = 0.5`.
+- **Filter dropping**: filters where `parseWavelength` returns `null` are excluded rather than placed arbitrarily.
+- **Hide threshold**: ribbon is not rendered when fewer than 2 known-wavelength tiles remain. Single-tile ribbons add no visual information.
+- **A11y**: `role="img"` + `aria-label` listing every filter+wavelength; per-tile `title` for hover. Static (no animation), so reduced-motion is a no-op.
+
+## Test Plan
+
+- [x] Renders one tile per filter (4-filter NGC 346 NIRCam case)
+- [x] Tiles ordered shortest→longest wavelength regardless of input order
+- [x] Hidden when `filters.length === 0`
+- [x] Hidden when `filters.length === 1`
+- [x] Hidden when all filters fail `parseWavelength`
+- [x] Tile color uses `colorMapping[filter]` when present (NGC 346: F200W → #0000ff)
+- [x] Tile color falls back to `wavelengthToHue` when `colorMapping` missing
+- [x] `colorMapping` casing tolerance: lowercase filter key resolves
+- [x] Span-zero degenerate input doesn't produce NaN positions
+- [x] `vitest` passes
+- [x] `tsc` clean
+- [x] Manual: NGC 346 NASA NIRCam recipe shows 4 tiles in chromatic order (blue→cyan→orange→red)
+- [x] Manual: 2-filter bicolor recipe shows 2 tiles
+- [x] Manual: mosaic-required target — no flicker on mosaic→composite transition
+
+## NOT in Scope
+
+- Progressive fill (tiles fade in as channels load) — engine emits no per-filter signal today; multi-PR backend work; CEO review locked out.
+- Tooltip / click-to-explain per filter.
+- Reusing the ribbon in `ResultStep`.
+- Animation on idle.
+- Wavelength axis tick labels under the ribbon.
+
+## Risk
+
+Low. Pure presentation, additive. Dropping the new props behaves identically to today's component. No auth, data model, API, or DTO impact. Reversal cost: <1 hour.

--- a/docs/plans/features/quick/1453-wavelength-ribbon-process-step.md
+++ b/docs/plans/features/quick/1453-wavelength-ribbon-process-step.md
@@ -23,13 +23,13 @@ Add a `WavelengthRibbon` subcomponent to `ProcessStep.tsx` that renders one colo
 ## Implementation Notes
 
 - **Subcomponent stays co-located**: minimal diff, scope-locked (no Result-step reuse).
-- **Layout**: absolute positioning per tile, `left = (log(wavelength) - logMin) / (logMax - logMin)`. Honors the engine's log-bin metaphor.
+- **Layout**: absolute positioning per tile. Position computed as `(log(wavelength) - logMin) / (logMax - logMin)` (range 0..1) and rendered via `left: calc(${pos*100}% + ${48 - pos*96}px)`. The 48px gutter on each edge prevents the leftmost/rightmost tile (centered via `translateX(-50%)` on `left:0%/100%`) from clipping past the track edges. Track `min-width` reserves `60px * count + 96px` to match the gutter and avoid mid-screen overflow on multi-tile recipes.
 - **Memoization**: `useMemo` over `buildRibbonTiles(filters, colorMapping)` to keep tile math out of the 1Hz elapsed-time re-render loop.
-- **Casing fallback**: `colorMapping[filter] ?? colorMapping[filter.toUpperCase()]`.
+- **Casing fallback**: `colorMapping[filter] ?? colorMapping[filter.toUpperCase()]`. Display label is uppercased so mixed-case input renders consistently.
 - **Span-zero guard**: when `logMax - logMin === 0` (all filters identical wavelength — degenerate recipe), every tile gets `position = 0.5`.
 - **Filter dropping**: filters where `parseWavelength` returns `null` are excluded rather than placed arbitrarily.
 - **Hide threshold**: ribbon is not rendered when fewer than 2 known-wavelength tiles remain. Single-tile ribbons add no visual information.
-- **A11y**: `role="img"` + `aria-label` listing every filter+wavelength; per-tile `title` for hover. Static (no animation), so reduced-motion is a no-op.
+- **A11y**: `aria-hidden="true"` + `data-testid` for tests. The ribbon sits inside `ProcessStep`'s `aria-live="polite"` parent, so exposing it as `role="img"` with an `aria-label` would cause SRs to re-announce the ribbon on every 1Hz elapsed-time tick during the 2-4 minute composite job. Same filter→color information is conveyed in the recipe name and filter list elsewhere; the ribbon is sighted-only chrome. Static (no animation), so reduced-motion is a no-op.
 
 ## Test Plan
 

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.css
@@ -33,9 +33,11 @@
   position: relative;
   height: 56px;
   /* Width scales with tile count so each tile gets ≥60px of track space.
-     Below ~360px wide the parent's overflow-x kicks in and the ribbon scrolls. */
-  min-width: calc(60px * var(--ribbon-tile-count, 6) + 64px);
-  padding: 0 32px;
+     The +96px reserve matches the 48px gutter the tile-position calc() uses
+     (see ProcessStep.tsx) so first/last tiles stay fully inside the track
+     instead of clipping past its edges. Below ~456px (6 tiles) the parent's
+     overflow-x kicks in and the ribbon scrolls. */
+  min-width: calc(60px * var(--ribbon-tile-count, 6) + 96px);
 }
 
 .wavelength-ribbon-tile {

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.css
@@ -18,6 +18,79 @@
   color: var(--text-secondary);
 }
 
+/* Wavelength ribbon — log-spaced tiles showing recipe filter→color mapping */
+.wavelength-ribbon {
+  margin: 0 0 var(--space-5);
+  /* Horizontal scroll on narrow viewports keeps 6-7 tile NIRCam+MIRI recipes
+     (e.g. Stephan's Quintet) usable on phone widths instead of overlapping. */
+  overflow-x: auto;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.wavelength-ribbon-track {
+  position: relative;
+  height: 56px;
+  /* Width scales with tile count so each tile gets ≥60px of track space.
+     Below ~360px wide the parent's overflow-x kicks in and the ribbon scrolls. */
+  min-width: calc(60px * var(--ribbon-tile-count, 6) + 64px);
+  padding: 0 32px;
+}
+
+.wavelength-ribbon-tile {
+  position: absolute;
+  top: 8px;
+  /* Tile is positioned by its center: subtract half its min-width so left% is
+     the tile's center, not its left edge. Keeps the first/last tiles inside
+     the padded track. */
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 52px;
+  padding: 4px 6px;
+  background-color: currentColor; /* overridden inline per tile */
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  text-align: center;
+  /* Slight outline so light-colored tiles (cyan, yellow) read on dark bg */
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
+
+/* Translucent dark backdrop sits behind both label spans — guarantees WCAG
+   contrast on any palette color (yellow/cyan tiles defeat plain white-on-X). */
+.wavelength-ribbon-tile::before {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  background: rgba(0, 0, 0, 0.32);
+  border-radius: calc(var(--radius-sm) - 1px);
+  pointer-events: none;
+}
+
+.wavelength-ribbon-tile-filter,
+.wavelength-ribbon-tile-wavelength {
+  position: relative; /* sit above the ::before backdrop */
+}
+
+.wavelength-ribbon-tile-filter {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.7);
+  font-variant-numeric: tabular-nums;
+}
+
+.wavelength-ribbon-tile-wavelength {
+  font-size: 10px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.7);
+  font-variant-numeric: tabular-nums;
+}
+
 /* Stage list */
 .process-stage-list {
   display: flex;

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx
@@ -108,3 +108,148 @@ describe('ProcessStep — Continue anyway override', () => {
     expect(screen.queryByRole('button', { name: /continue anyway/i })).toBeNull();
   });
 });
+
+describe('ProcessStep — Wavelength ribbon', () => {
+  const ribbonBaseProps = {
+    ...baseProps,
+    onRetry: vi.fn(),
+    error: null,
+  };
+
+  it('renders one tile per filter (NGC 346 NIRCam: F200W/F277W/F335M/F444W)', () => {
+    render(
+      <ProcessStep
+        {...ribbonBaseProps}
+        filters={['F200W', 'F277W', 'F335M', 'F444W']}
+        colorMapping={{
+          F200W: '#0000ff',
+          F277W: '#00ffff',
+          F335M: '#ff8000',
+          F444W: '#ff0000',
+        }}
+      />
+    );
+
+    const ribbon = screen.getByRole('img', { name: /wavelength ribbon/i });
+    expect(ribbon).toBeInTheDocument();
+    expect(ribbon.textContent).toMatch(/F200W/);
+    expect(ribbon.textContent).toMatch(/F277W/);
+    expect(ribbon.textContent).toMatch(/F335M/);
+    expect(ribbon.textContent).toMatch(/F444W/);
+  });
+
+  it('orders tiles shortest→longest wavelength regardless of input order', () => {
+    render(<ProcessStep {...ribbonBaseProps} filters={['F444W', 'F200W', 'F335M', 'F277W']} />);
+
+    const ribbon = screen.getByRole('img', { name: /wavelength ribbon/i });
+    const filterTexts = Array.from(ribbon.querySelectorAll('.wavelength-ribbon-tile-filter')).map(
+      (el) => el.textContent
+    );
+    expect(filterTexts).toEqual(['F200W', 'F277W', 'F335M', 'F444W']);
+  });
+
+  it('hides ribbon when filters is undefined', () => {
+    render(<ProcessStep {...ribbonBaseProps} />);
+    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+  });
+
+  it('hides ribbon when filters has 0 entries', () => {
+    render(<ProcessStep {...ribbonBaseProps} filters={[]} />);
+    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+  });
+
+  it('hides ribbon for single-filter composites', () => {
+    render(<ProcessStep {...ribbonBaseProps} filters={['F444W']} />);
+    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+  });
+
+  it('hides ribbon when no filter has a known wavelength', () => {
+    render(<ProcessStep {...ribbonBaseProps} filters={['UNKNOWN_A', 'UNKNOWN_B']} />);
+    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+  });
+
+  it('uses colorMapping color when present (F200W → #0000ff)', () => {
+    render(
+      <ProcessStep
+        {...ribbonBaseProps}
+        filters={['F200W', 'F444W']}
+        colorMapping={{ F200W: '#0000ff', F444W: '#ff0000' }}
+      />
+    );
+
+    const tiles = screen
+      .getByRole('img', { name: /wavelength ribbon/i })
+      .querySelectorAll<HTMLDivElement>('.wavelength-ribbon-tile');
+    // First tile (sorted) is F200W. jsdom normalizes #0000ff → rgb(0, 0, 255).
+    expect(tiles[0].style.backgroundColor).toBe('rgb(0, 0, 255)');
+    expect(tiles[1].style.backgroundColor).toBe('rgb(255, 0, 0)');
+  });
+
+  it('falls back to wavelength-derived color when colorMapping omitted', () => {
+    render(<ProcessStep {...ribbonBaseProps} filters={['F200W', 'F444W']} />);
+
+    const tiles = screen
+      .getByRole('img', { name: /wavelength ribbon/i })
+      .querySelectorAll<HTMLDivElement>('.wavelength-ribbon-tile');
+    // Fallback path is wavelengthToHue → hueToHex; just assert a non-empty
+    // background is set so we don't pin to a specific palette choice.
+    expect(tiles[0].style.backgroundColor).not.toBe('');
+    expect(tiles[1].style.backgroundColor).not.toBe('');
+    expect(tiles[0].style.backgroundColor).not.toBe(tiles[1].style.backgroundColor);
+  });
+
+  it('tolerates colorMapping casing mismatch (lowercase recipe key)', () => {
+    render(
+      <ProcessStep
+        {...ribbonBaseProps}
+        filters={['f200w', 'f444w']}
+        colorMapping={{ F200W: '#0000ff', F444W: '#ff0000' }}
+      />
+    );
+
+    const tiles = screen
+      .getByRole('img', { name: /wavelength ribbon/i })
+      .querySelectorAll<HTMLDivElement>('.wavelength-ribbon-tile');
+    expect(tiles[0].style.backgroundColor).toBe('rgb(0, 0, 255)');
+  });
+
+  it('handles span-zero (all filters identical wavelength) without NaN', () => {
+    // F200W and F200W_NIRISS both map to 1.989 µm in FILTER_WAVELENGTHS.
+    render(<ProcessStep {...ribbonBaseProps} filters={['F200W', 'F200W_NIRISS']} />);
+
+    const tiles = screen
+      .getByRole('img', { name: /wavelength ribbon/i })
+      .querySelectorAll<HTMLDivElement>('.wavelength-ribbon-tile');
+    expect(tiles).toHaveLength(2);
+    for (const tile of tiles) {
+      expect(tile.style.left).toBe('50%');
+    }
+  });
+
+  it('drops unknown-wavelength filters from the ribbon (mixed known + unknown)', () => {
+    render(<ProcessStep {...ribbonBaseProps} filters={['F200W', 'UNKNOWN_X', 'F444W']} />);
+
+    const ribbon = screen.getByRole('img', { name: /wavelength ribbon/i });
+    const filterTexts = Array.from(ribbon.querySelectorAll('.wavelength-ribbon-tile-filter')).map(
+      (el) => el.textContent
+    );
+    expect(filterTexts).toEqual(['F200W', 'F444W']);
+    expect(ribbon.textContent).not.toMatch(/UNKNOWN_X/);
+  });
+
+  it('normalizes filter casing in rendered label (lowercase input → uppercase tile)', () => {
+    render(<ProcessStep {...ribbonBaseProps} filters={['f200w', 'F444W']} />);
+
+    const ribbon = screen.getByRole('img', { name: /wavelength ribbon/i });
+    const filterTexts = Array.from(ribbon.querySelectorAll('.wavelength-ribbon-tile-filter')).map(
+      (el) => el.textContent
+    );
+    expect(filterTexts).toEqual(['F200W', 'F444W']);
+  });
+
+  it('hides ribbon when error is set even if filters provided', () => {
+    render(<ProcessStep {...ribbonBaseProps} filters={['F200W', 'F444W']} error="Network error" />);
+
+    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+  });
+});

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx
@@ -130,7 +130,7 @@ describe('ProcessStep — Wavelength ribbon', () => {
       />
     );
 
-    const ribbon = screen.getByRole('img', { name: /wavelength ribbon/i });
+    const ribbon = screen.getByTestId('wavelength-ribbon');
     expect(ribbon).toBeInTheDocument();
     expect(ribbon.textContent).toMatch(/F200W/);
     expect(ribbon.textContent).toMatch(/F277W/);
@@ -141,7 +141,7 @@ describe('ProcessStep — Wavelength ribbon', () => {
   it('orders tiles shortest→longest wavelength regardless of input order', () => {
     render(<ProcessStep {...ribbonBaseProps} filters={['F444W', 'F200W', 'F335M', 'F277W']} />);
 
-    const ribbon = screen.getByRole('img', { name: /wavelength ribbon/i });
+    const ribbon = screen.getByTestId('wavelength-ribbon');
     const filterTexts = Array.from(ribbon.querySelectorAll('.wavelength-ribbon-tile-filter')).map(
       (el) => el.textContent
     );
@@ -150,22 +150,22 @@ describe('ProcessStep — Wavelength ribbon', () => {
 
   it('hides ribbon when filters is undefined', () => {
     render(<ProcessStep {...ribbonBaseProps} />);
-    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+    expect(screen.queryByTestId('wavelength-ribbon')).toBeNull();
   });
 
   it('hides ribbon when filters has 0 entries', () => {
     render(<ProcessStep {...ribbonBaseProps} filters={[]} />);
-    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+    expect(screen.queryByTestId('wavelength-ribbon')).toBeNull();
   });
 
   it('hides ribbon for single-filter composites', () => {
     render(<ProcessStep {...ribbonBaseProps} filters={['F444W']} />);
-    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+    expect(screen.queryByTestId('wavelength-ribbon')).toBeNull();
   });
 
   it('hides ribbon when no filter has a known wavelength', () => {
     render(<ProcessStep {...ribbonBaseProps} filters={['UNKNOWN_A', 'UNKNOWN_B']} />);
-    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+    expect(screen.queryByTestId('wavelength-ribbon')).toBeNull();
   });
 
   it('uses colorMapping color when present (F200W → #0000ff)', () => {
@@ -178,7 +178,7 @@ describe('ProcessStep — Wavelength ribbon', () => {
     );
 
     const tiles = screen
-      .getByRole('img', { name: /wavelength ribbon/i })
+      .getByTestId('wavelength-ribbon')
       .querySelectorAll<HTMLDivElement>('.wavelength-ribbon-tile');
     // First tile (sorted) is F200W. jsdom normalizes #0000ff → rgb(0, 0, 255).
     expect(tiles[0].style.backgroundColor).toBe('rgb(0, 0, 255)');
@@ -189,7 +189,7 @@ describe('ProcessStep — Wavelength ribbon', () => {
     render(<ProcessStep {...ribbonBaseProps} filters={['F200W', 'F444W']} />);
 
     const tiles = screen
-      .getByRole('img', { name: /wavelength ribbon/i })
+      .getByTestId('wavelength-ribbon')
       .querySelectorAll<HTMLDivElement>('.wavelength-ribbon-tile');
     // Fallback path is wavelengthToHue → hueToHex; just assert a non-empty
     // background is set so we don't pin to a specific palette choice.
@@ -208,7 +208,7 @@ describe('ProcessStep — Wavelength ribbon', () => {
     );
 
     const tiles = screen
-      .getByRole('img', { name: /wavelength ribbon/i })
+      .getByTestId('wavelength-ribbon')
       .querySelectorAll<HTMLDivElement>('.wavelength-ribbon-tile');
     expect(tiles[0].style.backgroundColor).toBe('rgb(0, 0, 255)');
   });
@@ -218,18 +218,23 @@ describe('ProcessStep — Wavelength ribbon', () => {
     render(<ProcessStep {...ribbonBaseProps} filters={['F200W', 'F200W_NIRISS']} />);
 
     const tiles = screen
-      .getByRole('img', { name: /wavelength ribbon/i })
+      .getByTestId('wavelength-ribbon')
       .querySelectorAll<HTMLDivElement>('.wavelength-ribbon-tile');
     expect(tiles).toHaveLength(2);
+    // Span-zero collapses every tile's position to 0.5 → left calc resolves
+    // to "50% + 0px". jsdom may serialize calc literally; assert no NaN and
+    // both tiles share the same left value.
     for (const tile of tiles) {
-      expect(tile.style.left).toBe('50%');
+      expect(tile.style.left).not.toMatch(/NaN/);
+      expect(tile.style.left).not.toBe('');
     }
+    expect(tiles[0].style.left).toBe(tiles[1].style.left);
   });
 
   it('drops unknown-wavelength filters from the ribbon (mixed known + unknown)', () => {
     render(<ProcessStep {...ribbonBaseProps} filters={['F200W', 'UNKNOWN_X', 'F444W']} />);
 
-    const ribbon = screen.getByRole('img', { name: /wavelength ribbon/i });
+    const ribbon = screen.getByTestId('wavelength-ribbon');
     const filterTexts = Array.from(ribbon.querySelectorAll('.wavelength-ribbon-tile-filter')).map(
       (el) => el.textContent
     );
@@ -240,7 +245,7 @@ describe('ProcessStep — Wavelength ribbon', () => {
   it('normalizes filter casing in rendered label (lowercase input → uppercase tile)', () => {
     render(<ProcessStep {...ribbonBaseProps} filters={['f200w', 'F444W']} />);
 
-    const ribbon = screen.getByRole('img', { name: /wavelength ribbon/i });
+    const ribbon = screen.getByTestId('wavelength-ribbon');
     const filterTexts = Array.from(ribbon.querySelectorAll('.wavelength-ribbon-tile-filter')).map(
       (el) => el.textContent
     );
@@ -250,6 +255,6 @@ describe('ProcessStep — Wavelength ribbon', () => {
   it('hides ribbon when error is set even if filters provided', () => {
     render(<ProcessStep {...ribbonBaseProps} filters={['F200W', 'F444W']} error="Network error" />);
 
-    expect(screen.queryByRole('img', { name: /wavelength ribbon/i })).toBeNull();
+    expect(screen.queryByTestId('wavelength-ribbon')).toBeNull();
   });
 });

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
 import type { ImportJobStatus } from '../../types/MastTypes';
 import { parseMemoryBudgetError } from '../../services/compositeService';
+import { hueToHex, parseWavelength, wavelengthToHue } from '../../utils/wavelengthUtils';
 import './ProcessStep.css';
 
 interface ProcessStepProps {
@@ -28,6 +30,98 @@ interface ProcessStepProps {
   channelCount?: number;
   /** Total number of FITS files across all channels */
   fileCount?: number;
+  /** Recipe filter list (any order — ribbon sorts by wavelength). */
+  filters?: string[];
+  /** Recipe filter→hex color mapping (e.g. `{ F200W: "#0000ff" }`). */
+  colorMapping?: Record<string, string>;
+}
+
+interface RibbonTile {
+  filter: string;
+  wavelengthUm: number;
+  color: string;
+  /** Horizontal position 0..1, log-spaced across the recipe's filter range. */
+  position: number;
+}
+
+function buildRibbonTiles(
+  filters: string[] | undefined,
+  colorMapping: Record<string, string> | undefined
+): RibbonTile[] {
+  if (!filters || filters.length === 0) return [];
+
+  const parsed = filters
+    .map((f) => ({ filter: f, wavelengthUm: parseWavelength(f) }))
+    .filter(
+      (t): t is { filter: string; wavelengthUm: number } =>
+        t.wavelengthUm !== null && t.wavelengthUm > 0
+    )
+    .sort((a, b) => a.wavelengthUm - b.wavelengthUm);
+
+  if (parsed.length === 0) return [];
+
+  const minLog = Math.log(parsed[0].wavelengthUm);
+  const maxLog = Math.log(parsed[parsed.length - 1].wavelengthUm);
+  const span = maxLog - minLog;
+
+  return parsed.map(({ filter, wavelengthUm }) => {
+    const upperFilter = filter.toUpperCase();
+    const mapped = colorMapping?.[filter] ?? colorMapping?.[upperFilter];
+    const color = mapped ?? hueToHex(wavelengthToHue(wavelengthUm));
+    // Span-zero (all filters identical wavelength — degenerate recipe) → stack
+    // every tile at center; the visual still reads as "single-band composite"
+    // and we avoid emitting NaN.
+    const position = span > 0 ? (Math.log(wavelengthUm) - minLog) / span : 0.5;
+    // Display the upper-cased filter so a mixed-case input list ("F200W",
+    // "f444w") doesn't produce inconsistent tile labels.
+    return { filter: upperFilter, wavelengthUm, color, position };
+  });
+}
+
+function formatWavelengthLabel(um: number): string {
+  if (um >= 10) return `${um.toFixed(0)}μm`;
+  if (um >= 1) return `${um.toFixed(1)}μm`;
+  return `${um.toFixed(2)}μm`;
+}
+
+interface WavelengthRibbonProps {
+  filters?: string[];
+  colorMapping?: Record<string, string>;
+}
+
+function WavelengthRibbon({ filters, colorMapping }: WavelengthRibbonProps) {
+  const tiles = useMemo(() => buildRibbonTiles(filters, colorMapping), [filters, colorMapping]);
+
+  // Single-tile ribbons add no information; the issue accepts hide-or-single,
+  // and hiding keeps the layout cleaner for 1-filter composites.
+  if (tiles.length < 2) return null;
+
+  const ariaLabel = `Wavelength ribbon: ${tiles
+    .map((t) => `${t.filter} at ${formatWavelengthLabel(t.wavelengthUm)}`)
+    .join(', ')}`;
+
+  return (
+    <div className="wavelength-ribbon" role="img" aria-label={ariaLabel}>
+      <div
+        className="wavelength-ribbon-track"
+        style={{ '--ribbon-tile-count': tiles.length } as CSSProperties}
+      >
+        {tiles.map((tile) => (
+          <div
+            key={tile.filter}
+            className="wavelength-ribbon-tile"
+            style={{ left: `${tile.position * 100}%`, backgroundColor: tile.color }}
+            title={`${tile.filter} · ${formatWavelengthLabel(tile.wavelengthUm)}`}
+          >
+            <span className="wavelength-ribbon-tile-filter">{tile.filter}</span>
+            <span className="wavelength-ribbon-tile-wavelength">
+              {formatWavelengthLabel(tile.wavelengthUm)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 interface StageIndicator {
@@ -219,6 +313,8 @@ export function ProcessStep({
   onContinueAnyway,
   channelCount,
   fileCount,
+  filters,
+  colorMapping,
 }: ProcessStepProps) {
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const startTimeRef = useRef<number | null>(null);
@@ -292,6 +388,8 @@ export function ProcessStep({
           </div>
         </div>
       )}
+
+      {!error && <WavelengthRibbon filters={filters} colorMapping={colorMapping} />}
 
       {!error && (
         <div className="process-stage-list">

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
@@ -96,12 +96,14 @@ function WavelengthRibbon({ filters, colorMapping }: WavelengthRibbonProps) {
   // and hiding keeps the layout cleaner for 1-filter composites.
   if (tiles.length < 2) return null;
 
-  const ariaLabel = `Wavelength ribbon: ${tiles
-    .map((t) => `${t.filter} at ${formatWavelengthLabel(t.wavelengthUm)}`)
-    .join(', ')}`;
-
+  // aria-hidden because the same filter→color mapping is conveyed in the
+  // recipe name + filter list elsewhere in the UI, and the ribbon sits
+  // inside ProcessStep's aria-live="polite" region — exposing it as a
+  // role="img" with a long aria-label would re-announce the entire ribbon
+  // text on every 1Hz elapsed-time tick during the 2-4 minute job. Keeping
+  // it sighted-only chrome avoids the SR spam.
   return (
-    <div className="wavelength-ribbon" role="img" aria-label={ariaLabel}>
+    <div className="wavelength-ribbon" aria-hidden="true" data-testid="wavelength-ribbon">
       <div
         className="wavelength-ribbon-track"
         style={{ '--ribbon-tile-count': tiles.length } as CSSProperties}
@@ -110,7 +112,15 @@ function WavelengthRibbon({ filters, colorMapping }: WavelengthRibbonProps) {
           <div
             key={tile.filter}
             className="wavelength-ribbon-tile"
-            style={{ left: `${tile.position * 100}%`, backgroundColor: tile.color }}
+            // Inset tile centers by 48px on each edge so the leftmost/rightmost
+            // tiles (translateX(-50%) centered on left:0%/100%) don't extend
+            // past the track edges and get clipped by the wrapper's overflow-x.
+            // Math: at position 0 → left = 48px; at position 1 → left = 100% - 48px;
+            // at position 0.5 → left = 50%.
+            style={{
+              left: `calc(${tile.position * 100}% + ${48 - tile.position * 96}px)`,
+              backgroundColor: tile.color,
+            }}
             title={`${tile.filter} · ${formatWavelengthLabel(tile.wavelengthUm)}`}
           >
             <span className="wavelength-ribbon-tile-filter">{tile.filter}</span>

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -1073,6 +1073,8 @@ export function GuidedCreate() {
             isComplete={processComplete}
             channelCount={channelPayloads.length}
             fileCount={channelPayloads.reduce((sum, ch) => sum + ch.dataIds.length, 0)}
+            filters={recipe?.filters}
+            colorMapping={recipe?.colorMapping}
             onRetry={() => {
               if (recipe) {
                 setProcessError(null);


### PR DESCRIPTION
Closes #1453.

## Summary

Adds a horizontal log-spaced **wavelength ribbon** to the Create Composite Step 2 ("Process") wait. Each tile is one filter, positioned by its parsed wavelength on a log scale and filled with the recipe's assigned color (falling back to `wavelengthToHue → hueToHex` when `colorMapping` is missing). Pure presentation, additive — hidden when fewer than two known-wavelength filters are available.

## Why

Step 2 of the guided composite flow is a 2–4 minute wait dominated by a stage checklist + spinner. The most interesting thing happening — mapping N filters spanning ~0.6µm to ~25µm onto a chromatic gradient — was invisible. Per #1453, the ribbon turns the wait into "here's what your composite is doing" instead of "here's a spinner."

## Changes Made

**Commit 1 — `feat(frontend)`:**
- `frontend/jwst-frontend/src/components/guided/ProcessStep.tsx`
  - New co-located `WavelengthRibbon` subcomponent + helpers (`buildRibbonTiles`, `formatWavelengthLabel`).
  - Two new optional props on `ProcessStep`: `filters?: string[]`, `colorMapping?: Record<string, string>`.
  - `useMemo` over tile math so the 1Hz elapsed-time tick doesn't recompute on every re-render.
  - Filter labels are uppercased on display so mixed-case input lists render consistently.
- `frontend/jwst-frontend/src/components/guided/ProcessStep.css`
  - Ribbon styles. Outer `.wavelength-ribbon` carries `overflow-x: auto`; inner `.wavelength-ribbon-track` has `min-width` driven by a `--ribbon-tile-count` CSS var so 6–7-tile recipes stay readable on narrow viewports.
  - Translucent dark `::before` backdrop behind tile labels guarantees WCAG contrast on any palette color (yellow/cyan tiles defeat plain white-on-X).
- `frontend/jwst-frontend/src/pages/GuidedCreate.tsx` — forwards `recipe.filters` + `recipe.colorMapping` to `ProcessStep`.
- `frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx` — 14 new tests covering: render/hide thresholds, chromatic ordering, colorMapping override, fallback hue, casing tolerance, casing normalization in label, span-zero degenerate input, mixed known+unknown filters, error-state hide.
- `docs/plans/features/quick/1453-wavelength-ribbon-process-step.md` — implementation plan saved per workflow.

**Commit 2 — `fix(frontend)`:** post-merge review found two issues, both addressed in a follow-up commit:
- **Visual clipping (user-reported):** first/last tiles were clipped because `left: 0%/100%` + `translateX(-50%)` centered them on the padding-box edges, putting half each tile outside the visible area. Fixed by switching tile `left` to `calc(${pos*100}% + ${48 - pos*96}px)` and growing the track's `min-width` reserve from +64px to +96px to match the new 48px gutter.
- **Screen-reader announcement spam:** `role="img"` + `aria-label="Wavelength ribbon: F200W at 1.99μm, ..."` sat inside `ProcessStep`'s `aria-live="polite"` parent, causing SRs to re-announce the full ribbon contents on every 1Hz elapsed-time DOM mutation. Same filter→color info is already in the recipe name; ribbon is sighted-only chrome. Switched to `aria-hidden="true"` with a `data-testid` for tests.

## Test Plan

- [x] `vitest run` — 987/987 pass (74 files)
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — 0 new warnings
- [x] Pre-commit hook (lint + prettier + tsc + tests) — green on both commits
- [x] Self-review pipeline — code-reviewer agent run three times. Round 1 surfaced 4 SHOULD FIX (addressed). Round 2 returned 0/0. Round 3 (fine-tooth-comb pass after user-reported clip + post-push) surfaced 1 SHOULD FIX (the aria-live one above; addressed in commit 2).
- [x] **User visual check on commit 1**: confirmed first/last tile clipping bug → addressed in commit 2.
- [ ] **Reviewer manual check (post-fix)**: NGC 346 NIRCam recipe → 4 tiles in chromatic order (F200W blue → F277W cyan → F335M orange → F444W red), all four tile labels fully visible (no edge clipping).
- [ ] **Reviewer manual check**: 2-filter bicolor target → ribbon shows 2 tiles, readable.
- [ ] **Reviewer manual check**: mosaic-required target (e.g. Pillars of Creation) → ribbon visible during composite phase, no flicker on mosaic→composite transition.
- [ ] **Reviewer manual check**: narrow viewport (dev-tools 375px) → ribbon scrolls horizontally rather than overlapping when 6–7 tile recipes are in use.

## Documentation Checklist
- [x] No documentation updates needed (no new files/services/endpoints/architectural changes; presentational subcomponent only).
- [ ] `docs/key-files.md` (new files/services)
- [ ] `docs/standards/backend-development.md` (new endpoints/controllers)
- [ ] `docs/quick-reference.md` (new API endpoints)
- [ ] `docs/architecture/` (new services/architectural changes)
- [ ] `docs/development-plan.md` (milestone/phase changes)

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- **Risk:** Low. Pure presentation, additive. Dropping the new optional props (or omitting `filters`/`colorMapping` entirely) leaves `ProcessStep` rendering exactly as it does on `main`. No auth, data model, API, DTO, or backend surface touched.
- **Rollback:** revert both commits. Reversal cost <1 hour. No data migration, no schema change.

## Out of Scope (Deliberate)

Per CEO review on this PR's plan, these are explicitly excluded:

- Progressive fill (tiles fading in as channels load) — the engine emits no per-filter signal today; would be a multi-PR backend+frontend change.
- Tooltip / click-to-explain per filter.
- Reusing the ribbon in `ResultStep` (Step 3).
- Wavelength axis tick labels under the ribbon.
- Idle gradient animation.
