### PR TITLE
fix: log root cause when wait_for_healthy gives up (#1319)

### DIFF
--- a/scripts/recipe-walkthrough.py
+++ b/scripts/recipe-walkthrough.py
@@ -294,14 +294,20 @@ def build_observations(records: list[dict]) -> list[dict]:
 
 def wait_for_healthy(max_wait: int = 120) -> bool:
     """Wait for processing engine to become healthy after a crash."""
-    for i in range(max_wait // 5):
+    last_error: str | None = None
+    for _ in range(max_wait // 5):
         try:
             resp = requests.get(f"{BASE_URL}/api/health", timeout=5)
             if resp.ok:
                 return True
-        except Exception:
-            pass
+            last_error = f"HTTP {resp.status_code}"
+        except Exception as exc:  # noqa: BLE001 — best-effort poll, must not abort run
+            # Capture the most recent failure so a complete timeout produces
+            # an actionable diagnostic instead of "wait_for_healthy returned False". (#1319)
+            last_error = f"{type(exc).__name__}: {exc}"
         time.sleep(5)
+    if last_error is not None:
+        print(f"  wait_for_healthy: gave up after {max_wait}s — last error: {last_error}")
     return False
 
 


### PR DESCRIPTION
Closes #1319

## Summary

Capture the most recent connection / HTTP error in `wait_for_healthy()` and surface it via `print` when the poll times out, instead of silently returning `False`.

## Why

The bare `except Exception: pass` made every kind of failure look the same: an engine that refused connections for 120s and an engine that returned 502 the whole time both produced "False" with zero diagnostic output. Operators had to drop into the container to find out what was actually failing.

Stays a `print` (not `logger.warning`) for the same reason as #1320 — the script doesn't configure a logger.

## Changes Made

- `scripts/recipe-walkthrough.py` — capture exception type + message (or HTTP status code on a non-ok response) in `last_error`; print it on final timeout.

## Test Plan

- [x] Ruff lint + format clean (pre-commit hook).
- [x] Loop behavior preserved: still polls every 5 s, still aborts after `max_wait` seconds, still returns `True/False`.

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1319

## Risk & Rollback
- Risk: None. The new diagnostic only prints on the failure path that previously printed nothing.
- Rollback: revert the commit.
