### PR TITLE
chore(skills): port Tier 1+2 from gstack upstream into plan-{ceo,eng}-review

### DIFF
--- a/.claude/skills/plan-ceo-review/SKILL.md
+++ b/.claude/skills/plan-ceo-review/SKILL.md
@@ -23,6 +23,21 @@ You are not here to rubber-stamp this plan. You are here to make it extraordinar
 > feature, ask them sequentially so the user can give each one full
 > consideration. Batching is the failure mode this rule exists to prevent.
 
+## Mindset — Cognitive Patterns
+
+These are not checklist items. They are thinking instincts to internalize, not enumerate. Let them shape your perspective throughout the review.
+
+1. **Inversion reflex** — For every "how do we make this work?" also ask "what would make it fail?" (Munger). Failure mode hunting beats success enumeration.
+2. **Focus as subtraction** — Primary value-add is what to *not* do. Default: do fewer things, better. Bias toward Mode D (Reduction) when in doubt.
+3. **Speed calibration** — Fast is default. Only slow down for irreversible + high-magnitude decisions. 70% information is enough to decide. (Aligns with the reversal-cost gate — rip-it-out-in-an-hour → go.)
+4. **Proxy skepticism** — Are the metrics or success criteria still serving real users, or have they become self-referential? Question whether the stated goal is the actual goal.
+5. **Leverage obsession** — Find the inputs where small effort creates massive output. Solo dev: every hour spent on the wrong thing is doubly expensive — there's no team to absorb the cost.
+6. **Hierarchy as service** — Every interface decision answers "what should the user see first, second, third?" Respect their attention; that's the real currency.
+7. **Edge case paranoia (design)** — What if the value is 47 chars? Zero results? Network fails mid-action? First-time user vs power user? Empty states are features, not afterthoughts.
+8. **Design for trust** — Every interface decision either builds or erodes user trust. Pixel-level intentionality about safety, identity, and what the user thinks will happen next.
+
+When you challenge scope → focus as subtraction. When you assess timeline → speed calibration. When you probe whether the plan solves a real problem → proxy skepticism. When you evaluate UI → hierarchy as service, edge case paranoia, design for trust. When you evaluate architecture → inversion reflex.
+
 **First: detect the base branch.**
 ```bash
 git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"
@@ -114,6 +129,30 @@ For any plan touching the JWST stack, check:
 - Does this add/change a collection schema? → Load-bearing, requires EnterPlanMode
 - Does this add indexes? → Check existing index definitions first
 
+## Step 4b: Design & UX Check (skip if no UI scope)
+
+If the plan touches frontend components, a wizard step, dialogs, or any user-visible surface, evaluate design intentionality. This is not a pixel-level audit — that's the `interface-design` / `ux-designer` skills. This is ensuring the plan has thought about the user experience.
+
+Evaluate:
+
+- **Information architecture** — what does the user see first, second, third? Does the most important thing dominate the layout?
+- **Interaction state coverage map** — for the new feature, fill in the row:
+  | FEATURE | LOADING | EMPTY | ERROR | SUCCESS | PARTIAL |
+  | --- | --- | --- | --- | --- | --- |
+  | (name) | ? | ? | ? | ? | ? |
+  Each "?" must be answered or filed as a known gap.
+- **User journey coherence** — storyboard the emotional arc. What does the user feel at each step? Where does friction live? Is there a moment that delights?
+- **AI slop risk** — does the plan describe generic UI patterns ("a card with a button", "a modal with a form")? Push for specificity.
+- **DESIGN.md / existing pattern alignment** — does the plan match patterns already in the codebase (collapsible panels, wizard step layout, banner styles)?
+- **Responsive intention** — is mobile/narrow-viewport handling specified, or an afterthought?
+- **Accessibility basics** — keyboard nav, screen-reader behavior (especially aria-live regions like the wavelength ribbon), contrast, touch targets.
+
+Required ASCII diagram (if UI scope is significant): user flow showing screens/states and transitions.
+
+**EXPANSION mode addition:** What 30-minute UI touches would make a user think "oh nice, they thought of that"?
+
+If the plan has significant UI scope, recommend: "Consider running `/interface-design` or `/ux-designer` for a deep design pass before implementation."
+
 ## Step 5: Required Outputs
 
 Produce:
@@ -123,6 +162,7 @@ Produce:
 3. **NOT in scope** — explicit list of related things that were considered and excluded
 4. **What already exists** — any related code found during grep
 5. **Recommendation** — proceed as-is / proceed with changes / needs EnterPlanMode before starting
+6. **Stale Diagram Audit** — list every ASCII diagram in `docs/architecture/` (or any other doc this plan touches) that's still accurate after the change, and any that need updating in the same PR. If none touched, write "No diagrams in scope."
 
 If the plan requires EnterPlanMode (load-bearing change), say so explicitly and trigger it.
 

--- a/.claude/skills/plan-eng-review/SKILL.md
+++ b/.claude/skills/plan-eng-review/SKILL.md
@@ -94,29 +94,100 @@ Without seeing the code yet, predict quality risks based on the plan:
 
 ---
 
+## Step 2b: Confidence Calibration
+
+Every finding (in this review or in any AskUserQuestion you raise) MUST include a confidence score (1-10):
+
+| Score | Meaning | Display rule |
+|-------|---------|-------------|
+| 9-10 | Verified by reading specific code. Concrete bug or exploit demonstrated. | Show normally |
+| 7-8 | High confidence pattern match. Very likely correct. | Show normally |
+| 5-6 | Moderate. Could be a false positive. | Show with caveat: "Medium confidence, verify this is actually an issue" |
+| 3-4 | Low confidence. Pattern is suspicious but may be fine. | Suppress from main report. Include in appendix only. |
+| 1-2 | Speculation. | Only report if severity would be P0. |
+
+**Finding format:**
+
+`[SEVERITY] (confidence: N/10) file:line — description`
+
+Example:
+- `[P1] (confidence: 9/10) backend/Controllers/CompositeController.cs:142 — Missing auth check on /preview endpoint`
+- `[P2] (confidence: 5/10) processing-engine/services/composite.py:203 — Possible OOM if filter count > 12, verify against memory budget`
+
+**Calibration learning:** If you report a finding with confidence < 7 and the user confirms it IS a real issue, that's a calibration event — your initial confidence was too low. Note the corrected pattern in the review log so future reviews catch it with higher confidence.
+
+---
+
 ## Step 3: Test Plan Artifact
 
-Produce a concrete test plan as a structured artifact:
+The JWST stack has a fixed test framework topology — use it as the authoritative target:
+
+| Layer | Framework | How to run |
+|-------|-----------|-----------|
+| Frontend unit | vitest | `npm test --prefix frontend/jwst-frontend` |
+| Frontend E2E | @playwright/test | `npm run test:e2e --prefix frontend/jwst-frontend` |
+| Backend | xUnit + Moq | `dotnet test backend/Jwst.Backend.sln` |
+| Processing engine | pytest | `docker exec jwst-processing python -m pytest` |
+
+### Coverage trace (every plan)
+
+For each new or modified function, service, endpoint, or component in the plan:
+
+1. **Trace data flow** end-to-end from entry point (route handler, exported function, event listener, component render) — every branch (if/else, switch, ternary, guard clause, early return), every error path (try/catch, error boundary, fallback), every external call.
+2. **Map user flows** — the sequence of actions a real user takes that touches this code. For UI work, include: double-click/rapid resubmit, navigate-away mid-operation, stale data after long idle, slow connection, concurrent tabs.
+3. **Match against existing tests** — for each branch + each user flow, find the test that covers it. Use this quality rubric:
+   - ★★★ Behavior + edge cases + error paths
+   - ★★  Happy path only
+   - ★   Smoke / "renders without crashing"
+
+### REGRESSION RULE (mandatory)
+
+**IRON RULE:** When the coverage trace identifies a REGRESSION — code that previously worked but the diff breaks (modified existing behavior, no test covers the changed path, new failure mode for existing callers) — a regression test is added to the plan as a CRITICAL requirement. No AskUserQuestion. No skipping. Regressions are the highest-priority test because they prove something broke. When uncertain, err on the side of writing the test.
+
+### E2E Decision Matrix
+
+| Mark as | Use when |
+|---------|---------|
+| `[→E2E]` | User flow spans 3+ components/services, integration point where mocking hides real failures, auth/data-destruction flows |
+| `[→UNIT]` | Pure function, internal helper, edge case of a single function, obscure non-customer-facing flow |
+
+### Artifact format
+
+Produce the test plan as:
 
 ```
 TEST PLAN — [Feature Name]
 
-Unit Tests:
-- [ ] [service/component]: [what behavior is tested]
-- [ ] [service/component]: [edge case]
+## Affected Pages/Routes
+- [URL path or backend route] — [what to test and why]
 
-Integration Tests:
-- [ ] [endpoint or flow]: [happy path]
-- [ ] [endpoint or flow]: [error path]
+## Key Interactions to Verify
+- [interaction] on [page/endpoint]
 
-E2E Tests (if UI change):
-- [ ] [user action]: [expected result]
-- [ ] [user action]: [expected result with error state]
+## Edge Cases
+- [edge case] on [page/endpoint]
 
-Manual Verification:
+## Critical Paths
+- [end-to-end flow that must work]
+
+## Coverage Diagram
+[+] [file path]
+  ├── [function/method]
+  │   ├── [★★★ TESTED] [happy + edge + error] — [test file:line]
+  │   └── [GAP] [→E2E] [missing branch / user flow]
+
+COVERAGE: X/Y paths tested (Z%)  |  GAPS: N (M E2E)
+
+## Test Tasks (added to plan)
+- [ ] [unit/E2E/regression] [test file]: [what it asserts]
+- [ ] CRITICAL (regression): [test file]: [what broke that needs proving]
+
+## Manual Verification
 - [ ] [specific thing to click/observe in the running app]
 - [ ] [Docker rebuild required? yes/no]
 ```
+
+If all paths are covered: write "Test review: All new code paths have test coverage ✓" and continue.
 
 ---
 
@@ -126,6 +197,33 @@ Manual Verification:
 - Does this block the request thread during heavy processing? (should be async + job queue)
 - Does this load unbounded data? (large FITS files, full collection scans)
 - Does this affect any hot paths? (observation list loading, composite generation)
+
+---
+
+## Step 4b: Worktree Parallelization
+
+Analyze the plan's implementation steps for parallel execution opportunities. This helps decide whether to fan work out across git worktrees (`git worktree add`, or via the Agent tool with `isolation: "worktree"`).
+
+**Skip if** all steps touch the same primary module, or the plan has fewer than 2 independent workstreams. Write: "Sequential implementation, no parallelization opportunity."
+
+**Otherwise produce:**
+
+1. **Dependency table** — work at module/directory level (not file level — file-level is guesswork against an unfinished plan):
+
+| Step | Modules touched | Depends on |
+|------|-----------------|------------|
+| (step name) | (e.g. `backend/Controllers/`, `frontend/.../wizard/`) | (other steps, or —) |
+
+2. **Parallel lanes**:
+   - Steps with no shared modules and no dependency → separate lanes (parallel)
+   - Steps sharing a module directory → same lane (sequential)
+   - Steps depending on other steps → later lanes
+
+   Format: `Lane A: step1 → step2 (sequential, shared backend/Controllers/)` / `Lane B: step3 (independent)`
+
+3. **Execution order** — which lanes launch in parallel, which wait. Example: "Launch A + B in parallel worktrees. Merge both. Then C."
+
+4. **Conflict flags** — if two parallel lanes touch the same module directory, flag it: "Lanes X and Y both touch `frontend/.../wizard/` — potential merge conflict. Consider sequential execution."
 
 ---
 


### PR DESCRIPTION
No linked issue

## Summary

- Port the high-leverage, stack-agnostic upgrades that have landed in `garrytan/gstack` upstream into our local `plan-ceo-review` and `plan-eng-review` skills (last sync was 2026-04-23 / commit `8bcabc1`).
- Skip gstack-internal runtime infrastructure (gbrain/artifacts sync, telemetry, GSTACK REVIEW REPORT formatter, plan status footer) and Outside Voice integration (depends on `codex` CLI, not installed locally).
- Net diff: `plan-ceo-review` 152 → 192 lines (+40), `plan-eng-review` 170 → 268 lines (+98). Skills stay readable; tier-3 ceremonial growth (gstack's CEO went 152 → 2108 lines upstream) is left out.

## Why

Upstream `garrytan/gstack` has shipped ~10 commits to these skill files between 2026-04-23 and 2026-05-07. Several of the additions (confidence calibration, regression rule, structured test artifact, worktree parallelization, design/UX check, cognitive-patterns mindset) are stack-agnostic upgrades that strengthen review quality and dovetail with the existing JWST workflow. Bringing them in keeps our skills competitive with the source without inheriting gstack's runtime infrastructure.

## Changes Made

### `plan-eng-review` (170 → 268 lines)
- **New `Step 2b: Confidence Calibration`** — every finding (and any AskUserQuestion raised) must carry a confidence score 1-10. Format: `[SEVERITY] (confidence: N/10) file:line — description`. Findings ≤ 4 get suppressed/appendixed; ≤ 2 only surface for P0.
- **`Step 3: Test Plan Artifact` rewrite** — JWST has a fixed test framework topology, so the artifact now hardcodes the four runners (vitest, @playwright/test, xUnit+Moq, pytest in `jwst-processing`). Adds: 3-step coverage trace, ★/★★/★★★ quality rubric, REGRESSION RULE iron-rule (mandatory regression test for any modified existing behavior, no AskUserQuestion), E2E vs UNIT decision matrix, structured artifact format (Affected Pages / Key Interactions / Edge Cases / Critical Paths / Coverage Diagram / Test Tasks / Manual Verification).
- **New `Step 4b: Worktree Parallelization`** — dependency table at module level (not file level), parallel lane assignment, execution order, conflict flags. Skips when work is sequential.

### `plan-ceo-review` (152 → 192 lines)
- **New `Mindset — Cognitive Patterns`** section — 8 thinking instincts trimmed from upstream's 18 (kept the ones that map to the JWST workflow: Inversion Reflex, Focus as Subtraction, Speed Calibration, Proxy Skepticism, Leverage Obsession, Hierarchy as Service, Edge Case Paranoia, Design for Trust). Dropped corp-flavored ones (wartime awareness, willfulness as strategy, narrative coherence, etc.).
- **New `Step 4b: Design & UX Check`** — conditional on UI scope. Covers information architecture, FEATURE × LOADING/EMPTY/ERROR/SUCCESS/PARTIAL state coverage map, user journey coherence, AI slop risk, DESIGN.md alignment, responsive intention, a11y basics. Recommends `/interface-design` or `/ux-designer` for UI-heavy plans.
- **`Step 5 Required Outputs`** — added item 6: Stale Diagram Audit. Lists every ASCII diagram in `docs/architecture/` (or any other doc the plan touches) that's still accurate, and any that need updating in the same PR.

### Excluded from upstream (Tier 3)
- gbrain artifacts sync, `/sync-gbrain`, per-skill brain manifests
- Telemetry, plan status footer, GSTACK REVIEW REPORT delete-then-append formatter
- Outside Voice (codex/subagent independent challenge) — depends on `codex` CLI, not installed
- AskUserQuestion host-MCP fallback / format self-check — we already enforce one-question-per-call (PR #1416 / commit `8bcabc1`)
- Voice / Writing Style / Continuous Checkpoint Mode / Question Tuning / expanded cognitive-patterns set
- 11-section CEO review framework + Completion Summary ASCII table — overkill for solo passion project

## Test Plan

- [x] Line counts match targets: `wc -l .claude/skills/plan-{ceo,eng}-review/SKILL.md` → 192 and 268
- [x] Pre-commit hook passed (`✅ All pre-commit checks passed!`) — skill files are markdown-only, no code runtime risk
- [x] `git diff main -- .claude/skills/plan-ceo-review/SKILL.md .claude/skills/plan-eng-review/SKILL.md` reviewed — only the additions described above; no existing content removed except the old Step 3 test plan block which was rewritten in place
- [ ] Manual smoke: invoke `/plan-eng-review` on a small plan in a follow-up session — verify the new Step 2b confidence-calibration table renders, Step 3 surfaces the JWST framework table + REGRESSION RULE callout, and Step 4b worktree analysis appears
- [ ] Manual smoke: invoke `/plan-ceo-review` on a UI-touching feature — verify the new Mindset section is referenced in the agent's framing, Step 4b Design & UX Check fires (UI scope detected), Stale Diagram Audit appears in Required Outputs section 6

## Documentation Checklist

- [x] No documentation updates needed
- [ ] `docs/key-files.md` (new files/services)
- [ ] `docs/standards/backend-development.md` (new endpoints/controllers)
- [ ] `docs/quick-reference.md` (new API endpoints)
- [ ] `docs/architecture/` (new services/architectural changes)
- [ ] `docs/development-plan.md` (milestone/phase changes)

Skill files are agent-internal procedural knowledge; no public-facing documentation references them.

## Tech Debt Impact

- [x] No new tech debt introduced
- [ ] Tech debt introduced — GitHub Issue created and linked
- [ ] Existing tech debt reduced — GitHub Issue closed

Reduces drift from upstream `garrytan/gstack` without inheriting its runtime obligations. Future syncs will be smaller diffs as a result.

## Risk & Rollback

- **Risk:** Low. Skill content only — no production code, no API change, no data model change, no test changes. The skills are invoked interactively by an agent; worst case is the new sections produce output Shanon doesn't like, which surfaces immediately on next use.
- **Rollback:** `git revert <sha>` on this single commit, or selectively revert one of the two skill files. Both are single-file changes with no cross-cutting dependencies.

## Notes

- Source: extracted from `garrytan/gstack@7b4738b` (v1.27.1.0, 2026-05-07). Upstream raw section files cached at `/tmp/gstack-upstream/sections/` for reference.
- No related GitHub issue — work was triggered ad-hoc from a "have these moved upstream?" check.
