### PR TITLE
fix: surface token refresh failures in recipe-walkthrough (#1320)

### DIFF
--- a/scripts/recipe-walkthrough.py
+++ b/scripts/recipe-walkthrough.py
@@ -540,8 +540,10 @@ def run(
         # Re-authenticate before each target to avoid JWT expiry on long runs
         try:
             token = login(username, password)
-        except Exception:
-            pass  # keep old token if refresh fails
+        except Exception as exc:  # noqa: BLE001 — best-effort refresh, must not abort run
+            # Surface the failure so downstream 401s can be traced back to a
+            # stale token instead of looking like new auth bugs. (#1320)
+            print(f"  WARN: token refresh failed, reusing previous token: {exc}")
 
         filter_to_ids = get_unique_filters(target_records)
 


### PR DESCRIPTION
Closes #1320

## Summary

Replace the silent `except Exception: pass` in `scripts/recipe-walkthrough.py`'s per-target re-auth block with a `print` warning that names the underlying exception.

## Why

`recipe-walkthrough.py` re-authenticates before each target to avoid JWT expiry during long batch runs. A swallowed refresh failure left the script using a stale token and produced downstream 401s with no indication of the root cause. Surfacing the failure means anyone running the script can trace a 401 to "the refresh failed at HH:MM, here's the exception" rather than chasing it as a new auth bug.

Print rather than `logger.warning` because the script doesn't configure a logger — it uses `print` for all status output (`print(f"  SKIP {target_name}…")` etc).

## Changes Made

- `scripts/recipe-walkthrough.py` — capture the exception, emit a `WARN:` line, keep the existing token. The `# noqa: BLE001` keeps ruff's broad-except check happy and documents why the catch must stay broad (this is a best-effort refresh that must not abort the run).

## Test Plan

- [x] Ruff lint + format clean (pre-commit hook).
- [x] Behavior preserved: token is reused on failure, loop continues. Only the silent-swallow → warning shift.
- Note: This is a standalone script, not part of the FastAPI app — no test harness covers it.

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1320

## Risk & Rollback
- Risk: None. Only emits a warning string to stdout in a code path that previously did nothing observable.
- Rollback: revert the commit.
