### PR TITLE
feat: add top-level React ErrorBoundary (#1366)

### DIFF
--- a/frontend/jwst-frontend/src/components/ErrorBoundary.css
+++ b/frontend/jwst-frontend/src/components/ErrorBoundary.css
@@ -1,0 +1,63 @@
+.error-boundary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 2rem;
+}
+
+.error-boundary__panel {
+  max-width: 32rem;
+  padding: 2rem;
+  background: var(--surface-color, #ffffff);
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.error-boundary__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.5rem;
+  color: var(--text-color, #111111);
+}
+
+.error-boundary__message {
+  margin: 0 0 1rem;
+  color: var(--muted-text-color, #555555);
+}
+
+.error-boundary__detail {
+  margin: 0 0 1rem;
+  padding: 0.75rem;
+  background: var(--code-bg, #f5f5f5);
+  border-radius: 0.25rem;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-color, #111111);
+}
+
+.error-boundary__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.error-boundary__button {
+  padding: 0.5rem 1rem;
+  background: var(--primary-color, #3a7afe);
+  color: #ffffff;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.error-boundary__button:hover {
+  filter: brightness(0.95);
+}
+
+.error-boundary__button--secondary {
+  background: var(--surface-color, #ffffff);
+  color: var(--text-color, #111111);
+  border: 1px solid var(--border-color, #d0d0d0);
+}

--- a/frontend/jwst-frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/jwst-frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,79 @@
+import type { ReactElement } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function Boom(): never {
+  throw new Error('test boom');
+}
+
+function Safe(): ReactElement {
+  return <div data-testid="safe-child">safe</div>;
+}
+
+describe('ErrorBoundary', () => {
+  // React logs caught errors to console.error by design; silence for tests.
+  let originalError: typeof console.error;
+  beforeEach(() => {
+    originalError = console.error;
+    console.error = vi.fn();
+  });
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <Safe />
+      </ErrorBoundary>
+    );
+    expect(screen.getByTestId('safe-child')).toBeInTheDocument();
+  });
+
+  it('renders the default fallback when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload page/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('resets when the "Try again" button is clicked', () => {
+    let shouldThrow = true;
+    function Toggle(): ReactElement {
+      if (shouldThrow) throw new Error('one-time error');
+      return <div data-testid="recovered">recovered</div>;
+    }
+    render(
+      <ErrorBoundary>
+        <Toggle />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(screen.getByTestId('recovered')).toBeInTheDocument();
+  });
+
+  it('honors a custom fallback when provided', () => {
+    render(
+      <ErrorBoundary
+        fallback={(err, reset) => (
+          <div>
+            <span data-testid="custom-msg">caught: {err.message}</span>
+            <button onClick={reset}>custom-reset</button>
+          </div>
+        )}
+      >
+        <Boom />
+      </ErrorBoundary>
+    );
+    expect(screen.getByTestId('custom-msg')).toHaveTextContent('caught: test boom');
+  });
+});

--- a/frontend/jwst-frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/jwst-frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,83 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import './ErrorBoundary.css';
+
+/**
+ * Top-level error boundary for the JWST frontend.
+ *
+ * Without this, any uncaught exception thrown during render unmounts the
+ * entire tree and the user sees a blank white screen with no recovery
+ * affordance. The boundary catches the throw, logs it, and renders a
+ * minimal fallback UI with a reload button. (#1366)
+ *
+ * React error boundaries must be class components — there's no hook
+ * equivalent for `componentDidCatch` / `getDerivedStateFromError`.
+ */
+
+interface Props {
+  children: ReactNode;
+  /** Optional custom fallback. Receives the captured error and a reset callback. */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // Surface to whatever console / monitoring is wired up — `console.error`
+    // is the lowest-common-denominator and shows up in dev tools, browser
+    // diagnostics, and any wrapping logger.
+    // eslint-disable-next-line no-console -- error boundary fallback diagnostic
+    console.error('[ErrorBoundary] Uncaught render error:', error, errorInfo);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error === null) {
+      return this.props.children;
+    }
+    if (this.props.fallback) {
+      return this.props.fallback(error, this.reset);
+    }
+    return (
+      <div role="alert" className="error-boundary">
+        <div className="error-boundary__panel">
+          <h1 className="error-boundary__title">Something went wrong</h1>
+          <p className="error-boundary__message">
+            The application encountered an unexpected error and couldn't render this view.
+          </p>
+          {import.meta.env.DEV && <pre className="error-boundary__detail">{error.message}</pre>}
+          <div className="error-boundary__actions">
+            <button
+              type="button"
+              className="error-boundary__button"
+              onClick={() => window.location.reload()}
+            >
+              Reload page
+            </button>
+            <button
+              type="button"
+              className="error-boundary__button error-boundary__button--secondary"
+              onClick={this.reset}
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/jwst-frontend/src/index.tsx
+++ b/frontend/jwst-frontend/src/index.tsx
@@ -4,14 +4,17 @@ import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
 import { AuthProvider } from './context/AuthContext';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
Closes #1366

## Summary

Add a top-level `ErrorBoundary` component and wrap it around `BrowserRouter` / `AuthProvider` / `App` in `index.tsx`. Uncaught render-phase exceptions now show a "Something went wrong" panel with Reload and Try Again buttons instead of the blank white screen the issue reported.

## Why

React has no hook equivalent for `getDerivedStateFromError` / `componentDidCatch` — error boundaries must be class components. Without one, any throw during render (a chart with bad data, a stale prop, an unexpected null) unmounts the entire React tree and the user sees a blank page with no indication of what happened or how to recover.

## Changes Made

- **New file** `src/components/ErrorBoundary.tsx` — class component with `getDerivedStateFromError`, `componentDidCatch` (logs to `console.error`), and a default fallback UI. Accepts an optional `fallback` render prop so scoped boundaries can supply their own UI for individual widgets later.
- **New file** `src/components/ErrorBoundary.css` — minimal styling that honors the existing CSS variables (`--surface-color`, `--primary-color`, etc.) so it adapts to whatever theme is active.
- **New file** `src/components/ErrorBoundary.test.tsx` — 4 vitest cases:
  - Renders children on the happy path
  - Renders the fallback when a child throws
  - Recovers via the "Try again" button
  - Honors a custom `fallback` prop
- `src/index.tsx` — wrap the existing `BrowserRouter` / `AuthProvider` / `App` stack with `<ErrorBoundary>`.

In DEV the error message is shown in a `<pre>` block to aid debugging. In PROD it's omitted — the user sees only the friendly explanation and recovery buttons.

## Test Plan

- [x] `npx vitest run src/components/ErrorBoundary.test.tsx` — 4/4 pass.
- [x] `npx tsc --noEmit` — clean.
- [x] Wrapping placement verified: `ErrorBoundary` is the outermost component inside `React.StrictMode`, so it catches throws from every nested provider, the router, and the entire app tree.

## Documentation Checklist
- [x] No documentation updates needed (new component is self-documenting; scoped-boundary usage via `fallback` prop can be documented when consumers adopt it)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1366

## Risk & Rollback
- Risk: Low. Boundary is purely additive — the happy path passes children through unchanged. The only behavior change is that previously-fatal render exceptions now show a recovery UI.
- Rollback: revert the commit.
