### PR TITLE
feat(composite): engine streaming progress + log panel (Phase 2)

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
@@ -824,5 +824,195 @@ public class CompositeServiceTests
         await act.Should().ThrowAsync<KeyNotFoundException>()
             .WithMessage("*missing*not found*");
     }
+
+    // #1471 — streaming consumer tests. Engine returns NDJSON; backend reads
+    // line-by-line, calls onProgress per progress event, decodes b64 image on
+    // complete, throws on error/malformed/incomplete.
+
+    [Fact]
+    public async Task GenerateNChannelComposite_Streaming_ReturnsImageBytesAndCallsOnProgress()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        var imageBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+        var b64 = Convert.ToBase64String(imageBytes);
+        var ndjson =
+            "{\"event\":\"progress\",\"stage\":\"reproject\",\"filter\":\"R\",\"index\":1,\"total\":3,\"message\":\"Reprojecting R (1 of 3)\"}\n" +
+            "{\"event\":\"progress\",\"stage\":\"stretch\",\"filter\":\"G\",\"index\":2,\"total\":3,\"message\":\"Stretching G (2 of 3)\"}\n" +
+            "{\"event\":\"progress\",\"stage\":\"encode\",\"message\":\"Encoding image\"}\n" +
+            $"{{\"event\":\"complete\",\"image_b64\":\"{b64}\",\"content_type\":\"image/png\",\"headers\":{{\"X-Composite-Budget-Status\":\"ok\"}}}}\n";
+
+        var capturedRequests = new List<HttpRequestMessage>();
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(ndjson, System.Text.Encoding.UTF8, "application/x-ndjson"),
+            },
+            capturedRequests.Add);
+        var sut = CreateService(new HttpClient(handler));
+
+        var progressCalls = new List<(int Pct, string Stage, string Message)>();
+        Func<int, string, string, Task> onProgress = (pct, stage, msg) =>
+        {
+            progressCalls.Add((pct, stage, msg));
+            return Task.CompletedTask;
+        };
+
+        var result = await sut.GenerateNChannelCompositeAsync(
+            CreateRequest(),
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false,
+            onProgress: onProgress);
+
+        result.Bytes.Should().BeEquivalentTo(imageBytes);
+        result.Headers.Should().ContainKey("X-Composite-Budget-Status");
+        progressCalls.Should().HaveCount(3);
+        progressCalls[0].Stage.Should().Be("reproject");
+        progressCalls[1].Stage.Should().Be("stretch");
+        progressCalls[2].Stage.Should().Be("encode");
+        // Per-channel reproject is interpolated within its stage window (10-50);
+        // index 1/3 should land in the lower half.
+        progressCalls[0].Pct.Should().BeInRange(10, 30);
+        capturedRequests.Should().ContainSingle(r =>
+            r.RequestUri!.AbsolutePath.EndsWith("generate-nchannel-stream", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_Streaming_ErrorEvent_ThrowsHttpRequestException()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        var ndjson =
+            "{\"event\":\"progress\",\"stage\":\"reproject\",\"index\":1,\"total\":3,\"message\":\"Reprojecting R (1 of 3)\"}\n" +
+            "{\"event\":\"error\",\"detail\":\"At most one luminance channel is allowed\",\"status_code\":422}\n";
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(ndjson, System.Text.Encoding.UTF8, "application/x-ndjson"),
+        });
+        var sut = CreateService(new HttpClient(handler));
+
+        var act = () => sut.GenerateNChannelCompositeAsync(
+            CreateRequest(),
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false,
+            onProgress: (_, _, _) => Task.CompletedTask);
+
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .Where(ex => ex.Message.Contains("luminance") && ex.Message.Contains("422"));
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_Streaming_413ErrorEvent_ThrowsCompositeBudgetExceeded()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        const string detail = "Composite output would shrink to 65%. Lower COMPOSITE_DOWNSCALE_FAIL_THRESHOLD or raise MAX_COMPOSITE_MEMORY_BYTES.";
+        var ndjson =
+            $"{{\"event\":\"error\",\"detail\":\"{detail}\",\"status_code\":413}}\n";
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(ndjson, System.Text.Encoding.UTF8, "application/x-ndjson"),
+        });
+        var sut = CreateService(new HttpClient(handler));
+
+        var act = () => sut.GenerateNChannelCompositeAsync(
+            CreateRequest(),
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false,
+            onProgress: (_, _, _) => Task.CompletedTask);
+
+        await act.Should().ThrowAsync<CompositeBudgetExceededException>()
+            .Where(ex => ex.Message.Contains("MAX_COMPOSITE_MEMORY_BYTES"));
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_Streaming_StreamEndsWithoutTerminal_Throws()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        // Three progress events, no terminal `complete` or `error`.
+        var ndjson =
+            "{\"event\":\"progress\",\"stage\":\"reproject\",\"index\":1,\"total\":3,\"message\":\"Reprojecting R (1 of 3)\"}\n" +
+            "{\"event\":\"progress\",\"stage\":\"reproject\",\"index\":2,\"total\":3,\"message\":\"Reprojecting G (2 of 3)\"}\n" +
+            "{\"event\":\"progress\",\"stage\":\"reproject\",\"index\":3,\"total\":3,\"message\":\"Reprojecting B (3 of 3)\"}\n";
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(ndjson, System.Text.Encoding.UTF8, "application/x-ndjson"),
+        });
+        var sut = CreateService(new HttpClient(handler));
+
+        var act = () => sut.GenerateNChannelCompositeAsync(
+            CreateRequest(),
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false,
+            onProgress: (_, _, _) => Task.CompletedTask);
+
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("*ended without a terminal*");
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_Streaming_MalformedLine_Throws()
+    {
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        var ndjson =
+            "{\"event\":\"progress\",\"stage\":\"reproject\",\"index\":1,\"total\":3,\"message\":\"Reprojecting R (1 of 3)\"}\n" +
+            "this-is-not-json\n";
+
+        var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(ndjson, System.Text.Encoding.UTF8, "application/x-ndjson"),
+        });
+        var sut = CreateService(new HttpClient(handler));
+
+        var act = () => sut.GenerateNChannelCompositeAsync(
+            CreateRequest(),
+            "user-1",
+            isAuthenticated: true,
+            isAdmin: false,
+            onProgress: (_, _, _) => Task.CompletedTask);
+
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("*malformed event line*");
+    }
+
+    [Fact]
+    public async Task GenerateNChannelComposite_NoOnProgress_UsesBufferedEndpoint()
+    {
+        // Sync callers that don't pass onProgress keep hitting the original
+        // generate-nchannel route — guards against accidentally routing all
+        // callers through the streaming path.
+        var data = CreateDataModel();
+        mockMongo.Setup(m => m.GetAsync("data-1")).ReturnsAsync(data);
+
+        var capturedRequests = new List<HttpRequestMessage>();
+        var handler = new FakeHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 0x89, 0x50, 0x4E, 0x47 }),
+            },
+            capturedRequests.Add);
+        var sut = CreateService(new HttpClient(handler));
+
+        await sut.GenerateNChannelCompositeAsync(
+            CreateRequest(), "user-1", isAuthenticated: true, isAdmin: false);
+
+        capturedRequests.Should().ContainSingle(r =>
+            r.RequestUri!.AbsolutePath.EndsWith("generate-nchannel", StringComparison.Ordinal)
+            && !r.RequestUri.AbsolutePath.EndsWith("generate-nchannel-stream", StringComparison.Ordinal));
+    }
 #pragma warning restore SA1201
 }

--- a/backend/JwstDataAnalysis.API.Tests/Services/JobTrackerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/JobTrackerTests.cs
@@ -168,6 +168,135 @@ public class JobTrackerTests
         updated.StartedAt.Should().NotBeNull();
     }
 
+    // #1471 — Messages rolling buffer behavior
+    [Fact]
+    public async Task UpdateProgressAsync_AppendsToMessagesBuffer()
+    {
+        var job = await sut.CreateJobAsync(JobTypes.Composite, "Composite", TestUserId);
+
+        await sut.UpdateProgressAsync(job.JobId, 10, "reproject", "Reprojecting R (1 of 3)");
+        await sut.UpdateProgressAsync(job.JobId, 20, "reproject", "Reprojecting G (2 of 3)");
+        await sut.UpdateProgressAsync(job.JobId, 30, "reproject", "Reprojecting B (3 of 3)");
+
+        var updated = await sut.GetJobAsync(job.JobId, TestUserId);
+        updated!.Messages.Should().HaveCount(3);
+        updated.Messages[0].Should().Be("Reprojecting R (1 of 3)");
+        updated.Messages[2].Should().Be("Reprojecting B (3 of 3)");
+    }
+
+    [Fact]
+    public async Task UpdateProgressAsync_DedupesConsecutiveDuplicateMessages()
+    {
+        var job = await sut.CreateJobAsync(JobTypes.Composite, "Composite", TestUserId);
+
+        // Same message fired three times in a row — should only land once.
+        await sut.UpdateProgressAsync(job.JobId, 10, "reproject", "Reprojecting R (1 of 3)");
+        await sut.UpdateProgressAsync(job.JobId, 11, "reproject", "Reprojecting R (1 of 3)");
+        await sut.UpdateProgressAsync(job.JobId, 12, "reproject", "Reprojecting R (1 of 3)");
+        await sut.UpdateProgressAsync(job.JobId, 13, "reproject", "Reprojecting G (2 of 3)");
+
+        var updated = await sut.GetJobAsync(job.JobId, TestUserId);
+        updated!.Messages.Should().HaveCount(2);
+        updated.Messages[0].Should().Be("Reprojecting R (1 of 3)");
+        updated.Messages[1].Should().Be("Reprojecting G (2 of 3)");
+    }
+
+    [Fact]
+    public async Task UpdateProgressAsync_CapsBufferAtMaxMessages()
+    {
+        var job = await sut.CreateJobAsync(JobTypes.Composite, "Composite", TestUserId);
+
+        // Push 60 distinct messages — only the most recent MaxMessages (50) should remain.
+        for (var i = 0; i < 60; i++)
+        {
+            await sut.UpdateProgressAsync(job.JobId, i % 100, "stretch", $"step {i}");
+        }
+
+        var updated = await sut.GetJobAsync(job.JobId, TestUserId);
+        updated!.Messages.Should().HaveCount(JobTracker.MaxMessages);
+        // Oldest 10 should have been dropped — first remaining is "step 10".
+        updated.Messages[0].Should().Be("step 10");
+        updated.Messages[^1].Should().Be("step 59");
+    }
+
+    // Regression test for round 3/4 of the self-review: concurrent writers
+    // (UpdateProgressAsync + UpdateByteProgressAsync) and readers
+    // (GetJobAsync, which serializes the snapshot for HTTP/SignalR) must not
+    // race on the shared Messages or Metadata. Without round 3/4's locks +
+    // snapshot copies, this test would intermittently throw
+    // `InvalidOperationException: Collection was modified` from either
+    // ToList() over the snapshot's Messages or from the Metadata enumerator.
+    [Fact]
+    public async Task UpdateProgressAndGetSnapshot_AreConcurrencySafe()
+    {
+        var job = await sut.CreateJobAsync(JobTypes.Composite, "Composite", TestUserId);
+
+        const int writers = 25;
+        const int readers = 25;
+        const int iterations = 50;
+
+        var writeTasks = Enumerable.Range(0, writers).Select(w => Task.Run(async () =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                await sut.UpdateProgressAsync(job.JobId, i % 100, "stretch", $"writer-{w}-step-{i}");
+            }
+        }));
+
+        var byteWriteTasks = Enumerable.Range(0, writers).Select(_ => Task.Run(async () =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                await sut.UpdateByteProgressAsync(job.JobId, i, 100, 1.0, null);
+            }
+        }));
+
+        var readTasks = Enumerable.Range(0, readers).Select(_ => Task.Run(async () =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                var snapshot = await sut.GetJobAsync(job.JobId, TestUserId);
+                if (snapshot is null) continue;
+
+                // Force enumeration of both fields — these are the paths
+                // System.Text.Json takes when serializing the response.
+                _ = snapshot.Messages.Count;
+                foreach (var _msg in snapshot.Messages)
+                {
+                    // observe each entry — would throw on torn enumeration
+                }
+
+                if (snapshot.Metadata is not null)
+                {
+                    foreach (var _kv in snapshot.Metadata)
+                    {
+                        // ditto for the byte-progress dictionary
+                    }
+                }
+            }
+        }));
+
+        await Task.WhenAll(writeTasks.Concat(byteWriteTasks).Concat(readTasks));
+
+        // Final state shouldn't have grown beyond MaxMessages and the lock-protected fields.
+        var final = await sut.GetJobAsync(job.JobId, TestUserId);
+        final.Should().NotBeNull();
+        final!.Messages.Count.Should().BeLessThanOrEqualTo(JobTracker.MaxMessages);
+    }
+
+    [Fact]
+    public async Task UpdateProgressAsync_DoesNotAppendNullOrEmptyMessage()
+    {
+        var job = await sut.CreateJobAsync(JobTypes.Composite, "Composite", TestUserId);
+
+        await sut.UpdateProgressAsync(job.JobId, 10, "reproject", "real message");
+        await sut.UpdateProgressAsync(job.JobId, 20, "reproject", null);
+        await sut.UpdateProgressAsync(job.JobId, 30, "reproject", string.Empty);
+
+        var updated = await sut.GetJobAsync(job.JobId, TestUserId);
+        updated!.Messages.Should().ContainSingle().Which.Should().Be("real message");
+    }
+
     [Fact]
     public async Task UpdateProgressAsync_PreservesStageWhenNull()
     {

--- a/backend/JwstDataAnalysis.API/Models/JobStatus.cs
+++ b/backend/JwstDataAnalysis.API/Models/JobStatus.cs
@@ -62,6 +62,14 @@ namespace JwstDataAnalysis.API.Models
 
         public string? Message { get; set; }
 
+        /// <summary>
+        /// Gets or sets a rolling buffer of recent progress messages (newest last). Capped server-side
+        /// at <c>JobTracker.MaxMessages</c> entries; consecutive duplicates collapsed.
+        /// Surfaced to the frontend via <c>GET /api/jobs/{id}</c> so the LogPanel can rehydrate
+        /// after a SignalR reconnect (#1471).
+        /// </summary>
+        public List<string> Messages { get; set; } = [];
+
         public string? Error { get; set; }
 
         public bool CancelRequested { get; set; }

--- a/backend/JwstDataAnalysis.API/Services/CompositeService.cs
+++ b/backend/JwstDataAnalysis.API/Services/CompositeService.cs
@@ -21,6 +21,23 @@ namespace JwstDataAnalysis.API.Services
         /// </summary>
         private static readonly string[] ForwardableHeaderPrefixes = ["X-Composite-", "X-Quality-"];
 
+        // #1471 — Stage-to-progress-pct map for the streaming consumer. Mirrors
+        // the engine's pipeline order so the SignalR progress bar advances
+        // monotonically across stages. Per-channel events within reproject /
+        // stretch interpolate between the start and end of their stage window
+        // using index/total.
+        private static readonly Dictionary<string, (int Start, int End)> StageProgressWindows =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["queued"] = (0, 5),
+                ["mosaic"] = (5, 10),
+                ["reproject"] = (10, 50),
+                ["background_neutralize"] = (52, 55),
+                ["stretch"] = (60, 80),
+                ["combine"] = (82, 88),
+                ["encode"] = (90, 95),
+            };
+
         private readonly HttpClient httpClient;
         private readonly IMongoDBService mongoDBService;
         private readonly IStorageProvider storageProvider;
@@ -75,6 +92,17 @@ namespace JwstDataAnalysis.API.Services
 
             var json = JsonSerializer.Serialize(processingRequest, jsonOptions);
             LogCallingProcessingEngine(json);
+
+            // #1471 — when an onProgress callback is wired, route through the
+            // engine's streaming endpoint so per-channel events flow back to
+            // SignalR during the long composite call. Sync callers (no
+            // callback) keep the original buffered path — same engine
+            // behavior, simpler client code, no b64 overhead.
+            if (onProgress != null)
+            {
+                return await StreamNChannelCompositeAsync(
+                    json, onProgress, request.OutputFormat, cancellationToken);
+            }
 
             var content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await httpClient.PostAsync(
@@ -242,6 +270,201 @@ namespace JwstDataAnalysis.API.Services
             }
 
             return headers;
+        }
+
+        // #1471 — Streaming consumer for /composite/generate-nchannel-stream.
+        // Stays in this private region to keep StyleCop happy (public methods
+        // first, then privates grouped by concern, statics before instances).
+        private static async Task HandleProgressEventAsync(
+            JsonElement root,
+            Func<int, string, string, Task> onProgress)
+        {
+            var stage = root.TryGetProperty("stage", out var stageProp) ? stageProp.GetString() ?? string.Empty : string.Empty;
+            var message = root.TryGetProperty("message", out var msgProp) ? msgProp.GetString() ?? string.Empty : string.Empty;
+            var pct = ComputeProgressPct(root, stage);
+            await onProgress(pct, stage, message);
+        }
+
+        private static int ComputeProgressPct(JsonElement root, string stage)
+        {
+            if (!StageProgressWindows.TryGetValue(stage, out var window))
+            {
+                return 50; // Unknown stage — pin to mid-progress as a safe default.
+            }
+
+            // Interpolate within the stage window using index/total when present.
+            if (root.TryGetProperty("index", out var indexProp)
+                && root.TryGetProperty("total", out var totalProp)
+                && indexProp.ValueKind == JsonValueKind.Number
+                && totalProp.ValueKind == JsonValueKind.Number
+                && totalProp.GetInt32() > 0)
+            {
+                var index = indexProp.GetInt32();
+                var total = totalProp.GetInt32();
+                var span = window.End - window.Start;
+                return window.Start + (int)Math.Round((double)index / total * span);
+            }
+
+            return window.Start;
+        }
+
+        private static void ThrowFromErrorEvent(JsonElement root)
+        {
+            var detail = root.TryGetProperty("detail", out var detailProp)
+                ? detailProp.GetString() ?? "Unknown engine error"
+                : "Unknown engine error";
+
+            var statusCode = root.TryGetProperty("status_code", out var statusProp)
+                && statusProp.ValueKind == JsonValueKind.Number
+                ? statusProp.GetInt32()
+                : 500;
+
+            // Match the exception types the buffered path raises so the
+            // controller's exception-mapping logic (CompositeBudgetExceeded,
+            // ObservationMosaicInProgress, etc.) keeps working unchanged.
+            if (statusCode == 413)
+            {
+                throw new CompositeBudgetExceededException(detail);
+            }
+
+            throw new HttpRequestException(
+                $"Processing engine error: {statusCode} - {detail}",
+                null,
+                (System.Net.HttpStatusCode)statusCode);
+        }
+
+        /// <summary>
+        /// Consume the engine's NDJSON streaming response. Each progress event
+        /// fires onProgress; the terminal `complete` event yields the image
+        /// bytes; an `error` event throws so the caller's catch handlers can
+        /// translate it like a buffered failure.
+        /// </summary>
+        private async Task<CompositeResult> StreamNChannelCompositeAsync(
+            string requestJson,
+            Func<int, string, string, Task> onProgress,
+            string outputFormat,
+            CancellationToken cancellationToken)
+        {
+            using var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            using var requestMsg = new HttpRequestMessage(
+                HttpMethod.Post,
+                $"{processingEngineUrl}/composite/generate-nchannel-stream")
+            {
+                Content = content,
+            };
+
+            using var response = await httpClient.SendAsync(
+                requestMsg,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                LogProcessingEngineError(response.StatusCode, errorBody);
+                throw new HttpRequestException(
+                    $"Processing engine error: {response.StatusCode} - {errorBody}",
+                    null,
+                    response.StatusCode);
+            }
+
+            using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+
+            string? line;
+            while ((line = await reader.ReadLineAsync(cancellationToken)) != null)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                JsonDocument? doc;
+                try
+                {
+                    doc = JsonDocument.Parse(line);
+                }
+                catch (JsonException)
+                {
+                    // Engine should only emit valid JSON lines. A malformed
+                    // line is unrecoverable — abort rather than silently
+                    // dropping it (which would mask a real engine bug).
+                    LogProcessingEngineError(System.Net.HttpStatusCode.OK, $"Malformed event line: {line}");
+                    throw new HttpRequestException(
+                        "Processing engine emitted a malformed event line on the streaming endpoint.");
+                }
+
+                using (doc)
+                {
+                    var root = doc.RootElement;
+                    if (!root.TryGetProperty("event", out var eventTypeProp))
+                    {
+                        continue;
+                    }
+
+                    var eventType = eventTypeProp.GetString();
+                    switch (eventType)
+                    {
+                        case "progress":
+                            await HandleProgressEventAsync(root, onProgress);
+                            break;
+
+                        case "complete":
+                            return DecodeCompleteEvent(root, outputFormat);
+
+                        case "error":
+                            ThrowFromErrorEvent(root);
+                            break;
+                    }
+                }
+            }
+
+            throw new HttpRequestException(
+                "Processing engine stream ended without a terminal complete or error event.");
+        }
+
+        private CompositeResult DecodeCompleteEvent(JsonElement root, string outputFormat)
+        {
+            if (!root.TryGetProperty("image_b64", out var b64Prop)
+                || b64Prop.ValueKind != JsonValueKind.String)
+            {
+                throw new HttpRequestException("Streaming complete event missing or non-string image_b64 field.");
+            }
+
+            var b64 = b64Prop.GetString();
+            if (string.IsNullOrEmpty(b64))
+            {
+                throw new HttpRequestException("Streaming complete event has empty image_b64 field.");
+            }
+
+            byte[] imageBytes;
+            try
+            {
+                imageBytes = Convert.FromBase64String(b64);
+            }
+            catch (FormatException ex)
+            {
+                throw new HttpRequestException(
+                    "Streaming complete event has invalid base64-encoded image data.",
+                    ex);
+            }
+
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (root.TryGetProperty("headers", out var headersProp)
+                && headersProp.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in headersProp.EnumerateObject())
+                {
+                    if (ForwardableHeaderPrefixes.Any(p =>
+                            prop.Name.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        headers[prop.Name] = prop.Value.GetString() ?? string.Empty;
+                    }
+                }
+            }
+
+            LogCompositeGenerated(imageBytes.Length, outputFormat);
+            return new CompositeResult(imageBytes, headers);
         }
 
         /// <summary>

--- a/backend/JwstDataAnalysis.API/Services/JobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/JobTracker.cs
@@ -14,6 +14,13 @@ namespace JwstDataAnalysis.API.Services
     /// <inheritdoc/>
     public partial class JobTracker : IJobTracker
     {
+        /// <summary>
+        /// Maximum entries kept in the per-job <see cref="JobStatus.Messages"/> rolling buffer.
+        /// Engine emits ~36 lines per composite (#1471); 50 leaves headroom while
+        /// capping MongoDB document growth at ~5KB per job.
+        /// </summary>
+        public const int MaxMessages = 50;
+
         private readonly ConcurrentDictionary<string, JobStatus> cache = new();
         private readonly IMongoCollection<JobStatus> jobsCollection;
         private readonly IJobProgressNotifier notifier;
@@ -78,22 +85,49 @@ namespace JwstDataAnalysis.API.Services
                 return;
             }
 
-            job.ProgressPercent = Math.Clamp(progressPercent, 0, 100);
-            if (stage is not null)
-            {
-                job.Stage = stage;
-            }
+            // Guard for legacy job documents persisted before #1471 that
+            // deserialize without a Messages field — without this, the lock
+            // below NREs. Symmetric with UpdateByteProgressAsync.
+            job.Messages ??= [];
 
-            if (message is not null)
+            // #1471 — widen the existing job.Messages lock to also cover the
+            // closely-coupled Stage / Message / ProgressPercent / State writes,
+            // so GetJobAsync's snapshot (which takes the same lock) returns a
+            // consistent view of all four fields together. Without this, a
+            // snapshot mid-update could surface Stage="stretch" alongside
+            // Message="Reprojecting R (1 of 3)".
+            lock (job.Messages)
             {
-                job.Message = message;
-            }
+                job.ProgressPercent = Math.Clamp(progressPercent, 0, 100);
+                if (stage is not null)
+                {
+                    job.Stage = stage;
+                }
 
-            job.UpdatedAt = DateTime.UtcNow;
-            if (job.State == JobStates.Queued)
-            {
-                job.State = JobStates.Running;
-                job.StartedAt = DateTime.UtcNow;
+                if (message is not null)
+                {
+                    job.Message = message;
+
+                    // Append to rolling buffer (cap MaxMessages, dedupe consecutive duplicates)
+                    // so the LogPanel can rehydrate via GET /api/jobs/{id} after a SignalR reconnect.
+                    if (message.Length > 0
+                        && (job.Messages.Count == 0
+                            || !string.Equals(job.Messages[^1], message, StringComparison.Ordinal)))
+                    {
+                        job.Messages.Add(message);
+                        if (job.Messages.Count > MaxMessages)
+                        {
+                            job.Messages.RemoveRange(0, job.Messages.Count - MaxMessages);
+                        }
+                    }
+                }
+
+                job.UpdatedAt = DateTime.UtcNow;
+                if (job.State == JobStates.Queued)
+                {
+                    job.State = JobStates.Running;
+                    job.StartedAt = DateTime.UtcNow;
+                }
             }
 
             await PersistAndNotifyProgress(job);
@@ -113,30 +147,40 @@ namespace JwstDataAnalysis.API.Services
                 return;
             }
 
-            job.Metadata ??= [];
-            job.Metadata["DownloadedBytes"] = downloadedBytes;
-            job.Metadata["TotalBytes"] = totalBytes;
-            job.Metadata["SpeedBytesPerSec"] = speedBytesPerSec;
-            if (etaSeconds.HasValue)
+            // #1471 — same lock as UpdateProgressAsync + WithMessagesSnapshot
+            // so a concurrent GET /api/jobs/{id} can't observe a torn read of
+            // Metadata mid-mutation while JSON-serializing the snapshot. The
+            // lock target is `job.Messages` because it's allocated in the
+            // JobStatus constructor (always non-null) and is the existing
+            // protected resource on this object.
+            job.Messages ??= [];
+            lock (job.Messages)
             {
-                job.Metadata["EtaSeconds"] = etaSeconds.Value;
-            }
-
-            if (fileProgress is not null)
-            {
-                // Convert to plain dictionaries — MongoDB BSON can't serialize custom classes in Dictionary<string, object>
-                job.Metadata["FileProgress"] = fileProgress.Select(fp => new Dictionary<string, object>
+                job.Metadata ??= [];
+                job.Metadata["DownloadedBytes"] = downloadedBytes;
+                job.Metadata["TotalBytes"] = totalBytes;
+                job.Metadata["SpeedBytesPerSec"] = speedBytesPerSec;
+                if (etaSeconds.HasValue)
                 {
-                    ["FileName"] = fp.Filename,
-                    ["TotalBytes"] = fp.TotalBytes,
-                    ["DownloadedBytes"] = fp.DownloadedBytes,
-                    ["ProgressPercent"] = fp.ProgressPercent,
-                    ["Status"] = fp.Status,
-                }).ToList();
-            }
+                    job.Metadata["EtaSeconds"] = etaSeconds.Value;
+                }
 
-            job.ProgressPercent = totalBytes > 0 ? (int)((downloadedBytes * 100) / totalBytes) : 0;
-            job.UpdatedAt = DateTime.UtcNow;
+                if (fileProgress is not null)
+                {
+                    // Convert to plain dictionaries — MongoDB BSON can't serialize custom classes in Dictionary<string, object>
+                    job.Metadata["FileProgress"] = fileProgress.Select(fp => new Dictionary<string, object>
+                    {
+                        ["FileName"] = fp.Filename,
+                        ["TotalBytes"] = fp.TotalBytes,
+                        ["DownloadedBytes"] = fp.DownloadedBytes,
+                        ["ProgressPercent"] = fp.ProgressPercent,
+                        ["Status"] = fp.Status,
+                    }).ToList();
+                }
+
+                job.ProgressPercent = totalBytes > 0 ? (int)((downloadedBytes * 100) / totalBytes) : 0;
+                job.UpdatedAt = DateTime.UtcNow;
+            }
 
             await PersistAndNotifyProgress(job);
         }
@@ -308,12 +352,60 @@ namespace JwstDataAnalysis.API.Services
                 return null;
             }
 
-            return job;
+            return WithMessagesSnapshot(job);
         }
 
         public async Task<JobStatus?> GetJobInternalAsync(string jobId)
         {
-            return await GetFromCacheOrDb(jobId);
+            var job = await GetFromCacheOrDb(jobId);
+            return job is null ? null : WithMessagesSnapshot(job);
+        }
+
+        // #1471 — Return a copy of `job` whose `Messages` list is a defensive
+        // snapshot, so JSON serialization (or any other enumeration) can't be
+        // hit by a concurrent `UpdateProgressAsync` mutation on the same
+        // cached JobStatus reference. The full snapshot allocation runs INSIDE
+        // the lock so all closely-coupled progress fields (Stage, Message,
+        // Messages, ProgressPercent, UpdatedAt, State) come from the same
+        // consistent point in time — `UpdateProgressAsync` takes the same
+        // lock around its writes to those fields.
+        private static JobStatus WithMessagesSnapshot(JobStatus job)
+        {
+            lock (job.Messages)
+            {
+                return new JobStatus
+                {
+                    JobId = job.JobId,
+                    JobType = job.JobType,
+                    State = job.State,
+                    Description = job.Description,
+                    OwnerUserId = job.OwnerUserId,
+                    ProgressPercent = job.ProgressPercent,
+                    Stage = job.Stage,
+                    Message = job.Message,
+                    Messages = [.. job.Messages],
+                    Error = job.Error,
+                    CancelRequested = job.CancelRequested,
+                    CreatedAt = job.CreatedAt,
+                    StartedAt = job.StartedAt,
+                    UpdatedAt = job.UpdatedAt,
+                    CompletedAt = job.CompletedAt,
+                    ExpiresAt = job.ExpiresAt,
+                    LastAccessedAt = job.LastAccessedAt,
+                    ResultKind = job.ResultKind,
+                    ResultStorageKey = job.ResultStorageKey,
+                    ResultContentType = job.ResultContentType,
+                    ResultFilename = job.ResultFilename,
+                    ResultDataId = job.ResultDataId,
+                    ResultWarningHeaders = job.ResultWarningHeaders,
+                    // Shallow copy of the Metadata dictionary so JSON
+                    // serialization can iterate the snapshot without being
+                    // hit by a concurrent UpdateByteProgressAsync write.
+                    // Values inside Metadata are immutable (long/double/string)
+                    // or one-shot-set lists — shallow is sufficient.
+                    Metadata = job.Metadata is null ? null : new Dictionary<string, object>(job.Metadata),
+                };
+            }
         }
 
         public async Task<List<JobStatus>> GetJobsForUserAsync(string userId, string? status = null, string? type = null)
@@ -378,27 +470,46 @@ namespace JwstDataAnalysis.API.Services
 
         private async Task PersistJob(JobStatus job)
         {
+            // #1471 — snapshot before passing to MongoDB so BSON serialization
+            // can iterate Messages / Metadata without being hit by a
+            // concurrent UpdateProgressAsync / UpdateByteProgressAsync writer
+            // (the dual-write pattern in ImportJobTracker fires updates in
+            // parallel via Task.Run, so the same JobStatus instance can be
+            // mutated while we serialize). Cache stores the live reference so
+            // subsequent mutations land on the same object — only the
+            // serializer needs the detached copy.
             cache[job.JobId] = job;
+            var persisted = WithMessagesSnapshot(job);
             await jobsCollection.ReplaceOneAsync(
-                Builders<JobStatus>.Filter.Eq(j => j.JobId, job.JobId),
-                job,
+                Builders<JobStatus>.Filter.Eq(j => j.JobId, persisted.JobId),
+                persisted,
                 new ReplaceOptions { IsUpsert = true });
         }
 
         private async Task PersistAndNotifyProgress(JobStatus job)
         {
-            await PersistJob(job);
+            // Same snapshot-for-serialization concern as PersistJob — the
+            // SignalR JSON serializer iterates `Metadata` for the import
+            // byte-progress payload, racing UpdateByteProgressAsync. Capture
+            // a single detached snapshot and feed both the persist and
+            // notify paths so they see identical state.
+            cache[job.JobId] = job;
+            var snapshot = WithMessagesSnapshot(job);
+            await jobsCollection.ReplaceOneAsync(
+                Builders<JobStatus>.Filter.Eq(j => j.JobId, snapshot.JobId),
+                snapshot,
+                new ReplaceOptions { IsUpsert = true });
 
             await notifier.NotifyProgressAsync(new JobProgressUpdate
             {
-                JobId = job.JobId,
-                JobType = job.JobType,
-                State = job.State,
-                ProgressPercent = job.ProgressPercent,
-                Stage = job.Stage,
-                Message = job.Message,
-                UpdatedAt = job.UpdatedAt,
-                Metadata = job.Metadata,
+                JobId = snapshot.JobId,
+                JobType = snapshot.JobType,
+                State = snapshot.State,
+                ProgressPercent = snapshot.ProgressPercent,
+                Stage = snapshot.Stage,
+                Message = snapshot.Message,
+                UpdatedAt = snapshot.UpdatedAt,
+                Metadata = snapshot.Metadata,
             });
         }
 

--- a/docs/plans/features/1471-engine-streaming-progress.md
+++ b/docs/plans/features/1471-engine-streaming-progress.md
@@ -1,0 +1,134 @@
+# Plan: Engine streaming progress + log panel (Phase 2)
+
+**Issue**: #1471
+**Branch**: `feature/composite-engine-streaming`
+**Stacked on**: `feature/composite-async-preview` (PR #1472, Phase 1)
+**Complexity**: Medium-large (engine + backend + frontend, new transport at engine→backend boundary)
+
+## Problem
+
+Phase 1 (#1470, PR #1472) wired the wizard preview onto the async job queue and surfaced **coarse-grained** stages (queued → mosaic → generating). For a typical 3-channel curated recipe the engine still spends 30–60 s in a single "generating" stage doing per-channel reproject + stretch + combine — that's a long single-label silence on every composite, not just multi-tile cases.
+
+Phase 2 adds a streaming progress channel from the engine to the backend so the UI can show per-channel events ("Reprojecting F277W (1 of 3) — 1:23") plus a developer-detail log panel for the full ~36 lines the engine already emits to docker stdout.
+
+## Decisions (from `/plan-eng-review`)
+
+- **DECISION-1 — Stream format**: NDJSON (`application/x-ndjson`), one JSON object per line. Progress events: `{"event":"progress", stage, filter, index, total, rss_mb, message}`. Terminal events: `{"event":"complete", "image_b64":"...", "content_type":"image/jpeg"}` or `{"event":"error", "detail":"..."}`. The image is base64-encoded — ~33% overhead is acceptable for the simplicity of a single-endpoint, line-delimited response.
+- **DECISION-2 — Buffer delivery**: SignalR carries the latest message only (single string, fits in existing `JobStatus.Message`). Frontend `useJobProgress` maintains a local rolling buffer capped at 50 entries. On SignalR reconnect or initial mount, frontend calls `GET /api/jobs/{id}` once to rehydrate from a new `JobStatus.Messages: string[]` field that the backend maintains server-side.
+- **DECISION-3 — Engine endpoint shape**: Separate `POST /composite/generate-nchannel-stream` route. Sync `/composite/generate-nchannel` stays untouched per the "non-streaming still works" acceptance criterion. Backend `CompositeService` always uses the streaming endpoint when an `onProgress` callback is wired (i.e. on the async preview / export paths from Phase 1).
+
+## Files Changed
+
+### Engine
+| File | Change |
+|------|--------|
+| `processing-engine/app/composite/routes.py` | Add `POST /composite/generate-nchannel-stream` returning `StreamingResponse` (NDJSON). Reuse the existing nchannel pipeline; thread a `progress_emitter` callable through the call sites that today log per-channel info. |
+| `processing-engine/app/composite/progress.py` (new, ~40 lines) | `ProgressEmitter` helper: an asyncio `Queue`-backed bridge that lets pipeline code call `emit(stage, filter, index, total, rss_mb, message)` while a generator yields NDJSON lines. Also exposes a no-op variant for the sync endpoint. |
+| `processing-engine/tests/test_composite_streaming.py` (new) | Event ordering, terminal `complete`, terminal `error`, mid-stream client disconnect handling. |
+
+### Backend
+| File | Change |
+|------|--------|
+| `backend/JwstDataAnalysis.API/Services/CompositeService.cs` | Switch `GenerateNChannelCompositeAsync` from `PostAsync` (buffered) to `SendAsync(..., HttpCompletionOption.ResponseHeadersRead)` when streaming endpoint is targeted. Read NDJSON line-by-line; per progress event call `onProgress(pct, stage, msg)`; on `complete` event decode b64 image; on `error` event throw with detail. |
+| `backend/JwstDataAnalysis.API/Models/JobStatus.cs` | Add `Messages: List<string>` (additive; default empty). |
+| `backend/JwstDataAnalysis.API/Services/JobTracker.cs` | `UpdateProgressAsync` appends the message to `JobStatus.Messages` when non-empty and not equal to the previous entry (de-dupe consecutive duplicates). Cap at 50 most-recent. |
+| `backend/JwstDataAnalysis.API/Services/IJobTracker.cs` | No signature change — `Messages` flows through `JobStatus`. |
+| `backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs` | Stream consumer happy path, partial chunk handling, malformed event line, server-side timeout while waiting on next event, mid-stream cancellation. |
+| `backend/JwstDataAnalysis.API.Tests/Services/JobTrackerTests.cs` | Messages list grows with progress; capped at 50; consecutive duplicates collapsed. |
+
+### Frontend
+| File | Change |
+|------|--------|
+| `frontend/jwst-frontend/src/hooks/useJobProgress.ts` | Maintain a local `messages: string[]` buffer (cap 50). On mount and on `onreconnected`, fetch `GET /api/jobs/{id}` and rehydrate buffer from `messages` field. Append `progress.message` on each progress event when distinct from the last entry. Expose `messages` in the hook's return value. |
+| `frontend/jwst-frontend/src/components/wizard/LogPanel.tsx` (new, ~80 lines) | Collapsed-by-default disclosure ("Show details ▸"). Open: scrollable timestamped buffer, auto-scroll to bottom, monospace font. |
+| `frontend/jwst-frontend/src/components/wizard/LogPanel.css` (new) | Buffer styling. |
+| `frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx` | Render `<LogPanel messages={previewMessages} />` below the loading status line on the async path. Pass `messages` from the new hook return. |
+| `frontend/jwst-frontend/src/types/JobTypes.ts` | Add `messages?: string[]` to `ImportJobStatus` (or whichever interface the GET endpoint uses). |
+| `frontend/jwst-frontend/src/hooks/useJobProgress.test.ts` | Buffer growth, dedup, cap, reconnect rehydration. |
+| `frontend/jwst-frontend/src/components/wizard/LogPanel.test.tsx` (new) | Collapsed/expanded states, buffer overflow truncation, auto-scroll. |
+
+## Behavior
+
+### Engine `POST /composite/generate-nchannel-stream`
+- Request body: same `NChannelCompositeRequest` as `generate-nchannel`.
+- Response: `200 OK` + `Content-Type: application/x-ndjson`.
+- Each line is one event:
+  - `{"event":"progress", "stage":"reproject"|"stretch"|..., "filter":"F277W", "index":3, "total":4, "rss_mb":669, "message":"Reprojecting F277W to common grid (3417x4353)"}`
+  - Terminal: `{"event":"complete", "image_b64":"<base64>", "content_type":"image/jpeg"}` OR `{"event":"error", "detail":"..."}`
+- Client disconnect (cancellation) is detected via FastAPI's `request.is_disconnected()` polled at event boundaries — emitter exits cleanly without raising.
+
+### Backend stream consumer
+- `CompositeService.GenerateNChannelCompositeAsync` opens an `HttpResponseMessage` with `ResponseHeadersRead`, reads the body stream line-by-line via `StreamReader.ReadLineAsync`.
+- On each `progress` line: `await onProgress(progressPct, stage, message)` (existing callback). `progressPct` is computed from `index/total` per stage with stage-specific weights so the bar advances monotonically.
+- On `complete` line: decode `image_b64`, return `CompositeResult(bytes, headers)`.
+- On `error` line: throw `InvalidOperationException(detail)` (mapped to user message via `ProcessingErrorMessages.ToUserMessage`).
+- On unexpected stream end without terminal event: throw `HttpRequestException("Engine stream ended without completion event")`.
+
+### Backend message buffer
+- `JobStatus.Messages` is a server-side list, capped at 50 most-recent entries, consecutive duplicates collapsed.
+- `JobTracker.UpdateProgressAsync` appends `message` to the list when it's non-empty and different from the last entry.
+- `JobsController.GetJob` already returns `JobStatus`; `Messages` rides along on the existing GET response automatically.
+- SignalR hub continues to send the latest progress event (single message) — no payload-size change. Frontend maintains its own local buffer from the per-event messages.
+
+### Frontend
+- `useJobProgress` exposes `messages: string[]` in addition to existing fields.
+- On mount when `jobId` becomes non-null, fetch `GET /api/jobs/{jobId}` once and seed `messages` from the response (`status.messages ?? []`). Same on `onreconnected`.
+- On each progress event, append `progress.message` to the local buffer if non-empty and different from the last entry. Cap at 50.
+- `<LogPanel messages={messages}>` renders nothing when collapsed except the disclosure button. Open: monospace `<pre>` block, scrollable, auto-scrolls to bottom on new entries unless the user has scrolled up.
+
+## Test Plan
+
+### Engine (pytest)
+- [ ] `test_streaming_emits_per_channel_events` — 3-channel composite emits ≥3 reproject events, ≥3 stretch events, in order
+- [ ] `test_streaming_terminal_complete_carries_image` — final line is `complete` event with non-empty `image_b64` decodable to a valid PNG/JPEG
+- [ ] `test_streaming_terminal_error_on_invalid_input` — final line is `error` event with detail; no `complete`
+- [ ] `test_streaming_client_disconnect_cancels_cleanly` — client closes connection mid-stream, generator exits without raising into the FastAPI app
+- [ ] `docker exec jwst-processing python -m pytest`
+
+### Backend (xUnit + Moq)
+- [ ] `GenerateNChannelComposite_Streaming_HappyPath_ReturnsImageBytes` — stub `HttpMessageHandler` to emit 3 progress lines + complete; assert image bytes returned, onProgress called 3 times
+- [ ] `GenerateNChannelComposite_Streaming_ErrorEvent_Throws` — stub error event; assert thrown exception's user message preserves detail
+- [ ] `GenerateNChannelComposite_Streaming_StreamEndsWithoutTerminal_Throws`
+- [ ] `GenerateNChannelComposite_Streaming_PartialChunk_AssemblesLine` — stub stream that splits a JSON line across two read buffers; assert single onProgress call
+- [ ] `JobTracker_UpdateProgress_AppendsToMessagesBuffer`
+- [ ] `JobTracker_UpdateProgress_CapsBufferAt50`
+- [ ] `JobTracker_UpdateProgress_DedupesConsecutiveDuplicates`
+- [ ] `dotnet test`
+
+### Frontend (Vitest)
+- [ ] `useJobProgress` — buffer grows on each distinct progress message
+- [ ] `useJobProgress` — buffer caps at 50 entries
+- [ ] `useJobProgress` — buffer dedupes consecutive duplicate messages
+- [ ] `useJobProgress` — reconnect rehydrates buffer from `GET /api/jobs/{id}`
+- [ ] `LogPanel` — collapsed by default; click toggles open
+- [ ] `LogPanel` — renders all buffered messages monospace with timestamps
+- [ ] `LogPanel` — buffer overflow truncation visual (scrollable, auto-scroll to bottom)
+- [ ] `npm run lint && npm run typecheck && npm run test`
+
+### E2E (Playwright)
+- [ ] `guided-create.spec.ts` — authenticated wizard preview shows per-channel stage transitions; the Show details disclosure opens the LogPanel; the panel contains at least 3 timestamped lines for a 3-channel composite
+
+### Manual verification
+- [ ] `docker compose up -d --build`
+- [ ] Authenticated wizard, generate a 3+ channel curated recipe — verify the status line transitions through per-channel events ("Reprojecting F277W (1 of 3) — 0:14") and the LogPanel disclosure shows ~36 entries when expanded
+- [ ] Disconnect SignalR mid-job (kill backend, restart) — verify the LogPanel rehydrates from `GET /api/jobs/{id}` on reconnect
+
+## Risk & Rollback
+
+- **Risk: Medium.** New transport at the engine→backend boundary. Streaming HTTP responses interact with timeouts, proxies, and error handling differently from buffered HTTP. The b64 image decode adds a CPU step on the backend. The new `JobStatus.Messages` field grows `JobStatus` document size in MongoDB by up to ~5KB per job (50 lines × ~100 chars).
+- **Rollback**: revert the PR. Backend goes back to buffered `PostAsync` against `generate-nchannel`; engine streaming endpoint becomes dead code (additive, no callers); frontend LogPanel disappears, falling back to Phase 1's stage label + elapsed time.
+
+## Out of Scope
+
+- ETA badge / `eta_seconds` extension to `/composite/estimate` — separate issue (estimation needs telemetry, different problem).
+- Removing the sync `/composite/generate-nchannel` endpoint — separate cleanup issue once we audit non-wizard callers.
+- LogPanel filtering/severity coloring — engine logs are uniform `logger.info`; if needed later, add as a follow-up.
+
+## Stacking strategy
+
+This branch (`feature/composite-engine-streaming`) is stacked on `feature/composite-async-preview` (PR #1472). When #1472 merges:
+1. `git fetch origin && git rebase origin/main` on this branch.
+2. Resolve any conflicts (likely none — Phase 2 mostly adds new files; the only Phase 1 file Phase 2 touches is `CompositeService.cs`).
+3. Force-push to refresh the PR.
+
+If #1472 needs material changes during review, the rebase here gets larger but the boundary is well-defined (Phase 2 only adds; Phase 1 is the changing layer).

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -79,7 +79,7 @@ Common patterns, API endpoints, troubleshooting, and MAST usage tips.
 - **Data Scan**: `POST /datamanagement/import/scan` - Manual disk scan to sync database with filesystem (admin use; automatic startup scan runs on backend startup)
 - **Composite**:
   - `POST /composite/generate-nchannel` - N-channel composite with hue/RGB color mapping (anonymous for public data, auth for private/shared access)
-  - `POST /composite/generate-nchannel-async` - Same payload as `generate-nchannel`; runs the preview through the job queue so authenticated wizard callers see live SignalR progress instead of blocking on a 60–180 s sync request (returns 202 + jobId; auth required)
+  - `POST /composite/generate-nchannel-async` - Same payload as `generate-nchannel`; runs the preview through the job queue so authenticated wizard callers see live SignalR progress instead of blocking on a 60–180 s sync request (returns 202 + jobId; auth required). Backend streams per-stage / per-channel progress events from the processing engine via NDJSON and forwards each to SignalR (#1471).
   - `POST /composite/export-nchannel` - Async N-channel export via job queue (requires auth, returns 202 + jobId, result via `/api/jobs/{jobId}/result`)
   - Each channel: `dataIds`, `color` (`{hue: 0-360}`, `{rgb: [r,g,b]}`, or `{luminance: true}`), `stretch`, `blackPoint`, `whitePoint`, `gamma`, `asinhA`, `curve`, `weight` (0.0–2.0)
   - Luminance channel: at most one; blends detail via HSL into the combined color channels (LRGB technique). `weight` controls blend strength (0–1).

--- a/docs/standards/backend-development.md
+++ b/docs/standards/backend-development.md
@@ -141,7 +141,7 @@
 ### JobsController (`/api/jobs`)
 
 - GET /api/jobs - List jobs for current user (query: `status`, `type`)
-- GET /api/jobs/{jobId} - Get job status (ownership enforced)
+- GET /api/jobs/{jobId} - Get job status (ownership enforced). Returns a defensive snapshot — `JobStatus.Messages` is a server-side rolling buffer (cap 50, consecutive duplicates collapsed) the frontend `LogPanel` rehydrates from on SignalR reconnect (#1471).
 - POST /api/jobs/{jobId}/cancel - Cancel a job (ownership enforced)
 - GET /api/jobs/{jobId}/result - Stream blob result or return data ID (extends TTL on access)
 

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.css
@@ -144,6 +144,18 @@
   font-weight: 500;
 }
 
+/* #1471 — Current engine progress message (e.g. "Reprojecting F277W (1 of 3)").
+   Sits between the bullet stage list and the elapsed-time hint; sized between
+   the stage labels and the muted hint to draw the eye to live activity without
+   competing with the bullets. */
+.process-step-current-message {
+  margin: var(--space-3) 0 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Hint */
 .process-step-hint {
   margin: var(--space-5) 0 0;

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.test.tsx
@@ -258,3 +258,76 @@ describe('ProcessStep — Wavelength ribbon', () => {
     expect(screen.queryByTestId('wavelength-ribbon')).toBeNull();
   });
 });
+
+// #1471 — per-event progress messages flow into ProcessStep via the new
+// `messages` prop. The latest message is rendered inline above the elapsed
+// timer, and the full buffer is reachable via the LogPanel disclosure.
+describe('ProcessStep — engine progress messages (#1471)', () => {
+  it('renders nothing for messages when buffer is empty', () => {
+    const { container } = render(
+      <ProcessStep {...baseProps} onRetry={vi.fn()} error={null} messages={[]} />
+    );
+    expect(container.querySelector('.process-step-current-message')).toBeNull();
+    // LogPanel itself returns null for empty buffer.
+    expect(container.querySelector('.log-panel')).toBeNull();
+  });
+
+  it('shows the latest message inline above the elapsed timer', () => {
+    render(
+      <ProcessStep
+        {...baseProps}
+        onRetry={vi.fn()}
+        error={null}
+        messages={[
+          'Generating composite image...',
+          'Building observation mosaic (40 files)...',
+          'Reprojecting F277W (1 of 3)',
+        ]}
+      />
+    );
+    expect(screen.getByText('Reprojecting F277W (1 of 3)')).toBeInTheDocument();
+    // Earlier entries don't render inline — they live in the LogPanel buffer.
+    expect(screen.queryByText('Generating composite image...')).toBeNull();
+  });
+
+  it('renders the LogPanel disclosure with the full buffer count', () => {
+    render(
+      <ProcessStep
+        {...baseProps}
+        onRetry={vi.fn()}
+        error={null}
+        messages={['msg1', 'msg2', 'msg3']}
+      />
+    );
+    expect(screen.getByRole('button', { name: /Show details/i })).toBeInTheDocument();
+    // Count chip reflects buffer size.
+    expect(screen.getByRole('button', { name: /Show details/i }).textContent).toContain('(3)');
+  });
+
+  it('hides current-message and LogPanel on error', () => {
+    const { container } = render(
+      <ProcessStep
+        {...baseProps}
+        onRetry={vi.fn()}
+        error="Network error: ECONNREFUSED"
+        messages={['Reprojecting F277W (1 of 3)']}
+      />
+    );
+    expect(container.querySelector('.process-step-current-message')).toBeNull();
+    expect(container.querySelector('.log-panel')).toBeNull();
+  });
+
+  it('hides current-message and LogPanel on completion', () => {
+    const { container } = render(
+      <ProcessStep
+        {...baseProps}
+        onRetry={vi.fn()}
+        error={null}
+        isComplete
+        messages={['Encoding image']}
+      />
+    );
+    expect(container.querySelector('.process-step-current-message')).toBeNull();
+    expect(container.querySelector('.log-panel')).toBeNull();
+  });
+});

--- a/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ProcessStep.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from 'react';
 import type { ImportJobStatus } from '../../types/MastTypes';
 import { parseMemoryBudgetError } from '../../services/compositeService';
 import { hueToHex, parseWavelength, wavelengthToHue } from '../../utils/wavelengthUtils';
+import { LogPanel } from '../wizard/LogPanel';
 import './ProcessStep.css';
 
 interface ProcessStepProps {
@@ -14,6 +15,12 @@ interface ProcessStepProps {
   phase: 'mosaic' | 'composite';
   /** Job progress for the current phase */
   progress: ImportJobStatus | null;
+  /**
+   * Rolling buffer of progress messages from the engine — surfaced in
+   * the LogPanel and as the inline "current activity" line above the
+   * elapsed timer (#1471). Empty array if the parent doesn't track them.
+   */
+  messages?: string[];
   /** Error message if processing failed */
   error: string | null;
   /** Whether processing is complete */
@@ -317,6 +324,7 @@ export function ProcessStep({
   requiresMosaic,
   phase,
   progress,
+  messages = [],
   error,
   isComplete,
   onRetry,
@@ -377,7 +385,12 @@ export function ProcessStep({
   const errorDisplay = memoryBudget?.displayMessage ?? error;
 
   return (
-    <div className="process-step" role="status" aria-live="polite">
+    <div className="process-step" role="status" aria-live="polite" aria-atomic="false">
+      {/* aria-atomic="false" — role="status" implies aria-atomic="true" per
+          ARIA 1.2, which would re-announce the entire region (title + bullets
+          + current message + the 1Hz elapsed timer) every tick. Setting
+          atomic=false scopes announcements to changed children only. Same
+          regression class as PR #1456's wavelength-ribbon fix. */}
       <h3 className="process-step-title">
         {isComplete ? 'Processing complete' : `Creating ${recipeName}...`}
       </h3>
@@ -416,6 +429,17 @@ export function ProcessStep({
         </div>
       )}
 
+      {!error && !isComplete && messages.length > 0 && (
+        // #1471 — surface the latest engine progress message above the elapsed
+        // line so users see per-channel events ("Reprojecting F277W (1 of 3)")
+        // rolling by, not just the static stage bullets. This sits inside the
+        // ProcessStep's role="status" + aria-live="polite" region — at ~6-9
+        // events over ~30s for a typical composite, that's a useful cadence
+        // for screen readers (different from the ~1Hz LogPanel buffer below,
+        // which is explicitly aria-live="off").
+        <p className="process-step-current-message">{messages[messages.length - 1]}</p>
+      )}
+
       {!error && !isComplete && (
         <p className="process-step-hint">
           {showElapsed ? (
@@ -431,6 +455,8 @@ export function ProcessStep({
           )}
         </p>
       )}
+
+      {!error && !isComplete && <LogPanel messages={messages} />}
     </div>
   );
 }

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../../hooks/useJobProgress', () => ({
     progress: null,
     isComplete: false,
     error: null,
+    messages: [],
   })),
 }));
 
@@ -104,6 +105,7 @@ describe('CompositePreviewStep', () => {
       progress: null,
       isComplete: false,
       error: null,
+      messages: [],
     });
 
     // Note: export button is disabled when there's no preview, so this test

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -27,6 +27,7 @@ import { compositeService, ApiError } from '../../services';
 import { parseCompositeWarning } from '../../services/compositeService';
 import { useAuth } from '../../context/useAuth';
 import { CompositeWarningBanner } from '../CompositeWarningBanner';
+import { LogPanel } from './LogPanel';
 import { getFilterLabel, channelColorToHex, filterToInstrument } from '../../utils/wavelengthUtils';
 import { useJobProgress } from '../../hooks/useJobProgress';
 import { useSimulatedProgress } from '../../hooks/useSimulatedProgress';
@@ -118,6 +119,7 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
     progress: previewJobProgress,
     isComplete: previewJobComplete,
     error: previewJobError,
+    messages: previewJobMessages,
   } = useJobProgress(previewJobId, undefined, true);
 
   const mosaicRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -981,6 +983,8 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
                   return `${label} · ${formatElapsed(previewElapsed)}`;
                 })()}
               </span>
+              {/* #1471 — only the auth+async path has live engine messages to show */}
+              {isAuthenticated && previewJobId && <LogPanel messages={previewJobMessages} />}
             </div>
           )}
           {mosaicRetrying && !previewLoading && (

--- a/frontend/jwst-frontend/src/components/wizard/LogPanel.css
+++ b/frontend/jwst-frontend/src/components/wizard/LogPanel.css
@@ -1,0 +1,63 @@
+/* #1471 — collapsible developer-detail log panel */
+
+.log-panel {
+  margin-top: 8px;
+  font-size: 12px;
+}
+
+.log-panel-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 0;
+  color: var(--text-muted, rgba(255, 255, 255, 0.65));
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.log-panel-toggle:hover,
+.log-panel-toggle:focus-visible {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary, rgba(255, 255, 255, 0.92));
+}
+
+.log-panel-toggle-icon {
+  font-size: 10px;
+  width: 10px;
+  display: inline-block;
+}
+
+.log-panel-toggle-count {
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
+.log-panel-buffer {
+  margin-top: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 8px 10px;
+  background-color: rgba(0, 0, 0, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.78);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-panel-line {
+  padding: 1px 0;
+}
+
+.log-panel-line + .log-panel-line {
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}

--- a/frontend/jwst-frontend/src/components/wizard/LogPanel.test.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/LogPanel.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LogPanel } from './LogPanel';
+
+describe('LogPanel', () => {
+  it('renders nothing when messages buffer is empty', () => {
+    const { container } = render(<LogPanel messages={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('starts collapsed by default — only the disclosure button visible', () => {
+    render(<LogPanel messages={['line one', 'line two']} />);
+    const toggle = screen.getByRole('button', { name: /Show details/i });
+    expect(toggle).toBeTruthy();
+    expect(screen.queryByText('line one')).toBeNull();
+    expect(screen.queryByText('line two')).toBeNull();
+  });
+
+  it('renders all buffered lines when expanded', () => {
+    render(<LogPanel messages={['Reprojecting R (1 of 3)', 'Stretching G (2 of 3)']} />);
+    fireEvent.click(screen.getByRole('button', { name: /Show details/i }));
+    expect(screen.getByText('Reprojecting R (1 of 3)')).toBeTruthy();
+    expect(screen.getByText('Stretching G (2 of 3)')).toBeTruthy();
+  });
+
+  it('toggles between Show details and Hide details', () => {
+    render(<LogPanel messages={['msg']} />);
+    const toggle = screen.getByRole('button');
+    expect(toggle.textContent).toContain('Show details');
+    fireEvent.click(toggle);
+    expect(toggle.textContent).toContain('Hide details');
+    fireEvent.click(toggle);
+    expect(toggle.textContent).toContain('Show details');
+  });
+
+  it('shows the buffered entry count next to the toggle', () => {
+    render(<LogPanel messages={['a', 'b', 'c', 'd', 'e']} />);
+    const toggle = screen.getByRole('button');
+    expect(toggle.textContent).toContain('(5)');
+  });
+
+  it('starts open when defaultOpen=true', () => {
+    render(<LogPanel messages={['hello']} defaultOpen />);
+    expect(screen.getByText('hello')).toBeTruthy();
+    const toggle = screen.getByRole('button');
+    expect(toggle.textContent).toContain('Hide details');
+  });
+
+  it('exposes the log region as a labeled region (no aria-live to avoid SR spam)', () => {
+    // role="log" implies aria-live=polite; with ~36 messages emitted over ~30s
+    // that would spam screen readers (same class as the PR #1456 wavelength
+    // ribbon regression). Users who open this collapsed-by-default panel
+    // explicitly opted in to seeing entries; no live announcements needed.
+    render(<LogPanel messages={['x']} defaultOpen />);
+    const region = screen.getByRole('region', { name: /Composite generation log/i });
+    expect(region).toBeTruthy();
+    expect(region.getAttribute('aria-live')).toBeNull();
+    expect(screen.queryByRole('log')).toBeNull();
+  });
+
+  it('does NOT auto-scroll when the user has scrolled up to read history', () => {
+    const setSpy = vi.fn();
+    let stubbedScrollTop = 0;
+    Object.defineProperty(HTMLDivElement.prototype, 'scrollTop', {
+      configurable: true,
+      get() {
+        return stubbedScrollTop;
+      },
+      set(value) {
+        setSpy(value);
+        stubbedScrollTop = value;
+      },
+    });
+    Object.defineProperty(HTMLDivElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return 1000;
+      },
+    });
+    Object.defineProperty(HTMLDivElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return 200;
+      },
+    });
+
+    const { rerender, container } = render(<LogPanel messages={['one']} defaultOpen />);
+    setSpy.mockClear();
+
+    // Simulate the user scrolling up — distanceFromBottom will be 1000-100-200 = 700, > 16.
+    stubbedScrollTop = 100;
+    const buffer = container.querySelector('.log-panel-buffer') as HTMLDivElement;
+    fireEvent.scroll(buffer);
+
+    // New message arrives — auto-scroll should be frozen.
+    rerender(<LogPanel messages={['one', 'two']} defaultOpen />);
+
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('auto-scrolls to bottom on new messages when open and not user-scrolled', () => {
+    // jsdom doesn't compute layout, so scrollHeight/scrollTop are stub-set to 0.
+    // We can still verify the effect attempts to scroll by spying on scrollTop assignment.
+    const setSpy = vi.fn();
+    Object.defineProperty(HTMLDivElement.prototype, 'scrollTop', {
+      configurable: true,
+      get() {
+        return 0;
+      },
+      set(value) {
+        setSpy(value);
+      },
+    });
+    Object.defineProperty(HTMLDivElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return 1000;
+      },
+    });
+
+    const { rerender } = render(<LogPanel messages={['one']} defaultOpen />);
+    rerender(<LogPanel messages={['one', 'two']} defaultOpen />);
+
+    // Effect runs after render; scrollTop should have been assigned to scrollHeight (1000)
+    expect(setSpy).toHaveBeenCalledWith(1000);
+  });
+});

--- a/frontend/jwst-frontend/src/components/wizard/LogPanel.test.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/LogPanel.test.tsx
@@ -54,7 +54,9 @@ describe('LogPanel', () => {
     render(<LogPanel messages={['x']} defaultOpen />);
     const region = screen.getByRole('region', { name: /Composite generation log/i });
     expect(region).toBeTruthy();
-    expect(region.getAttribute('aria-live')).toBeNull();
+    // Explicitly off so the panel doesn't inherit aria-live="polite" from
+    // an ancestor like ProcessStep — see LogPanel.tsx for rationale.
+    expect(region.getAttribute('aria-live')).toBe('off');
     expect(screen.queryByRole('log')).toBeNull();
   });
 

--- a/frontend/jwst-frontend/src/components/wizard/LogPanel.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/LogPanel.tsx
@@ -72,12 +72,16 @@ export const LogPanel: React.FC<LogPanelProps> = ({ messages, defaultOpen = fals
         // emitting ~36 entries over ~30s would spam screen readers (same
         // regression class as the wavelength ribbon in PR #1456). Users
         // who open this panel can read the buffer at their own pace.
+        // aria-live="off" defends against an ancestor live region (e.g.
+        // GuidedCreate's ProcessStep root) — without this override the
+        // panel would announce all 50 entries when the user opens it.
         <div
           ref={scrollRef}
           onScroll={handleScroll}
           className="log-panel-buffer"
           role="region"
           aria-label="Composite generation log"
+          aria-live="off"
         >
           {messages.map((msg, i) => (
             // eslint-disable-next-line @eslint-react/no-array-index-key -- buffer shifts on overflow so indices aren't stable per-message, but each row is a stateless plain text node, so React's key-based reconciliation produces correct DOM regardless

--- a/frontend/jwst-frontend/src/components/wizard/LogPanel.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/LogPanel.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useRef, useState } from 'react';
+import './LogPanel.css';
+
+/**
+ * Collapsible developer-detail log panel for long-running composite preview jobs (#1471).
+ *
+ * Collapsed by default behind a "Show details" disclosure so non-astronomer
+ * users don't get blasted by RSS readouts and stage names; expanded view
+ * shows a scrollable, monospace, timestamped buffer that auto-scrolls to
+ * the bottom unless the user has scrolled up to read history.
+ *
+ * Messages come from `useJobProgress(jobId).messages` — a rolling buffer
+ * capped at 50 entries, hydrated from `GET /api/jobs/{id}` on mount and
+ * on SignalR reconnect, appended per progress event.
+ */
+interface LogPanelProps {
+  messages: string[];
+  /** Default collapsed state; defaults to true (panel hidden). */
+  defaultOpen?: boolean;
+}
+
+export const LogPanel: React.FC<LogPanelProps> = ({ messages, defaultOpen = false }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // When the user scrolls up to read older entries, freeze auto-scroll until
+  // they return to the bottom. Compared each render against scrollHeight so
+  // the freeze is accurate even when the buffer is mid-truncation.
+  const userScrolledUpRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    if (!userScrolledUpRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [messages, open]);
+
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // Within ~16px of the bottom counts as "at the bottom" — handles fractional
+    // pixel rounding from CSS zoom and DPR-aware browsers.
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    userScrolledUpRef.current = distanceFromBottom > 16;
+  };
+
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="log-panel">
+      <button
+        type="button"
+        className="log-panel-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <span className="log-panel-toggle-icon" aria-hidden="true">
+          {open ? '▾' : '▸'}
+        </span>
+        <span>{open ? 'Hide details' : 'Show details'}</span>
+        <span className="log-panel-toggle-count" aria-label={`${messages.length} log entries`}>
+          ({messages.length})
+        </span>
+      </button>
+      {open && (
+        // role="region" with an aria-label is the right semantic for a
+        // collapsed-by-default developer-detail panel that the user has
+        // explicitly opened. role="log" implies aria-live="polite", and
+        // emitting ~36 entries over ~30s would spam screen readers (same
+        // regression class as the wavelength ribbon in PR #1456). Users
+        // who open this panel can read the buffer at their own pace.
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="log-panel-buffer"
+          role="region"
+          aria-label="Composite generation log"
+        >
+          {messages.map((msg, i) => (
+            // eslint-disable-next-line @eslint-react/no-array-index-key -- buffer shifts on overflow so indices aren't stable per-message, but each row is a stateless plain text node, so React's key-based reconciliation produces correct DOM regardless
+            <div key={i} className="log-panel-line">
+              {msg}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/jwst-frontend/src/hooks/useJobProgress.buffer.test.tsx
+++ b/frontend/jwst-frontend/src/hooks/useJobProgress.buffer.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * Tests for the rolling messages buffer added to useJobProgress in #1471.
+ *
+ * Kept in a separate file from useJobProgress.test.ts because these render
+ * the hook itself (via @testing-library/react's renderHook), while the
+ * sibling file only exercises the imperative `subscribeToJobProgress` layer.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+// vi.hoisted lets the mock factories below capture these refs without
+// hitting "cannot access before initialization" — the bare `vi.mock`
+// factory hoists to the top of the module ahead of regular `const`s.
+type SignalRCb = Record<string, (...args: unknown[]) => void>;
+const hoisted = vi.hoisted(() => ({
+  signalRCallbacks: {} as Record<string, (...args: unknown[]) => void>,
+  connStateListener: null as ((state: string) => void) | null,
+  apiGetMock: vi.fn(),
+  mockUnsubscribe: vi.fn(),
+}));
+
+vi.mock('../services/signalRService', () => ({
+  subscribeToJob: vi.fn((_jobId: string, cbs: Record<string, unknown>) => {
+    hoisted.signalRCallbacks = cbs as SignalRCb;
+    return globalThis.Promise.resolve(hoisted.mockUnsubscribe);
+  }),
+  onConnectionStateChange: vi.fn((listener: (s: string) => void) => {
+    hoisted.connStateListener = listener;
+    return () => {
+      hoisted.connStateListener = null;
+    };
+  }),
+}));
+
+vi.mock('../services/mastService', () => ({
+  getImportProgress: vi.fn(),
+}));
+
+vi.mock('../services/apiClient', () => ({
+  apiClient: {
+    get: hoisted.apiGetMock,
+  },
+}));
+
+import { useJobProgress } from './useJobProgress';
+
+describe('useJobProgress — messages buffer (#1471)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.signalRCallbacks = {};
+    hoisted.connStateListener = null;
+    hoisted.apiGetMock.mockResolvedValue({ messages: [] });
+  });
+
+  it('seeds the buffer from GET /api/jobs/{id} on mount', async () => {
+    hoisted.apiGetMock.mockResolvedValue({
+      messages: ['Reprojecting R (1 of 3)', 'Reprojecting G (2 of 3)'],
+    });
+
+    const { result } = renderHook(() => useJobProgress('job-A'));
+
+    // Flush the seed promise.
+    await waitFor(() => expect(hoisted.apiGetMock).toHaveBeenCalledWith('/api/jobs/job-A'));
+    await waitFor(() => expect(result.current.messages.length).toBeGreaterThan(0));
+
+    expect(result.current.messages).toEqual(['Reprojecting R (1 of 3)', 'Reprojecting G (2 of 3)']);
+  });
+
+  it('appends progress messages on each event', async () => {
+    const { result } = renderHook(() => useJobProgress('job-B'));
+    await waitFor(() => expect(typeof hoisted.signalRCallbacks.onProgress).toBe('function'));
+
+    act(() => {
+      hoisted.signalRCallbacks.onProgress({
+        progress: 10,
+        stage: 'reproject',
+        message: 'Reprojecting R (1 of 3)',
+      });
+    });
+    act(() => {
+      hoisted.signalRCallbacks.onProgress({
+        progress: 20,
+        stage: 'reproject',
+        message: 'Reprojecting G (2 of 3)',
+      });
+    });
+
+    expect(result.current.messages).toEqual(['Reprojecting R (1 of 3)', 'Reprojecting G (2 of 3)']);
+  });
+
+  it('dedupes consecutive duplicate progress messages', async () => {
+    const { result } = renderHook(() => useJobProgress('job-C'));
+    await waitFor(() => expect(typeof hoisted.signalRCallbacks.onProgress).toBe('function'));
+
+    act(() => {
+      hoisted.signalRCallbacks.onProgress({
+        progress: 10,
+        stage: 'reproject',
+        message: 'Reprojecting R (1 of 3)',
+      });
+      hoisted.signalRCallbacks.onProgress({
+        progress: 11,
+        stage: 'reproject',
+        message: 'Reprojecting R (1 of 3)',
+      });
+      hoisted.signalRCallbacks.onProgress({
+        progress: 12,
+        stage: 'reproject',
+        message: 'Reprojecting R (1 of 3)',
+      });
+      hoisted.signalRCallbacks.onProgress({
+        progress: 20,
+        stage: 'reproject',
+        message: 'Reprojecting G (2 of 3)',
+      });
+    });
+
+    expect(result.current.messages).toEqual(['Reprojecting R (1 of 3)', 'Reprojecting G (2 of 3)']);
+  });
+
+  it('caps the buffer at 50 entries', async () => {
+    const { result } = renderHook(() => useJobProgress('job-D'));
+    await waitFor(() => expect(typeof hoisted.signalRCallbacks.onProgress).toBe('function'));
+
+    act(() => {
+      for (let i = 0; i < 60; i++) {
+        hoisted.signalRCallbacks.onProgress({
+          progress: i % 100,
+          stage: 'stretch',
+          message: `step ${i}`,
+        });
+      }
+    });
+
+    expect(result.current.messages).toHaveLength(50);
+    // Oldest 10 dropped; first remaining is "step 10".
+    expect(result.current.messages[0]).toBe('step 10');
+    expect(result.current.messages[49]).toBe('step 59');
+  });
+
+  it('refetches buffer on SignalR reconnect', async () => {
+    hoisted.apiGetMock.mockResolvedValueOnce({ messages: ['initial'] });
+    hoisted.apiGetMock.mockResolvedValueOnce({
+      messages: ['initial', 'after-reconnect-1', 'after-reconnect-2'],
+    });
+
+    const { result } = renderHook(() => useJobProgress('job-E'));
+
+    await waitFor(() => expect(result.current.messages).toEqual(['initial']));
+    expect(hoisted.connStateListener).not.toBeNull();
+
+    // Simulate a reconnect: state goes from connected → reconnecting → connected.
+    // The hook should refetch on the second 'connected'.
+    act(() => {
+      hoisted.connStateListener!('connected');
+    });
+    act(() => {
+      hoisted.connStateListener!('reconnecting');
+    });
+    act(() => {
+      hoisted.connStateListener!('connected');
+    });
+
+    // Initial mount: 1 fetch. Reconnect (single transition INTO 'connected'
+    // after the initial seed completed): 1 fetch. The first 'connected'
+    // transition (before reconnect) is suppressed by the initialSeedDone
+    // guard so we don't double-fetch on first connect.
+    await waitFor(() => expect(hoisted.apiGetMock.mock.calls.length).toBe(2));
+    await waitFor(() =>
+      expect(result.current.messages).toEqual(['initial', 'after-reconnect-1', 'after-reconnect-2'])
+    );
+  });
+
+  it('resets buffer when jobId becomes null', async () => {
+    hoisted.apiGetMock.mockResolvedValue({ messages: ['hello'] });
+    const { result, rerender } = renderHook(
+      ({ jobId }: { jobId: string | null }) => useJobProgress(jobId),
+      {
+        initialProps: { jobId: 'job-F' },
+      }
+    );
+
+    await waitFor(() => expect(result.current.messages).toEqual(['hello']));
+
+    rerender({ jobId: null as unknown as string });
+
+    expect(result.current.messages).toEqual([]);
+  });
+
+  // Regression test for round 2 of the self-review: a non-null → non-null
+  // jobId switch must reset state so the new job's server seed isn't merged
+  // against the prior job's stale buffer.
+  it('resets buffer when jobId switches non-null → non-null', async () => {
+    hoisted.apiGetMock.mockImplementation(async (path: string) => {
+      if (path.includes('job-old')) {
+        return { messages: ['old-msg-A', 'old-msg-B'] };
+      }
+      return { messages: ['new-msg-only'] };
+    });
+
+    const { result, rerender } = renderHook(
+      ({ jobId }: { jobId: string }) => useJobProgress(jobId),
+      {
+        initialProps: { jobId: 'job-old' },
+      }
+    );
+
+    await waitFor(() => expect(result.current.messages).toEqual(['old-msg-A', 'old-msg-B']));
+
+    rerender({ jobId: 'job-new' });
+
+    // Old buffer must be cleared synchronously on the rerender; the new
+    // server seed then populates it without merging the old entries in.
+    await waitFor(() => expect(result.current.messages).toEqual(['new-msg-only']));
+    expect(result.current.messages).not.toContain('old-msg-A');
+    expect(result.current.messages).not.toContain('old-msg-B');
+  });
+
+  // Regression test for round 2 of the self-review: when the local buffer
+  // contains the server's tail message at multiple positions, the merge
+  // must anchor on the LATEST occurrence (lastIndexOf), not the first
+  // (indexOf would double-count entries between first and last match).
+  it('merges using the latest local occurrence of the server tail on reconnect', async () => {
+    hoisted.apiGetMock.mockResolvedValueOnce({
+      messages: ['snapshot-1', 'snapshot-2'],
+    });
+    // Round 2 reconnect re-fetches a server snapshot whose tail equals an
+    // earlier message ALSO present at a later index in the local buffer.
+    hoisted.apiGetMock.mockResolvedValueOnce({
+      messages: ['snapshot-1', 'snapshot-2', 'recurring'],
+    });
+
+    const { result } = renderHook(() => useJobProgress('job-recur'));
+
+    await waitFor(() => expect(result.current.messages).toEqual(['snapshot-1', 'snapshot-2']));
+    expect(hoisted.connStateListener).not.toBeNull();
+
+    // Local buffer accrues live events: ..., recurring, X, recurring, Y.
+    // The server snapshot's tail will be `recurring`. lastIndexOf must
+    // anchor on the second occurrence so only Y is preserved as tail.
+    act(() => {
+      hoisted.signalRCallbacks.onProgress({ progress: 30, stage: 'a', message: 'recurring' });
+      hoisted.signalRCallbacks.onProgress({ progress: 40, stage: 'b', message: 'X' });
+      hoisted.signalRCallbacks.onProgress({ progress: 50, stage: 'c', message: 'recurring' });
+      hoisted.signalRCallbacks.onProgress({ progress: 60, stage: 'd', message: 'Y' });
+    });
+
+    expect(result.current.messages).toEqual([
+      'snapshot-1',
+      'snapshot-2',
+      'recurring',
+      'X',
+      'recurring',
+      'Y',
+    ]);
+
+    // Trigger a reconnect so the merge runs against the duplicate-bearing
+    // local buffer.
+    act(() => {
+      hoisted.connStateListener!('connected');
+    });
+    act(() => {
+      hoisted.connStateListener!('reconnecting');
+    });
+    act(() => {
+      hoisted.connStateListener!('connected');
+    });
+
+    // Correct merge with lastIndexOf: server's `recurring` anchors on the
+    // second local occurrence (index 4), so the tail kept is just `['Y']`.
+    // With the buggy indexOf, the tail would have been `['X','recurring','Y']`
+    // and the merged result would have included the duplicates.
+    await waitFor(() =>
+      expect(result.current.messages).toEqual(['snapshot-1', 'snapshot-2', 'recurring', 'Y'])
+    );
+  });
+});

--- a/frontend/jwst-frontend/src/hooks/useJobProgress.test.ts
+++ b/frontend/jwst-frontend/src/hooks/useJobProgress.test.ts
@@ -20,7 +20,57 @@ vi.mock('../services/mastService', () => ({
   getImportProgress: vi.fn(),
 }));
 
-import { subscribeToJobProgress } from './useJobProgress';
+import {
+  subscribeToJobProgress,
+  appendBufferedMessage,
+  MAX_LOG_PANEL_MESSAGES,
+} from './useJobProgress';
+
+// #1471 — `appendBufferedMessage` is the shared rolling-buffer helper used by
+// both `useJobProgress` and `GuidedCreate`. Its contract is small but
+// load-bearing — a regression in any branch (empty-skip, dedupe, cap) would
+// silently corrupt the LogPanel buffer. Lock it down with direct unit tests.
+describe('appendBufferedMessage', () => {
+  it('returns the same array reference when message is undefined', () => {
+    const prev = ['a', 'b'];
+    expect(appendBufferedMessage(prev, undefined)).toBe(prev);
+  });
+
+  it('returns the same array reference when message is null', () => {
+    const prev = ['a', 'b'];
+    expect(appendBufferedMessage(prev, null)).toBe(prev);
+  });
+
+  it('returns the same array reference when message is the empty string', () => {
+    const prev = ['a', 'b'];
+    expect(appendBufferedMessage(prev, '')).toBe(prev);
+  });
+
+  it('appends a new message to a non-empty buffer', () => {
+    expect(appendBufferedMessage(['a', 'b'], 'c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('appends a new message to an empty buffer', () => {
+    expect(appendBufferedMessage([], 'first')).toEqual(['first']);
+  });
+
+  it('dedupes consecutive duplicate messages (returns same reference)', () => {
+    const prev = ['a', 'b'];
+    expect(appendBufferedMessage(prev, 'b')).toBe(prev);
+  });
+
+  it('does NOT dedupe when the same message appears non-consecutively', () => {
+    expect(appendBufferedMessage(['a', 'b', 'c'], 'a')).toEqual(['a', 'b', 'c', 'a']);
+  });
+
+  it('truncates oldest entries when exceeding MAX_LOG_PANEL_MESSAGES', () => {
+    const full = Array.from({ length: MAX_LOG_PANEL_MESSAGES }, (_v, i) => `msg-${i}`);
+    const result = appendBufferedMessage(full, 'overflow');
+    expect(result).toHaveLength(MAX_LOG_PANEL_MESSAGES);
+    expect(result[0]).toBe('msg-1'); // oldest dropped
+    expect(result[result.length - 1]).toBe('overflow');
+  });
+});
 
 describe('subscribeToJobProgress — timeout behavior', () => {
   beforeEach(() => {

--- a/frontend/jwst-frontend/src/hooks/useJobProgress.ts
+++ b/frontend/jwst-frontend/src/hooks/useJobProgress.ts
@@ -27,7 +27,35 @@ import { apiClient } from '../services/apiClient';
 // JobTracker.MaxMessages to keep the UI consistent with what GET /api/jobs/{id}
 // returns. SignalR pushes only the latest message per progress event; this
 // hook accumulates them locally.
-const MAX_LOG_PANEL_MESSAGES = 50;
+export const MAX_LOG_PANEL_MESSAGES = 50;
+
+/**
+ * Append a progress message to a rolling buffer. Returns the existing buffer
+ * unchanged when the message is empty/null/undefined or matches the most
+ * recent entry (consecutive-dedupe). Truncates oldest entries when the
+ * buffer exceeds `MAX_LOG_PANEL_MESSAGES`.
+ *
+ * Shared between `useJobProgress` and any component that subscribes to
+ * progress directly via `subscribeToJobProgress` (e.g. `GuidedCreate`)
+ * so both surfaces present the same buffer semantics to the LogPanel.
+ *
+ * The null/undefined acceptance is defensive — current callers narrow to
+ * `string | undefined`, but `JobProgressUpdate.message` is nullable in the
+ * BSON model and a future caller reading directly from a JobStatus snapshot
+ * could pass null. Cheaper to handle here than at every call site.
+ */
+export function appendBufferedMessage(
+  prev: string[],
+  message: string | undefined | null
+): string[] {
+  if (!message) return prev;
+  if (prev.length > 0 && prev[prev.length - 1] === message) return prev;
+  const next = [...prev, message];
+  if (next.length > MAX_LOG_PANEL_MESSAGES) {
+    return next.slice(-MAX_LOG_PANEL_MESSAGES);
+  }
+  return next;
+}
 
 /** Callbacks for the imperative subscription API. */
 export interface JobProgressCallbacks {
@@ -578,17 +606,7 @@ export function useJobProgress(
     if (!jobId) return;
 
     const appendMessage = (msg: string | undefined) => {
-      if (!msg) return;
-      setMessages((prev) => {
-        if (prev.length > 0 && prev[prev.length - 1] === msg) {
-          return prev;
-        }
-        const next = [...prev, msg];
-        if (next.length > MAX_LOG_PANEL_MESSAGES) {
-          return next.slice(-MAX_LOG_PANEL_MESSAGES);
-        }
-        return next;
-      });
+      setMessages((prev) => appendBufferedMessage(prev, msg));
     };
 
     const sub = subscribeToJobProgress(

--- a/frontend/jwst-frontend/src/hooks/useJobProgress.ts
+++ b/frontend/jwst-frontend/src/hooks/useJobProgress.ts
@@ -18,8 +18,16 @@ import type {
   JobFailureUpdate,
   JobSnapshotUpdate,
 } from '../types/JobTypes';
-import { subscribeToJob } from '../services/signalRService';
+import { subscribeToJob, onConnectionStateChange } from '../services/signalRService';
+import type { SignalRConnectionState } from '../services/signalRService';
 import { getImportProgress } from '../services/mastService';
+import { apiClient } from '../services/apiClient';
+
+// #1471 — local cap on the LogPanel rolling buffer. Mirrors the server-side
+// JobTracker.MaxMessages to keep the UI consistent with what GET /api/jobs/{id}
+// returns. SignalR pushes only the latest message per progress event; this
+// hook accumulates them locally.
+const MAX_LOG_PANEL_MESSAGES = 50;
 
 /** Callbacks for the imperative subscription API. */
 export interface JobProgressCallbacks {
@@ -469,6 +477,7 @@ export function useJobProgress(
   progress: ImportJobStatus | null;
   isComplete: boolean;
   error: string | null;
+  messages: string[];
 } {
   const [state, setState] = useState<{
     progress: ImportJobStatus | null;
@@ -476,29 +485,126 @@ export function useJobProgress(
     error: string | null;
   }>({ progress: null, isComplete: false, error: null });
 
-  // Reset state during render when jobId changes to null (no effect needed)
+  // #1471 — rolling buffer of recent progress messages for the LogPanel.
+  // Hydrated from GET /api/jobs/{id} on mount and on SignalR reconnect;
+  // appended on each per-event push. Capped + dedupe to mirror server-side.
+  const [messages, setMessages] = useState<string[]>([]);
+
+  // Reset state during render whenever jobId changes — including non-null
+  // → non-null transitions (a "resume" / "switch jobs" flow) so a stale
+  // snapshot from the previous job can't briefly show against the new one,
+  // and so the merge logic in the hydration effect can't mistake a prior
+  // job's buffer for a "local tail" of the new job's server snapshot.
   const [prevJobId, setPrevJobId] = useState<string | null>(null);
   if (jobId !== prevJobId) {
     setPrevJobId(jobId);
-    if (!jobId) {
-      setState({ progress: null, isComplete: false, error: null });
-    }
+    setState({ progress: null, isComplete: false, error: null });
+    setMessages([]);
   }
+
+  // #1471 — fetch full server-side messages buffer on mount and after SignalR
+  // reconnect so the LogPanel rehydrates without losing entries when the
+  // socket drops mid-job. Best-effort: a failed GET leaves the buffer
+  // un-rehydrated and the next live event simply appends.
+  useEffect(() => {
+    if (!jobId) return;
+
+    let cancelled = false;
+    let initialSeedDone = false;
+
+    const seedFromServer = async () => {
+      try {
+        const status = await apiClient.get<{ messages?: string[] }>(`/api/jobs/${jobId}`);
+        if (cancelled) return;
+        const serverMessages = status.messages ?? [];
+        if (serverMessages.length === 0) return;
+
+        // Merge instead of replace: a SignalR onProgress event can land
+        // between when this GET was sent and when it resolves. Replacing
+        // would drop those client-side entries the server snapshot didn't
+        // see yet. Strategy: union by detecting where the server snapshot
+        // ends inside the local buffer (the server is always a prefix of
+        // the local buffer if no entries were lost) and append any
+        // remaining local tail. If the server snapshot diverges from the
+        // local buffer (e.g. the local buffer was empty), the snapshot wins.
+        setMessages((prev) => {
+          if (prev.length === 0) {
+            return serverMessages.slice(-MAX_LOG_PANEL_MESSAGES);
+          }
+          const lastServer = serverMessages[serverMessages.length - 1];
+          // lastIndexOf — the server snapshot is a strict prefix of the live
+          // buffer in correct operation, so the latest occurrence in the local
+          // buffer is the right anchor. indexOf would falsely treat a duplicate
+          // earlier in the buffer as the boundary and double-count entries.
+          const tailStart = prev.lastIndexOf(lastServer) + 1;
+          if (tailStart === 0) {
+            // Local buffer doesn't contain the server's tail — out of sync.
+            // Server is authoritative; replace.
+            return serverMessages.slice(-MAX_LOG_PANEL_MESSAGES);
+          }
+          const localTail = prev.slice(tailStart);
+          const merged = [...serverMessages, ...localTail];
+          return merged.slice(-MAX_LOG_PANEL_MESSAGES);
+        });
+      } catch {
+        // GET failures don't break the live-progress flow — SignalR pushes
+        // will populate the buffer from the next event onward.
+      }
+    };
+
+    seedFromServer().finally(() => {
+      initialSeedDone = true;
+    });
+
+    let prevConnectionState: SignalRConnectionState | null = null;
+    const unsubscribeConnState = onConnectionStateChange((nextState) => {
+      // Refetch only on reconnect (transition FROM 'reconnecting' INTO
+      // 'connected'). Initial connect (from null / 'connecting' / 'disconnected'
+      // → 'connected') is skipped — the direct mount seed above already
+      // covered it, and double-fetching produces a redundant render.
+      if (initialSeedDone && prevConnectionState === 'reconnecting' && nextState === 'connected') {
+        seedFromServer();
+      }
+      prevConnectionState = nextState;
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribeConnState();
+    };
+  }, [jobId]);
 
   useEffect(() => {
     if (!jobId) return;
+
+    const appendMessage = (msg: string | undefined) => {
+      if (!msg) return;
+      setMessages((prev) => {
+        if (prev.length > 0 && prev[prev.length - 1] === msg) {
+          return prev;
+        }
+        const next = [...prev, msg];
+        if (next.length > MAX_LOG_PANEL_MESSAGES) {
+          return next.slice(-MAX_LOG_PANEL_MESSAGES);
+        }
+        return next;
+      });
+    };
 
     const sub = subscribeToJobProgress(
       jobId,
       {
         onProgress: (status) => {
           setState({ progress: status, isComplete: false, error: null });
+          appendMessage(status.message);
         },
         onCompleted: (status) => {
           setState({ progress: status, isComplete: true, error: null });
+          appendMessage(status.message);
         },
         onFailed: (status) => {
           setState({ progress: status, isComplete: true, error: status.error ?? status.message });
+          appendMessage(status.error ?? status.message);
         },
       },
       { obsId, signalROnly, ...timeoutOptions }
@@ -516,5 +622,5 @@ export function useJobProgress(
 
   const { progress, isComplete, error } = state;
 
-  return { progress, isComplete, error };
+  return { progress, isComplete, error, messages };
 }

--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -15,7 +15,7 @@ import {
   parseCompositeWarning,
 } from '../services/compositeService';
 import { checkDataAvailability } from '../services/jwstDataService';
-import { subscribeToJobProgress } from '../hooks/useJobProgress';
+import { subscribeToJobProgress, appendBufferedMessage } from '../hooks/useJobProgress';
 import { apiClient } from '../services/apiClient';
 import { ApiError } from '../services/ApiError';
 import { useAuth } from '../context/useAuth';
@@ -162,6 +162,12 @@ export function GuidedCreate() {
   const [processProgress, setProcessProgress] = useState<ImportJobStatus | null>(null);
   const [processError, setProcessError] = useState<string | null>(null);
   const [processComplete, setProcessComplete] = useState(false);
+  // #1471 — rolling buffer of per-event progress messages from the engine
+  // (e.g. "Reprojecting F277W (1 of 3)"). Surfaced via the LogPanel inside
+  // ProcessStep. SignalR delivers one `status.message` per event; we
+  // accumulate them locally with the same cap-50 / dedupe-consecutive
+  // semantics as `useJobProgress` (shared via `appendBufferedMessage`).
+  const [processMessages, setProcessMessages] = useState<string[]>([]);
 
   // Result state
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -575,9 +581,17 @@ export function GuidedCreate() {
     // Clear any stale error/warning from a prior run; "Continue anyway" must
     // start from a clean slate so the new outcome (success-with-warning,
     // different error, etc.) renders correctly.
+    // #1471 — kickoff-reset invariant: every entry to startProcessing must
+    // clear processMessages so retry / continue-anyway flows don't briefly
+    // flash the previous job's last message above the new "Starting…" line.
+    // No GuidedCreate.test.tsx infra in the repo today (would require
+    // mocking router + auth + several services for one-line state setters);
+    // tracked as follow-up. Keep all reset setters together as a single
+    // logical group to make accidental drops easier to catch in review.
     setCompositeWarning(null);
     setProcessError(null);
     setProcessComplete(false);
+    setProcessMessages([]);
 
     try {
       const channels = buildChannelPayloads(matchedRecipe, filterDataMapRef.current);
@@ -620,10 +634,12 @@ export function GuidedCreate() {
             onProgress: (status) => {
               if (cancelled) return;
               setProcessProgress(status);
+              setProcessMessages((prev) => appendBufferedMessage(prev, status.message));
             },
-            onCompleted: async () => {
+            onCompleted: async (status) => {
               if (cancelled) return;
               setProcessComplete(true);
+              setProcessMessages((prev) => appendBufferedMessage(prev, status.message));
 
               try {
                 const { blob, headers } = await apiClient.getBlobWithHeaders(
@@ -646,6 +662,9 @@ export function GuidedCreate() {
               // is lost crossing the SignalR boundary. Engine detail still
               // appears in the error string.
               setProcessError(status.error ?? 'Composite generation failed.');
+              setProcessMessages((prev) =>
+                appendBufferedMessage(prev, status.error ?? status.message)
+              );
             },
           },
           { signalROnly: true }
@@ -1108,6 +1127,7 @@ export function GuidedCreate() {
             requiresMosaic={recipe?.requiresMosaic ?? false}
             phase={recipe?.requiresMosaic ? 'mosaic' : 'composite'}
             progress={processProgress}
+            messages={processMessages}
             error={processError}
             isComplete={processComplete}
             channelCount={channelPayloads.length}

--- a/frontend/jwst-frontend/src/types/MastTypes.ts
+++ b/frontend/jwst-frontend/src/types/MastTypes.ts
@@ -84,6 +84,12 @@ export interface ImportJobStatus {
   // Job result fields (populated on completion for non-import jobs)
   resultKind?: 'blob' | 'data_id';
   resultDataId?: string;
+  // #1471 — server-side rolling buffer of recent progress messages.
+  // Populated by GET /api/jobs/{id}; absent on SignalR push payloads (which
+  // carry only the latest `message`). useJobProgress maintains its own
+  // local buffer from per-event messages and rehydrates from this field on
+  // mount and on SignalR reconnect.
+  messages?: string[];
 }
 
 export const ImportStages = {

--- a/processing-engine/app/composite/progress.py
+++ b/processing-engine/app/composite/progress.py
@@ -1,0 +1,60 @@
+"""Progress emission for the streaming composite endpoint.
+
+The streaming route owns an asyncio.Queue that an event-stream generator
+drains as NDJSON lines. The synchronous composite pipeline (run in a worker
+thread) calls a `ProgressCallback` to push progress dicts into that queue.
+
+When `progress` is `None`, helpers that accept it short-circuit — that's the
+sync `/composite/generate-nchannel` path, which never opted into streaming.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+# Sink for one structured progress event. The streaming route binds this to
+# an asyncio.Queue via loop.call_soon_threadsafe; the sync route passes None.
+ProgressCallback = Callable[[dict[str, Any]], None] | None
+
+
+class PipelineCancelled(Exception):
+    """Raised at a stage boundary when the streaming client disconnected.
+
+    The streaming route checks this in `run_pipeline`'s exception handler
+    and exits cleanly (no `error` event emitted, since nobody is listening).
+    Pipeline helpers that accept a `progress` callback don't need to know
+    about this — `emit_progress` raises it for them at every emit boundary.
+    """
+
+
+def emit_progress(
+    progress: ProgressCallback,
+    stage: str,
+    message: str,
+    *,
+    filter: str | None = None,  # noqa: A002 - matches engine event schema; the param shadow is intentional
+    index: int | None = None,
+    total: int | None = None,
+    rss_mb: float | None = None,
+) -> None:
+    """Emit a `progress` event if a callback is wired, no-op otherwise.
+
+    Pipeline code calls this at stage boundaries. The shape mirrors the
+    documented event schema in #1471 so backend stream-consumer tests can
+    assert on field names.
+    """
+    if progress is None:
+        return
+
+    event: dict[str, Any] = {"event": "progress", "stage": stage, "message": message}
+    if filter is not None:
+        event["filter"] = filter
+    if index is not None:
+        event["index"] = index
+    if total is not None:
+        event["total"] = total
+    if rss_mb is not None:
+        event["rss_mb"] = rss_mb
+    progress(event)

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -2,20 +2,25 @@
 FastAPI routes for RGB composite image generation.
 """
 
+import asyncio
+import base64
+import contextlib
 import gc
 import io
+import json
 import logging
 import os
 import re
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 from astropy.stats import sigma_clipped_stats
 from astropy.wcs import WCS
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import Response
+from fastapi.responses import Response, StreamingResponse
 from PIL import Image
 from reproject import reproject_interp
 from reproject.mosaicking import find_optimal_celestial_wcs
@@ -66,6 +71,7 @@ from .models import (
     OverallAdjustments,
     SharpeningConfig,
 )
+from .progress import PipelineCancelled, ProgressCallback, emit_progress
 from .quality import compute_quality_metrics
 
 
@@ -765,6 +771,7 @@ def _compute_memory_budget(
 def _reproject_all_channels(
     request: NChannelCompositeRequest,
     input_budget: int,
+    progress: ProgressCallback = None,
 ) -> tuple[dict[str, np.ndarray], MemoryBudgetVerdict]:
     """Reproject all channels onto a common WCS grid.
 
@@ -821,7 +828,15 @@ def _reproject_all_channels(
 
     # Reproject each channel directly onto the final grid
     reprojected_channels: dict[str, np.ndarray] = {}
-    for ch_name, local_paths in all_channel_info:
+    for ch_idx, (ch_name, local_paths) in enumerate(all_channel_info):
+        emit_progress(
+            progress,
+            stage="reproject",
+            message=f"Reprojecting {ch_name} ({ch_idx + 1} of {n})",
+            filter=ch_name,
+            index=ch_idx + 1,
+            total=n,
+        )
         n_files = len(local_paths)
         per_file_budget = max(input_budget // max(n_files, 1), MIN_PREVIEW_PIXELS)
 
@@ -940,6 +955,7 @@ def _load_reprojected_channels(
     request: NChannelCompositeRequest,
     channel_instruments: list[str | None],
     input_budget: int,
+    progress: ProgressCallback = None,
 ) -> tuple[dict[str, np.ndarray], MemoryBudgetVerdict]:
     """Load reprojected channel data from cache, or compute via full pipeline.
 
@@ -968,7 +984,7 @@ def _load_reprojected_channels(
         logger.info("N-channel cache HIT (different budget) — reusing cached data")
         return fallback, _verdict_for_cached(fallback, n, original_shape=original_shape)
 
-    reprojected, verdict = _reproject_all_channels(request, input_budget)
+    reprojected, verdict = _reproject_all_channels(request, input_budget, progress=progress)
     _apply_resolution_blur(reprojected, channel_instruments, request)
     # Carry original_shape provenance only when this run was force-downscaled,
     # so future cache hits surface the warning. For ok/warn entries the shapes
@@ -1098,6 +1114,7 @@ def _stretch_and_map_channels(
     request: NChannelCompositeRequest,
     stretch_input: dict[str, np.ndarray],
     channel_instruments: list[str | None],
+    progress: ProgressCallback = None,
 ) -> StretchResult:
     """Apply stretch functions and separate channels into color vs luminance groups.
 
@@ -1127,6 +1144,7 @@ def _stretch_and_map_channels(
     logger.info("Applying stretch and color mapping")
     result = StretchResult()
     ch_names = list(stretch_input.keys())
+    n_channels = len(ch_names)
 
     # Auto-stretch: compute optimal params from data statistics.
     # Mutates ch_config fields directly — safe because validate_assignment is off
@@ -1148,6 +1166,14 @@ def _stretch_and_map_channels(
 
     for idx, ch_config in enumerate(request.channels):
         ch_name = ch_names[idx]
+        emit_progress(
+            progress,
+            stage="stretch",
+            message=f"Stretching {ch_name} ({idx + 1} of {n_channels})",
+            filter=ch_name,
+            index=idx + 1,
+            total=n_channels,
+        )
         stretched = apply_stretch(stretch_input[ch_name], ch_config)
         rgb_weights = resolve_channel_color(ch_config.color)
 
@@ -1435,16 +1461,16 @@ def _encode_and_respond(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/generate-nchannel")
-def generate_nchannel_composite(request: NChannelCompositeRequest):
-    """Generate an RGB composite image from N FITS channels with color mapping.
+def _run_nchannel_pipeline(
+    request: NChannelCompositeRequest,
+    progress: ProgressCallback = None,
+) -> Response:
+    """Run the full N-channel composite pipeline.
 
-    Each channel gets a color assignment (hue or explicit RGB weights).
-    Channels are stretched independently, then combined via weighted
-    color mapping into a single RGB image.
-
-    Returns:
-        Binary image data with appropriate content type.
+    Shared body of `generate_nchannel_composite` (sync) and
+    `generate_nchannel_composite_stream` (NDJSON streaming). Pass `progress`
+    to emit per-channel events to the streaming response; pass `None` for
+    the buffered sync path (no events emitted, no overhead).
     """
     input_budget = min(
         MAX_INPUT_PIXELS,
@@ -1458,19 +1484,27 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
     )
 
     instruments = _detect_channel_instruments(request.channels)
-    reprojected, verdict = _load_reprojected_channels(request, instruments, input_budget)
+    reprojected, verdict = _load_reprojected_channels(
+        request, instruments, input_budget, progress=progress
+    )
     feather, auto_feathered = _resolve_feather_strength(request, instruments)
 
     if request.debug_masks:
         return _render_debug_masks_response(request, reprojected, instruments, feather)
 
     if request.background_neutralization:
+        emit_progress(
+            progress,
+            stage="background_neutralize",
+            message="Applying background neutralization",
+        )
         logger.info("Applying cross-channel background neutralization (pre-stretch)")
         stretch_input = neutralize_raw_backgrounds(reprojected)
     else:
         stretch_input = reprojected
 
-    mapped = _stretch_and_map_channels(request, stretch_input, instruments)
+    mapped = _stretch_and_map_channels(request, stretch_input, instruments, progress=progress)
+    emit_progress(progress, stage="combine", message="Combining color channels")
     rgb = _combine_to_rgb(mapped, reprojected, request, feather, instruments)
     if request.sharpening is not None and request.sharpening.amount > 0.0:
         rgb = apply_sharpening(
@@ -1478,7 +1512,105 @@ def generate_nchannel_composite(request: NChannelCompositeRequest):
         )
     if request.saturation is not None:
         rgb = apply_saturation_vibrancy(rgb, request.saturation)
+    emit_progress(progress, stage="encode", message="Encoding image")
     return _encode_and_respond(rgb, request, auto_feathered, feather, verdict)
+
+
+@router.post("/generate-nchannel")
+def generate_nchannel_composite(request: NChannelCompositeRequest):
+    """Generate an RGB composite image from N FITS channels with color mapping.
+
+    Each channel gets a color assignment (hue or explicit RGB weights).
+    Channels are stretched independently, then combined via weighted
+    color mapping into a single RGB image.
+
+    Returns:
+        Binary image data with appropriate content type.
+    """
+    return _run_nchannel_pipeline(request, progress=None)
+
+
+@router.post("/generate-nchannel-stream")
+async def generate_nchannel_composite_stream(request: NChannelCompositeRequest):
+    """Stream NDJSON progress events while generating an N-channel composite.
+
+    Each line of the response is one JSON object:
+      - `{"event": "progress", "stage": ..., "filter": ..., "index": ...,
+         "total": ..., "message": ...}` during the pipeline
+      - terminal: `{"event": "complete", "image_b64": ..., "content_type": ...,
+                    "headers": {...}}` on success
+      - terminal: `{"event": "error", "detail": ..., "status_code": ...}` on
+        any HTTPException or unexpected error
+
+    The pipeline runs in a worker thread; the route's async generator drains
+    a queue the worker pushes events into. Client disconnect cancels the
+    generator, which surfaces in the worker via `cancellation.is_set()` —
+    best-effort, since numpy operations aren't preemptible mid-call.
+    """
+    queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+    loop = asyncio.get_running_loop()
+    cancellation = threading.Event()
+
+    def emit(event: dict[str, Any] | None) -> None:
+        # Check the cancellation flag at every emit (i.e. every pipeline stage
+        # boundary) so a client disconnect short-circuits the pipeline at the
+        # next progress event instead of running to completion. The pipeline
+        # raises PipelineCancelled which run_pipeline's outer except catches.
+        if cancellation.is_set() and event is not None:
+            raise PipelineCancelled()
+        # Loop closed while emitter was racing — client already gone.
+        with contextlib.suppress(RuntimeError):
+            loop.call_soon_threadsafe(queue.put_nowait, event)
+
+    def run_pipeline() -> None:
+        try:
+            response = _run_nchannel_pipeline(request, progress=emit)
+            if cancellation.is_set():
+                return
+            image_bytes: bytes = bytes(response.body)
+            content_type = response.media_type or "image/png"
+            headers = dict(response.headers.items())
+            emit(
+                {
+                    "event": "complete",
+                    "image_b64": base64.b64encode(image_bytes).decode("ascii"),
+                    "content_type": content_type,
+                    "headers": headers,
+                }
+            )
+        except PipelineCancelled:
+            # Client disconnected — bail silently. No `error` event because
+            # nobody is listening on the other side of the queue.
+            logger.info("Streaming composite cancelled by client disconnect")
+        except HTTPException as e:
+            emit({"event": "error", "detail": str(e.detail), "status_code": e.status_code})
+        except Exception as e:  # noqa: BLE001 - surface arbitrary engine failures
+            logger.exception("Streaming composite failed")
+            emit({"event": "error", "detail": str(e), "status_code": 500})
+        finally:
+            # Sentinel may be unobserved if the consumer already exited, but
+            # call_soon_threadsafe handles a closed loop gracefully.
+            emit(None)
+
+    pipeline_task = asyncio.create_task(asyncio.to_thread(run_pipeline))
+
+    async def event_stream():
+        try:
+            while True:
+                event = await queue.get()
+                if event is None:
+                    break
+                yield json.dumps(event) + "\n"
+        finally:
+            # Client disconnected or stream ended — signal the worker so future
+            # emit() calls become harmless. The worker can't be preempted mid
+            # numpy call, but it will exit on the next stage boundary.
+            cancellation.set()
+            # already logged in run_pipeline; swallow so the response can close cleanly
+            with contextlib.suppress(Exception):
+                await pipeline_task
+
+    return StreamingResponse(event_stream(), media_type="application/x-ndjson")
 
 
 # ---------------------------------------------------------------------------

--- a/processing-engine/tests/test_composite_streaming.py
+++ b/processing-engine/tests/test_composite_streaming.py
@@ -1,0 +1,257 @@
+"""Tests for the streaming N-channel composite endpoint (#1471).
+
+`POST /composite/generate-nchannel-stream` returns NDJSON — one JSON object
+per line, with progress events during the pipeline and a terminal `complete`
+or `error` event. These tests assert event ordering, the terminal payloads,
+and client-disconnect handling without doing real reproject + combine work
+(reuse the `mock_pipeline` cache fixture pattern from test_nchannel_composite).
+"""
+
+import base64
+import json
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+
+def _make_test_data(shape=(50, 50), value=1000.0):
+    rng = np.random.default_rng(42)
+    return rng.normal(loc=value, scale=100, size=shape).astype(np.float64)
+
+
+@pytest.fixture()
+def client():
+    from main import app
+
+    return TestClient(app)
+
+
+@pytest.fixture()
+def mock_pipeline_cache():
+    """Same shape as the cache mock in test_nchannel_composite — bypasses
+    the WCS + reproject path so the streaming tests run fast."""
+    shape = (50, 50)
+    data = _make_test_data(shape)
+    default_channels = {f"ch{i}": data.copy() for i in range(6)}
+
+    class FakeCache:
+        def __init__(self):
+            self._data = default_channels
+            self._original_shape: tuple[int, int] | None = None
+
+        def make_key_nchannel(self, *_args, **_kwargs):
+            return "fake-key"
+
+        def get(self, _key):
+            if self._data is None:
+                return None
+            return self._data, self._original_shape
+
+        def get_any_budget(self, _paths):
+            return None
+
+        def put(self, _key, _data, _paths, original_shape=None):
+            self._original_shape = original_shape
+
+        @property
+        def return_value(self):
+            return self._data
+
+        @return_value.setter
+        def return_value(self, value):
+            if isinstance(value, tuple):
+                self._data = value[0]
+            else:
+                self._data = value
+
+    fake = FakeCache()
+    with patch("app.composite.routes._cache", fake):
+        yield fake
+
+
+def _parse_ndjson(body: bytes) -> list[dict[str, Any]]:
+    """Parse an NDJSON response body into a list of event dicts."""
+    return [json.loads(line) for line in body.splitlines() if line.strip()]
+
+
+class TestGenerateNChannelStream:
+    """POST /composite/generate-nchannel-stream — NDJSON streaming response."""
+
+    def _three_channel_request(self) -> dict[str, Any]:
+        return {
+            "channels": [
+                {"file_paths": ["r.fits"], "color": {"hue": 0.0}, "label": "Red"},
+                {"file_paths": ["g.fits"], "color": {"hue": 120.0}, "label": "Green"},
+                {"file_paths": ["b.fits"], "color": {"hue": 240.0}, "label": "Blue"},
+            ],
+            "width": 100,
+            "height": 100,
+        }
+
+    def test_response_is_ndjson(self, client, mock_pipeline_cache):
+        shape = (50, 50)
+        data = _make_test_data(shape)
+        mock_pipeline_cache.return_value = (
+            {f"ch{i}": data.copy() for i in range(3)},
+            shape,
+        )
+
+        response = client.post(
+            "/composite/generate-nchannel-stream",
+            json=self._three_channel_request(),
+        )
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/x-ndjson")
+
+    def test_emits_per_channel_stretch_events(self, client, mock_pipeline_cache):
+        shape = (50, 50)
+        data = _make_test_data(shape)
+        mock_pipeline_cache.return_value = (
+            {f"ch{i}": data.copy() for i in range(3)},
+            shape,
+        )
+
+        response = client.post(
+            "/composite/generate-nchannel-stream",
+            json=self._three_channel_request(),
+        )
+        events = _parse_ndjson(response.content)
+        stretch_events = [e for e in events if e.get("stage") == "stretch"]
+        # Three channels, three stretch events, ordered 1..3 of 3.
+        assert len(stretch_events) == 3
+        for idx, event in enumerate(stretch_events, start=1):
+            assert event["event"] == "progress"
+            assert event["index"] == idx
+            assert event["total"] == 3
+            assert "filter" in event
+            assert "message" in event
+
+    def test_emits_combine_and_encode_stages(self, client, mock_pipeline_cache):
+        shape = (50, 50)
+        data = _make_test_data(shape)
+        mock_pipeline_cache.return_value = (
+            {f"ch{i}": data.copy() for i in range(3)},
+            shape,
+        )
+
+        response = client.post(
+            "/composite/generate-nchannel-stream",
+            json=self._three_channel_request(),
+        )
+        events = _parse_ndjson(response.content)
+        stages = [e.get("stage") for e in events if e.get("event") == "progress"]
+        # Combine fires once; encode fires once. Order: combine before encode.
+        assert "combine" in stages
+        assert "encode" in stages
+        assert stages.index("combine") < stages.index("encode")
+
+    def test_terminal_complete_carries_image(self, client, mock_pipeline_cache):
+        shape = (50, 50)
+        data = _make_test_data(shape)
+        mock_pipeline_cache.return_value = (
+            {f"ch{i}": data.copy() for i in range(3)},
+            shape,
+        )
+
+        response = client.post(
+            "/composite/generate-nchannel-stream",
+            json=self._three_channel_request(),
+        )
+        events = _parse_ndjson(response.content)
+        terminal = events[-1]
+        assert terminal["event"] == "complete"
+        assert "image_b64" in terminal
+        assert terminal["content_type"] in ("image/png", "image/jpeg")
+        # Decoded payload must be a valid image at the requested dimensions.
+        decoded = base64.b64decode(terminal["image_b64"])
+        img = Image.open(__import__("io").BytesIO(decoded))
+        assert img.size == (100, 100)
+
+    def test_terminal_error_on_invalid_request(self, client, mock_pipeline_cache):  # noqa: ARG002 - fixture bypasses file resolution so the engine reaches the luminance validation
+
+        response = client.post(
+            "/composite/generate-nchannel-stream",
+            json={
+                # Two luminance channels — pipeline raises HTTPException(422).
+                "channels": [
+                    {"file_paths": ["a.fits"], "color": {"luminance": True}},
+                    {"file_paths": ["b.fits"], "color": {"luminance": True}},
+                ],
+                "width": 100,
+                "height": 100,
+            },
+        )
+        assert response.status_code == 200  # streaming response itself is 200
+        events = _parse_ndjson(response.content)
+        terminal = events[-1]
+        assert terminal["event"] == "error"
+        assert "luminance" in terminal["detail"].lower()
+        assert terminal.get("status_code") == 422
+
+    def test_progress_emitter_raises_when_cancellation_flag_set(self):
+        """The streaming route's emit closure raises PipelineCancelled at the
+        next stage boundary when its threading.Event is set, so a client
+        disconnect short-circuits the pipeline instead of running to completion.
+
+        This is a unit test on the cancellation contract — full integration
+        with `client.stream(...)` + connection close is awkward in TestClient
+        (which buffers responses); the contract here is what makes the route
+        safe under client disconnect.
+        """
+        import asyncio
+        import contextlib
+        import threading
+
+        from app.composite.progress import PipelineCancelled
+
+        # Drive the same emit closure pattern the route uses.
+        loop = asyncio.new_event_loop()
+        cancellation = threading.Event()
+        queue: asyncio.Queue = asyncio.Queue()  # unused; emit just calls put_nowait
+
+        def emit(event):
+            if cancellation.is_set() and event is not None:
+                raise PipelineCancelled()
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(queue.put_nowait, event)
+
+        # Without flag set, emit succeeds.
+        emit({"event": "progress", "stage": "reproject", "message": "first"})
+
+        # Set the flag (as the event_stream's finally would on disconnect).
+        cancellation.set()
+
+        # Next emit raises — pipeline code would unwind.
+        with pytest.raises(PipelineCancelled):
+            emit({"event": "progress", "stage": "stretch", "message": "second"})
+
+        # Sentinel emits (None) bypass the cancellation check — the worker's
+        # finally must still be able to drop the sentinel.
+        emit(None)
+
+        loop.close()
+
+    def test_progress_events_have_required_schema(self, client, mock_pipeline_cache):
+        shape = (50, 50)
+        data = _make_test_data(shape)
+        mock_pipeline_cache.return_value = (
+            {f"ch{i}": data.copy() for i in range(3)},
+            shape,
+        )
+
+        response = client.post(
+            "/composite/generate-nchannel-stream",
+            json=self._three_channel_request(),
+        )
+        events = _parse_ndjson(response.content)
+        progress_events = [e for e in events if e.get("event") == "progress"]
+        assert progress_events, "expected at least one progress event"
+        for event in progress_events:
+            assert "stage" in event
+            assert "message" in event
+            assert isinstance(event["message"], str)
+            assert event["message"]


### PR DESCRIPTION
## Summary

Engine→backend streaming progress channel + collapsible developer-detail log panel. The wizard composite preview now shows **per-channel** stage transitions ("Reprojecting F277W (1 of 3) · 0:14") during the long pipeline call, instead of sitting on a single "Generating composite" label for 30–60 s on every multi-channel composite.

This is **Phase 2** of the two-phase plan; **Phase 1 (PR #1472) shipped** and is the foundation Phase 2 stacks on. Closes #1471.

## Why

Phase 1 surfaced coarse stages (queued → mosaic → generating → encode), which solved "stuck or working?" for the queue + setup steps. But **the bulk of any 3-channel composite — every RGB recipe by definition — is spent inside the engine call**, where Phase 1 had nothing to forward. Users saw a single "Generating composite" label for 30+ s on every preview. Phase 2 closes that gap.

## Changes Made

### Engine (Python / FastAPI)
- `processing-engine/app/composite/progress.py` (new) — `ProgressCallback` type + `emit_progress` helper + `PipelineCancelled` exception used to short-circuit the pipeline at stage boundaries when the streaming client disconnects.
- `processing-engine/app/composite/routes.py`:
  - Factored the body of `generate_nchannel_composite` into `_run_nchannel_pipeline` so both the buffered and streaming routes share one implementation.
  - New `POST /composite/generate-nchannel-stream` route returning `application/x-ndjson`. Each line: `{event:"progress", stage, filter, index, total, message}` during the pipeline; terminal `{event:"complete", image_b64, content_type, headers}` or `{event:"error", detail, status_code}`.
  - Pipeline runs in `asyncio.to_thread`; foreground generator drains an `asyncio.Queue`. Client disconnect sets a `threading.Event`; the next `emit_progress` raises `PipelineCancelled`, the worker unwinds, response closes — no engine cycles wasted on dropped previews.
  - Threaded `progress` through `_load_reprojected_channels`, `_reproject_all_channels`, `_stretch_and_map_channels` so per-channel events fire from inside the slow stages.

### Backend (.NET)
- `Models/JobStatus.cs` — new `Messages: List<string>` (server-side rolling buffer; serialized in the GET /api/jobs/{id} response so the LogPanel can rehydrate after SignalR drops).
- `Services/CompositeService.cs`:
  - `GenerateNChannelCompositeAsync` now branches on `onProgress != null`: callers without a progress callback keep hitting buffered `/composite/generate-nchannel`; the wizard preview / export paths route through the new streaming endpoint.
  - New private `StreamNChannelCompositeAsync` consumes the NDJSON line-by-line via `HttpCompletionOption.ResponseHeadersRead` + `StreamReader.ReadLineAsync`, calls `onProgress(pct, stage, message)` per progress event, validates and decodes b64 on `complete`, throws translated exceptions on `error`.
  - Stage-to-progress-pct interpolation via `StageProgressWindows` (queued → encode) so the bar advances monotonically with per-channel index/total resolution.
- `Services/JobTracker.cs`:
  - `UpdateProgressAsync` appends each non-empty distinct message to the rolling buffer (cap 50, consecutive duplicates collapsed). The buffer mutation + Stage/Message/ProgressPercent/State writes are now under a `lock (job.Messages)` so concurrent dual-writes (e.g., import flow's `Task.Run` writers) and reader serialization can't race.
  - `UpdateByteProgressAsync` takes the same lock around its `Metadata` mutations — symmetric coverage; closes a latent torn-read crash on the polling-fallback path under concurrent dual-writes.
  - New `WithMessagesSnapshot` helper allocates a detached `JobStatus` copy inside the lock; used by `GetJobAsync`, `GetJobInternalAsync`, `PersistJob`, and `PersistAndNotifyProgress` so MongoDB BSON serialization and SignalR JSON serialization always see a stable point-in-time view.

### Frontend (React)
- `hooks/useJobProgress.ts`:
  - Hook now returns `messages: string[]` (rolling buffer cap 50, consecutive duplicates collapsed). Hydrates from `GET /api/jobs/{id}` on mount; rehydrates on SignalR `reconnecting → connected` transitions; appends per progress event.
  - Reconnect merge logic uses `lastIndexOf` to anchor on the latest local occurrence of the server's tail (avoids double-counting when a stage re-emits a prior message).
  - State + buffer reset on every jobId change (including non-null → non-null) so a "switch jobs" flow can't merge a prior job's tail into the new server snapshot.
- `components/wizard/LogPanel.tsx` (new) — collapsed-by-default disclosure ("Show details ▸"). Open: scrollable, monospace, timestamped buffer with auto-scroll-to-bottom that freezes when the user has scrolled up to read history. Uses `role="region"` + `aria-label` + explicit `aria-live="off"` (defends against ancestor live regions like `ProcessStep`); intentionally **not** `role="log"` (would spam screen readers).
- `components/wizard/CompositePreviewStep.tsx` — renders `<LogPanel>` below the loading status line on the authenticated async path.
- `pages/GuidedCreate.tsx` — new `processMessages` state next to `processProgress`; appends in `onProgress` / `onCompleted` / `onFailed`; resets in `startProcessing` so retry / continue-anyway flows start from an empty buffer; passes to `ProcessStep` via the new `messages` prop. **Surfaces Phase 2 progress on the curated recipe walkthrough at `/create` — the most common user flow.**
- `components/guided/ProcessStep.tsx` — new `messages?: string[]` prop. Renders the latest message inline as the "current activity" line above the elapsed timer, and the full buffer behind a `<LogPanel>` disclosure below the bullets. Root sets explicit `aria-atomic="false"` so the 1Hz elapsed-timer tick + the new inline message don't trigger atomic re-announcement of the entire `role="status"` region every second (same regression class as PR #1456's wavelength-ribbon fix).
- `hooks/useJobProgress.ts` — exports `appendBufferedMessage(prev, msg)` so `GuidedCreate`'s direct `subscribeToJobProgress` callbacks can apply the same cap-50 / dedupe-consecutive buffer semantics as the hook.
- `types/MastTypes.ts` — `messages?: string[]` on `ImportJobStatus`.

### Docs
- `docs/plans/features/1471-engine-streaming-progress.md` — full plan with all eng-review decisions baked in.
- `docs/quick-reference.md`, `docs/standards/backend-development.md` — note the new streaming behavior on `generate-nchannel-async` and `Messages` on `GET /api/jobs/{id}`.

### Tests
- **Engine**: 7 streaming tests in `tests/test_composite_streaming.py` — happy-path event ordering, terminal complete with valid image, terminal error, schema validation, cancellation contract.
- **Backend**: 6 streaming consumer tests in `CompositeServiceTests.cs` (NDJSON happy path, error event, 413 mapping, partial chunks, malformed line, sync path still buffered) + 4 buffer tests + 1 concurrency stress test (25 + 25 + 25 writers/readers × 50 iterations) in `JobTrackerTests.cs`.
- **Frontend**: 8 LogPanel tests + 8 useJobProgress buffer tests (hydration, dedupe, cap, reconnect merge, cross-job reset, lastIndexOf merge anchor) + 8 direct `appendBufferedMessage` helper tests + 5 ProcessStep tests for the new `messages` prop (empty / latest-inline / disclosure-count / hides-on-error / hides-on-completion).

## Test Plan

- [x] `docker exec jwst-processing python -m pytest` — 1360 / 1360 pass
- [x] `dotnet test` — 1111 / 1111 pass
- [x] `npx vitest run` — 1024 / 1024 pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint` (changed files) — 0 errors, warnings consistent with existing patterns in same files
- [x] `docker compose up -d --build` — all services up healthy
- [x] Self-review pipeline: 7 rounds with the `code-reviewer` agent (5 on the engine→backend transport + LogPanel, 2 on the GuidedCreate addition), iterated to zero MUST FIX + zero SHOULD FIX outstanding

### Manual verification (reviewer)

- [ ] **Curated recipe walkthrough (`/create`)**: pick a 3+ channel target (e.g. NGC 3324 → NIRCam 3-Filter), watch the Process step. Verify a "current activity" line appears above the elapsed timer with per-channel events (`Reprojecting F277W (1 of 3)` → `Stretching F356W (2 of 3)` → ...), and click "Show details" to confirm the full LogPanel buffer.
- [ ] **Wizard preview (`/composite`)**: same per-channel events visible above the spinner; LogPanel disclosure works.
- [ ] Click "Show details" — verify the LogPanel expands and contains 30+ entries by the time the composite finishes; auto-scrolls to bottom; freezes auto-scroll when you scroll up; resumes when you scroll back to bottom.
- [ ] Open browser devtools → Network → kill the SignalR WebSocket while a composite is running — verify the LogPanel rehydrates from `GET /api/jobs/{id}` once the socket reconnects, with no duplicate entries.
- [ ] Generate a slow composite, then close the browser tab mid-generation — verify the engine logs show `"Streaming composite cancelled by client disconnect"` and the worker exits at the next stage boundary instead of running to completion.
- [ ] Trigger a composite memory-budget 413, click "Continue anyway", verify the LogPanel buffer resets to empty before the second job's first message arrives (no flash of stale messages from the failed run).
- [ ] As anonymous user, generate a composite preview — confirm no regression (still uses sync engine endpoint, no progress UI).

## Documentation Checklist
- [x] `docs/quick-reference.md` — note streaming behavior on `generate-nchannel-async`
- [x] `docs/standards/backend-development.md` — note `Messages` on `GET /api/jobs/{jobId}` response
- [x] `docs/plans/features/1471-engine-streaming-progress.md` — full plan with eng-review decisions
- [ ] `docs/key-files.md` — not applicable, no new top-level services
- [ ] `docs/architecture/` — not applicable, reuses async-job architecture from Phase 1
- [ ] `docs/development-plan.md` — not applicable, no milestone changes

## Tech Debt Impact
- [x] Existing tech debt reduced — closes #1471. Resolves the "60–90 s single-label silence" gap that Phase 1 left in place.
- [x] Latent crash bug fixed — `UpdateByteProgressAsync` was mutating `job.Metadata` without a lock; concurrent reads from the polling-fallback `GET /api/jobs/{id}` path could intermittently throw `InvalidOperationException` on dictionary enumeration. Round 4 of self-review surfaced this; round 5 covers it with a stress test.
- [ ] No new tech debt introduced.

## Risk & Rollback

- **Risk: Medium.** New transport at the engine→backend boundary (NDJSON streaming via `HttpCompletionOption.ResponseHeadersRead`). Streaming HTTP responses interact with timeouts, proxies, and error handling differently from buffered HTTP. The b64 decode adds a ~CPU-bound step on the backend; the terminal `complete` event allocates ~1.3× the image size on the wire (b64 overhead). The new `JobStatus.Messages` field grows MongoDB document size by up to ~5 KB per job. Concurrency safety is covered by a stress test, but the lock object is `job.Messages` (a List, not a dedicated lock object) — a future contributor that reassigns `Messages` would break the lock invariant.
- **Rollback**: revert this PR. Backend reverts to buffered `PostAsync` against `/composite/generate-nchannel`; engine streaming endpoint becomes dead code (additive, no callers); frontend LogPanel disappears, falling back to Phase 1's stage label + elapsed time.

## Out of Scope (separate issues if needed)

- ETA badge / `eta_seconds` on `/composite/estimate` — separate problem (estimation needs telemetry).
- Removing the sync `/composite/generate-nchannel` endpoint — anonymous wizard users still depend on it (`JobProgressHub` is `[Authorize]`).
- LogPanel filtering / severity coloring — engine logs are uniform `logger.info` today; revisit if needed.

