### PR TITLE
fix: separate "cached over-budget" title from "output reduced" (#1444)

### DIFF
--- a/frontend/jwst-frontend/src/components/CompositeWarningBanner.test.tsx
+++ b/frontend/jwst-frontend/src/components/CompositeWarningBanner.test.tsx
@@ -78,6 +78,23 @@ describe('CompositeWarningBanner', () => {
     expect(screen.getByText(/38% of original side length/)).toBeInTheDocument();
   });
 
+  it('shows cached-over-budget title when warn + !wasDownscaled (#1444)', () => {
+    // Cached result is served back under a tightened budget — nothing was actually
+    // downscaled, but the engine flags the cached size as mildly over the new budget.
+    const warning: CompositeWarning = {
+      budgetStatus: 'warn',
+      wasDownscaled: false,
+    };
+    render(<CompositeWarningBanner warning={warning} />);
+
+    // Must NOT claim the output was reduced — nothing was reduced.
+    expect(screen.queryByText(/Output reduced to fit memory budget/i)).toBeNull();
+    expect(
+      screen.getByText(/Cached result is over the current memory budget/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/MAX_COMPOSITE_MEMORY_BYTES/)).toBeInTheDocument();
+  });
+
   it('reveals again when a fresh warning arrives after dismissal', () => {
     const initial: CompositeWarning = {
       budgetStatus: 'warn',

--- a/frontend/jwst-frontend/src/components/CompositeWarningBanner.tsx
+++ b/frontend/jwst-frontend/src/components/CompositeWarningBanner.tsx
@@ -40,12 +40,17 @@ export const CompositeWarningBanner: React.FC<CompositeWarningBannerProps> = ({ 
 
   const isFail = warning.budgetStatus === 'fail';
   const isForced = warning.budgetStatus === 'forced';
+  // 'warn' + not-downscaled means the cached result is mildly over the
+  // current budget but no reduction occurred — title must not claim "reduced". (#1444)
+  const isCachedWarnNoDownscale = warning.budgetStatus === 'warn' && !warning.wasDownscaled;
 
   const title = isFail
     ? 'Result served from cache exceeds current memory budget'
     : isForced
       ? 'Output force-downscaled to fit memory budget'
-      : 'Output reduced to fit memory budget';
+      : isCachedWarnNoDownscale
+        ? 'Cached result is over the current memory budget'
+        : 'Output reduced to fit memory budget';
 
   return (
     <div
@@ -60,8 +65,8 @@ export const CompositeWarningBanner: React.FC<CompositeWarningBannerProps> = ({ 
         <div className="composite-warning-banner__title">{title}</div>
         <div className="composite-warning-banner__detail">
           {warning.wasDownscaled && sizeText && <span>{sizeText} </span>}
-          {reductionText && <span>{reductionText}</span>}
-          {!warning.wasDownscaled && isFail && (
+          {warning.wasDownscaled && reductionText && <span>{reductionText}</span>}
+          {!warning.wasDownscaled && (isFail || isCachedWarnNoDownscale) && (
             <span>
               Clear cache (restart processing-engine) or raise{' '}
               <code>MAX_COMPOSITE_MEMORY_BYTES</code> to refresh.


### PR DESCRIPTION
Closes #1444

## Summary

Add a dedicated banner branch for the `budgetStatus='warn' && wasDownscaled=false` state — the case where a cached result is served back under a tightened memory budget. The old banner fell through to "Output reduced to fit memory budget," which was factually wrong (no reduction actually happened).

## Why

The state is reachable via the sequence #1444 documents:

1. Operator lowers `MAX_COMPOSITE_MEMORY_BYTES` at runtime.
2. A subsequent request hits the in-process cache.
3. `_verdict_for_cached` re-runs budget math; the cached shape is mildly over the new limit (`side_factor ≥ fail_threshold` → `status='warn'`).
4. Because `output_shape == original_shape` in the cached verdict, the backend emits `X-Composite-Budget-Status: warn` without `X-Composite-Was-Downscaled: true`.

Previously the frontend rendered "Output reduced to fit memory budget" — a lie. The new branch is honest: "Cached result is over the current memory budget," plus the existing "clear cache or raise the env var" recovery hint.

## Changes Made

- `frontend/jwst-frontend/src/components/CompositeWarningBanner.tsx`:
  - New `isCachedWarnNoDownscale = budgetStatus === 'warn' && !wasDownscaled` branch.
  - Title swap to "Cached result is over the current memory budget" on that branch.
  - Suppress the from→to size text and reduction percent when nothing was actually reduced.
  - Extend the recovery-hint copy to fire on both `isFail` and `isCachedWarnNoDownscale`.
- `frontend/jwst-frontend/src/components/CompositeWarningBanner.test.tsx` — new `it('shows cached-over-budget title when warn + !wasDownscaled (#1444)')` test.

## Test Plan

- [x] `npx vitest run src/components/CompositeWarningBanner.test.tsx` — 8/8 pass (was 7/7).
- [x] Verified the existing `'shows reduction details when wasDownscaled'` test still passes (the `warn && wasDownscaled=true` path remains the "Output reduced…" title).
- [x] Verified the `'shows fail-mode message for stale-cache fail status'` test still passes (`fail` short-circuits before the new branch).

## Documentation Checklist
- [x] No documentation updates needed (UI copy fix)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1444

## Risk & Rollback
- Risk: Low. Banner-only change; no backend or routing effect. The new branch is additive — `warn && wasDownscaled=true` (the only state previously routed through the "Output reduced…" title) is unchanged.
- Rollback: revert the commit.
