### PR TITLE
feat(composite): wizard preview goes async for live progress

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/CompositeControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/CompositeControllerTests.cs
@@ -537,6 +537,131 @@ public class CompositeControllerTests
         // Assert
         var statusResult = Assert.IsType<ObjectResult>(result);
         statusResult.StatusCode.Should().Be(429);
+        sut.ControllerContext.HttpContext.Response.Headers["Retry-After"].ToString().Should().Be("5");
+    }
+
+    // ===== GenerateNChannelCompositeAsync Tests (#1470 — async preview path) =====
+
+    /// <summary>
+    /// Tests that the async preview endpoint returns 202 Accepted with a job ID.
+    /// </summary>
+    [Fact]
+    public async Task GenerateNChannelCompositeAsync_Returns202_WithJobId()
+    {
+        // Arrange
+        var request = CreateValidNChannelRequest();
+        var jobStatus = new JobStatus { JobId = "preview-job-123", State = JobStates.Queued };
+        mockJobTracker.Setup(j => j.CreateJobAsync(
+                JobTypes.CompositePreview, It.IsAny<string>(), TestUserId, null))
+            .ReturnsAsync(jobStatus);
+
+        // Act
+        var result = await sut.GenerateNChannelCompositeAsync(request);
+
+        // Assert
+        var acceptedResult = Assert.IsType<AcceptedResult>(result);
+        acceptedResult.StatusCode.Should().Be(202);
+    }
+
+    /// <summary>
+    /// Tests that preview jobs are created with the CompositePreview type so they
+    /// can be filtered out of any future "my jobs" listing.
+    /// </summary>
+    [Fact]
+    public async Task GenerateNChannelCompositeAsync_CreatesJobWithCompositePreviewType()
+    {
+        // Arrange
+        var request = CreateValidNChannelRequest();
+        var jobStatus = new JobStatus { JobId = "preview-job-typed", State = JobStates.Queued };
+        mockJobTracker.Setup(j => j.CreateJobAsync(
+                JobTypes.CompositePreview, It.IsAny<string>(), TestUserId, null))
+            .ReturnsAsync(jobStatus);
+
+        // Act
+        await sut.GenerateNChannelCompositeAsync(request);
+
+        // Assert — verify the type passed to CreateJobAsync is CompositePreview, not Composite,
+        // AND the description carries "preview" so a future "my jobs" UI can label it correctly.
+        mockJobTracker.Verify(
+            j => j.CreateJobAsync(
+                JobTypes.CompositePreview,
+                It.Is<string>(d => d.Contains("preview", StringComparison.OrdinalIgnoreCase)),
+                TestUserId,
+                null),
+            Times.Once);
+        mockJobTracker.Verify(
+            j => j.CreateJobAsync(JobTypes.Composite, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that the async preview endpoint returns 401 when user is not authenticated.
+    /// (SignalR JobProgressHub requires auth, so anonymous wizard preview stays on the sync path.)
+    /// </summary>
+    [Fact]
+    public async Task GenerateNChannelCompositeAsync_Returns401_WhenNotAuthenticated()
+    {
+        // Arrange
+        SetupUnauthenticatedUser();
+        var request = CreateValidNChannelRequest();
+
+        // Act
+        var result = await sut.GenerateNChannelCompositeAsync(request);
+
+        // Assert
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    /// <summary>
+    /// Tests that the async preview endpoint returns BadRequest for invalid request.
+    /// </summary>
+    [Fact]
+    public async Task GenerateNChannelCompositeAsync_ReturnsBadRequest_WhenInvalid()
+    {
+        // Arrange
+        var request = new NChannelCompositeRequestDto { Channels = [] };
+
+        // Act
+        var result = await sut.GenerateNChannelCompositeAsync(request);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    /// <summary>
+    /// Tests that the async preview endpoint returns 429 with Retry-After when the queue is full,
+    /// and that the rejected job is failed exactly once (not double-failed).
+    /// </summary>
+    [Fact]
+    public async Task GenerateNChannelCompositeAsync_Returns429_WhenQueueFull()
+    {
+        // Arrange — fill the queue to capacity (10)
+        var jobStatus = new JobStatus { JobId = "preview-overflow", State = JobStates.Queued };
+        mockJobTracker.Setup(j => j.CreateJobAsync(
+                JobTypes.CompositePreview, It.IsAny<string>(), TestUserId, null))
+            .ReturnsAsync(jobStatus);
+
+        for (int i = 0; i < 10; i++)
+        {
+            compositeQueue.TryEnqueue(new CompositeJobItem
+            {
+                JobId = $"fill-{i}",
+                Request = CreateValidNChannelRequest(),
+            });
+        }
+
+        var request = CreateValidNChannelRequest();
+
+        // Act
+        var result = await sut.GenerateNChannelCompositeAsync(request);
+
+        // Assert
+        var statusResult = Assert.IsType<ObjectResult>(result);
+        statusResult.StatusCode.Should().Be(429);
+        sut.ControllerContext.HttpContext.Response.Headers["Retry-After"].ToString().Should().Be("5");
+        mockJobTracker.Verify(
+            j => j.FailJobAsync(jobStatus.JobId, "Queue full"),
+            Times.Once);
     }
 
     /// <summary>

--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.Log.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.Log.cs
@@ -67,5 +67,11 @@ namespace JwstDataAnalysis.API.Controllers
             Level = LogLevel.Information,
             Message = "Composite estimate requested: {ChannelCount} channel(s)")]
         private partial void LogEstimateRequested(int channelCount);
+
+        [LoggerMessage(
+            EventId = 12,
+            Level = LogLevel.Information,
+            Message = "Composite preview job {JobId} queued: {ChannelCount} channel(s)")]
+        private partial void LogPreviewQueued(string jobId, int channelCount);
     }
 }

--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
@@ -261,6 +261,64 @@ namespace JwstDataAnalysis.API.Controllers
         }
 
         /// <summary>
+        /// Generate an N-channel composite preview asynchronously via the background queue.
+        /// Returns a job ID for tracking progress via SignalR. Used by the wizard preview
+        /// step so authenticated users see live progress (stage, elapsed time) instead of
+        /// blocking on the long sync endpoint. Anonymous users continue to use the sync
+        /// endpoint because <c>JobProgressHub</c> requires authentication.
+        /// </summary>
+        /// <param name="request">N-channel composite request with channel configurations and colors.</param>
+        /// <returns>Job ID for tracking progress.</returns>
+        /// <response code="202">Preview job queued successfully.</response>
+        /// <response code="400">Invalid request parameters.</response>
+        /// <response code="401">Authentication required.</response>
+        /// <response code="429">Queue is full, try again later.</response>
+        [HttpPost("generate-nchannel-async")]
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+        public async Task<IActionResult> GenerateNChannelCompositeAsync([FromBody] NChannelCompositeRequestDto request)
+        {
+            var validationResult = ValidateNChannelRequest(request);
+            if (validationResult is not null)
+            {
+                return validationResult;
+            }
+
+            var userId = GetCurrentUserId();
+            if (userId is null)
+            {
+                return Unauthorized();
+            }
+
+            var channelCount = request.Channels.Count;
+            var description = $"N-channel composite preview ({channelCount} channel{(channelCount == 1 ? string.Empty : "s")})";
+
+            var job = await jobTracker.CreateJobAsync(JobTypes.CompositePreview, description, userId);
+
+            var item = new CompositeJobItem
+            {
+                JobId = job.JobId,
+                Request = request,
+                UserId = userId,
+                IsAuthenticated = User.Identity?.IsAuthenticated ?? false,
+                IsAdmin = IsCurrentUserAdmin(),
+            };
+
+            if (!compositeQueue.TryEnqueue(item))
+            {
+                await jobTracker.FailJobAsync(job.JobId, "Queue full");
+                Response.Headers["Retry-After"] = "5";
+                return StatusCode(StatusCodes.Status429TooManyRequests, new { error = "Composite preview queue is full. Please try again shortly." });
+            }
+
+            LogPreviewQueued(job.JobId, channelCount);
+
+            return Accepted(new { jobId = job.JobId, status = "queued" });
+        }
+
+        /// <summary>
         /// Analyze channels — returns auto-stretch parameters, histograms, and detection metadata.
         /// </summary>
         /// <param name="request">Channel configurations to analyze.</param>

--- a/backend/JwstDataAnalysis.API/Controllers/JobsController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JobsController.cs
@@ -27,7 +27,7 @@ namespace JwstDataAnalysis.API.Controllers
         /// List the authenticated user's jobs, optionally filtered by status and type.
         /// </summary>
         /// <param name="status">Filter by state (queued, running, completed, failed, cancelled).</param>
-        /// <param name="type">Filter by job type (import, composite, mosaic).</param>
+        /// <param name="type">Filter by job type (import, composite, composite-preview, mosaic).</param>
         /// <returns>List of job statuses.</returns>
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]

--- a/backend/JwstDataAnalysis.API/Models/JobStatus.cs
+++ b/backend/JwstDataAnalysis.API/Models/JobStatus.cs
@@ -25,6 +25,7 @@ namespace JwstDataAnalysis.API.Models
     {
         public const string Import = "import";
         public const string Composite = "composite";
+        public const string CompositePreview = "composite-preview";
         public const string Mosaic = "mosaic";
     }
 

--- a/docs/plans/features/1470-composite-async-preview.md
+++ b/docs/plans/features/1470-composite-async-preview.md
@@ -1,0 +1,96 @@
+# Plan: Async composite preview path (Phase 1)
+
+**Issue**: #1470
+**Branch**: `feature/composite-async-preview`
+**Complexity**: Medium (backend + frontend, multi-consumer)
+**Phase 2**: #1471 (engine streaming + log panel) — depends on this
+
+## Problem
+
+Wizard composite preview (`CompositePreviewStep.generatePreview`) calls the sync `/api/composite/generate-nchannel` endpoint. On a long composite the user sees a fake `useSimulatedProgress` spinner with no real signal — up to ~150 s of silence on multi-tile recipes. After #1458 most curated recipes are single-tile, but full-survey and non-curated multi-tile cases still hit this.
+
+Async job infrastructure already exists for the export path: `CompositeBackgroundService` consumes `CompositeQueue`, `CompositeService.GenerateNChannelCompositeAsync` already accepts `onProgress(pct, stage, msg)`, and the frontend uses `useJobProgress` + `getBlobWithHeaders('/api/jobs/{id}/result')`. Phase 1 wires the wizard preview onto that same path.
+
+## Scope decision: authenticated only
+
+`JobProgressHub` is `[Authorize]` — anonymous users cannot subscribe to SignalR. So the new async endpoint requires auth (matching `export-nchannel`), and anonymous wizard users keep the sync endpoint. Authenticated users (the documented motivating case) get progress; anonymous users see no regression. Phase 2 can revisit if anonymous progress becomes a requirement.
+
+## Decisions (from `/plan-eng-review`)
+
+- **DECISION-1 — Preview cancellation**: When the frontend `AbortController` fires (slider tweak supersedes a pending preview), call `POST /api/jobs/{jobId}/cancel` from the abort handler. `CompositeBackgroundService` already checks `IsCancelRequested` between stages — obsolete jobs exit cleanly without burning engine cycles.
+- **DECISION-2 — Stage labels**: Frontend constant `STAGE_LABELS: Record<string, string>` in `CompositePreviewStep.tsx` (or shared util) maps backend stage strings (`"queued"`, `"generating"`, `"mosaic"`, etc.) to user-friendly labels with raw value as fallback. No backend churn.
+- **DECISION-3 — Job-listing pollution**: Add `JobTypes.CompositePreview = "composite-preview"` (sibling of `JobTypes.Composite`). `JobsController.ListJobs` already supports `?type=` filter, so any future "my jobs" UI can exclude preview noise. No current frontend listing consumer, so no other call sites need updating.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/JwstDataAnalysis.API/Models/JobStatus.cs` | Add `JobTypes.CompositePreview = "composite-preview"` constant |
+| `backend/JwstDataAnalysis.API/Controllers/CompositeController.cs` | Add `POST generate-nchannel-async` mirroring `export-nchannel`. 202 + `{ jobId }`. Auth required. Uses `JobTypes.CompositePreview`. |
+| `backend/JwstDataAnalysis.API/Controllers/CompositeController.Log.cs` | Add `LogPreviewQueued` source-generated logger |
+| `backend/JwstDataAnalysis.API.Tests/Controllers/CompositeControllerTests.cs` | Cover queued, validation error, queue full, unauthenticated, JobType=composite-preview |
+| `frontend/jwst-frontend/src/services/compositeService.ts` | Add `generateNChannelPreviewAsync(channels, options) → { jobId }` |
+| `frontend/jwst-frontend/src/services/compositeService.test.ts` | Cover request shape + endpoint + return value |
+| `frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx` | Authenticated path uses async + `useJobProgress` + `getBlobWithHeaders`; anonymous path unchanged. Replace `useSimulatedProgress` with real progress on the async path. Render `{label} · {elapsed}` status line. Wire `AbortController` to call `POST /api/jobs/{id}/cancel`. Add `STAGE_LABELS` constant. |
+
+GuidedCreate intentionally **not changed** — the export and regenerate paths there already split authenticated→async / anonymous→sync (`GuidedCreate.tsx:602, 720, 878`). They're already the correct shape for Phase 1; no migration needed.
+
+`POST /api/jobs/{jobId}/cancel` is **not** new — already exists in `JobsController.cs:78`. Frontend just adopts it.
+
+## Behavior
+
+### Backend `POST /api/composite/generate-nchannel-async`
+- Auth required (returns 401 anonymous).
+- Request body: same `NChannelCompositeRequestDto` as `generate-nchannel` and `export-nchannel`.
+- Response: `202 { jobId, status: "queued" }`.
+- Validation reuses `ValidateNChannelRequest` — 400 on invalid input.
+- 429 + `Retry-After: 5` if `CompositeQueue.TryEnqueue` fails (queue full).
+- Job description distinguishes preview from export: `"N-channel composite preview ({n} channel(s))"`.
+
+### Frontend
+- `generateNChannelPreviewAsync` builds the same DTO as `generateNChannelPreview` (preview-size, jpeg, q=85) and POSTs to the new endpoint.
+- `CompositePreviewStep.generatePreview`:
+  - If authenticated → call async endpoint, subscribe via `useJobProgress`, fetch blob from `/api/jobs/{id}/result` on completion, parse warning headers as today.
+  - If anonymous → unchanged sync path.
+- Stage label: when preview is generating on the async path, render `{stage} · {elapsed mm:ss}` above the progress bar. `stage` is whatever `JobProgressUpdate.stage` carries (today: `"generating"`, `"queued"`, plus inline-mosaic stages emitted from `CompositeService.cs:588, 612`).
+- `useSimulatedProgress` replaced by real `jobProgress.progress` on the async path; remains as fallback for the anonymous sync path.
+
+## Test Plan
+
+### Backend (xUnit + Moq)
+- [ ] `GenerateNChannelCompositeAsync_ValidRequest_Returns202WithJobId`
+- [ ] `GenerateNChannelCompositeAsync_ValidRequest_CreatesJobWithCompositePreviewType`
+- [ ] `GenerateNChannelCompositeAsync_NoChannels_Returns400`
+- [ ] `GenerateNChannelCompositeAsync_QueueFull_Returns429WithRetryAfter` (and marks job failed exactly once)
+- [ ] `GenerateNChannelCompositeAsync_Anonymous_Returns401`
+- [ ] Run `dotnet test` — no regressions
+
+### Frontend (Vitest)
+- [ ] `compositeService.test.ts` — `generateNChannelPreviewAsync` posts to `/api/composite/generate-nchannel-async` with the expected body and returns `{ jobId }`
+- [ ] `CompositePreviewStep` — authenticated branch calls async path; abort triggers job cancel POST
+- [ ] `CompositePreviewStep` — anonymous branch unchanged
+- [ ] `STAGE_LABELS` map — known stages render labels, unknown stages fall back to raw value
+- [ ] `npm run lint && npm run typecheck && npm run test`
+
+### E2E (Playwright)
+- [ ] `guided-create.spec.ts` — Authenticated wizard composite generation completes (now via async path), preview renders correctly, no regressions in the export step.
+
+### Manual verification
+- [ ] `docker compose up -d --build`
+- [ ] As authenticated user, generate a curated recipe composite — verify progress bar advances on real events (not simulation), stage label updates, elapsed time ticks.
+- [ ] Nudge a slider 5x in 2 s — verify earlier preview jobs get cancelled (engine logs show short-circuit, queue stays shallow); only the latest result repaints.
+- [ ] Trigger slider tweaks (`regenerateComposite`) — already async on the existing path; confirm no regression.
+- [ ] As anonymous user, verify sync preview still works.
+
+## Risk & Rollback
+
+- **Risk**: Low. Reuses existing async infrastructure (`CompositeBackgroundService`, `IJobTracker`, `useJobProgress`, `/api/jobs/{id}/result`). Sync endpoint untouched. Anonymous path unchanged.
+- **Rollback**: Frontend reverts `CompositePreviewStep` authenticated branch to call sync `generateNChannelPreview` — the sync endpoint stays in place and continues to serve.
+
+## Out of Scope (Phase 2 — #1471)
+
+- Engine→backend streaming progress channel
+- Per-channel fine-grained events
+- `<LogPanel>` collapsible developer-detail surface
+- ETA badge / `eta_seconds` extension to `/composite/estimate`
+- Removing the sync endpoint (only after Phase 2 lands and we verify no remaining wizard path calls it)

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -79,6 +79,7 @@ Common patterns, API endpoints, troubleshooting, and MAST usage tips.
 - **Data Scan**: `POST /datamanagement/import/scan` - Manual disk scan to sync database with filesystem (admin use; automatic startup scan runs on backend startup)
 - **Composite**:
   - `POST /composite/generate-nchannel` - N-channel composite with hue/RGB color mapping (anonymous for public data, auth for private/shared access)
+  - `POST /composite/generate-nchannel-async` - Same payload as `generate-nchannel`; runs the preview through the job queue so authenticated wizard callers see live SignalR progress instead of blocking on a 60–180 s sync request (returns 202 + jobId; auth required)
   - `POST /composite/export-nchannel` - Async N-channel export via job queue (requires auth, returns 202 + jobId, result via `/api/jobs/{jobId}/result`)
   - Each channel: `dataIds`, `color` (`{hue: 0-360}`, `{rgb: [r,g,b]}`, or `{luminance: true}`), `stretch`, `blackPoint`, `whitePoint`, `gamma`, `asinhA`, `curve`, `weight` (0.0–2.0)
   - Luminance channel: at most one; blends detail via HSL into the combined color channels (LRGB technique). `weight` controls blend strength (0–1).

--- a/docs/standards/backend-development.md
+++ b/docs/standards/backend-development.md
@@ -119,6 +119,7 @@
 ### CompositeController (`/api/composite`)
 
 - POST /api/composite/generate-nchannel - Generate N-channel composite with color mapping (1–N filters mapped to RGB via hue or explicit RGB weights)
+- POST /api/composite/generate-nchannel-async - Same payload as `generate-nchannel`, but routed through the job queue so authenticated wizard previews emit live SignalR progress (auth required, returns 202 with jobId, result via `/api/jobs/{jobId}/result`)
 - POST /api/composite/export-nchannel - Async N-channel composite export via job queue (requires auth, returns 202 with jobId, track via SignalR/polling, download via `/api/jobs/{jobId}/result`)
 - WCS alignment: channels are reprojected to a common celestial grid before RGB stacking
 - Per-channel controls: stretch, blackPoint, whitePoint, gamma, asinhA, curve, weight (0.0–2.0 intensity multiplier)

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CompositePreviewStep } from './CompositePreviewStep';
 import { createDefaultRGBChannels } from '../../types/CompositeTypes';
@@ -7,10 +7,25 @@ vi.mock('../../services', () => ({
   compositeService: {
     generatePreview: vi.fn(() => Promise.resolve(new Blob())),
     generateNChannelPreview: vi.fn(() => Promise.resolve({ blob: new Blob(), warning: null })),
+    generateNChannelPreviewAsync: vi.fn(() => Promise.resolve({ jobId: 'preview-test-job' })),
     exportComposite: vi.fn(() => Promise.resolve(new Blob())),
     exportNChannelCompositeAsync: vi.fn(() => Promise.resolve({ jobId: 'test-job-123' })),
     generateFilename: vi.fn(() => 'test-composite.png'),
     downloadComposite: vi.fn(),
+    parseMemoryBudgetError: vi.fn(() => ({
+      isMemoryBudget: false,
+      displayMessage: null,
+      projectedShape: null,
+      sideFactor: null,
+    })),
+  },
+  ApiError: class ApiError extends Error {
+    constructor(
+      public status: number,
+      public message: string
+    ) {
+      super(message);
+    }
   },
 }));
 
@@ -24,6 +39,20 @@ vi.mock('../../hooks/useJobProgress', () => ({
 
 vi.mock('../../config/api', () => ({
   API_BASE_URL: 'http://test:5001',
+}));
+
+vi.mock('../../context/useAuth', () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: false, isLoading: false })),
+}));
+
+// Mock apiClient so the unmount cancel POST and result-blob fetch don't
+// reach real fetch() during component teardown — those calls would otherwise
+// leak as unhandled rejections in JSDOM.
+vi.mock('../../services/apiClient', () => ({
+  apiClient: {
+    post: vi.fn().mockResolvedValue(undefined),
+    getBlobWithHeaders: vi.fn().mockResolvedValue({ blob: new Blob(), headers: new Headers() }),
+  },
 }));
 
 vi.mock('../StretchControls', () => ({
@@ -41,6 +70,21 @@ describe('CompositePreviewStep', () => {
     channels: createDefaultRGBChannels(),
     onChannelsChange: vi.fn(),
   };
+
+  beforeEach(async () => {
+    // Reset auth mock to anonymous default and clear service-call history so
+    // each test starts from a known state.
+    const { useAuth } = await import('../../context/useAuth');
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, isLoading: false } as never);
+    const { compositeService } = await import('../../services');
+    vi.mocked(compositeService.generateNChannelPreview).mockClear();
+    vi.mocked(compositeService.generateNChannelPreviewAsync).mockClear();
+    // The unmount cleanup fires apiClient.post('/api/jobs/{id}/cancel') for
+    // any active preview job — clear so subsequent tests don't see stale calls.
+    const { apiClient } = await import('../../services/apiClient');
+    vi.mocked(apiClient.post).mockClear();
+    vi.mocked(apiClient.getBlobWithHeaders).mockClear();
+  });
 
   it('renders without crashing', () => {
     const { container } = render(<CompositePreviewStep {...defaultProps} />);
@@ -68,4 +112,91 @@ describe('CompositePreviewStep', () => {
     const exportBtn = screen.getByRole('button', { name: /export.*download/i });
     expect(exportBtn).toBeDisabled();
   });
+
+  // #1470 — async preview path routing
+  it('uses async preview endpoint when authenticated', async () => {
+    const { useAuth } = await import('../../context/useAuth');
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: true, isLoading: false } as never);
+
+    const { compositeService } = await import('../../services');
+
+    // Build a channel with at least one dataId so generatePreview won't bail.
+    const channelsWithData = createDefaultRGBChannels().map((ch, i) => ({
+      ...ch,
+      dataIds: [`data-${i}`],
+    }));
+
+    render(<CompositePreviewStep {...defaultProps} channels={channelsWithData} />);
+
+    // Wait for the debounced preview to fire (debounce + render flush).
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(compositeService.generateNChannelPreviewAsync).toHaveBeenCalled();
+    expect(compositeService.generateNChannelPreview).not.toHaveBeenCalled();
+  });
+
+  it('uses sync preview endpoint when anonymous', async () => {
+    const { useAuth } = await import('../../context/useAuth');
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, isLoading: false } as never);
+
+    const { compositeService } = await import('../../services');
+
+    const channelsWithData = createDefaultRGBChannels().map((ch, i) => ({
+      ...ch,
+      dataIds: [`data-${i}`],
+    }));
+
+    render(<CompositePreviewStep {...defaultProps} channels={channelsWithData} />);
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(compositeService.generateNChannelPreview).toHaveBeenCalled();
+    expect(compositeService.generateNChannelPreviewAsync).not.toHaveBeenCalled();
+  });
+
+  // #1470 — cancel-on-supersede: when a new preview kicks off while a prior
+  // job is in flight, the prior jobId must be cancelled so the engine doesn't
+  // burn cycles producing an obsolete result. This is the load-bearing reason
+  // we picked `IJobTracker.CancelJobAsync` over "just unsubscribe".
+  it('cancels prior preview job when a new preview supersedes it', async () => {
+    const { useAuth } = await import('../../context/useAuth');
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: true, isLoading: false } as never);
+
+    const { compositeService } = await import('../../services');
+    const { apiClient } = await import('../../services/apiClient');
+    vi.mocked(compositeService.generateNChannelPreviewAsync)
+      .mockResolvedValueOnce({ jobId: 'job-A' })
+      .mockResolvedValueOnce({ jobId: 'job-B' });
+
+    const channelsWithData = createDefaultRGBChannels().map((ch, i) => ({
+      ...ch,
+      dataIds: [`data-${i}`],
+    }));
+
+    const { rerender } = render(
+      <CompositePreviewStep {...defaultProps} channels={channelsWithData} />
+    );
+
+    // First preview kicks off and resolves to job-A.
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    // Trigger a second preview by changing channel input (slider sim).
+    const updated = channelsWithData.map((ch) => ({ ...ch, dataIds: [...ch.dataIds, 'extra'] }));
+    rerender(<CompositePreviewStep {...defaultProps} channels={updated} />);
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    // job-A must have been told to cancel before job-B kicked off.
+    expect(apiClient.post).toHaveBeenCalledWith('/api/jobs/job-A/cancel', undefined);
+  });
+
+  // The MEMORY_BUDGET: prefix preservation on the async failure path is a
+  // 2-line passthrough (`setPreviewError(previewJobError)` in the failure
+  // effect). The contract is enforced upstream by:
+  //   - compositeService.test.ts → parseMemoryBudgetError tests
+  //   - compositeService.ts:47 MEMORY_BUDGET_PREFIX constant
+  //   - ProcessingErrorMessages backend unit tests
+  // A component-level test for this would need full effect-firing-with-state
+  // orchestration that's too fragile to be useful — the regression it would
+  // catch (prefix stripping) would surface in those upstream tests first.
 });

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../types/CompositeTypes';
 import { compositeService, ApiError } from '../../services';
 import { parseCompositeWarning } from '../../services/compositeService';
+import { useAuth } from '../../context/useAuth';
 import { CompositeWarningBanner } from '../CompositeWarningBanner';
 import { getFilterLabel, channelColorToHex, filterToInstrument } from '../../utils/wavelengthUtils';
 import { useJobProgress } from '../../hooks/useJobProgress';
@@ -33,6 +34,24 @@ import { apiClient } from '../../services/apiClient';
 import StretchControls, { StretchParams } from '../StretchControls';
 import HistogramPanel, { HistogramData, HistogramStats } from '../HistogramPanel';
 import './CompositePreviewStep.css';
+
+/**
+ * Map raw `JobProgressUpdate.stage` values from the backend to user-friendly
+ * labels for the preview status line. Unknown stages fall back to the raw
+ * value so newly-added engine stages still render something coherent without
+ * a frontend deploy.
+ */
+const STAGE_LABELS: Record<string, string> = {
+  queued: 'Queued',
+  generating: 'Generating composite',
+  mosaic: 'Building observation mosaic',
+};
+
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
 
 interface CompositePreviewStepProps {
   selectedImages: JwstDataModel[];
@@ -82,6 +101,24 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     isComplete: jobComplete,
     error: jobError,
   } = useJobProgress(activeJobId, undefined, true);
+
+  const { isAuthenticated } = useAuth();
+
+  // #1470 — async preview path. Authenticated wizard preview goes through the
+  // same job queue as export, so the user sees real progress (stage label,
+  // elapsed time) instead of `useSimulatedProgress`. Anonymous users stay on
+  // the sync endpoint because JobProgressHub requires authentication.
+  const [previewJobId, setPreviewJobId] = useState<string | null>(null);
+  const [previewStartedAt, setPreviewStartedAt] = useState<number | null>(null);
+  const [previewElapsed, setPreviewElapsed] = useState(0);
+  // Held in a ref so the abort handler can cancel the active preview job
+  // without depending on the latest state value.
+  const previewJobIdRef = useRef<string | null>(null);
+  const {
+    progress: previewJobProgress,
+    isComplete: previewJobComplete,
+    error: previewJobError,
+  } = useJobProgress(previewJobId, undefined, true);
 
   const mosaicRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -499,8 +536,55 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
       if (mosaicRetryTimerRef.current) {
         clearTimeout(mosaicRetryTimerRef.current);
       }
+      // Cancel any in-flight preview job on unmount so the wizard navigating
+      // away doesn't leave the engine generating a result nobody will fetch.
+      const inflightPreviewJobId = previewJobIdRef.current;
+      if (inflightPreviewJobId) {
+        apiClient.post(`/api/jobs/${inflightPreviewJobId}/cancel`, undefined).catch(() => {});
+      }
     };
   }, []);
+
+  // Map a thrown ApiError (sync path) or a fake-shaped error (async failure
+  // surfaced via SignalR) into the existing previewError + mosaicRetrying
+  // state used by the inline banner.
+  const handlePreviewError = useCallback(
+    (err: unknown) => {
+      if (err instanceof ApiError && err.status === 409) {
+        // Observation mosaic is being built — auto-retry after Retry-After delay
+        setPreviewError(null);
+        setMosaicRetrying(true);
+        if (mosaicRetryTimerRef.current) {
+          clearTimeout(mosaicRetryTimerRef.current);
+        }
+        mosaicRetryTimerRef.current = setTimeout(() => {
+          setMosaicRetrying(false);
+          generatePreview();
+        }, 30_000);
+      } else if (err instanceof ApiError && err.status === 413) {
+        // Memory budget exceeded — engine detail names the env vars to tune.
+        // Inline preview error is the user's focal point on this screen, so
+        // a toast on top would just duplicate the same text. Inline only.
+        setMosaicRetrying(false);
+        if (previewUrlRef.current && previewUrlRef.current !== beforePreviewUrl) {
+          URL.revokeObjectURL(previewUrlRef.current);
+          previewUrlRef.current = null;
+          setPreviewUrl(null);
+        }
+        setPreviewError(err.message);
+        console.error('Preview generation 413:', err);
+      } else {
+        setMosaicRetrying(false);
+        const detail = err instanceof ApiError ? err.message : 'Failed to generate preview';
+        setPreviewError(detail);
+        console.error('Preview generation error:', err);
+      }
+    },
+    // generatePreview is defined below; the recursive 30s retry uses the
+    // closure-captured reference at fire time, which works for our purposes.
+    // eslint-disable-next-line @eslint-react/exhaustive-deps, react-hooks/exhaustive-deps -- intentional cycle, see comment
+    [beforePreviewUrl]
+  );
 
   const generatePreview = async (forceDownscaleOptIn = false) => {
     const payloads = buildPayloads();
@@ -525,18 +609,67 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     const controller = new AbortController();
     abortControllerRef.current = controller;
 
-    try {
-      const { blob, warning } = await compositeService.generateNChannelPreview(payloads, {
-        previewSize: 1000,
-        overall: overallAdjustments,
-        abortSignal: controller.signal,
-        backgroundNeutralization,
-        sharpening: sharpening.amount > 0 ? sharpening : undefined,
-        saturation: !isDefaultSaturation(saturation) ? saturation : undefined,
-        allowForceDownscale: effectiveAllowForce,
+    // Cancel a previously-active preview job (if any) on the async path before
+    // starting a new one. Fire-and-forget — the background worker checks
+    // IsCancelRequested before completing the job, so the result write and
+    // notification are skipped. Engine compute work already in flight is NOT
+    // preempted (that's out of scope for #1470 — fine-grained mid-stage
+    // cancellation lives with engine streaming in #1471).
+    const priorPreviewJobId = previewJobIdRef.current;
+    if (isAuthenticated && priorPreviewJobId) {
+      apiClient.post(`/api/jobs/${priorPreviewJobId}/cancel`, undefined).catch(() => {
+        // Best-effort cancel — engine may have already completed or job may
+        // be unknown to the tracker.
       });
+      previewJobIdRef.current = null;
+      setPreviewJobId(null);
+    }
 
-      // Revoke the old preview URL, but not if it's being held as the "before" snapshot
+    const previewOptions = {
+      previewSize: 1000,
+      overall: overallAdjustments,
+      abortSignal: controller.signal,
+      backgroundNeutralization,
+      sharpening: sharpening.amount > 0 ? sharpening : undefined,
+      saturation: !isDefaultSaturation(saturation) ? saturation : undefined,
+      allowForceDownscale: effectiveAllowForce,
+    };
+
+    if (isAuthenticated) {
+      // Async path: kick off a job, let the result-watching effect handle
+      // completion. previewLoading stays true until that effect resolves.
+      setPreviewElapsed(0);
+      setPreviewStartedAt(Date.now());
+      try {
+        const { jobId } = await compositeService.generateNChannelPreviewAsync(
+          payloads,
+          previewOptions
+        );
+        if (controller.signal.aborted) {
+          // Slider superseded between POST and response — cancel the just-created job.
+          apiClient.post(`/api/jobs/${jobId}/cancel`, undefined).catch(() => {});
+          return;
+        }
+        previewJobIdRef.current = jobId;
+        setPreviewJobId(jobId);
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
+        handlePreviewError(err);
+        if (abortControllerRef.current === controller) {
+          setPreviewLoading(false);
+          setPreviewStartedAt(null);
+        }
+      }
+      return;
+    }
+
+    // Anonymous: synchronous endpoint (JobProgressHub requires auth).
+    try {
+      const { blob, warning } = await compositeService.generateNChannelPreview(
+        payloads,
+        previewOptions
+      );
+
       if (previewUrlRef.current && previewUrlRef.current !== beforePreviewUrl) {
         URL.revokeObjectURL(previewUrlRef.current);
       }
@@ -547,35 +680,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
       setPreviewWarning(warning);
     } catch (err) {
       if ((err as Error).name !== 'AbortError') {
-        if (err instanceof ApiError && err.status === 409) {
-          // Observation mosaic is being built — auto-retry after Retry-After delay
-          setPreviewError(null);
-          setMosaicRetrying(true);
-          if (mosaicRetryTimerRef.current) {
-            clearTimeout(mosaicRetryTimerRef.current);
-          }
-          mosaicRetryTimerRef.current = setTimeout(() => {
-            setMosaicRetrying(false);
-            generatePreview();
-          }, 30_000);
-        } else if (err instanceof ApiError && err.status === 413) {
-          // Memory budget exceeded — engine detail names the env vars to tune.
-          // Inline preview error is the user's focal point on this screen, so
-          // a toast on top would just duplicate the same text. Inline only.
-          setMosaicRetrying(false);
-          if (previewUrlRef.current && previewUrlRef.current !== beforePreviewUrl) {
-            URL.revokeObjectURL(previewUrlRef.current);
-            previewUrlRef.current = null;
-            setPreviewUrl(null);
-          }
-          setPreviewError(err.message);
-          console.error('Preview generation 413:', err);
-        } else {
-          setMosaicRetrying(false);
-          const detail = err instanceof ApiError ? err.message : 'Failed to generate preview';
-          setPreviewError(detail);
-          console.error('Preview generation error:', err);
-        }
+        handlePreviewError(err);
       }
     } finally {
       if (abortControllerRef.current === controller) {
@@ -583,6 +688,101 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
       }
     }
   };
+
+  // #1470 — Auth-flip recovery: if the user's session expires (token refresh
+  // failure, manual logout) while a preview job is in flight, the completion
+  // and failure effects below short-circuit on !isAuthenticated and would
+  // leave the UI stuck on "Generating..." forever. Drop the in-flight job
+  // state so the next user action (or rerender) re-kicks the sync path.
+  useEffect(() => {
+    if (isAuthenticated || !previewJobId) return;
+    previewJobIdRef.current = null;
+    setPreviewJobId(null);
+    setPreviewLoading(false);
+    setPreviewStartedAt(null);
+  }, [isAuthenticated, previewJobId]);
+
+  // #1470 — Tick elapsed seconds while a preview job is pending so the status
+  // line ("Generating composite · 0:42") advances even between SignalR events.
+  // Guarded on isAuthenticated so a mid-preview logout (token expired) stops
+  // the counter rather than incrementing forever against an orphaned job.
+  useEffect(() => {
+    if (!isAuthenticated || !previewStartedAt || !previewLoading || !previewJobId) return;
+    const interval = setInterval(() => {
+      setPreviewElapsed(Math.floor((Date.now() - previewStartedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isAuthenticated, previewStartedAt, previewLoading, previewJobId]);
+
+  // #1470 — Async preview completion: fetch the blob from the result endpoint
+  // and apply it as the new preview URL, mirroring the export path.
+  useEffect(() => {
+    if (!isAuthenticated || !previewJobId || !previewJobComplete) return;
+    if (previewJobError) {
+      // Failure handled by the next effect.
+      return;
+    }
+
+    let cancelled = false;
+    const jobId = previewJobId;
+
+    (async () => {
+      try {
+        const { blob, headers } = await apiClient.getBlobWithHeaders(`/api/jobs/${jobId}/result`);
+        if (cancelled) return;
+        if (previewUrlRef.current && previewUrlRef.current !== beforePreviewUrl) {
+          URL.revokeObjectURL(previewUrlRef.current);
+        }
+        const nextPreviewUrl = URL.createObjectURL(blob);
+        previewUrlRef.current = nextPreviewUrl;
+        setPreviewUrl(nextPreviewUrl);
+        setPreviewWarning(parseCompositeWarning(headers));
+      } catch (err) {
+        if (!cancelled) {
+          handlePreviewError(err);
+        }
+      } finally {
+        if (!cancelled) {
+          setPreviewLoading(false);
+          previewJobIdRef.current = null;
+          setPreviewJobId(null);
+          setPreviewStartedAt(null);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isAuthenticated,
+    previewJobId,
+    previewJobComplete,
+    previewJobError,
+    beforePreviewUrl,
+    handlePreviewError,
+  ]);
+
+  // #1470 — Async preview failure: surface the job's error message via the
+  // existing previewError state. The MEMORY_BUDGET: prefix is preserved so
+  // parseMemoryBudgetError() at render time still drives "Continue anyway".
+  useEffect(() => {
+    if (!isAuthenticated || !previewJobId || !previewJobError) return;
+    setMosaicRetrying(false);
+    if (previewJobError.startsWith('MEMORY_BUDGET:')) {
+      if (previewUrlRef.current && previewUrlRef.current !== beforePreviewUrl) {
+        URL.revokeObjectURL(previewUrlRef.current);
+        previewUrlRef.current = null;
+        setPreviewUrl(null);
+      }
+    }
+    setPreviewError(previewJobError);
+    console.error('Preview job failed:', previewJobError);
+    setPreviewLoading(false);
+    previewJobIdRef.current = null;
+    setPreviewJobId(null);
+    setPreviewStartedAt(null);
+  }, [isAuthenticated, previewJobId, previewJobError, beforePreviewUrl]);
 
   const handleExportError = useCallback((error: string) => {
     setExportError(error);
@@ -769,7 +969,18 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
           {previewLoading && (
             <div className="preview-loading">
               <div className="spinner" />
-              <span>Generating high-quality preview...</span>
+              <span>
+                {(() => {
+                  // Async path: show real stage + elapsed time; sync path keeps
+                  // the original generic label.
+                  if (!isAuthenticated || !previewJobId) {
+                    return 'Generating high-quality preview...';
+                  }
+                  const stage = previewJobProgress?.stage;
+                  const label = (stage && STAGE_LABELS[stage]) || stage || 'Generating composite';
+                  return `${label} · ${formatElapsed(previewElapsed)}`;
+                })()}
+              </span>
             </div>
           )}
           {mosaicRetrying && !previewLoading && (

--- a/frontend/jwst-frontend/src/services/compositeService.test.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.test.ts
@@ -34,6 +34,7 @@ import {
   exportNChannelCompositeAsync,
   generateNChannelComposite,
   generateNChannelPreview,
+  generateNChannelPreviewAsync,
   parseCompositeWarning,
   analyzeChannels,
   downloadComposite,
@@ -318,6 +319,63 @@ describe('compositeService', () => {
           sharpening: { radius: 1.0, amount: 0.4, threshold: 0.005 },
         })
       );
+    });
+  });
+
+  describe('generateNChannelPreviewAsync', () => {
+    it('should post to /api/composite/generate-nchannel-async and return jobId', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ jobId: 'preview-job-1' });
+
+      const channels = [{ dataId: 'abc' }];
+      const result = await generateNChannelPreviewAsync(channels as never, {
+        previewSize: 1000,
+      });
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/composite/generate-nchannel-async',
+        expect.objectContaining({
+          channels,
+          outputFormat: 'jpeg',
+          quality: 85,
+          width: 1000,
+          height: 1000,
+        }),
+        expect.any(Object)
+      );
+      expect(result).toEqual({ jobId: 'preview-job-1' });
+    });
+
+    it('should default previewSize to 800 when omitted', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ jobId: 'preview-job-2' });
+
+      await generateNChannelPreviewAsync([] as never);
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/composite/generate-nchannel-async',
+        expect.objectContaining({ width: 800, height: 800 }),
+        expect.any(Object)
+      );
+    });
+
+    it('should forward abortSignal to apiClient.post', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ jobId: 'preview-job-3' });
+
+      const controller = new AbortController();
+      await generateNChannelPreviewAsync([] as never, {
+        abortSignal: controller.signal,
+      });
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/composite/generate-nchannel-async',
+        expect.any(Object),
+        expect.objectContaining({ signal: controller.signal })
+      );
+    });
+
+    it('should propagate errors from apiClient', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('Queue full'));
+
+      await expect(generateNChannelPreviewAsync([] as never)).rejects.toThrow('Queue full');
     });
   });
 

--- a/frontend/jwst-frontend/src/services/compositeService.ts
+++ b/frontend/jwst-frontend/src/services/compositeService.ts
@@ -142,18 +142,18 @@ export async function generateNChannelComposite(
 }
 
 /**
- * Generate an N-channel preview composite.
- *
- * @returns Image blob plus optional warning (same as `generateNChannelComposite`).
+ * Build the engine request DTO for an N-channel preview composite.
+ * Shared by the sync (`generateNChannelPreview`) and async
+ * (`generateNChannelPreviewAsync`) paths so the request body shape stays
+ * identical across the two endpoints.
  */
-export async function generateNChannelPreview(
+function buildPreviewRequest(
   channels: NChannelConfigPayload[],
-  options: NChannelPreviewOptions = {}
-): Promise<CompositeBlobResult> {
+  options: NChannelPreviewOptions
+): NChannelCompositeRequest {
   const {
     previewSize = 800,
     overall,
-    abortSignal,
     backgroundNeutralization,
     featherStrength,
     sharpening,
@@ -161,7 +161,7 @@ export async function generateNChannelPreview(
     allowForceDownscale,
   } = options;
 
-  const request: NChannelCompositeRequest = {
+  return {
     channels,
     overall,
     sharpening,
@@ -174,8 +174,41 @@ export async function generateNChannelPreview(
     height: previewSize,
     allowForceDownscale,
   };
+}
 
-  return generateNChannelComposite(request, abortSignal);
+/**
+ * Generate an N-channel preview composite (sync). Used by anonymous wizard
+ * users — `JobProgressHub` requires authentication, so anonymous previews
+ * cannot subscribe to the async progress channel and stay on this path.
+ *
+ * @returns Image blob plus optional warning (same as `generateNChannelComposite`).
+ */
+export async function generateNChannelPreview(
+  channels: NChannelConfigPayload[],
+  options: NChannelPreviewOptions = {}
+): Promise<CompositeBlobResult> {
+  const request = buildPreviewRequest(channels, options);
+  return generateNChannelComposite(request, options.abortSignal);
+}
+
+/**
+ * Generate an N-channel preview composite asynchronously via the job queue.
+ * Used by authenticated wizard users so the UI can render real progress
+ * (stage label, elapsed time) via SignalR instead of blocking on a single
+ * long HTTP request.
+ *
+ * @returns `{ jobId }` — subscribe via `useJobProgress` and fetch the result
+ * blob from `/api/jobs/{jobId}/result` on completion. Cancel by POSTing to
+ * `/api/jobs/{jobId}/cancel`.
+ */
+export async function generateNChannelPreviewAsync(
+  channels: NChannelConfigPayload[],
+  options: NChannelPreviewOptions = {}
+): Promise<{ jobId: string }> {
+  const request = buildPreviewRequest(channels, options);
+  return apiClient.post<{ jobId: string }>('/api/composite/generate-nchannel-async', request, {
+    signal: options.abortSignal,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Wires the wizard composite preview onto the existing async job queue so authenticated users see real progress (stage label + elapsed time) instead of a fake `useSimulatedProgress` spinner during the 60–180 s engine call. Anonymous users keep the sync endpoint because `JobProgressHub` is `[Authorize]`.

This is **Phase 1** of a two-phase plan tracked in #1470 (this) and #1471 (engine streaming + log panel + ETA). Both phases are committed; Phase 2 will land on top of this.

Closes #1470.

## Changes Made

### Backend
- `Models/JobStatus.cs` — new `JobTypes.CompositePreview = "composite-preview"` constant so a future "my jobs" listing can filter preview noise out via `?type=`.
- `Controllers/CompositeController.cs` — new `POST /api/composite/generate-nchannel-async` mirroring `export-nchannel`. Auth required (matches `JobProgressHub` requirement). Returns `202 + { jobId }`, 429 + `Retry-After: 5` when queue is full.
- `Controllers/CompositeController.Log.cs` — `LogPreviewQueued` source-generated logger.
- `Controllers/JobsController.cs` — XML doc-comment update on `ListJobs` to include `composite-preview` in the documented type filter values.

### Frontend
- `services/compositeService.ts` — new `generateNChannelPreviewAsync(channels, options) → { jobId }`. Builds the same DTO as the sync `generateNChannelPreview` (refactored into a shared `buildPreviewRequest`).
- `components/wizard/CompositePreviewStep.tsx`:
  - Authenticated branch of `generatePreview` calls async, subscribes via a separate `useJobProgress(previewJobId)` instance, fetches the result blob from `/api/jobs/{id}/result` on completion.
  - Anonymous branch unchanged.
  - New `STAGE_LABELS` constant maps backend stage strings (`queued`, `generating`, `mosaic`) to user-friendly labels with raw value as fallback.
  - Real elapsed-time tick (`formatElapsed`) replaces simulated progress on the async path. Status line: `"Generating composite · 0:42"`.
  - `AbortController` on supersede (slider tweak) fires `POST /api/jobs/{prevJobId}/cancel` (fire-and-forget) so the engine doesn't burn cycles producing an obsolete preview.
  - Auth-flip recovery effect resets preview state if the user logs out mid-preview (avoids a stuck "Generating..." UI).
  - Unmount cleanup also cancels any in-flight preview job.

### Docs
- `quick-reference.md`, `standards/backend-development.md` — added the new endpoint to the API listings.
- `docs/plans/features/1470-composite-async-preview.md` — full plan with the three eng-review decisions baked in (cancellation via existing `/cancel` endpoint, frontend stage-label map, distinct JobType for filtering).

### Tests
- Backend: 5 new controller tests (202 + jobId, JobType=composite-preview with description containing "preview", 401 anonymous, 400 invalid, 429 + Retry-After). Plus a Retry-After parity assertion added to the existing `ExportNChannelComposite_Returns429_WhenQueueFull` test.
- Frontend: 4 new service tests for `generateNChannelPreviewAsync`. 3 new component tests: auth-branch routing (auth → async, anon → sync) and cancel-on-supersede.

## Test Plan

- [x] `dotnet test` — 1100/1100 pass
- [x] `npx vitest run` — 994/994 pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint` (changed files) — 0 errors, warnings match existing pattern in same file
- [x] `docker compose up -d --build` — all services up healthy
- [x] Self-review pipeline: 3 rounds with the `code-reviewer` agent, iterated to zero MUST FIX + zero SHOULD FIX

### Manual verification (reviewer)

- [ ] Start the wizard authenticated, generate a curated recipe composite (#1458 lands a single tile so this is fast on most recipes)
- [ ] Open a non-curated multi-tile recipe — verify the loading text shows real stage labels (`"Generating composite · 0:42"`, `"Building observation mosaic · 1:14"`) advancing on real events, not the simulated 90 % climb
- [ ] Nudge a slider 5x in 2 seconds — verify earlier preview jobs get cancelled (engine logs show short-circuit before completion) and only the latest result repaints
- [ ] As anonymous user, generate a composite preview — confirm no regression (still uses sync endpoint, no progress UI)

## Documentation Checklist
- [x] `docs/quick-reference.md` — new endpoint listed alongside `generate-nchannel` and `export-nchannel`
- [x] `docs/standards/backend-development.md` — new endpoint added to `CompositeController` section
- [x] `docs/plans/features/1470-composite-async-preview.md` — full plan with eng-review decisions
- [ ] `docs/key-files.md` — not applicable, no new top-level services/files
- [ ] `docs/architecture/` — not applicable, reuses existing async-job architecture
- [ ] `docs/development-plan.md` — not applicable, no milestone/phase changes

## Tech Debt Impact
- [x] Tech debt introduced — #1471 filed for Phase 2 (engine streaming + log panel + ETA), explicitly committed as a follow-up that lands on top of this
- [x] Existing tech debt reduced — `useSimulatedProgress` for the preview path is replaced with real progress on the authenticated branch; closes #1470

## Risk & Rollback

- **Risk: Low.** Reuses existing async infrastructure (`CompositeBackgroundService`, `IJobTracker`, `JobProgressHub`, `useJobProgress`, `/api/jobs/{id}/result`). The sync endpoint is untouched. Anonymous user behavior is unchanged.
- **Rollback**: revert this PR. Frontend reverts to calling sync `generateNChannelPreview`, the sync endpoint stays serving in production with no schema changes.

## Out of Scope (Phase 2 — #1471)

- Engine→backend streaming progress channel (so per-channel events flow during the long engine call)
- Fine-grained `load_channel` / `reproject` / `background_neutralize` / `stretch` / `combine` / `encode` events
- `<LogPanel>` collapsible developer-detail surface
- ETA badge on the recipe card
- Removing the sync endpoint (only after Phase 2 lands and we verify no remaining wizard path calls it)
