### PR TITLE
fix: gate AuthContext debug logs behind import.meta.env.DEV (#1420)

### DIFF
--- a/frontend/jwst-frontend/src/context/AuthContext.tsx
+++ b/frontend/jwst-frontend/src/context/AuthContext.tsx
@@ -33,6 +33,16 @@ const STORAGE_KEYS = {
   EXPIRES_AT: 'jwst_expires_at',
 };
 
+/**
+ * Dev-only console emitter for auth diagnostics. In production the call is a
+ * no-op so token-refresh internals (token presence, refresh attempts, error
+ * text) don't leak through browser DevTools. (#1420)
+ */
+function devAuthLog(message: string, ...rest: unknown[]): void {
+  if (!import.meta.env.DEV) return;
+  console.warn(message, ...rest);
+}
+
 // Initial auth state
 const initialState: AuthState = {
   user: null,
@@ -273,7 +283,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
             response = await doRefresh();
           }
           if (sessionIdRef.current !== sessionId) return;
-          console.warn('[AuthContext] Init refresh succeeded');
+          devAuthLog('[AuthContext] Init refresh succeeded');
           saveAuth(response);
           setState({
             user: response.user,
@@ -284,7 +294,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
             isLoading: false,
           });
         } catch (err) {
-          console.warn(
+          devAuthLog(
             '[AuthContext] Init refresh failed:',
             err instanceof Error ? err.message : String(err)
           );
@@ -315,15 +325,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // sessionIdRef is a stable ref, safe to capture.
     setTokenRefresher(async () => {
       const refreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
-      console.warn('[AuthContext] Refresh callback invoked, hasRefreshToken:', !!refreshToken);
+      devAuthLog('[AuthContext] Refresh callback invoked, hasRefreshToken:', !!refreshToken);
       if (!refreshToken) {
-        console.warn('[AuthContext] No refresh token in localStorage');
+        devAuthLog('[AuthContext] No refresh token in localStorage');
         return false;
       }
 
       const sessionId = sessionIdRef.current;
       const doRefresh = () => {
-        console.warn('[AuthContext] Calling authService.refreshToken...');
+        devAuthLog('[AuthContext] Calling authService.refreshToken...');
         return authService.refreshToken({ refreshToken });
       };
 
@@ -340,7 +350,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
           response = await doRefresh();
         }
         if (sessionIdRef.current !== sessionId) return false;
-        console.warn('[AuthContext] Refresh succeeded, saving new tokens');
+        devAuthLog('[AuthContext] Refresh succeeded, saving new tokens');
         saveAuth(response);
         setState({
           user: response.user,
@@ -352,7 +362,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         });
         return true;
       } catch (err) {
-        console.warn(
+        devAuthLog(
           '[AuthContext] Refresh failed:',
           err instanceof Error ? err.message : String(err)
         );


### PR DESCRIPTION
Closes #1420

## Summary

Replace 7 `console.warn('[AuthContext] …')` calls with a dev-gated `devAuthLog()` helper that no-ops outside `import.meta.env.DEV`. Production bundles tree-shake the entire log payload — internal token-refresh state no longer leaks to browser DevTools in release.

## Why

The seven `console.warn` calls were left over from the #1376 refresh-flow debugging:

- "Init refresh succeeded"
- "Init refresh failed: …"
- "Refresh callback invoked, hasRefreshToken: …"
- "No refresh token in localStorage"
- "Calling authService.refreshToken…"
- "Refresh succeeded, saving new tokens"
- "Refresh failed: …"

In production these statements ran on every refresh attempt for every user, exposing token presence, refresh timing, and error text to anyone with DevTools open. They're useful diagnostic tools — but only in DEV.

Vite replaces `import.meta.env.DEV` with `false` in production builds, so the entire helper body is dead-code-eliminated.

## Changes Made

- `frontend/jwst-frontend/src/context/AuthContext.tsx`:
  - New `devAuthLog(message, ...rest)` helper near the file's top-level constants.
  - All seven `console.warn('[AuthContext] …')` sites → `devAuthLog('[AuthContext] …')`.

## Test Plan

- [x] `npx tsc --noEmit` — clean.
- [x] `grep -n "console.warn" src/context/AuthContext.tsx` — only the helper's internal call remains; all `[AuthContext]` payloads route through the gate.
- [x] Manually traced each call site to confirm no other side effects depend on the log firing.

## Documentation Checklist
- [x] No documentation updates needed (security hygiene)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1420

## Risk & Rollback
- Risk: None for prod (logs simply disappear). DEV builds retain identical visibility.
- Rollback: revert the commit.
