### PR TITLE
fix: clean up stale state .tmp files on startup (#1397)

### DIFF
--- a/processing-engine/app/mast/download_state_manager.py
+++ b/processing-engine/app/mast/download_state_manager.py
@@ -333,6 +333,36 @@ class DownloadStateManager:
 
         return removed
 
+    def cleanup_stale_state_tmp_files(self) -> int:
+        """Remove ``*.tmp`` state files left from a previous crashed write.
+
+        ``save_job_state`` writes ``<job>.json.tmp`` then atomically renames
+        it to ``<job>.json`` via ``os.replace``. If the process is killed
+        between the write and the rename, the ``.tmp`` file is orphaned —
+        it will be overwritten on the next save, but accumulates on disk
+        until then.
+
+        Returns:
+            Number of files removed.
+        """
+        removed = 0
+        try:
+            for filename in os.listdir(self.state_dir):
+                if not filename.endswith(".json.tmp"):
+                    continue
+                tmp_path = os.path.join(self.state_dir, filename)
+                try:
+                    os.remove(tmp_path)
+                    removed += 1
+                    logger.debug(f"Removed stale state tmp file: {filename}")
+                except OSError:
+                    logger.debug(f"Stale state tmp file already gone: {filename}")
+        except OSError as e:
+            logger.error(f"Failed to scan state dir for tmp files: {e}")
+        if removed > 0:
+            logger.info(f"Removed {removed} stale state tmp file(s)")
+        return removed
+
     def cleanup_orphaned_partial_files(self) -> int:
         """
         Remove orphaned .part files that don't have corresponding state files.

--- a/processing-engine/app/mast/routes.py
+++ b/processing-engine/app/mast/routes.py
@@ -907,6 +907,7 @@ async def _run_chunked_download_job(
         try:
             state_manager.cleanup_completed()
             state_manager.cleanup_orphaned_partial_files()
+            state_manager.cleanup_stale_state_tmp_files()
         except (OSError, json.JSONDecodeError, ValueError) as cleanup_error:
             logger.warning(f"Post-download cleanup failed: {cleanup_error}")
 

--- a/processing-engine/main_mast.py
+++ b/processing-engine/main_mast.py
@@ -34,11 +34,13 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     removed_states = state_manager.cleanup_completed()
     removed_partials = state_manager.cleanup_orphaned_partial_files()
+    removed_tmps = state_manager.cleanup_stale_state_tmp_files()
 
-    if removed_states > 0 or removed_partials > 0:
+    if removed_states > 0 or removed_partials > 0 or removed_tmps > 0:
         logger.info(
             f"Startup cleanup: removed {removed_states} old state files, "
-            f"{removed_partials} orphaned partial files"
+            f"{removed_partials} orphaned partial files, "
+            f"{removed_tmps} stale state tmp files"
         )
 
     yield

--- a/processing-engine/tests/test_download_state_manager.py
+++ b/processing-engine/tests/test_download_state_manager.py
@@ -102,3 +102,38 @@ class TestCleanupOrphanedPartialFilesRaceCondition:
                 state_manager.cleanup_orphaned_partial_files()
                 mock_logger.debug.assert_called_once()
                 assert "already removed" in mock_logger.debug.call_args[0][0]
+
+
+class TestCleanupStaleStateTmpFiles:
+    """Tests for cleanup_stale_state_tmp_files — recovery from crashed writes (#1397)."""
+
+    def test_removes_stale_tmp_files(self, state_manager):
+        """``*.json.tmp`` files in the state dir are deleted."""
+        state_dir = state_manager.state_dir
+        for name in ("job1.json.tmp", "job2.json.tmp"):
+            with open(f"{state_dir}/{name}", "w") as f:
+                f.write("{}")
+
+        removed = state_manager.cleanup_stale_state_tmp_files()
+
+        assert removed == 2
+
+    def test_leaves_real_state_files_alone(self, state_manager):
+        """Production ``*.json`` state files are not touched."""
+        state_dir = state_manager.state_dir
+        with open(f"{state_dir}/keep.json", "w") as f:
+            f.write("{}")
+        with open(f"{state_dir}/stale.json.tmp", "w") as f:
+            f.write("{}")
+
+        removed = state_manager.cleanup_stale_state_tmp_files()
+
+        import os
+
+        assert removed == 1
+        assert os.path.exists(f"{state_dir}/keep.json")
+        assert not os.path.exists(f"{state_dir}/stale.json.tmp")
+
+    def test_empty_dir_returns_zero(self, state_manager):
+        """No tmp files → zero removed, no error."""
+        assert state_manager.cleanup_stale_state_tmp_files() == 0


### PR DESCRIPTION
Closes #1397

## Summary

`save_job_state` already uses an atomic write (temp file + `os.replace`). What was missing was the **recovery path** for crashes between the temp write and the rename. Orphan `<job>.json.tmp` files would otherwise accumulate forever in the state dir.

This PR adds `cleanup_stale_state_tmp_files()` and wires it into the existing startup and post-download cleanup hooks.

## Why

The issue describes a real correctness gap: even though writes are atomic, crashes can leave orphan `.tmp` files. The existing `cleanup_orphaned_partial_files()` only handles `.part` files in observation directories; the state dir's `.tmp` siblings had no scrubber.

The fix is small, additive, and uses the same pattern as the existing cleanup methods.

## Changes Made

- `processing-engine/app/mast/download_state_manager.py` — new `cleanup_stale_state_tmp_files()` method that removes any `*.json.tmp` files in the state dir.
- `processing-engine/main_mast.py` — call the new cleanup at MAST service startup, alongside the existing `cleanup_completed` and `cleanup_orphaned_partial_files`.
- `processing-engine/app/mast/routes.py` — call it from the post-download cleanup path so long-running services don't have to wait for the next restart.
- `processing-engine/tests/test_download_state_manager.py` — new `TestCleanupStaleStateTmpFiles` class with 3 cases (removes tmp files, leaves real state files alone, empty dir returns 0).

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_download_state_manager.py --no-cov -v` — 9/9 pass (was 6/6).
- [x] Verified `cleanup_stale_state_tmp_files()` only matches `*.json.tmp` (`.json` files preserved).
- [x] Verified empty-dir case returns 0 and logs no warning.
- [x] Ruff lint + format clean (pre-commit hook).

## Documentation Checklist
- [x] No documentation updates needed (internal cleanup wiring)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1397

## Risk & Rollback
- Risk: Low. Only touches files with the `.json.tmp` suffix, which by convention are write-in-progress temp artifacts. No legitimate process should be holding one open across the cleanup window (the temp file is closed before `os.replace`).
- Rollback: revert the commit; behavior reverts to leaving orphan `.tmp` files in the state dir.
