### PR TITLE
fix: replace brittle dir() check with sentinel None (#1323)

### DIFF
--- a/processing-engine/app/mast/routes.py
+++ b/processing-engine/app/mast/routes.py
@@ -744,6 +744,11 @@ async def _run_chunked_download_job(
     speed_tracker = SpeedTracker()
     _speed_trackers[job_id] = speed_tracker
 
+    # Initialize to sentinel so the failure handler can detect whether the
+    # download actually started before the exception. Replaces a brittle
+    # `if "job_state" in dir()` check that depended on local-name scoping. (#1323)
+    job_state: DownloadJobState | None = None
+
     try:
         download_tracker.update_stage(
             job_id, DownloadStage.FETCHING_PRODUCTS, "Fetching product information from MAST..."
@@ -891,8 +896,9 @@ async def _run_chunked_download_job(
     except Exception as e:
         logger.error(f"Chunked download job {job_id} failed: {e}")
         download_tracker.fail_job(job_id, str(e), is_resumable=True)
-        # Save state for potential retry
-        if "job_state" in dir():
+        # Save state for potential retry — only when job_state was assigned
+        # (i.e. the download made it past product lookup).
+        if job_state is not None:
             job_state.status = "failed"
             job_state.error = str(e)
             state_manager.save_job_state(job_state)


### PR DESCRIPTION
Closes #1323

## Summary

Replace `if "job_state" in dir():` with an explicit `job_state: DownloadJobState | None = None` sentinel + `if job_state is not None:` check in the failure handler of `_run_chunked_download_job`.

## Why

The `dir()` lookup relied on whether Python had bound the name in the local scope — implementation-dependent, hostile to static analysis, and the kind of thing that quietly breaks under closure rewrites or async transformations. The replacement is the standard pattern: declare the variable up front, set it where it gets meaningful state, check for `None` to decide whether persistence is worth attempting.

## Changes Made

- `processing-engine/app/mast/routes.py` — declare `job_state: DownloadJobState | None = None` before the `try:` block; change the `except` handler from `if "job_state" in dir():` to `if job_state is not None:`.

## Test Plan

- [x] Ruff lint + format clean (pre-commit hook).
- [x] Behavior preserved: the failure handler still skips state persistence when the download bailed before `job_state` was assigned, and still persists it when the download made it past product lookup.

## Documentation Checklist
- [x] No documentation updates needed (internal error-path refactor)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1323

## Risk & Rollback
- Risk: Low. Branch behavior identical for both paths (job_state assigned / not assigned). Sentinel is set to `None` in the only path that matters.
- Rollback: revert the commit.
