### PR TITLE
fix: raise ValueError instead of asserting in _build_coverage_mask (#1190)

### DIFF
--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -540,7 +540,8 @@ def _build_coverage_mask(reprojected: dict[str, np.ndarray]) -> np.ndarray:
     for data in reprojected.values():
         ch_mask = data != 0
         mask = ch_mask if mask is None else (mask | ch_mask)
-    assert mask is not None, "reprojected must contain at least one channel"
+    if mask is None:
+        raise ValueError("reprojected must contain at least one channel")
     return mask
 
 

--- a/processing-engine/tests/test_nchannel_composite.py
+++ b/processing-engine/tests/test_nchannel_composite.py
@@ -1484,6 +1484,15 @@ class TestApplySharpening:
         assert not mask[1, 0]
         assert not mask[3, 3]
 
+    def test_build_coverage_mask_raises_on_empty_dict(self):
+        """Empty reprojected dict raises ValueError, not AssertionError — #1190.
+
+        Assertions are stripped under `python -O`; ValueError survives and
+        gives callers a meaningful exception type to catch.
+        """
+        with pytest.raises(ValueError, match="at least one channel"):
+            _build_coverage_mask({})
+
     def test_preserves_color_balance_on_gray(self):
         """Sharpening gray input (R=G=B) keeps R=G=B — luminance-based, not per-channel."""
         rng = np.random.default_rng(11)


### PR DESCRIPTION
Closes #1190

## Summary

Swap `assert mask is not None` → `if mask is None: raise ValueError(...)` in `_build_coverage_mask`.

## Why

Python strips `assert` statements when invoked with `-O` (optimised) mode. The empty-dict invariant check at `composite/routes.py:543` would silently disappear in that build, and any caller would get whatever NumPy operations downstream produced from `None` — most likely an opaque `TypeError` far from the actual cause. `ValueError` survives optimisation and gives callers a clear, catchable exception type.

## Changes Made

- `processing-engine/app/composite/routes.py` — replace assert with explicit raise.
- `processing-engine/tests/test_nchannel_composite.py` — add `test_build_coverage_mask_raises_on_empty_dict` covering the empty-dict path.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_nchannel_composite.py -k build_coverage_mask --no-cov -v` — 2/2 pass.
- [x] Ruff lint + format pass via pre-commit hook.

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1190

## Risk & Rollback
- Risk: Low. Behavior identical in standard CPython (asserts run); the difference shows only under `-O`. No production caller relies on `AssertionError` vs `ValueError`.
- Rollback: revert the commit.
