### PR TITLE
fix: guard empty channel list in debug masks (#1285)

### DIFF
--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -228,6 +228,11 @@ def _render_debug_masks(
     Panels are arranged horizontally with labels.
     """
     n = len(ch_names)
+    if n == 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Debug masks require at least one color channel; all channels are luminance-only.",
+        )
     ref_shape = reprojected[ch_names[0]].shape
     h, w = ref_shape
 

--- a/processing-engine/tests/test_nchannel_composite.py
+++ b/processing-engine/tests/test_nchannel_composite.py
@@ -1370,6 +1370,32 @@ class TestRenderDebugMasksResponse:
 
         assert "x-debug-warning" not in response.headers
 
+    def test_all_luminance_raises_400(self):
+        """All-luminance channels yield no color masks — must raise 400, not IndexError (#1285)."""
+        import pytest
+        from fastapi import HTTPException
+
+        shape = (50, 50)
+        reprojected = {"L1": np.ones(shape), "L2": np.ones(shape)}
+        request = NChannelCompositeRequest(
+            channels=[
+                NChannelConfig(
+                    file_paths=["a.fits"], color=ChannelColor(luminance=True), label="L1"
+                ),
+                NChannelConfig(
+                    file_paths=["b.fits"], color=ChannelColor(luminance=True), label="L2"
+                ),
+            ],
+            width=200,
+            height=100,
+            debug_masks=True,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            _render_debug_masks_response(request, reprojected, [None, None], 0.0)
+        assert exc.value.status_code == 400
+        assert "luminance" in exc.value.detail.lower()
+
 
 class TestApplySharpening:
     """Tests for the apply_sharpening helper (luminance-preserving unsharp mask)."""


### PR DESCRIPTION
Closes #1285

## Summary

Guard against the all-luminance edge case in `_render_debug_masks`: instead of raising `IndexError`, raise `HTTPException(400)` with a clear message.

## Why

When every channel in an `NChannelCompositeRequest` is flagged `luminance=True`, the upstream filter in `_render_debug_masks_response` (composite/routes.py:1296-1299) returns an empty `color_ch_names` list. `_render_debug_masks` then does `ref_shape = reprojected[ch_names[0]].shape` (line 231), which raises `IndexError` and surfaces as an HTTP 500 with no diagnostic info. The request is well-formed in shape but semantically meaningless, so 400 is the right code.

## Changes Made

- `processing-engine/app/composite/routes.py` — early-return guard at the top of `_render_debug_masks` raising `HTTPException(400)` when `ch_names` is empty.
- `processing-engine/tests/test_nchannel_composite.py` — new `test_all_luminance_raises_400` in `TestRenderDebugMasksResponse`.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_nchannel_composite.py::TestRenderDebugMasksResponse -v --no-cov` — 5/5 pass (was 4/4).
- [x] New test asserts `HTTPException` is raised, `status_code == 400`, and detail contains `"luminance"`.
- [x] Ruff lint + format clean (pre-commit hook).

## Documentation Checklist
- [x] No documentation updates needed (internal behavior, error path)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: Low. New code path only triggers when the upstream `color_ch_names` filter would have produced an empty list — previously the only behavior in that case was a crash. No legitimate composite request reaches this branch.
- Rollback: revert the commit; behavior returns to IndexError on the edge case.
