### PR TITLE
fix: capture SignalR connection reference to close TOCTOU race (#1287)

### DIFF
--- a/frontend/jwst-frontend/src/services/signalRService.ts
+++ b/frontend/jwst-frontend/src/services/signalRService.ts
@@ -179,8 +179,11 @@ export async function subscribeToJob(
 
   try {
     await ensureConnected();
-    if (connection) {
-      await connection.invoke('SubscribeToJob', jobId);
+    // Capture the connection reference locally so a concurrent disconnect
+    // (which sets `connection = null`) can't race the invoke. (#1287)
+    const conn = connection;
+    if (conn && conn.state === HubConnectionState.Connected) {
+      await conn.invoke('SubscribeToJob', jobId);
     }
   } catch (err) {
     console.error(`[SignalR] Failed to subscribe to job ${jobId}:`, err);
@@ -194,22 +197,26 @@ export async function subscribeToJob(
       subs.delete(callbacks);
       if (subs.size === 0) {
         jobSubscriptions.delete(jobId);
-        // Unsubscribe from server group
-        if (connection?.state === HubConnectionState.Connected) {
-          connection.invoke('UnsubscribeFromJob', jobId).catch((err) => {
+        // Unsubscribe from server group — capture reference to avoid race. (#1287)
+        const conn = connection;
+        if (conn && conn.state === HubConnectionState.Connected) {
+          conn.invoke('UnsubscribeFromJob', jobId).catch((err) => {
             console.warn('[SignalR] Failed to unsubscribe from job', jobId, err);
           });
         }
       }
     }
 
-    // If no more subscriptions, stop the connection
-    if (jobSubscriptions.size === 0 && connection) {
-      connection.stop().catch((err) => {
-        console.warn('[SignalR] Failed to stop connection', err);
-      });
-      connection = null;
-      notifyStateChange('disconnected');
+    // If no more subscriptions, stop the connection (capture reference). (#1287)
+    if (jobSubscriptions.size === 0) {
+      const conn = connection;
+      if (conn) {
+        conn.stop().catch((err) => {
+          console.warn('[SignalR] Failed to stop connection', err);
+        });
+        connection = null;
+        notifyStateChange('disconnected');
+      }
     }
   };
 }


### PR DESCRIPTION
Closes #1287

## Summary

Replace `if (connection) { await connection.invoke(...) }` with a captured-reference pattern (`const conn = connection; if (conn && conn.state === Connected) { await conn.invoke(...) }`) at three sites in `signalRService.ts`. Closes the TOCTOU race where a concurrent disconnect could set `connection = null` between the guard and the await.

## Why

`connection` is a module-level `let`. Three async paths could be in flight simultaneously:

- `subscribeToJob` (line 168)
- Its returned unsubscribe closure
- The auto-disconnect when `jobSubscriptions.size === 0` (line 211)

The unsubscribe path explicitly assigns `connection = null` after `stop()`. If that runs while a `subscribeToJob` await is suspended on `ensureConnected()`, the check on the next line (`if (connection)`) passes a stale snapshot — but by the time the JS engine resumes the next statement (`connection.invoke(...)`), `connection` is `null` and we get a runtime TypeError.

Capturing into a local `const conn` makes the reference stable across awaits.

## Changes Made

- `frontend/jwst-frontend/src/services/signalRService.ts`:
  - `subscribeToJob` line 180–188 — capture `conn` after `ensureConnected()` and gate on `conn.state === Connected`.
  - Unsubscribe closure (was line 198) — capture `conn` before `invoke('UnsubscribeFromJob', …)`.
  - Auto-disconnect block (was line 211) — capture `conn` before `stop()` and the `connection = null` assignment.

## Test Plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint src/services/signalRService.ts` — clean.
- [x] No behavior change on the happy path (`connection` stable across the await window).
- [x] Pre-commit hook (build, tests) passed.

## Documentation Checklist
- [x] No documentation updates needed (internal concurrency hardening)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1287

## Risk & Rollback
- Risk: Low. Captured-reference pattern is strictly safer than the original. The only behavioral nuance is the tightened state check inside `subscribeToJob` — now requires `Connected`, where previously just any non-null value was accepted. `ensureConnected()` already waits for the `Connected` state before returning on the happy path, so the new check is a no-op on the happy path and only catches the unsubscribe race.
- Rollback: revert the commit.
