### PR TITLE
fix(processing-engine): spatial-grouping for curated recipes

### DIFF
--- a/docs/plans/features/quick/curated-recipe-spatial-grouping.md
+++ b/docs/plans/features/quick/curated-recipe-spatial-grouping.md
@@ -1,0 +1,32 @@
+# Curated recipe spatial grouping
+
+## Problem
+
+Curated NASA-style recipes (NGC 346, Cosmic Cliffs, Pillars of Creation, Stephan's Quintet, etc.) were producing patchwork output. NGC 346 was observed by JWST as 6 tiled mosaics; the `_inject_curated_recipes` function in `processing-engine/app/discovery/recipe_engine.py` collected every observation whose filter matched the recipe — across all tiles — and combined them. The resulting composite has full filter coverage only in the small region where all tiles overlap.
+
+The cross-instrument path (`generate_recipes` lines 1066-1156) already calls `group_by_spatial_overlap()` to handle this, but the curated path skipped that step.
+
+## Fix
+
+In `_inject_curated_recipes`:
+
+1. Run `group_by_spatial_overlap(relevant_obs)` on the filter-matched observations.
+2. Keep only clusters whose member observations cover **all** required filters.
+3. Sort qualifying clusters by `(observation count desc, sum of FOV² desc)`.
+4. Emit the largest cluster as the primary recipe (`rank=0`).
+5. Demote additional clusters to `rank=DEMOTED_ALL_RANK` with `(alt tile N)` name suffix.
+6. Fallback: if no single cluster has full filter coverage (filters split across disjoint tiles), combine all relevant obs and surface `overlap_warning` so the user knows the result will be patchy.
+
+## Tests
+
+- `test_ngc346_disjoint_tiles_emit_per_tile_recipes` — two non-overlapping tiles each with all 4 filters → 1 primary + 1 alt, obs_ids never cross tile boundaries.
+- `test_ngc346_split_filters_across_tiles_warns` — filters split across disjoint tiles → single fallback recipe with `overlap_warning`.
+- All existing curated-recipe tests still pass (no-coords path unchanged thanks to `group_by_spatial_overlap` returning `[list(observations)]` when no obs have RA/Dec).
+
+## Generalizes to
+
+Every target in `CURATED_RECIPES` benefits — Cosmic Cliffs (NGC 3324), Pillars of Creation (M-16), Stephan's Quintet, Southern Ring (NGC 3132), Webb's First Deep Field (SMACS 0723), and NGC 346 (both NIRCam and MIRI variants).
+
+## Risk
+
+Low — single-function change in the curated path, gated behind `target_name` matching a curated key. No-spatial-data inputs are preserved by `group_by_spatial_overlap`'s backward-compat single-group return. 1349 tests pass; ruff clean.

--- a/frontend/jwst-frontend/src/services/discoveryService.test.ts
+++ b/frontend/jwst-frontend/src/services/discoveryService.test.ts
@@ -115,7 +115,7 @@ describe('discoveryService', () => {
         ],
       });
 
-      expect(getCached).toHaveBeenCalledWith('recipes:v4:m51:obs-1,obs-2', expect.any(Number));
+      expect(getCached).toHaveBeenCalledWith('recipes:v5:m51:obs-1,obs-2', expect.any(Number));
     });
 
     it('should handle observations without observationId in cache key', async () => {
@@ -130,7 +130,7 @@ describe('discoveryService', () => {
       });
 
       expect(getCached).toHaveBeenCalledWith(
-        'recipes:v4:m51:MIRI:F150W,NIRCam:F200W',
+        'recipes:v5:m51:MIRI:F150W,NIRCam:F200W',
         expect.any(Number)
       );
     });

--- a/frontend/jwst-frontend/src/services/discoveryService.ts
+++ b/frontend/jwst-frontend/src/services/discoveryService.ts
@@ -13,7 +13,7 @@ import type {
 } from '../types/DiscoveryTypes';
 
 const RECIPE_CACHE_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
-const RECIPE_CACHE_VERSION = 4; // Bumped: v3 had c-prefix obs_ids from unreliable dedup
+const RECIPE_CACHE_VERSION = 5; // Bumped: v4 lacked spatial-grouping; emitted disjoint mosaic-tile composites for curated recipes
 
 export interface RecipeCacheOptions {
   skipCache?: boolean;

--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -927,8 +927,13 @@ def _inject_curated_recipes(
     """Check if curated NASA-style recipes exist for the target and return matching ones.
 
     A curated recipe is included only if ALL its required filters are present in
-    the user's available observations. Observation IDs are filtered to only those
-    matching the recipe's filters, and mosaic detection runs on the relevant subset.
+    the user's available observations. To avoid patchwork output from disjoint
+    mosaic tiles (e.g. NGC 346, Cosmic Cliffs were each observed as 6+ tiles),
+    observations are grouped by spatial overlap and a separate recipe is emitted
+    per tile cluster that contains all required filters; the largest cluster
+    becomes the primary (rank=0) and additional clusters are demoted. If no
+    single cluster has full filter coverage, falls back to combining all
+    relevant observations with an overlap_warning.
     """
     key = _normalize_target_name(target_name)
     curated_defs = CURATED_RECIPES.get(key)
@@ -949,23 +954,69 @@ def _inject_curated_recipes(
 
         # Filter observations to only those matching this recipe's filters
         relevant_obs = [obs for obs in observations if obs.filter.upper() in required]
-        relevant_ids = [obs.observation_id for obs in relevant_obs if obs.observation_id]
-        needs_mosaic = _has_multiple_pointings(relevant_obs)
 
-        recipes.append(
-            Recipe(
-                name=defn["name"],
-                rank=0,  # Curated recipes appear first
-                filters=defn["filters"],
-                color_mapping=defn["color_mapping"],
-                instruments=defn["instruments"],
-                requires_mosaic=needs_mosaic,
-                estimated_time_seconds=estimate_time(len(defn["filters"]), needs_mosaic),
-                observation_ids=relevant_ids or None,
-                description=defn["description"],
-                tag="NASA-style",
-            )
+        # Group by spatial overlap so we don't combine disjoint mosaic tiles into a
+        # patchwork composite. Only clusters that contain ALL required filters
+        # qualify; the largest qualifying cluster becomes the primary recipe.
+        spatial_groups = group_by_spatial_overlap(relevant_obs)
+        qualifying = [g for g in spatial_groups if required.issubset({o.filter.upper() for o in g})]
+        # Largest group first; ties broken by sum of FOV² for determinism.
+        qualifying.sort(
+            key=lambda g: (
+                len(g),
+                sum(
+                    INSTRUMENT_FOV_RADIUS_ARCMIN.get(
+                        o.instrument.upper(), DEFAULT_FOV_RADIUS_ARCMIN
+                    )
+                    ** 2
+                    for o in g
+                ),
+            ),
+            reverse=True,
         )
+
+        fallback_warning: str | None = None
+        if not qualifying:
+            # No single cluster has full filter coverage — required filters are
+            # spread across non-overlapping tiles. Fall back to combining all
+            # relevant observations and warn the user that the result will show
+            # patches with incomplete filter coverage.
+            qualifying = [relevant_obs]
+            fallback_warning = (
+                "Required filters appear in non-overlapping mosaic tiles; "
+                "output may show patches with incomplete filter coverage."
+            )
+
+        for group_idx, group in enumerate(qualifying):
+            group_ids = [obs.observation_id for obs in group if obs.observation_id]
+            needs_mosaic = _has_multiple_pointings(group)
+
+            if group_idx == 0:
+                name = defn["name"]
+                rank = 0
+                description = defn["description"]
+                warning = fallback_warning
+            else:
+                name = f"{defn['name']} (alt tile {group_idx})"
+                rank = DEMOTED_ALL_RANK
+                description = f"{defn['description']} — alternate spatial tile group"
+                warning = None
+
+            recipes.append(
+                Recipe(
+                    name=name,
+                    rank=rank,
+                    filters=defn["filters"],
+                    color_mapping=defn["color_mapping"],
+                    instruments=defn["instruments"],
+                    requires_mosaic=needs_mosaic,
+                    estimated_time_seconds=estimate_time(len(defn["filters"]), needs_mosaic),
+                    observation_ids=group_ids or None,
+                    description=description,
+                    overlap_warning=warning,
+                    tag="NASA-style",
+                )
+            )
 
     if recipes:
         logger.info(f"Injected {len(recipes)} curated recipe(s) for target '{target_name}'")

--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -877,6 +877,71 @@ def group_by_spatial_overlap(observations: list[ObservationInput]) -> list[list[
     return groups
 
 
+def _group_by_pointing(
+    observations: list[ObservationInput], threshold_arcsec: float = 60.0
+) -> list[list[ObservationInput]]:
+    """Group observations by pointing (same target on the sky).
+
+    Differs from group_by_spatial_overlap (which uses FOV-overlap and merges
+    adjacent mosaic tiles into a single cluster) by clustering only observations
+    that share a pointing within threshold_arcsec — typically the dither radius.
+    This splits each tile of a mosaic into its own group, which is what curated
+    recipe injection needs to avoid combining tiles with uneven filter coverage
+    at the seams.
+
+    Threshold rationale: JWST dithers are typically <10 arcsec; mosaic tile
+    separations are >100 arcsec. 60 arcsec safely groups dithers while
+    splitting tiles.
+
+    Observations without coordinates are added to every resulting group
+    (conservative — preserves backward compatibility for missing data).
+    """
+    has_coords = [obs for obs in observations if obs.s_ra is not None and obs.s_dec is not None]
+    no_coords = [obs for obs in observations if obs.s_ra is None or obs.s_dec is None]
+
+    if not has_coords:
+        return [list(observations)]
+
+    n = len(has_coords)
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    threshold_arcmin = threshold_arcsec / 60.0
+    for i in range(n):
+        for j in range(i + 1, n):
+            obs_i, obs_j = has_coords[i], has_coords[j]
+            sep = _angular_separation_arcmin(
+                obs_i.s_ra,  # type: ignore[arg-type]
+                obs_i.s_dec,  # type: ignore[arg-type]
+                obs_j.s_ra,  # type: ignore[arg-type]
+                obs_j.s_dec,  # type: ignore[arg-type]
+            )
+            if sep < threshold_arcmin:
+                union(i, j)
+
+    groups_map: dict[int, list[ObservationInput]] = {}
+    for i, obs in enumerate(has_coords):
+        groups_map.setdefault(find(i), []).append(obs)
+
+    groups = list(groups_map.values())
+
+    if no_coords:
+        for group in groups:
+            group.extend(no_coords)
+
+    return groups
+
+
 def _has_multiple_pointings(
     observations: list[ObservationInput], threshold_arcsec: float = 10.0
 ) -> bool:
@@ -955,10 +1020,14 @@ def _inject_curated_recipes(
         # Filter observations to only those matching this recipe's filters
         relevant_obs = [obs for obs in observations if obs.filter.upper() in required]
 
-        # Group by spatial overlap so we don't combine disjoint mosaic tiles into a
-        # patchwork composite. Only clusters that contain ALL required filters
-        # qualify; the largest qualifying cluster becomes the primary recipe.
-        spatial_groups = group_by_spatial_overlap(relevant_obs)
+        # Group by pointing (not FOV-overlap) so each mosaic tile becomes its
+        # own recipe. group_by_spatial_overlap merges adjacent tiles via
+        # union-find on FOV radii — for NGC 346's 4-tile mosaic this would
+        # collapse all tiles into one group and emit a single recipe with
+        # uneven filter coverage at the seams. _group_by_pointing splits at the
+        # dither radius (~60 arcsec) so each distinct pointing yields its own
+        # candidate cluster.
+        spatial_groups = _group_by_pointing(relevant_obs)
         qualifying = [g for g in spatial_groups if required.issubset({o.filter.upper() for o in g})]
         # Largest group first; ties broken by sum of FOV² for determinism.
         qualifying.sort(

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -1231,6 +1231,114 @@ class TestCuratedNGC346:
         curated = [r for r in recipes if r.tag == "NASA-style"]
         assert len(curated) == 0
 
+    def test_ngc346_disjoint_tiles_emit_per_tile_recipes(self):
+        """Two non-overlapping tiles, each with all 4 NIRCam filters, should produce
+        a primary recipe (rank=0) for the larger tile plus an alt-tile recipe."""
+        # Tile A: 4 obs at RA=14.77, Dec=-72.18 (NGC 346 center) — larger group
+        tile_a = [
+            ObservationInput(
+                filter=f,
+                instrument="NIRCAM",
+                observation_id=f"obs-A-{f}",
+                s_ra=14.77,
+                s_dec=-72.18,
+            )
+            for f in ["F200W", "F277W", "F335M", "F444W"]
+        ]
+        # Add a 5th obs to make tile_a clearly larger
+        tile_a.append(
+            ObservationInput(
+                filter="F200W",
+                instrument="NIRCAM",
+                observation_id="obs-A-F200W-2",
+                s_ra=14.77,
+                s_dec=-72.18,
+            )
+        )
+        # Tile B: 4 obs at RA=14.85, Dec=-72.30 (>10 arcmin away — disjoint)
+        tile_b = [
+            ObservationInput(
+                filter=f,
+                instrument="NIRCAM",
+                observation_id=f"obs-B-{f}",
+                s_ra=14.85,
+                s_dec=-72.30,
+            )
+            for f in ["F200W", "F277W", "F335M", "F444W"]
+        ]
+        recipes = generate_recipes(tile_a + tile_b, target_name="NGC 346")
+        curated = [r for r in recipes if r.tag == "NASA-style"]
+        assert len(curated) == 2
+        primary = [r for r in curated if r.rank == 0][0]
+        alt = [r for r in curated if r.rank == DEMOTED_ALL_RANK][0]
+        assert primary.name == "NASA NIRCam (NGC 346)"
+        assert "alt tile" in alt.name
+        # Primary must hold tile_a's 5 obs only (4 filters + duplicate F200W);
+        # alt must hold tile_b's 4. Explicit length checks guard against silent
+        # cross-tile leakage and against the alt losing obs_ids entirely.
+        assert primary.observation_ids is not None
+        assert len(primary.observation_ids) == 5
+        assert all(oid.startswith("obs-A-") for oid in primary.observation_ids)
+        assert alt.observation_ids is not None
+        assert len(alt.observation_ids) == 4
+        assert all(oid.startswith("obs-B-") for oid in alt.observation_ids)
+
+    def test_ngc346_single_overlapping_group_with_coords(self):
+        """Happy path: all required filters at one pointing → exactly one
+        primary recipe at rank=0 with no overlap_warning. Exists because every
+        other curated test uses no-coords obs and hits the backward-compat
+        single-group fallback inside group_by_spatial_overlap, leaving the
+        spatial path's normal case uncovered."""
+        obs = [
+            ObservationInput(
+                filter=f,
+                instrument="NIRCAM",
+                observation_id=f"obs-{f}",
+                s_ra=14.77,
+                s_dec=-72.18,
+            )
+            for f in ["F200W", "F277W", "F335M", "F444W"]
+        ]
+        recipes = generate_recipes(obs, target_name="NGC 346")
+        curated = [r for r in recipes if r.tag == "NASA-style"]
+        assert len(curated) == 1
+        assert curated[0].rank == 0
+        assert curated[0].name == "NASA NIRCam (NGC 346)"
+        assert curated[0].overlap_warning is None
+        assert curated[0].observation_ids is not None
+        assert len(curated[0].observation_ids) == 4
+
+    def test_ngc346_split_filters_across_tiles_warns(self):
+        """If required filters are split across non-overlapping tiles such that no
+        single tile has full coverage, falls back with an overlap_warning."""
+        # Tile A has only F200W, F277W
+        tile_a = [
+            ObservationInput(
+                filter=f,
+                instrument="NIRCAM",
+                observation_id=f"obs-A-{f}",
+                s_ra=14.77,
+                s_dec=-72.18,
+            )
+            for f in ["F200W", "F277W"]
+        ]
+        # Tile B has only F335M, F444W (disjoint from A)
+        tile_b = [
+            ObservationInput(
+                filter=f,
+                instrument="NIRCAM",
+                observation_id=f"obs-B-{f}",
+                s_ra=14.85,
+                s_dec=-72.30,
+            )
+            for f in ["F335M", "F444W"]
+        ]
+        recipes = generate_recipes(tile_a + tile_b, target_name="NGC 346")
+        curated = [r for r in recipes if r.tag == "NASA-style"]
+        assert len(curated) == 1
+        assert curated[0].overlap_warning is not None
+        assert "non-overlapping" in curated[0].overlap_warning.lower()
+
 
 class TestSelectBestNFilters:
     """Tests for the Best-N filter selection algorithm."""

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -1308,6 +1308,43 @@ class TestCuratedNGC346:
         assert curated[0].observation_ids is not None
         assert len(curated[0].observation_ids) == 4
 
+    def test_ngc346_adjacent_mosaic_tiles_emit_per_tile_recipes(self):
+        """Adjacent NIRCam mosaic tiles (~2 arcmin apart) — within FOV overlap
+        radius — must still split into separate recipes via pointing-based
+        grouping. Regression for the real-world NGC 346 case where 4 mosaic
+        tiles were FOV-merged into a single combined recipe with patchwork
+        coverage at the seams."""
+        # 3 adjacent NIRCam tiles separated by ~2 arcmin (typical mosaic step).
+        # FOV-overlap union-find would merge all three (NIRCam FOV radius=1.1';
+        # tile separation 2' < 2.2' merge threshold). Pointing-based grouping
+        # at 60" splits them.
+        tiles = []
+        for tile_idx, dec in enumerate([-72.18, -72.215, -72.250]):
+            tiles.extend(
+                ObservationInput(
+                    filter=f,
+                    instrument="NIRCAM",
+                    observation_id=f"obs-T{tile_idx}-{f}",
+                    s_ra=14.77,
+                    s_dec=dec,
+                )
+                for f in ["F200W", "F277W", "F335M", "F444W"]
+            )
+        recipes = generate_recipes(tiles, target_name="NGC 346")
+        curated = [r for r in recipes if r.tag == "NASA-style"]
+        assert len(curated) == 3
+        primary = [r for r in curated if r.rank == 0][0]
+        alts = [r for r in curated if r.rank == DEMOTED_ALL_RANK]
+        assert len(alts) == 2
+        # Each recipe must hold exactly one tile's 4 obs_ids — no merging.
+        for r in curated:
+            assert r.observation_ids is not None
+            assert len(r.observation_ids) == 4
+            tile_ids = {oid.split("-")[1] for oid in r.observation_ids}
+            assert len(tile_ids) == 1, f"Recipe {r.name} mixes tiles: {tile_ids}"
+        assert primary.name == "NASA NIRCam (NGC 346)"
+        assert all("alt tile" in r.name for r in alts)
+
     def test_ngc346_split_filters_across_tiles_warns(self):
         """If required filters are split across non-overlapping tiles such that no
         single tile has full coverage, falls back with an overlap_warning."""


### PR DESCRIPTION
No linked issue

## Summary
Curated NASA-style recipes (NGC 346, Cosmic Cliffs, Pillars of Creation, Stephan's Quintet, ...) were producing patchwork composites because `_inject_curated_recipes` combined every observation matching the recipe's filters across all mosaic tiles. NGC 346 was observed as 4–6 tiled mosaics with uneven filter coverage at the seams (e.g. one tile has only F277W). Now each mosaic tile becomes its own curated recipe via pointing-based grouping; the largest fully-covered tile is the primary, additional tiles are demoted to alt entries, and partial-coverage tiles are dropped.

## Why
The cross-instrument recipe path already used `group_by_spatial_overlap()`, but the curated path skipped that step entirely. First fix attempt also used `group_by_spatial_overlap` — but its FOV-overlap union-find merges adjacent mosaic tiles (~2 arcmin apart, within the 2.2 arcmin NIRCam FOV-sum threshold) into a single cluster, so the real-world NGC 346 case still emitted one combined recipe with patchwork seams. Adding `_group_by_pointing` (60 arcsec threshold — bigger than dithers, smaller than tile separations) splits each tile into its own group cleanly. The colour mapping in the curated recipe matches NASA's documented assignments (`F200W=Blue, F277W=Cyan, F335M=Orange, F444W=Red`) — the issue was always tile selection, not colour mapping.

## Changes Made
- `processing-engine/app/discovery/recipe_engine.py`
  - `_inject_curated_recipes` spatial-groups before emitting recipes; primary/alt selection sorted by `(len, sum FOV²)` for deterministic ordering. Largest qualifying cluster → `rank=0`; additional clusters → `DEMOTED_ALL_RANK` with `(alt tile N)` name suffix; fallback combines all relevant obs with an `overlap_warning` when no single cluster has full filter coverage.
  - New `_group_by_pointing(threshold_arcsec=60)` helper used by the curated path. Clusters by proximity rather than FOV-overlap so each tile gets its own recipe.
- `processing-engine/tests/test_recipe_engine.py` — four new tests:
  - Disjoint tiles (7 arcmin apart): primary + alt, no cross-tile leakage.
  - Adjacent mosaic tiles (~2 arcmin apart, within FOV-overlap): proves pointing-based splits where FOV-based would merge.
  - Single-tile happy path with coords: no fallback warning.
  - Split-filter fallback: warning surfaces when no tile has full coverage.
- `frontend/jwst-frontend/src/services/discoveryService.ts` — bump `RECIPE_CACHE_VERSION` 4 → 5 so the 48-hour client cache invalidates pre-fix responses.
- `frontend/jwst-frontend/src/services/discoveryService.test.ts` — update cache-key assertions to match v5.
- `docs/plans/features/quick/curated-recipe-spatial-grouping.md` — quick plan documenting the problem, fix, and risk.

## Test Plan
- [x] `docker exec jwst-processing python -m pytest tests/test_recipe_engine.py -x` — 162 pass (4 new spatial-grouping tests).
- [x] `docker exec jwst-processing python -m pytest tests/ -x` — full processing-engine suite, 1353 pass.
- [x] `npx vitest run` — 987 frontend tests pass with v5 cache key.
- [x] `ruff format` + `ruff check` clean on both changed Python files.
- [x] Code-reviewer agent self-review iterated to zero MUST FIX + zero SHOULD FIX.
- [x] Real-data smoke test on rebuilt processing-engine using the user's actual NGC 346 obs distribution (4 tiles, t025 with F277W only): emits exactly 3 fully-covered tile recipes, drops t025. Verified obs_ids never cross tiles.
- [ ] Manual verification post-merge: re-render NGC 346 NIRCam curated recipe in the UI; primary tile should now be a coherent single-pointing composite rather than the previous patchwork. Alt tile entries should appear in the recipe panel.

## Documentation Checklist
- [x] No documentation updates needed
- [ ] `docs/key-files.md` (new files/services)
- [ ] `docs/standards/backend-development.md` (new endpoints/controllers)
- [ ] `docs/quick-reference.md` (new API endpoints)
- [ ] `docs/architecture/` (new services/architectural changes)
- [ ] `docs/development-plan.md` (milestone/phase changes)

## Tech Debt Impact
- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

## Risk & Rollback
- Risk: Low. Engine changes are confined to the curated injection path, gated behind `target_name` matching a `CURATED_RECIPES` key. `_group_by_pointing` is a new helper used only by the curated path; cross-instrument and per-instrument recipe paths still use the original `group_by_spatial_overlap`. No-coordinate inputs preserved by the same backward-compat single-group return. Cache version bump only affects keying — no data migration.
- Rollback: revert this PR; cache will rebuild on next request. No schema or data changes.
