### PR TITLE
fix: reject empty user-id in authenticated JwstData query (#1356)

### DIFF
--- a/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs
@@ -54,8 +54,15 @@ namespace JwstDataAnalysis.API.Controllers
                     return Ok(publicData.Select(MapToDataResponse).ToList());
                 }
 
+                // Reject authenticated-but-no-user-id: the token must carry a subject
+                // claim, otherwise `string.Empty` could match owner-less records. (#1356)
+                if (string.IsNullOrEmpty(userId))
+                {
+                    return Unauthorized(new { error = "Authenticated user has no identifier." });
+                }
+
                 // Get data accessible to the current user
-                var data = await mongoDBService.GetAccessibleDataAsync(userId ?? string.Empty, isAdmin);
+                var data = await mongoDBService.GetAccessibleDataAsync(userId, isAdmin);
 
                 // Filter out archived data if not requested
                 if (!includeArchived)


### PR DESCRIPTION
Closes #1356

## Summary

Add a guard between the `IsAuthenticated` check and `GetAccessibleDataAsync` in `JwstDataController.GetAll`: if the user is authenticated but the subject claim is missing/empty, return `Unauthorized` instead of querying MongoDB with `string.Empty` as the owner filter.

## Why

`GetAccessibleDataAsync(userId ?? string.Empty, isAdmin)` was the pattern at line 58. For an authenticated user, `GetCurrentUserId()` should always return a non-null value, but the `?? string.Empty` fallback existed defensively. The defensive value is wrong: empty-string-as-owner matches records whose `OwnerId` was never set (legacy/seed data, partial migrations) — a silent data leak to whoever holds the malformed token.

The fix shifts that branch to an explicit 401 rather than a silent permissive query.

## Changes Made

- `backend/JwstDataAnalysis.API/Controllers/JwstDataController.cs:57-65` — `if (string.IsNullOrEmpty(userId)) return Unauthorized(...)`. Drop the `?? string.Empty` fallback in the subsequent call.

## Test Plan

- [x] `dotnet build` — clean.
- [x] `dotnet test` — 1111/1111 pass.
- [x] Confirmed `GetCurrentUserId()` returns null when `User.FindFirst(ClaimTypes.NameIdentifier)?.Value` is null — so the guard only fires in malformed-token states, never on normal auth flows.

## Documentation Checklist
- [x] No documentation updates needed

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1356

## Risk & Rollback
- Risk: Low. Normal authenticated users have a subject claim and won't hit the new branch. The only behavioral change is for malformed tokens, which now get a clean 401 instead of an over-permissive empty-string query.
- Rollback: revert the commit.
