### PR TITLE
fix: defensive manifest validation in MAST download methods (#1251)

### DIFF
--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -506,6 +506,13 @@ class MastService:
                 target_product, download_dir=obs_dir, cache=True
             )
 
+            # Defensive: astroquery may return None or a table without the
+            # expected column on certain failure modes. (#1251)
+            if manifest is None or "Local Path" not in manifest.colnames:
+                raise MASTServiceError(
+                    f"Download manifest for product {product_id} is missing 'Local Path'"
+                )
+
             # Get the downloaded file paths
             downloaded_files = [str(p) for p in manifest["Local Path"]]
 
@@ -557,6 +564,12 @@ class MastService:
 
             logger.info(f"Downloading {len(filtered)} files...")
             manifest = Observations.download_products(filtered, download_dir=obs_dir, cache=True)
+
+            # Defensive: see #1251 — astroquery can return None / empty / wrong shape.
+            if manifest is None or "Local Path" not in manifest.colnames:
+                raise MASTServiceError(
+                    f"Download manifest for observation {obs_id} is missing 'Local Path'"
+                )
 
             downloaded_files = [str(p) for p in manifest["Local Path"]]
 


### PR DESCRIPTION
Closes #1251

## Summary

Add `manifest is None or "Local Path" not in manifest.colnames` guards before `manifest["Local Path"]` access in `download_product` and `download_observation`. Failure modes that previously surfaced as opaque `KeyError`/`NoneType` errors now raise `MASTServiceError` with a clear cause.

## Why

`Observations.download_products` from astroquery can return None or an empty/malformed table under several real-world conditions:

- Network blip mid-download.
- All products filtered out (filter set produces an empty manifest).
- MAST API contract drift (rare but documented in astroquery release notes).

The existing `manifest["Local Path"]` access throws an opaque `KeyError` or `'NoneType' object is not subscriptable`. With the guards, the failure routes through `MASTServiceError`, which the controllers already handle with a structured 5xx response.

## Changes Made

- `processing-engine/app/mast/mast_service.py`:
  - `download_product` (lines 505-510 area): manifest validity check before `manifest["Local Path"]`.
  - `download_observation` (lines 559-561 area): same check.

## Test Plan

- [x] Ruff lint + format clean (pre-commit hook).
- [x] Both guards short-circuit only on explicit failure shapes — the happy path is unchanged.
- [x] Raising `MASTServiceError` integrates with the existing `MASTServiceError` exception handler in `app/exceptions.py` (no new mapping needed).

## Documentation Checklist
- [x] No documentation updates needed (defensive guard)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1251

## Risk & Rollback
- Risk: Low. Adds two short-circuit branches; well-formed manifests skip them entirely.
- Rollback: revert the commit.
