### PR TITLE
fix: surface silent stretch fallback in response header (#1394)

### DIFF
--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -149,6 +149,9 @@ class StretchResult:
     color_ch_instruments: list[str | None] = field(default_factory=list)
     lum_data: np.ndarray | None = None
     lum_weight: float = 1.0
+    # Channels where the requested stretch failed and fell back to zscale.
+    # Format: "<channel>:<requested>->zscale", e.g. "F444W:asinh->zscale". (#1394)
+    stretch_fallbacks: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -393,7 +396,12 @@ def apply_stretch_method(
     return stretched
 
 
-def apply_stretch(data: np.ndarray, config: ChannelConfig) -> np.ndarray:
+def apply_stretch(
+    data: np.ndarray,
+    config: ChannelConfig,
+    fallback_sink: list[str] | None = None,
+    channel_label: str | None = None,
+) -> np.ndarray:
     """
     Apply stretch and level adjustments to channel data.
 
@@ -411,6 +419,12 @@ def apply_stretch(data: np.ndarray, config: ChannelConfig) -> np.ndarray:
     except (ValueError, RuntimeError) as e:
         logger.warning(f"Stretch {stretch} failed: {e}, falling back to zscale")
         stretched, _, _ = zscale_stretch(data)
+        # Surface to the response header so callers can detect "you asked for
+        # asinh but got zscale" — previously a silent UX divergence. (#1394)
+        if fallback_sink is not None:
+            entry = f"{channel_label or '?'}:{stretch}->zscale"
+            if entry not in fallback_sink:
+                fallback_sink.append(entry)
 
     # Apply black/white point clipping
     if config.black_point > 0.0 or config.white_point < 1.0:
@@ -1180,7 +1194,12 @@ def _stretch_and_map_channels(
             index=idx + 1,
             total=n_channels,
         )
-        stretched = apply_stretch(stretch_input[ch_name], ch_config)
+        stretched = apply_stretch(
+            stretch_input[ch_name],
+            ch_config,
+            fallback_sink=result.stretch_fallbacks,
+            channel_label=ch_name,
+        )
         rgb_weights = resolve_channel_color(ch_config.color)
 
         if rgb_weights is None:
@@ -1336,6 +1355,7 @@ def _encode_and_respond(
     auto_feathered: bool,
     effective_feather: float,
     verdict: MemoryBudgetVerdict | None = None,
+    stretch_fallbacks: list[str] | None = None,
 ) -> Response:
     """Encode the final RGB array into a Response with quality headers.
 
@@ -1459,6 +1479,12 @@ def _encode_and_respond(
             )
             quality_headers["X-Composite-Side-Factor"] = f"{verdict.side_factor:.3f}"
 
+    # Surface stretch fallbacks so the frontend (and recipe walkthroughs) can
+    # detect "I asked for asinh but got zscale" instead of silently rendering
+    # a different stretch. (#1394)
+    if stretch_fallbacks:
+        quality_headers["X-Composite-Stretch-Fallbacks"] = ",".join(stretch_fallbacks)
+
     return Response(content=buf.getvalue(), media_type=media_type, headers=quality_headers)
 
 
@@ -1519,7 +1545,14 @@ def _run_nchannel_pipeline(
     if request.saturation is not None:
         rgb = apply_saturation_vibrancy(rgb, request.saturation)
     emit_progress(progress, stage="encode", message="Encoding image")
-    return _encode_and_respond(rgb, request, auto_feathered, feather, verdict)
+    return _encode_and_respond(
+        rgb,
+        request,
+        auto_feathered,
+        feather,
+        verdict,
+        stretch_fallbacks=mapped.stretch_fallbacks,
+    )
 
 
 @router.post("/generate-nchannel")

--- a/processing-engine/tests/test_nchannel_composite.py
+++ b/processing-engine/tests/test_nchannel_composite.py
@@ -17,6 +17,7 @@ from app.composite.cache import CompositeCache
 from app.composite.color_mapping import blend_luminance, hsl_to_rgb, rgb_to_hsl
 from app.composite.models import (
     ChannelColor,
+    ChannelConfig,
     NChannelCompositeRequest,
     NChannelConfig,
     SharpeningConfig,
@@ -31,6 +32,7 @@ from app.composite.routes import (
     _resolve_feather_strength,
     _stretch_and_map_channels,
     apply_sharpening,
+    apply_stretch,
     resolve_channel_color,
 )
 
@@ -1395,6 +1397,61 @@ class TestRenderDebugMasksResponse:
             _render_debug_masks_response(request, reprojected, [None, None], 0.0)
         assert exc.value.status_code == 400
         assert "luminance" in exc.value.detail.lower()
+
+
+class TestApplyStretchFallback:
+    """apply_stretch records failed-stretch fallbacks to the sink list (#1394)."""
+
+    @staticmethod
+    def _config(stretch: str) -> ChannelConfig:
+        return ChannelConfig(
+            file_paths=["dummy.fits"],
+            stretch=stretch,
+            asinh_a=0.1,
+            gamma=1.0,
+        )
+
+    def test_records_fallback_on_runtime_error(self):
+        """When the requested stretch raises, the channel + name pair is appended."""
+        sink: list[str] = []
+        config = self._config("asinh")
+        rng = np.random.default_rng(1)
+        data = rng.normal(size=(8, 8))
+
+        with patch("app.composite.routes.apply_stretch_method", side_effect=RuntimeError("boom")):
+            apply_stretch(data, config, fallback_sink=sink, channel_label="F444W")
+
+        assert sink == ["F444W:asinh->zscale"]
+
+    def test_no_record_on_success(self):
+        """Successful stretch leaves the sink empty."""
+        sink: list[str] = []
+        rng = np.random.default_rng(2)
+        data = rng.normal(loc=1000.0, scale=100.0, size=(8, 8))
+        apply_stretch(data, self._config("zscale"), fallback_sink=sink, channel_label="F090W")
+        assert sink == []
+
+    def test_dedupes_repeated_fallback_entries(self):
+        """A second call with the same channel+stretch doesn't duplicate the entry."""
+        sink: list[str] = []
+        config = self._config("asinh")
+        rng = np.random.default_rng(3)
+        data = rng.normal(size=(8, 8))
+
+        with patch("app.composite.routes.apply_stretch_method", side_effect=RuntimeError("boom")):
+            apply_stretch(data, config, fallback_sink=sink, channel_label="F090W")
+            apply_stretch(data, config, fallback_sink=sink, channel_label="F090W")
+
+        assert sink == ["F090W:asinh->zscale"]
+
+    def test_works_without_sink(self):
+        """Backward-compat: omitting fallback_sink keeps old behavior."""
+        rng = np.random.default_rng(4)
+        data = rng.normal(size=(8, 8))
+        # Should not raise — just silently falls back to zscale.
+        with patch("app.composite.routes.apply_stretch_method", side_effect=RuntimeError("boom")):
+            result = apply_stretch(data, self._config("asinh"))
+        assert result.shape == data.shape
 
 
 class TestApplySharpening:


### PR DESCRIPTION
Closes #1394

## Summary

Surface silent stretch fallbacks in a new `X-Composite-Stretch-Fallbacks` response header so callers can detect "I requested asinh, the engine fell back to zscale" instead of seeing different pixels with no indication anything changed.

## Why

`apply_stretch` catches `ValueError`/`RuntimeError` from the requested stretch and silently substitutes `zscale_stretch`. The pixels come back stretched (by a different algorithm), so the request appears successful but the output diverges from what was asked. Recipe walkthroughs and UI flows had no way to detect the divergence.

The new header is opt-in for clients (frontend can render a "stretch fell back" banner; recipe walkthroughs can log it). Backend behavior is unchanged — the graceful zscale fallback still happens, just no longer silent.

## Changes Made

- `processing-engine/app/composite/routes.py`:
  - `apply_stretch` gains a `fallback_sink: list[str] | None` parameter plus a `channel_label` for tagging.
  - On fallback, appends `f"{channel}:{stretch}->zscale"` to the sink (with dedupe).
  - `StretchResult` carries a `stretch_fallbacks: list[str]` field; `_stretch_and_map_channels` plumbs it through.
  - `_encode_and_respond` gains a `stretch_fallbacks` parameter and emits `X-Composite-Stretch-Fallbacks` when non-empty.
  - `_run_nchannel_pipeline` passes `mapped.stretch_fallbacks` into `_encode_and_respond`.
- `processing-engine/tests/test_nchannel_composite.py`:
  - New `TestApplyStretchFallback` with 4 cases (records on RuntimeError, no-op on success, dedupes repeats, backward-compat when sink omitted).

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_nchannel_composite.py --no-cov -q` — 92/92 pass (was 88/88).
- [x] `ruff check` clean.
- [x] Verified backward compat: `apply_stretch(data, config)` without sink continues to fall back silently to zscale (existing callers untouched).

## Documentation Checklist
- [x] No documentation updates needed (new header is additive; documented in code comments)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1394

## Risk & Rollback
- Risk: Low. Pipeline behavior is unchanged; only adds an optional response header. Pre-existing callers continue to receive the same image bytes.
- Rollback: revert the commit.
