### PR TITLE
feat: log warning when MAST results may be truncated at pagesize (#1221)

### DIFF
--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -54,7 +54,10 @@ def _convert_mast_uris(rows: list[dict[str, Any]]) -> None:
 class MastService:
     """Service for interacting with MAST portal via astroquery."""
 
-    # Default page size for MAST queries (astroquery defaults to 10)
+    # Default page size for MAST queries (astroquery defaults to 10).
+    # When a query returns exactly this many rows, the result is likely
+    # truncated — `_warn_if_truncated` logs a warning so operators can spot
+    # the case in production and tune the limit. (#1221)
     DEFAULT_PAGE_SIZE = 500
 
     # Valid MAST data URI pattern: mast:{collection}/product/{filename}
@@ -66,6 +69,25 @@ class MastService:
 
     # MAST download base URL
     MAST_DOWNLOAD_BASE = "https://mast.stsci.edu/api/v0.1/Download/file"
+
+    @classmethod
+    def _warn_if_truncated(cls, obs_table, search_description: str) -> None:
+        """Log a clear warning when a result set is likely truncated. (#1221)
+
+        Astroquery's ``Observations.query_criteria`` returns at most
+        ``pagesize`` rows; if we asked for ``DEFAULT_PAGE_SIZE`` and got
+        exactly that many back, the next page worth of results is silently
+        cut off. Surfacing this in logs lets operators spot the case in
+        production and tune the limit before users hit it.
+        """
+        if len(obs_table) >= cls.DEFAULT_PAGE_SIZE:
+            logger.warning(
+                "MAST results may be truncated at pagesize=%d for %s — "
+                "consider narrowing filters (calib_level, instrument) "
+                "or raising DEFAULT_PAGE_SIZE.",
+                cls.DEFAULT_PAGE_SIZE,
+                search_description,
+            )
 
     # Target normalization patterns for resilient name resolution
     TARGET_SEPARATOR_PATTERN = re.compile(r"[-_\s]+")
@@ -260,6 +282,7 @@ class MastService:
             obs_table = Observations.query_criteria(**query_params)
 
             logger.info(f"Found {len(obs_table)} JWST observations")
+            self._warn_if_truncated(obs_table, "target/coordinate search")
             return self._table_to_dict_list(obs_table)
         except Exception as e:
             logger.error(f"MAST target search failed: {e}")
@@ -304,6 +327,7 @@ class MastService:
             obs_table = Observations.query_criteria(**query_params)
 
             logger.info(f"Found {len(obs_table)} JWST observations")
+            self._warn_if_truncated(obs_table, "target/coordinate search")
             return self._table_to_dict_list(obs_table)
         except Exception as e:
             logger.error(f"MAST coordinate search failed: {e}")
@@ -342,6 +366,7 @@ class MastService:
 
             obs_table = Observations.query_criteria(**query_params)
             logger.info(f"Found {len(obs_table)} observations")
+            self._warn_if_truncated(obs_table, "observation/program search")
             return self._table_to_dict_list(obs_table)
         except Exception as e:
             logger.error(f"MAST observation ID search failed: {e}")
@@ -376,6 +401,7 @@ class MastService:
                 query_params["t_obs_release"] = [0, _today_mjd()]
             obs_table = Observations.query_criteria(**query_params)
             logger.info(f"Found {len(obs_table)} observations")
+            self._warn_if_truncated(obs_table, "observation/program search")
             return self._table_to_dict_list(obs_table)
         except Exception as e:
             logger.error(f"MAST program ID search failed: {e}")

--- a/processing-engine/tests/test_mast_pagination.py
+++ b/processing-engine/tests/test_mast_pagination.py
@@ -111,3 +111,32 @@ class TestSearchRecentReleasesPagination:
         results = self.service.search_recent_releases(days_back=30, limit=10, offset=0)
 
         assert len(results) == 3
+
+
+class TestWarnIfTruncated:
+    """`_warn_if_truncated` logs a warning when results saturate DEFAULT_PAGE_SIZE (#1221)."""
+
+    def test_warns_at_pagesize(self, caplog):
+        import logging
+
+        table = _make_obs_table(MastService.DEFAULT_PAGE_SIZE)
+        with caplog.at_level(logging.WARNING, logger="app.mast.mast_service"):
+            MastService._warn_if_truncated(table, "test search")
+        assert any("may be truncated" in r.message for r in caplog.records)
+        assert any("test search" in r.message for r in caplog.records)
+
+    def test_no_warning_below_pagesize(self, caplog):
+        import logging
+
+        table = _make_obs_table(MastService.DEFAULT_PAGE_SIZE - 1)
+        with caplog.at_level(logging.WARNING, logger="app.mast.mast_service"):
+            MastService._warn_if_truncated(table, "test search")
+        assert not any("may be truncated" in r.message for r in caplog.records)
+
+    def test_no_warning_on_empty(self, caplog):
+        import logging
+
+        table = _make_obs_table(0)
+        with caplog.at_level(logging.WARNING, logger="app.mast.mast_service"):
+            MastService._warn_if_truncated(table, "test search")
+        assert not any("may be truncated" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes #1221

## Summary

Add a `_warn_if_truncated(obs_table, search_description)` helper on `MastService` and call it from all four search paths (target, coordinate, observation, program). When a query returns exactly `DEFAULT_PAGE_SIZE` rows it's almost certainly truncated by astroquery's `pagesize` cap — the new warning makes that visible in logs so operators can spot the case before users do.

## Why

`Observations.query_criteria` returns at most `pagesize` rows with no "more available" indicator. Full cursor-style pagination isn't a one-line change on the JWST collection — astroquery doesn't expose a `page` parameter for `query_criteria`, so proper pagination needs CAOM-level batching or a result-id cursor (out of scope for one PR).

The minimum signal — log a warning when truncation is likely — turns a silent correctness gap into one that's diagnosable in production. Operators can:
- Spot the case in logs and raise `DEFAULT_PAGE_SIZE` (current 500 → 5000 is a single-line env-var change).
- Narrow filters (calib_level, instrument) to push the result set under the cap.

## Changes Made

- `processing-engine/app/mast/mast_service.py`:
  - New `_warn_if_truncated` classmethod with a clear log message naming the search description and the pagesize.
  - Called from `search_by_target`, `search_by_coordinates`, `search_by_observation_id`, `search_by_program_id` (all four hit the same `obs_table` log line, so the change is centralised via the existing helper).
- `processing-engine/tests/test_mast_pagination.py`:
  - New `TestWarnIfTruncated` with three cases (warns at pagesize, no warning below, no warning on empty).

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_mast_pagination.py --no-cov -v` — 10/10 pass (was 7/7).
- [x] Manual trace: a mocked obs_table with exactly `DEFAULT_PAGE_SIZE` rows triggers the warning; one fewer doesn't.

## Documentation Checklist
- [x] No documentation updates needed (operator-facing warning in logs)

## Tech Debt Impact
- [x] No new tech debt introduced
- [x] Existing tech debt reduced — closes #1221

## Risk & Rollback
- Risk: Low. Helper is observation-only — logs a warning. No behavior change to result data.
- Rollback: revert the commit.
