### PR TITLE
fix: rename _filters to filters and wire it through (#1388)

### DIFF
--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -208,7 +208,7 @@ class MastService:
         self,
         target_name: str,
         radius: float = 0.2,
-        _filters: dict[str, Any] | None = None,
+        filters: dict[str, Any] | None = None,
         calib_level: list[int] | None = None,
         exclude_proprietary: bool = True,
     ) -> list[dict[str, Any]]:
@@ -254,6 +254,9 @@ class MastService:
                 query_params["calib_level"] = calib_level
             if exclude_proprietary:
                 query_params["t_obs_release"] = [0, _today_mjd()]
+            # Caller-supplied filters override the above (e.g. instrument=NIRCAM).
+            if filters:
+                query_params.update(filters)
             obs_table = Observations.query_criteria(**query_params)
 
             logger.info(f"Found {len(obs_table)} JWST observations")

--- a/processing-engine/app/mast/routes.py
+++ b/processing-engine/app/mast/routes.py
@@ -106,7 +106,7 @@ async def search_by_target(request: MastTargetSearchRequest):
                 mast_service.search_by_target,
                 target_name=request.target_name,
                 radius=request.radius,
-                _filters=request.filters,
+                filters=request.filters,
                 calib_level=request.calib_level,
             ),
             timeout=MAST_SEARCH_TIMEOUT,


### PR DESCRIPTION
Closes #1388

## Summary

Rename the leading-underscore parameter `_filters` to `filters` and wire it into the MAST query so it's actually applied. The underscore was a lint-silencer for an unused public parameter — the controller passed it through, but `search_by_target` discarded it.

## Why

Two issues conflated into one:

1. **API naming**: `_filters` violates Python convention for public method parameters. Callers rightly read it as "internal/private — don't use."
2. **Dead parameter**: `MastTargetSearchRequest.filters` was wired all the way through the route into `mast_service.search_by_target(_filters=...)`, then dropped on the floor inside the method. Any caller that supplied filters had no effect on the resulting query.

Fixing both at once because they're causally the same: someone named the parameter `_filters` to make the lint "unused argument" warning go away, instead of either using it or removing it.

## Changes Made

- `processing-engine/app/mast/mast_service.py:211, 252` — drop underscore prefix; `query_params.update(filters)` after the calib/proprietary fields so caller filters override the defaults (e.g. `instrument=NIRCAM`).
- `processing-engine/app/mast/routes.py:109` — match the renamed parameter.

## Test Plan

- [x] `ruff check app/mast/mast_service.py app/mast/routes.py` — clean.
- [x] `docker exec jwst-processing python -m pytest tests/test_mast_target_search_variants.py tests/test_mast_service_security.py tests/test_mast_pagination.py --no-cov -q` — 92/92 pass.
- [x] Confirmed: `filters=None` (the default) leaves `query_params` unchanged, so existing callers see no behavior difference.

## Documentation Checklist
- [x] No documentation updates needed (internal API tweak)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1388

## Risk & Rollback
- Risk: Low. Callers that were not supplying filters see no change. Callers that *were* supplying them previously saw a silent no-op; they now actually filter (the intended behavior of the parameter).
- Rollback: revert the commit.
