### PR TITLE
fix: surface composite warning on anonymous export path (#1445)

### DIFF
--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -970,7 +970,7 @@ export function GuidedCreate() {
           },
         });
       } else {
-        const { blob } = await exportNChannelComposite(channelPayloads, {
+        const { blob, warning } = await exportNChannelComposite(channelPayloads, {
           format: result.format,
           quality: result.format === 'jpeg' ? 92 : 95,
           width: result.width,
@@ -982,6 +982,10 @@ export function GuidedCreate() {
           sharpening: effectiveSharpening,
           allowForceDownscale: useForceDownscale,
         });
+        // Surface the same downscale/over-budget banner the preview and the
+        // authenticated export path show — without this, anonymous users got a
+        // lower-resolution file with no indication anything had been reduced. (#1445)
+        setCompositeWarning(warning);
         downloadComposite(blob, generateFilename(result.format));
         lastExportResultRef.current = null;
         setIsExporting(false);


### PR DESCRIPTION
Closes #1445

## Summary

Capture and surface the `warning` returned from `exportNChannelComposite` on the anonymous-user export path in `GuidedCreate.tsx`. The destructure was `{ blob }`, silently discarding `warning` — so downscaled exports landed as a smaller file with no UI banner.

## Why

`exportNChannelComposite` returns `CompositeBlobResult` with both the blob and a verdict object. The preview, authenticated export, and authenticated anonymous-generate paths all already feed `warning` into `setCompositeWarning(...)`. The anonymous export path was the lone gap — one line of destructure plus one line to route the warning.

## Changes Made

- `frontend/jwst-frontend/src/pages/GuidedCreate.tsx` — destructure `{ blob, warning }`; call `setCompositeWarning(warning)` before the file download fires.

## Test Plan

- [x] `npx tsc --noEmit` — clean.
- [x] Verified `setCompositeWarning(null)` is the existing "ok" outcome (the type allows null, the banner short-circuits on `budgetStatus === 'ok'`), so happy-path exports stay banner-free.
- [x] Reviewed sibling call sites (preview/authenticated paths) — same pattern as #1444's banner consumer.

## Documentation Checklist
- [x] No documentation updates needed (frontend wiring fix)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1445

## Risk & Rollback
- Risk: Low. Single-line additive change. Anonymous users now see the same banner authenticated users already saw on downscale/over-budget exports.
- Rollback: revert the commit.
