### PR TITLE
fix: distinguish client-cancel from timeout in TaskCanceledException handlers (#1372)

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/CompositeController.cs
@@ -115,6 +115,12 @@ namespace JwstDataAnalysis.API.Controllers
                 LogProcessingEngineError(ex);
                 return StatusCode(503, new { error = "Processing engine is temporarily unavailable. Please retry." });
             }
+            catch (TaskCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                // Client disconnected — not an error, response will be discarded anyway.
+                // Suppress to avoid noisy 504s in logs for normal user navigation. (#1372)
+                return new EmptyResult();
+            }
             catch (TaskCanceledException)
             {
                 return StatusCode(504, new { error = "Processing timed out. The image may be too large — try a smaller size." });
@@ -194,6 +200,10 @@ namespace JwstDataAnalysis.API.Controllers
             {
                 LogProcessingEngineError(ex);
                 return StatusCode(503, new { error = "Processing engine is temporarily unavailable. Please retry." });
+            }
+            catch (TaskCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (TaskCanceledException)
             {
@@ -374,6 +384,10 @@ namespace JwstDataAnalysis.API.Controllers
             {
                 LogProcessingEngineError(ex);
                 return StatusCode(503, new { error = "Processing engine is temporarily unavailable. Please retry." });
+            }
+            catch (TaskCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (TaskCanceledException)
             {


### PR DESCRIPTION
Closes #1372

## Summary

Add a `when (HttpContext.RequestAborted.IsCancellationRequested)` filter to the three `TaskCanceledException` catch blocks in `CompositeController`. Client disconnects now produce `EmptyResult` (no body, no log spam) instead of 504 "timed out" errors. The original 504 path still fires for genuine timeouts (the engine took longer than the upstream timeout policy).

## Why

ASP.NET surfaces a client navigating away mid-request as a `TaskCanceledException` whose `CancellationToken` matches `HttpContext.RequestAborted`. The existing handlers treat that as a server-side timeout and:

1. Emit a 504 status code that the disconnected client will never see.
2. Pollute logs with "timeout" entries that aren't actually timeouts.
3. Misdirect debugging when looking at error rates ("why are so many composites timing out?").

The `when` filter cleanly splits the two paths: client-cancelled → `EmptyResult`, genuine timeout → original 504 JSON body.

## Changes Made

- `backend/JwstDataAnalysis.API/Controllers/CompositeController.cs` — three sites (composite render, composite estimate, channel analysis): add `when` filter before each existing `TaskCanceledException` catch.

## Test Plan

- [x] `dotnet build` — clean (0 errors, 2 pre-existing StyleCop warnings unrelated to this change).
- [x] `dotnet test` — 1111/1111 pass.
- [x] Verified the `when` filter compiles against .NET 10 and matches the documented exception-filter pattern.

## Documentation Checklist
- [x] No documentation updates needed (internal error-path refinement)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1372

## Risk & Rollback
- Risk: Low. Client-cancelled requests already produced no useful response; the change only adjusts what gets logged/serialized on the server side. Genuine timeouts still surface as 504s.
- Rollback: revert the commit; client cancellations go back to producing 504s.
