### PR TITLE
fix: load embedding model outside FAISS lock to avoid service-wide stall (#1524)

### DIFF
--- a/docs/plans/features/quick/1524-faiss-lock-during-retry.md
+++ b/docs/plans/features/quick/1524-faiss-lock-during-retry.md
@@ -1,0 +1,45 @@
+# Fix #1524 — FAISS lock held during model-load retry backoff
+
+**Branch**: `fix/1524-faiss-lock-during-retry`
+**Type**: Bug fix (concurrency), processing-engine, priority: high
+**Complexity**: Low (single module + tests)
+
+## Problem
+
+`EmbeddingService._ensure_model()` runs a bounded retry loop with `time.sleep()`
+backoff (1s, 4s, 16s — up to ~21s) introduced in #1513/#1102. Every public path
+(`embed`, `embed_batch`, `search`) acquires `self._lock` (the FAISS index lock)
+and *then* calls `_encode` → `_ensure_model`. So a transient HuggingFace
+rate-limit on first use makes the retrying thread sleep **while holding
+`self._lock`**, blocking all concurrent semantic queries for the full backoff
+window — a service-wide availability outage.
+
+## Fix
+
+1. Add a dedicated `self._model_load_lock`, separate from the FAISS index lock.
+2. Rewrite `_ensure_model` with double-checked locking on `_model_load_lock`
+   (fast-path boolean read, then lock + re-check, then the retry loop).
+3. Call `self._ensure_model()` **before** acquiring `self._lock` in `embed`,
+   `embed_batch`, and `search`, so the slow load happens outside the FAISS lock.
+   - `search` keeps a lock-free empty-index fast path (snapshotting `self._index`)
+     so it doesn't load the model just to search an empty index, and re-checks
+     emptiness under the lock.
+   - `embed_batch` wraps the pre-lock load in `except (OSError, ValueError,
+     RuntimeError)` to preserve its "errors list" contract (OSError is the
+     canonical transient failure).
+4. `_encode` still calls `_ensure_model()` — now a fast no-op since callers
+   pre-load — kept as defense for any future internal caller.
+
+## Tests (TDD)
+
+- `test_faiss_lock_not_held_during_model_load` — records `self._lock.locked()` at
+  model-construction time; was `[True]` (red), now `[False]` (green).
+- `test_concurrent_callers_load_model_once` — Barrier(8) + slow ctor forces
+  contention; asserts exactly one construction (double-checked locking).
+- `test_embed_batch_load_failure_returns_errors_not_raises` — OSError load
+  failure surfaces as the errors list, not a 500.
+
+## Verification
+
+`docker exec jwst-processing python -m pytest tests/test_embedding_service.py` —
+16 passed. Ruff clean.

--- a/processing-engine/app/semantic/embedding_service.py
+++ b/processing-engine/app/semantic/embedding_service.py
@@ -31,6 +31,10 @@ class EmbeddingService:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
+        # Dedicated lock for the one-time model load. Kept separate from
+        # `self._lock` so the retry/backoff sleep in `_ensure_model` never
+        # blocks concurrent FAISS index operations (embed/search) (#1524).
+        self._model_load_lock = threading.Lock()
         self._model = None
         self._tokenizer = None
         self._index: faiss.IndexFlatIP | None = None
@@ -50,49 +54,59 @@ class EmbeddingService:
     def _ensure_model(self) -> None:
         """Lazy-load the ONNX model on first use, with bounded retry on transient
         failures (network, HuggingFace rate-limit, transient filesystem).
+
+        Guarded by the dedicated `_model_load_lock` (double-checked) rather than
+        the FAISS index lock, and callers invoke this *before* taking
+        `self._lock`. That keeps the retry/backoff sleep — up to ~21s — from
+        stalling every concurrent embed/search call during a transient load
+        failure (#1524).
         """
-        if self._model_loaded:
+        if self._model_loaded:  # fast path — no lock once loaded
             return
 
-        logger.info("Loading embedding model %s (first use)...", MODEL_NAME)
-        start = time.time()
+        with self._model_load_lock:
+            if self._model_loaded:  # re-check: another thread may have loaded it
+                return
 
-        from sentence_transformers import SentenceTransformer
+            logger.info("Loading embedding model %s (first use)...", MODEL_NAME)
+            start = time.time()
 
-        last_error: Exception | None = None
-        for attempt in range(self._MODEL_LOAD_MAX_RETRIES):
-            try:
-                self._model = SentenceTransformer(MODEL_NAME, backend="onnx")
-                break
-            except (OSError, RuntimeError, ValueError) as exc:
-                last_error = exc
-                if attempt == self._MODEL_LOAD_MAX_RETRIES - 1:
-                    logger.error(
-                        "Embedding model load failed after %d attempts: %s",
+            from sentence_transformers import SentenceTransformer
+
+            last_error: Exception | None = None
+            for attempt in range(self._MODEL_LOAD_MAX_RETRIES):
+                try:
+                    self._model = SentenceTransformer(MODEL_NAME, backend="onnx")
+                    break
+                except (OSError, RuntimeError, ValueError) as exc:
+                    last_error = exc
+                    if attempt == self._MODEL_LOAD_MAX_RETRIES - 1:
+                        logger.error(
+                            "Embedding model load failed after %d attempts: %s",
+                            self._MODEL_LOAD_MAX_RETRIES,
+                            exc,
+                        )
+                        raise
+                    backoff = self._MODEL_LOAD_BACKOFF_SECONDS[
+                        min(attempt, len(self._MODEL_LOAD_BACKOFF_SECONDS) - 1)
+                    ]
+                    logger.warning(
+                        "Embedding model load attempt %d/%d failed (%s); retrying in %.1fs",
+                        attempt + 1,
                         self._MODEL_LOAD_MAX_RETRIES,
                         exc,
+                        backoff,
                     )
-                    raise
-                backoff = self._MODEL_LOAD_BACKOFF_SECONDS[
-                    min(attempt, len(self._MODEL_LOAD_BACKOFF_SECONDS) - 1)
-                ]
-                logger.warning(
-                    "Embedding model load attempt %d/%d failed (%s); retrying in %.1fs",
-                    attempt + 1,
-                    self._MODEL_LOAD_MAX_RETRIES,
-                    exc,
-                    backoff,
+                    time.sleep(backoff)
+            if self._model is None:
+                # Unreachable in practice — the loop either sets self._model or raises.
+                raise RuntimeError(
+                    f"Embedding model load failed without exception: last_error={last_error}"
                 )
-                time.sleep(backoff)
-        if self._model is None:
-            # Unreachable in practice — the loop either sets self._model or raises.
-            raise RuntimeError(
-                f"Embedding model load failed without exception: last_error={last_error}"
-            )
 
-        elapsed = time.time() - start
-        logger.info("Model loaded in %.1fs", elapsed)
-        self._model_loaded = True
+            elapsed = time.time() - start
+            logger.info("Model loaded in %.1fs", elapsed)
+            self._model_loaded = True
 
     def _load_index(self) -> None:
         """Load FAISS index and ID map from disk if they exist."""
@@ -143,6 +157,8 @@ class EmbeddingService:
 
     def embed(self, file_id: str, text: str) -> int:
         """Embed a single text and add to index. Returns total indexed count."""
+        # Load the model outside the FAISS lock (#1524).
+        self._ensure_model()
         with self._lock:
             index = self._get_or_create_index()
 
@@ -160,6 +176,15 @@ class EmbeddingService:
         """Embed multiple (file_id, text) pairs. Returns (total_indexed, errors)."""
         if not items:
             return self.total_indexed, []
+
+        # Load the model outside the FAISS lock (#1524), preserving the
+        # "errors list" contract for transient load failures. OSError is the
+        # canonical transient case (network / DNS / HuggingFace rate-limit), so
+        # it must be caught here too — not just ValueError/RuntimeError.
+        try:
+            self._ensure_model()
+        except (OSError, ValueError, RuntimeError) as e:
+            return self.total_indexed, [f"Model load failed: {e}"]
 
         errors: list[str] = []
         with self._lock:
@@ -186,7 +211,20 @@ class EmbeddingService:
         self, query: str, top_k: int = 20, min_score: float = 0.3
     ) -> tuple[list[dict], float, float]:
         """Search the index. Returns (results, embed_time_ms, search_time_ms)."""
+        # Lock-free fast path: nothing indexed yet means no model load and no
+        # FAISS work. Avoids loading the model just to search an empty index.
+        # Snapshot the reference once so a concurrent index rebuild can't turn
+        # this into a None-deref between the two reads.
+        idx = self._index
+        if idx is None or idx.ntotal == 0:
+            return [], 0.0, 0.0
+
+        # Load the model outside the FAISS lock (#1524) so a slow/retrying load
+        # doesn't stall concurrent queries.
+        self._ensure_model()
+
         with self._lock:
+            # Re-check under the lock: a concurrent rebuild may have emptied it.
             if self._index is None or self._index.ntotal == 0:
                 return [], 0.0, 0.0
 

--- a/processing-engine/tests/test_embedding_service.py
+++ b/processing-engine/tests/test_embedding_service.py
@@ -221,3 +221,97 @@ class TestEnsureModelRetry:
 
         # Never even tried to construct — fast-path hit.
         mock_ctor.assert_not_called()
+
+
+class TestModelLoadOutsideFaissLock:
+    """Model loading must not hold the FAISS index lock (#1524).
+
+    `_ensure_model` runs a bounded retry loop with `time.sleep()` backoff
+    (#1102). If that ran while `self._lock` was held, a transient HuggingFace
+    rate-limit on first use would stall every concurrent embed/search call for
+    the full backoff window — a service-wide availability outage.
+    """
+
+    def _make_svc(self):
+        with patch.object(EmbeddingService, "_load_index"):
+            return EmbeddingService()
+
+    def test_faiss_lock_not_held_during_model_load(self):
+        svc = self._make_svc()
+        svc._save_index = MagicMock()  # avoid disk writes
+        lock_states: list[bool] = []
+
+        def fake_ctor(*_args, **_kwargs):
+            # Record whether the FAISS lock is held at the moment the (slow,
+            # retrying) model load runs. It must not be.
+            lock_states.append(svc._lock.locked())
+            model = MagicMock()
+            model.encode.return_value = np.zeros((1, 384), dtype=np.float32)
+            return model
+
+        with patch("sentence_transformers.SentenceTransformer", side_effect=fake_ctor):
+            svc.embed("f1", "hello world")
+
+        assert lock_states == [False], (
+            "FAISS lock must not be held while the embedding model loads (#1524)"
+        )
+
+    def test_embed_batch_load_failure_returns_errors_not_raises(self):
+        """A transient OSError model-load failure must surface as the errors
+        list, not propagate as a 500 (#1524 error-contract preservation)."""
+        svc = self._make_svc()
+        svc._save_index = MagicMock()
+        mock_ctor = MagicMock(side_effect=OSError("rate limited"))
+
+        with (
+            patch("sentence_transformers.SentenceTransformer", mock_ctor),
+            patch("time.sleep"),  # don't wait the backoff
+        ):
+            total, errors = svc.embed_batch([("f1", "hello world")])
+
+        assert total == 0
+        assert len(errors) == 1
+        assert "Model load failed" in errors[0]
+        assert svc._model_loaded is False
+
+    def test_concurrent_callers_load_model_once(self):
+        """Double-checked locking: many threads contend, exactly one ctor call.
+
+        `fake_ctor` blocks until every worker has reached `_ensure_model`, so
+        multiple threads provably pass the lock-free outer check before the
+        winner finishes — forcing the inner re-check branch to execute.
+        """
+        import threading
+        import time as _time
+
+        svc = self._make_svc()
+        svc._save_index = MagicMock()
+        ctor_calls = []
+        all_arrived = threading.Barrier(8)
+
+        def fake_ctor(*_args, **_kwargs):
+            ctor_calls.append(1)
+            # Hold the model-load lock briefly so the other workers (released
+            # together by the barrier) pile up on it and exercise the inner
+            # double-checked re-check branch rather than the fast path.
+            _time.sleep(0.05)
+            model = MagicMock()
+            model.encode.return_value = np.zeros((1, 384), dtype=np.float32)
+            return model
+
+        def worker():
+            # Ensure all 8 threads are running and have passed the outer
+            # `if self._model_loaded` check (still False) before any one
+            # acquires the model-load lock and constructs the model.
+            all_arrived.wait(timeout=5)
+            svc.embed("f1", "hello world")
+
+        with patch("sentence_transformers.SentenceTransformer", side_effect=fake_ctor):
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert len(ctor_calls) == 1, "model should be constructed exactly once"
+        assert svc._model_loaded is True


### PR DESCRIPTION
## Summary

Fixes a high-priority concurrency bug (#1524): `EmbeddingService._ensure_model()` ran its retry/backoff `time.sleep()` loop (1s → 4s → 16s, ~21s cumulative) **while holding `self._lock`**, the FAISS index lock. Because `embed`, `embed_batch`, and `search` all acquire `self._lock` *before* reaching `_encode → _ensure_model`, a transient HuggingFace rate-limit on first use stalled **every** concurrent semantic query for the full backoff window — a service-wide availability outage from a single slow first-load.

The fix moves model loading out from under the FAISS lock and guards the one-time load with its own lock.

## Changes Made

**`processing-engine/app/semantic/embedding_service.py`**
- Added `self._model_load_lock` — a dedicated lock for the one-time model load, separate from the FAISS index lock (`self._lock`).
- Rewrote `_ensure_model` with **double-checked locking** on `_model_load_lock`: lock-free `_model_loaded` fast path, then acquire + re-check, then the existing retry loop. Safe under CPython/GIL.
- `embed`, `embed_batch`, `search` now call `self._ensure_model()` **before** acquiring `self._lock`, so the slow/retrying load never blocks concurrent FAISS operations.
- `search` keeps a lock-free empty-index fast path (snapshots `self._index` to avoid a None-deref TOCTOU) so it doesn't load the model just to search an empty index, then re-checks emptiness under the lock.
- `embed_batch` wraps its pre-lock load in `except (OSError, ValueError, RuntimeError)` to preserve its "errors list" contract — `OSError` is the canonical transient failure (network/DNS/rate-limit), so it must surface as `errors` rather than a 500.

**`processing-engine/tests/test_embedding_service.py`**
- `test_faiss_lock_not_held_during_model_load` — records `self._lock.locked()` at model-construction time. Was `[True]` before the fix (red), now `[False]`.
- `test_concurrent_callers_load_model_once` — `Barrier(8)` + a brief sleep in the ctor forces real contention so the inner double-checked re-check branch executes; asserts exactly one construction.
- `test_embed_batch_load_failure_returns_errors_not_raises` — an `OSError` load failure surfaces as the errors list, not an unhandled 500.

**`docs/plans/features/quick/1524-faiss-lock-during-retry.md`** — quick plan.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_embedding_service.py` — **16 passed**
- [x] New lock-not-held test fails on the pre-fix source (`[True] == [False]`) and passes after the fix (TDD red→green)
- [x] `ruff check` clean on both changed files
- [x] code-reviewer agent run twice — round 2 returned zero MUST FIX / zero SHOULD FIX

## Documentation Checklist

- [x] No public API / endpoint / model changes — `embed`/`embed_batch`/`search` signatures and return contracts unchanged.
- [x] Internal concurrency behavior documented inline (docstrings on `_ensure_model` and each caller) and in the quick plan.
- [x] No user-facing docs (`setup-guide.md`, API reference) affected.

## Tech Debt Impact

- [x] **Reduces** tech debt: removes a latent availability hazard in the semantic-search hot path and adds the first concurrency regression tests for `EmbeddingService`.
- [x] No new debt introduced. The lock-free `ntotal` read in `search`'s fast path is a known, bounded FAISS read (reference snapshotted; correctness re-checked under the lock) and is consistent with the existing `total_indexed` property.

## Risk & Rollback

- **Risk: Low.** Single processing-engine module. Public API signatures and return contracts are unchanged — the only external consumer is `semantic/routes.py`, unaffected. Concurrency semantics reviewed twice (double-checked locking is GIL-safe; no path remains where the slow load holds `self._lock`).
- **Rollback:** revert the single commit / merge — no migrations, no schema or config changes, no state to unwind.

Closes #1524
