### PR TITLE
fix: surface sessionStorage failures (once) in apiClient auth logs (#1263)

### DIFF
--- a/frontend/jwst-frontend/src/services/apiClient.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.ts
@@ -19,6 +19,12 @@ import { safeParseJson } from '../utils/responseUtils';
 const AUTH_LOG_KEY = 'jwst_auth_debug_log';
 const MAX_LOG_ENTRIES = 50;
 
+// Once-per-session flags so sessionStorage errors surface in DevTools but
+// don't spam the console on every authLog call (e.g. when storage is
+// blocked in incognito mode). (#1263)
+let storageWarnedWrite = false;
+let storageWarnedRead = false;
+
 function authLog(message: string, data?: unknown): void {
   if (!import.meta.env.DEV) return;
 
@@ -35,8 +41,13 @@ function authLog(message: string, data?: unknown): void {
     logs.push(entry);
     while (logs.length > MAX_LOG_ENTRIES) logs.shift();
     sessionStorage.setItem(AUTH_LOG_KEY, JSON.stringify(logs));
-  } catch {
-    // Ignore storage errors
+  } catch (err) {
+    // Surface the first failure so blocked sessionStorage doesn't masquerade
+    // as "auth logging just doesn't work"; suppress repeats. (#1263)
+    if (!storageWarnedWrite) {
+      storageWarnedWrite = true;
+      console.warn('[Auth] sessionStorage write failed (logs will not persist):', err);
+    }
   }
 }
 
@@ -47,7 +58,11 @@ export function getAuthLogs(): string[] {
   try {
     const stored = sessionStorage.getItem(AUTH_LOG_KEY);
     return stored ? JSON.parse(stored) : [];
-  } catch {
+  } catch (err) {
+    if (!storageWarnedRead) {
+      storageWarnedRead = true;
+      console.warn('[Auth] sessionStorage read failed (logs unavailable):', err);
+    }
     return [];
   }
 }


### PR DESCRIPTION
Closes #1263

## Summary

Replace empty `catch {}` blocks in `authLog()` and `getAuthLogs()` with once-per-session `console.warn` calls so a blocked sessionStorage surfaces in DevTools the first time it fails — without spamming the console on every subsequent auth log call.

## Why

`authLog` is the dev-only auth debug logger. When sessionStorage is blocked (incognito, strict storage policies, quota-exceeded), the empty catch meant the logs simply… didn't appear, with no way to distinguish "nothing was logged" from "logging is broken." A one-time warning per session gives the developer a clear signal of *why* the logs are empty.

Both `authLog` (write path) and `getAuthLogs` (read path) get independent one-time flags so each is reported the first time it fires.

Stays DEV-only — `authLog` already early-returns when `!import.meta.env.DEV`, and `getAuthLogs` is only called by `printAuthLogs()` / dev tooling.

## Changes Made

- `frontend/jwst-frontend/src/services/apiClient.ts`:
  - Module-level `storageWarnedWrite` / `storageWarnedRead` flags.
  - `authLog` catch: capture `err`, emit `console.warn` the first time, set the flag.
  - `getAuthLogs` catch: same pattern.

## Test Plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint src/services/apiClient.ts` — clean.
- [x] Verified the flag-gate ensures repeat failures don't spam (manual trace: second call short-circuits on `storageWarnedWrite` check).

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1263

## Risk & Rollback
- Risk: None. Dev-only diagnostic — production users never hit this path.
- Rollback: revert the commit.
