### PR TITLE
fix: validate FITS magic byte before astropy.fits.open (#1392)

### DIFF
--- a/processing-engine/app/processing/utils.py
+++ b/processing-engine/app/processing/utils.py
@@ -9,6 +9,22 @@ from astropy.io import fits
 logger = logging.getLogger(__name__)
 
 
+# FITS standard: every conforming file begins with "SIMPLE  =" in the first
+# header record (per FITS Standard §3.3.1). Checking this upfront turns a
+# deep astropy parse error on a truncated/misnamed file into a clear
+# "not a FITS file" message at the source. (#1392)
+_FITS_MAGIC = b"SIMPLE  ="
+
+
+def _looks_like_fits(file_path: str) -> bool:
+    """Return True when the file's first 9 bytes match the FITS SIMPLE keyword."""
+    try:
+        with open(file_path, "rb") as f:
+            return f.read(len(_FITS_MAGIC)) == _FITS_MAGIC
+    except OSError:
+        return False
+
+
 def load_fits_data(file_path: str) -> tuple[np.ndarray | None, dict[str, Any]]:
     """
     Load data and header from a FITS file.
@@ -22,6 +38,10 @@ def load_fits_data(file_path: str) -> tuple[np.ndarray | None, dict[str, Any]]:
     try:
         if not os.path.exists(file_path):
             logger.error(f"File not found: {file_path}")
+            return None, {}
+
+        if not _looks_like_fits(file_path):
+            logger.error(f"Not a valid FITS file (missing SIMPLE magic): {file_path}")
             return None, {}
 
         with fits.open(file_path) as hdul:

--- a/processing-engine/tests/test_utils.py
+++ b/processing-engine/tests/test_utils.py
@@ -74,6 +74,23 @@ class TestLoadFitsData:
         finally:
             os.unlink(path)
 
+    def test_non_fits_magic_logged_as_invalid(self, caplog):
+        """Files lacking the FITS SIMPLE magic surface a clear log message (#1392)."""
+        import logging
+
+        with tempfile.NamedTemporaryFile(suffix=".fits", delete=False, mode="wb") as f:
+            f.write(b"\x89PNG\r\n\x1a\n")  # PNG magic — definitely not FITS
+            path = f.name
+
+        try:
+            with caplog.at_level(logging.ERROR, logger="app.processing.utils"):
+                data, header = load_fits_data(path)
+            assert data is None
+            assert header == {}
+            assert any("Not a valid FITS file" in r.message for r in caplog.records)
+        finally:
+            os.unlink(path)
+
 
 class TestSaveFitsData:
     def test_save_and_reload(self):


### PR DESCRIPTION
Closes #1392

## Summary

`load_fits_data` now checks the FITS SIMPLE magic byte sequence before calling `fits.open`. Files that don't begin with `"SIMPLE  ="` (FITS Standard §3.3.1) return `(None, {})` with a clear log message instead of bubbling out a deep astropy parse stack trace.

## Why

The existing path checks file existence but immediately calls `astropy.fits.open` on the bytes. A truncated, misnamed, or wrong-format file (PNG, JPEG, junk text) produces a confusing astropy exception that mentions HDU parsing rather than the actual root cause ("this isn't a FITS file"). Operators reading logs had no fast signal of the actual failure mode.

The fix is a 9-byte read at the top of the function — negligible cost on the happy path, large diagnostic win on the bad path.

## Changes Made

- `processing-engine/app/processing/utils.py` — new `_looks_like_fits()` helper, called before `fits.open`. Returns `(None, {})` with an "Not a valid FITS file" log on mismatch.
- `processing-engine/tests/test_utils.py` — new `test_non_fits_magic_logged_as_invalid` writing a PNG-magic file to confirm the new path returns empty result + emits the new log message. Existing `test_corrupt_file_returns_none` (text-content file) keeps passing through the same path.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_utils.py::TestLoadFitsData --no-cov -v` — 5/5 pass (was 4/4).
- [x] Verified the new test covers the magic-byte rejection path (PNG bytes → "Not a valid FITS file" log).
- [x] Ruff lint + format clean.

## Documentation Checklist
- [x] No documentation updates needed (internal error-path hardening)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1392

## Risk & Rollback
- Risk: Low. Adds a 9-byte read on the happy path; any file that's a valid FITS will still parse. The new rejection path only triggers on files that would have failed `fits.open` anyway — just with a clearer message.
- Rollback: revert the commit; bad-file errors revert to opaque astropy stack traces.
