### PR TITLE
fix: guard zero-length first axis in FITS cube slicing (#1234)

### DIFF
--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -330,6 +330,14 @@ def generate_preview(
         # Handle 3D+ data cubes
         n_slices = original_shape[0] if len(original_shape) > 2 else 1
         if len(data.shape) > 2:
+            if data.shape[0] == 0:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"FITS data has zero-length first axis (shape={data.shape}); "
+                        "cannot select a slice."
+                    ),
+                )
             if slice_index < 0:
                 slice_index = data.shape[0] // 2
             slice_index = max(0, min(slice_index, data.shape[0] - 1))
@@ -340,6 +348,14 @@ def generate_preview(
 
         # Continue reducing if still > 2D
         while len(data.shape) > 2:
+            if data.shape[0] == 0:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"FITS data has zero-length axis during cube reduction "
+                        f"(shape={data.shape})."
+                    ),
+                )
             mid_idx = data.shape[0] // 2
             data = data[mid_idx]
             logger.info(f"Further reduced to shape: {data.shape}")


### PR DESCRIPTION
Closes #1234

## Summary

Guard against `data.shape[0] == 0` in the FITS cube-slicing code path: raise `HTTPException(422)` with a diagnostic message instead of letting `data[slice_index]` raise `IndexError` → unhandled 500.

## Why

Slicing happens twice in `process_fits` in `main.py`:

1. Initial 3D-to-2D reduction (line 335 before the fix).
2. Subsequent while-loop further reducing >2D residuals.

When `data.shape[0] == 0` (e.g. a MAST placeholder HDU), `max(0, min(slice_index, -1))` evaluates to `0`, but `data[0]` still raises `IndexError: index 0 is out of bounds for axis 0 with size 0`. The exception bubbles out as a generic HTTP 500 with no user-readable cause.

## Changes Made

- `processing-engine/main.py` — add `data.shape[0] == 0` guard raising `HTTPException(status_code=422, detail=…)` before each `data[…]` access in the cube-reduction path.

## Test Plan

- [x] `ruff check processing-engine/main.py` — clean.
- [x] `docker exec jwst-processing python -c "import main"` — imports without error.
- [x] Manually traced the two slicing call sites; both now guarded.
- Note: No existing pytest covers the FITS-loading endpoint at this granularity. The full Python test suite still runs in CI.

## Documentation Checklist
- [x] No documentation updates needed (error-path hardening, no API contract change)

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: Low. The new code path only fires when `data.shape[0] == 0`, which was previously an unhandled 500. Behavior on non-empty cubes is unchanged.
- Rollback: revert the commit; empty-axis cubes go back to producing 500s.
