### PR TITLE
fix: validate S3 keys before storage operations (#1258)

### DIFF
--- a/processing-engine/app/storage/s3_storage.py
+++ b/processing-engine/app/storage/s3_storage.py
@@ -19,6 +19,28 @@ from .temp_cache import TempFileCache
 
 logger = logging.getLogger(__name__)
 
+# AWS S3 key limit is 1024 bytes; we use char-count as a conservative proxy.
+_MAX_KEY_LENGTH = 1024
+
+
+def _validate_s3_key(key: str) -> None:
+    """Reject S3 keys that could escape the local cache path or break clients.
+
+    The validation is a security boundary (rejects path-traversal artefacts
+    that would otherwise reach `TempFileCache` and write outside its dir)
+    plus a basic well-formedness check. (#1258)
+    """
+    if not isinstance(key, str) or not key:
+        raise ValueError("S3 key must be a non-empty string")
+    if "\x00" in key:
+        raise ValueError("S3 key contains null byte")
+    if len(key) > _MAX_KEY_LENGTH:
+        raise ValueError(f"S3 key exceeds {_MAX_KEY_LENGTH}-byte limit")
+    # The cache derives a filesystem path from the key; `..` segments could
+    # escape the cache directory once the key is path-joined.
+    if ".." in key.split("/"):
+        raise ValueError("S3 key contains parent-directory traversal segment")
+
 
 class S3Storage(StorageProvider):
     """S3-compatible storage implementation of StorageProvider."""
@@ -66,6 +88,7 @@ class S3Storage(StorageProvider):
 
     def read_to_temp(self, key: str) -> Path:
         """Download from S3 to local temp cache if not already cached."""
+        _validate_s3_key(key)
         cached = self._cache.get(key)
         if cached is not None:
             return cached
@@ -88,15 +111,18 @@ class S3Storage(StorageProvider):
 
     def write_from_path(self, key: str, local_path: Path) -> None:
         """Upload a local file to S3."""
+        _validate_s3_key(key)
         self._client.upload_file(str(local_path), self._bucket, key)
         logger.debug("Uploaded %s -> s3://%s/%s", local_path, self._bucket, key)
 
     def write_from_bytes(self, key: str, data: bytes) -> None:
         """Write raw bytes to S3."""
+        _validate_s3_key(key)
         self._client.put_object(Bucket=self._bucket, Key=key, Body=data)
 
     def exists(self, key: str) -> bool:
         """Check whether a key exists in S3."""
+        _validate_s3_key(key)
         try:
             self._client.head_object(Bucket=self._bucket, Key=key)
             return True
@@ -107,10 +133,12 @@ class S3Storage(StorageProvider):
 
     def delete(self, key: str) -> None:
         """Delete an object from S3."""
+        _validate_s3_key(key)
         self._client.delete_object(Bucket=self._bucket, Key=key)
 
     def presigned_url(self, key: str, expiry: int = 900) -> str | None:
         """Generate a presigned download URL."""
+        _validate_s3_key(key)
         url = self._client.generate_presigned_url(
             "get_object",
             Params={"Bucket": self._bucket, "Key": key},

--- a/processing-engine/tests/test_s3_storage.py
+++ b/processing-engine/tests/test_s3_storage.py
@@ -178,6 +178,37 @@ class TestS3Storage:
             Bucket="test-bucket", Key="mast/obs/file.fits"
         )
 
+    @pytest.mark.parametrize(
+        "bad_key,expected_msg",
+        [
+            ("", "non-empty"),
+            ("a/../b", "parent-directory"),
+            ("foo\x00bar", "null byte"),
+            ("x" * 1100, "1024-byte"),
+        ],
+    )
+    def test_read_to_temp_rejects_bad_keys(self, s3_storage, bad_key, expected_msg):
+        """#1258 — malformed S3 keys raise ValueError before reaching boto."""
+        with pytest.raises(ValueError, match=expected_msg):
+            s3_storage.read_to_temp(bad_key)
+
+    @pytest.mark.parametrize(
+        "bad_key",
+        ["", "..", "a/../b", "foo\x00bar"],
+    )
+    def test_write_methods_reject_bad_keys(self, s3_storage, bad_key, tmp_path):
+        """write_from_bytes / write_from_path / delete / exists all validate keys."""
+        with pytest.raises(ValueError):
+            s3_storage.write_from_bytes(bad_key, b"data")
+        with pytest.raises(ValueError):
+            s3_storage.delete(bad_key)
+        with pytest.raises(ValueError):
+            s3_storage.exists(bad_key)
+        source = tmp_path / "local.fits"
+        source.write_bytes(b"local data")
+        with pytest.raises(ValueError):
+            s3_storage.write_from_path(bad_key, source)
+
     def test_presigned_url(self, s3_storage, mock_boto3):
         mock_boto3.generate_presigned_url.return_value = (
             "http://localhost:8333/test-bucket/key?sig=abc"


### PR DESCRIPTION
Closes #1258

## Summary

Add `_validate_s3_key()` to `app/storage/s3_storage.py` and call it at every public entry point. Rejects malformed/dangerous keys (empty, null-byte, parent-directory segments, over-length) before they reach boto or the local cache.

## Why

S3 keys were passed verbatim from upstream callers through `TempFileCache.get(key)` → `key_to_filepath`, which derives a filesystem path from the key. A key like `"a/../b"` could write outside the cache directory once joined. Null bytes would cause cryptic OS errors at file-open time. Oversized keys would fail later with a confusing AWS-side error.

Validating at the storage boundary fails fast with a clear `ValueError` naming the issue.

## Changes Made

- `processing-engine/app/storage/s3_storage.py`:
  - Module-level `_MAX_KEY_LENGTH = 1024` (AWS S3 documented limit).
  - New `_validate_s3_key(key)` raising `ValueError` for empty / null-byte / parent-traversal / over-length keys.
  - Call sites: `read_to_temp`, `write_from_path`, `write_from_bytes`, `exists`, `delete`, `presigned_url`.
- `processing-engine/tests/test_s3_storage.py`:
  - `test_read_to_temp_rejects_bad_keys` (parametrized: empty, traversal, null byte, over-length).
  - `test_write_methods_reject_bad_keys` (parametrized across all four mutation methods).

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_s3_storage.py --no-cov -q` — 27/27 pass (was 19/19).
- [x] Existing happy-path tests (`test_exists_true`, `test_write_from_bytes`, etc.) still pass — the validator is a no-op for well-formed keys.

## Documentation Checklist
- [x] No documentation updates needed (security hardening at storage boundary)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1258

## Risk & Rollback
- Risk: Low. Validates strictly against documented S3 constraints + the local-path-derivation invariant. Well-formed keys (which is what all in-repo callers produce — keys are derived from MAST obs IDs that go through their own regex) see no behavior change.
- Rollback: revert the commit.
