### PR TITLE
fix: treat whitespace-only search as no search (#1357)

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/AnalysisController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/AnalysisController.cs
@@ -281,6 +281,14 @@ namespace JwstDataAnalysis.API.Controllers
                     return BadRequest(new { error = "search term must be 500 characters or less" });
                 }
 
+                // Reject whitespace-only search; treat it the same as "no search". An empty
+                // string passed to the MongoDB aggregation triggers a full-collection scan
+                // that's expensive and produces no meaningful filtering. (#1357)
+                if (search != null && string.IsNullOrWhiteSpace(search))
+                {
+                    search = null;
+                }
+
                 var data = await mongoDBService.GetAsync(dataId);
                 if (data == null)
                 {


### PR DESCRIPTION
Closes #1357

## Summary

Treat a whitespace-only `search` value as "no search" by normalising it to `null` before passing to the analysis service. Empty `search` arrived as an empty string and was passed verbatim into the MongoDB aggregation, triggering a full-collection regex scan with no useful filtering.

## Why

`GetTableDataAsync` short-circuits cleanly on `search == null`. An empty string was the only case that reached the aggregation but contributed nothing to the result — pure overhead. The fix is a 4-line normalisation at the controller boundary.

## Changes Made

- `backend/JwstDataAnalysis.API/Controllers/AnalysisController.cs:279-289` — after the length-cap check, normalise `string.IsNullOrWhiteSpace(search)` to `null`.

## Test Plan

- [x] `dotnet build` — clean (0 errors).
- [x] `dotnet test` — 1111/1111 pass.
- [x] Verified: `?search=` and `?search=%20%20` now route through the null-search branch; `?search=abc` is unchanged.

## Documentation Checklist
- [x] No documentation updates needed (internal optimisation)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1357

## Risk & Rollback
- Risk: Low. Empty-search consumers were not relying on the full-table-scan behavior; they expect "show everything", which is what `search == null` produces.
- Rollback: revert the commit.
