### PR TITLE
fix: wrap get_data_products exceptions in MASTServiceError (#1250)

### DIFF
--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -468,8 +468,11 @@ class MastService:
             logger.info(f"Found {len(filtered)} FITS science products")
             return self._table_to_dict_list(filtered)
         except Exception as e:
+            # Wrap in MASTServiceError so callers can catch a single exception
+            # type for any MastService failure (matches every other method in
+            # this class). (#1250)
             logger.error(f"Failed to get data products: {e}")
-            raise
+            raise MASTServiceError(str(e)) from e
 
     def download_product(self, product_id: str, obs_id: str) -> dict[str, Any]:
         """


### PR DESCRIPTION
Closes #1250

## Summary

Wrap the upstream exception in `MASTServiceError(...) from e` inside `get_data_products`, matching every other method in `MastService` (e.g. line 266, 310, 348, 382, 441).

## Why

`get_data_products` was the lone method that re-raised the raw `Exception` instead of wrapping it. Callers handling MAST adapter failures uniformly with `except MASTServiceError` would silently miss this method's failures and get a generic 500 instead of the structured error response wired up for `MASTServiceError`.

## Changes Made

- `processing-engine/app/mast/mast_service.py:470-472` — replace bare `raise` with `raise MASTServiceError(str(e)) from e`.

## Test Plan

- [x] Ruff lint + format clean (pre-commit hook).
- [x] Visual diff against sibling methods (lines 266, 310, 348, 382, 441) — identical pattern.
- [x] No call-site change required: existing `except MASTServiceError` handlers in `app/mast/routes.py` now catch this path too.

## Documentation Checklist
- [x] No documentation updates needed (internal consistency fix)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1250

## Risk & Rollback
- Risk: Low. Callers that catch `Exception` still see the failure; callers that catch `MASTServiceError` now see it too. The exception chain (`from e`) preserves the original traceback for diagnosis.
- Rollback: revert the commit.
