### PR TITLE
docs: explain safe Docker rebuild after rollback (#1425)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -371,6 +371,16 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml start backend
 > See the Restore procedure above for the safety prompts
 > `restore-mongo.sh` runs if `backend` is still connected.
 
+**To rebuild the Docker stack while staying on the rolled-back version** (e.g. after an env-var change or a failed container restart), use the Docker Compose commands directly — they read the current working-tree, which is whatever commit you've checked out for the rollback:
+
+```sh
+cd ~/jwst-app
+docker compose -f docker-compose.yml -f docker-compose.prod.yml build
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+Do **not** run `git pull` before this — that would re-introduce the broken commits. The rollback target stays checked out until the underlying bug is fixed and a new deploy goes through `server-setup-prod.sh`.
+
 Estimated downtime during a normal deploy or rollback: **30–90s** (image
 build + container swap). Not yet measured on the target VPS — record the
 first prod deploy timing and update. Pick an off-peak window.


### PR DESCRIPTION
Closes #1425

## Summary

Add a "rebuild Docker stack without re-running `server-setup-prod.sh`" block to the rollback section of `docs/deployment.md`. Names the right `docker compose build` / `up -d` commands and warns operators to **not** `git pull` first (which would re-introduce the broken commit).

## Why

The rollback procedure correctly warns operators that `server-setup-prod.sh` will undo the rollback (it does `git reset --hard origin/main`). But it didn't tell them what to do when they need to rebuild containers while staying on the rolled-back tree — e.g. after editing an env var, after a failed container restart, or to apply a partial fix without a full re-deploy. Operators had to figure out the safe sequence by inference.

## Changes Made

- `docs/deployment.md` — append a block to the rollback section with the explicit `docker compose -f docker-compose.yml -f docker-compose.prod.yml build && up -d` commands, plus a "don't `git pull` first" caveat.

## Test Plan

- [x] Markdown renders cleanly (no broken code blocks).
- [x] Commands match the pattern used in the surrounding "Update after git pull" row and the "Tail logs" / "Restart all" entries.

## Documentation Checklist
- [x] `docs/deployment.md` updated (sole change)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1425

## Risk & Rollback
- Risk: None. Docs-only.
- Rollback: revert the commit.
