### PR TITLE
fix: don't reject WCS at celestial origin (RA=0, CRPIX1=0) (#1235)

### DIFF
--- a/processing-engine/app/processing/avm.py
+++ b/processing-engine/app/processing/avm.py
@@ -235,8 +235,11 @@ def extract_wcs_for_avm(
         crval1 = float(header.get("CRVAL1", 0))
         crval2 = float(header.get("CRVAL2", 0))
 
-        # Check we have meaningful WCS
-        if crpix1 == 0 and crval1 == 0:
+        # Treat WCS as missing only when projection type is also absent —
+        # observations near RA=0 (CRVAL1=0) with CRPIX1=0 are valid but were
+        # previously rejected by `crpix1 == 0 and crval1 == 0`. (#1235)
+        ctype1 = str(header.get("CTYPE1", ""))
+        if not ctype1 and crpix1 == 0 and crval1 == 0:
             return {}
 
         # Get pixel scale from CD matrix or CDELT

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -808,8 +808,15 @@ def get_pixel_data(
                     "ctype1": str(header.get("CTYPE1", "")),
                     "ctype2": str(header.get("CTYPE2", "")),
                 }
-                # Only include WCS if we have valid reference pixel and values
-                if wcs_params["crpix1"] == 0 and wcs_params["crval1"] == 0:
+                # Treat WCS as missing only when the projection isn't set
+                # (CTYPE1 absent) AND the reference values look defaulted.
+                # The previous `crpix1==0 and crval1==0` check rejected
+                # observations near RA=0 with CRPIX1=0 — rare but valid. (#1235)
+                if (
+                    not wcs_params["ctype1"]
+                    and wcs_params["crpix1"] == 0
+                    and wcs_params["crval1"] == 0
+                ):
                     wcs_params = None
             except (ValueError, KeyError) as e:
                 logger.warning(f"Could not extract WCS parameters: {e}")

--- a/processing-engine/tests/test_avm_embedding.py
+++ b/processing-engine/tests/test_avm_embedding.py
@@ -192,6 +192,23 @@ class TestExtractWcsForAvm:
         result = extract_wcs_for_avm(header, 1024, 1024, 512, 512)
         assert result == {}
 
+    def test_wcs_at_celestial_origin_accepted(self):
+        """A valid WCS pointing at RA=0 with CRPIX1=0 is no longer rejected (#1235)."""
+        header = {
+            "CRPIX1": 0,
+            "CRPIX2": 512.0,
+            "CRVAL1": 0.0,  # RA = 0° — was wrongly treated as "missing"
+            "CRVAL2": -45.2,
+            "CD1_1": -1e-5,
+            "CD2_2": 1e-5,
+            "CTYPE1": "RA---TAN",
+            "CTYPE2": "DEC--TAN",
+        }
+        result = extract_wcs_for_avm(header, 1024, 1024, 512, 512)
+        assert result != {}
+        assert result["ra"] == 0.0
+        assert result["dec"] == -45.2
+
     def test_missing_cd_matrix_returns_empty(self):
         header = {
             "CRPIX1": 512.0,


### PR DESCRIPTION
Closes #1235

## Summary

Replace `crpix1 == 0 and crval1 == 0` with `not ctype1 and crpix1 == 0 and crval1 == 0` in both WCS-extraction call sites. A header that explicitly sets `CTYPE1="RA---TAN"` (or similar) is now treated as having a valid WCS regardless of CRVAL/CRPIX values.

## Why

Two places used the zeros-pair as a proxy for "header has no WCS":

- `processing-engine/main.py:812` — `process_fits` preview WCS extraction.
- `processing-engine/app/processing/avm.py:239` — AVM/XMP metadata extraction.

The proxy is wrong: a perfectly valid WCS can have `CRVAL1=0` (RA at the vernal equinox) and `CRPIX1=0` (reference pixel at the edge). Observations in Pisces/Andromeda would silently lose their coordinate overlay and AVM metadata. The fix anchors validity on `CTYPE1` (the WCS projection type, e.g. `RA---TAN`), which is the keyword that *defines* whether a WCS is set. The legacy zeros-check is kept as additional defense only for headers that omit CTYPE1 entirely.

## Changes Made

- `processing-engine/main.py` — `process_fits`: tighten WCS-missing check to `not ctype1 and crpix1 == 0 and crval1 == 0`.
- `processing-engine/app/processing/avm.py` — `extract_wcs_for_avm`: same predicate.
- `processing-engine/tests/test_avm_embedding.py` — new `test_wcs_at_celestial_origin_accepted` asserting a header with `CRPIX1=0, CRVAL1=0, CTYPE1="RA---TAN"` returns a populated WCS dict, not `{}`.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_avm_embedding.py --no-cov -v` — 25/25 pass (was 24/24).
- [x] Verified `test_no_wcs_returns_empty` (header without CTYPE1, all zeros) still returns `{}` — preserves the no-WCS-at-all rejection path.
- [x] Verified `test_missing_cd_matrix_returns_empty` still returns `{}` — preserves the missing-pixel-scale rejection.
- [x] Verified `test_cdelt_fallback` still passes — CTYPE1-only headers still process correctly.

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced

## Risk & Rollback
- Risk: Low. The check is strictly more permissive than before — previously-accepted WCS headers still pass; previously-rejected `(0,0,no CTYPE)` headers still get rejected. The only new behavior is accepting `(0,0,CTYPE1="RA---TAN")` headers, which is the bug fix.
- Rollback: revert the commit; valid RA=0 observations go back to losing their overlay.
