### PR TITLE
fix: retry transient embedding model loads with bounded backoff (#1102)

### DIFF
--- a/processing-engine/app/semantic/embedding_service.py
+++ b/processing-engine/app/semantic/embedding_service.py
@@ -41,8 +41,16 @@ class EmbeddingService:
         # Load existing index if available
         self._load_index()
 
+    # Retry config for the first-use model download. Transient HuggingFace
+    # rate-limits / DNS hiccups shouldn't fail the user's first semantic query
+    # outright when a short backoff would have succeeded. (#1102)
+    _MODEL_LOAD_MAX_RETRIES = 3
+    _MODEL_LOAD_BACKOFF_SECONDS = (1.0, 4.0, 16.0)
+
     def _ensure_model(self) -> None:
-        """Lazy-load the ONNX model on first use."""
+        """Lazy-load the ONNX model on first use, with bounded retry on transient
+        failures (network, HuggingFace rate-limit, transient filesystem).
+        """
         if self._model_loaded:
             return
 
@@ -51,7 +59,36 @@ class EmbeddingService:
 
         from sentence_transformers import SentenceTransformer
 
-        self._model = SentenceTransformer(MODEL_NAME, backend="onnx")
+        last_error: Exception | None = None
+        for attempt in range(self._MODEL_LOAD_MAX_RETRIES):
+            try:
+                self._model = SentenceTransformer(MODEL_NAME, backend="onnx")
+                break
+            except (OSError, RuntimeError, ValueError) as exc:
+                last_error = exc
+                if attempt == self._MODEL_LOAD_MAX_RETRIES - 1:
+                    logger.error(
+                        "Embedding model load failed after %d attempts: %s",
+                        self._MODEL_LOAD_MAX_RETRIES,
+                        exc,
+                    )
+                    raise
+                backoff = self._MODEL_LOAD_BACKOFF_SECONDS[
+                    min(attempt, len(self._MODEL_LOAD_BACKOFF_SECONDS) - 1)
+                ]
+                logger.warning(
+                    "Embedding model load attempt %d/%d failed (%s); retrying in %.1fs",
+                    attempt + 1,
+                    self._MODEL_LOAD_MAX_RETRIES,
+                    exc,
+                    backoff,
+                )
+                time.sleep(backoff)
+        if self._model is None:
+            # Unreachable in practice — the loop either sets self._model or raises.
+            raise RuntimeError(
+                f"Embedding model load failed without exception: last_error={last_error}"
+            )
 
         elapsed = time.time() - start
         logger.info("Model loaded in %.1fs", elapsed)

--- a/processing-engine/tests/test_embedding_service.py
+++ b/processing-engine/tests/test_embedding_service.py
@@ -171,3 +171,53 @@ class TestSearchNoIndex:
         assert results == []
         assert embed_ms == 0.0
         assert search_ms == 0.0
+
+
+class TestEnsureModelRetry:
+    """_ensure_model retries transient failures before giving up (#1102)."""
+
+    def _make_svc(self):
+        with patch.object(EmbeddingService, "_load_index"):
+            return EmbeddingService()
+
+    def test_succeeds_on_second_attempt(self):
+        svc = self._make_svc()
+        # First call raises a transient OSError; second succeeds.
+        sentinel_model = MagicMock()
+        mock_ctor = MagicMock(side_effect=[OSError("network blip"), sentinel_model])
+
+        with (
+            patch("sentence_transformers.SentenceTransformer", mock_ctor),
+            patch("time.sleep"),  # don't actually wait the backoff
+        ):
+            svc._ensure_model()
+
+        assert svc._model_loaded is True
+        assert svc._model is sentinel_model
+        assert mock_ctor.call_count == 2
+
+    def test_raises_after_max_retries(self):
+        svc = self._make_svc()
+        mock_ctor = MagicMock(side_effect=OSError("permanent network failure"))
+
+        with (
+            patch("sentence_transformers.SentenceTransformer", mock_ctor),
+            patch("time.sleep"),
+            pytest.raises(OSError, match="permanent network failure"),
+        ):
+            svc._ensure_model()
+
+        # Three attempts per _MODEL_LOAD_MAX_RETRIES.
+        assert mock_ctor.call_count == 3
+        assert svc._model_loaded is False
+
+    def test_no_op_when_already_loaded(self):
+        svc = self._make_svc()
+        svc._model_loaded = True
+        mock_ctor = MagicMock()
+
+        with patch("sentence_transformers.SentenceTransformer", mock_ctor):
+            svc._ensure_model()
+
+        # Never even tried to construct — fast-path hit.
+        mock_ctor.assert_not_called()


### PR DESCRIPTION
Closes #1102

## Summary

Wrap the cold-start `SentenceTransformer(MODEL_NAME, backend="onnx")` call in a bounded retry loop (3 attempts, 1s/4s/16s backoff). Transient network or filesystem failures no longer surface as a failed semantic-search request on the user's first query.

## Why

`_ensure_model` lazy-loads the ONNX embedding model on first use. The first call may need to download the model from HuggingFace (~80 MB), which can hit:

- Transient DNS / TCP failures on the container's first network reach
- HuggingFace rate limits (especially during noisy ramp-up periods)
- Filesystem contention as the cache directory is created

A short retry with exponential backoff turns those failures into a 1–20s delay instead of a user-facing 500. After the third attempt fails, the last exception is re-raised so a real outage still surfaces.

Exception list (`OSError | RuntimeError | ValueError`) covers the surface area HuggingFace Hub / sentence-transformers raise for transient I/O; deliberately narrow so a true ImportError or AttributeError still bubbles immediately.

## Changes Made

- `processing-engine/app/semantic/embedding_service.py`:
  - Class-level `_MODEL_LOAD_MAX_RETRIES = 3` and `_MODEL_LOAD_BACKOFF_SECONDS = (1.0, 4.0, 16.0)`.
  - `_ensure_model` wraps the constructor in a `for attempt in range(...)` loop; on the final iteration the exception propagates; earlier iterations log a warning, sleep, and retry.
- `processing-engine/tests/test_embedding_service.py` — new `TestEnsureModelRetry` with three cases:
  - `test_succeeds_on_second_attempt`
  - `test_raises_after_max_retries`
  - `test_no_op_when_already_loaded`

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_embedding_service.py::TestEnsureModelRetry --no-cov -v` — 3/3 pass.
- [x] `ruff check app/semantic/embedding_service.py` — clean.
- [x] `time.sleep` patched out in tests so the 20s backoff doesn't run in CI.

## Documentation Checklist
- [x] No documentation updates needed (resilience improvement, no API change)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1102

## Risk & Rollback
- Risk: Low. The happy path (model already cached) is unchanged. Failure modes that were 500s become 1–20s delays then 500s; if anything, slightly more user-friendly on the first request after a HuggingFace blip.
- Rollback: revert the commit; cold-start model loads go back to fail-fast.
