### PR TITLE
fix: escape S3 Content-Disposition filename to prevent 400s and header injection (#1540)

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/S3StorageProviderTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/S3StorageProviderTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using JwstDataAnalysis.API.Services.Storage;
+
+namespace JwstDataAnalysis.API.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="S3StorageProvider"/> Content-Disposition building (#1540).
+/// </summary>
+public class S3StorageProviderTests
+{
+    [Fact]
+    public void BuildContentDisposition_PlainAsciiName_QuotedAsIs()
+    {
+        var result = S3StorageProvider.BuildContentDisposition("jw01234_nircam_i2d.fits");
+
+        result.Should().Be("attachment; filename=\"jw01234_nircam_i2d.fits\"");
+    }
+
+    [Fact]
+    public void BuildContentDisposition_NameWithDoubleQuote_EscapesIt()
+    {
+        // RFC 6266 §4.1: a double-quote inside the quoted-string must be escaped
+        // as \" — otherwise S3 rejects the override header with HTTP 400.
+        var result = S3StorageProvider.BuildContentDisposition("we\"ird.fits");
+
+        result.Should().Be("attachment; filename=\"we\\\"ird.fits\"");
+    }
+
+    [Fact]
+    public void BuildContentDisposition_NameWithBackslash_EscapesIt()
+    {
+        var result = S3StorageProvider.BuildContentDisposition("back\\slash.fits");
+
+        result.Should().Be("attachment; filename=\"back\\\\slash.fits\"");
+    }
+
+    [Theory]
+    [InlineData("evil\r\nSet-Cookie: x=1.fits")]
+    [InlineData("line\rbreak.fits")]
+    [InlineData("line\nbreak.fits")]
+    public void BuildContentDisposition_NameWithCrlf_StripsControlChars(string input)
+    {
+        var result = S3StorageProvider.BuildContentDisposition(input);
+
+        result.Should().NotContain("\r").And.NotContain("\n");
+    }
+
+    [Theory]
+    [InlineData("tab\there.fits", '\t')]
+    [InlineData("null\0byte.fits", '\0')]
+    [InlineData("del\u007Fchar.fits", '\u007F')]
+    public void BuildContentDisposition_NameWithOtherControlChars_StripsThem(string input, char control)
+    {
+        // RFC 7230 quoted-string forbids control chars beyond just CR/LF; a bare
+        // TAB/NUL/DEL would still produce an invalid header (S3 400).
+        var result = S3StorageProvider.BuildContentDisposition(input);
+
+        result.Should().NotContain(control.ToString());
+    }
+
+    [Fact]
+    public void BuildContentDisposition_NonAsciiNameWithQuoteAndApostrophe_EscapesAndEncodesBoth()
+    {
+        var result = S3StorageProvider.BuildContentDisposition("ná\"me's.fits");
+
+        // ASCII fallback: the double-quote is backslash-escaped in the quoted-string.
+        result.Should().Contain("filename=\"ná\\\"me's.fits\"");
+
+        // RFC 5987 filename*: non-ASCII (%C3%A1), the double-quote (%22) and the
+        // apostrophe (%27) are all percent-encoded so none can be mistaken for the
+        // quoted-string or charset/language delimiters.
+        result.Should().Contain("filename*=UTF-8''");
+        result.Should().Contain("n%C3%A1%22me%27s.fits");
+    }
+
+    [Fact]
+    public void BuildContentDisposition_NonAsciiName_EmitsRfc5987FilenameStar()
+    {
+        var result = S3StorageProvider.BuildContentDisposition("náme.fits");
+
+        // ASCII fallback retained for legacy clients, plus a percent-encoded
+        // UTF-8 filename* parameter (RFC 5987) for the real name.
+        result.Should().StartWith("attachment; filename=");
+        result.Should().Contain("filename*=UTF-8''");
+        result.Should().Contain("n%C3%A1me.fits");
+    }
+
+    [Fact]
+    public void BuildContentDisposition_AsciiName_DoesNotEmitFilenameStar()
+    {
+        var result = S3StorageProvider.BuildContentDisposition("plain.fits");
+
+        result.Should().NotContain("filename*");
+    }
+}

--- a/backend/JwstDataAnalysis.API/Services/Storage/S3StorageProvider.cs
+++ b/backend/JwstDataAnalysis.API/Services/Storage/S3StorageProvider.cs
@@ -146,7 +146,7 @@ namespace JwstDataAnalysis.API.Services.Storage
             if (!string.IsNullOrEmpty(downloadFilename))
             {
                 request.ResponseHeaderOverrides.ContentDisposition =
-                    $"attachment; filename=\"{downloadFilename}\"";
+                    BuildContentDisposition(downloadFilename);
             }
 
             var url = client.GetPreSignedURL(request);
@@ -202,6 +202,44 @@ namespace JwstDataAnalysis.API.Services.Storage
                 client.Dispose();
                 disposed = true;
             }
+        }
+
+        /// <summary>
+        /// Builds an RFC 6266-compliant <c>Content-Disposition</c> header value for a
+        /// download. A raw filename interpolated between quotes breaks the header when
+        /// the name contains a <c>"</c> (S3 rejects the override with HTTP 400) or a
+        /// CR/LF (header injection). This escapes backslash and double-quote per §4.1,
+        /// strips CR/LF, and adds an RFC 5987 <c>filename*</c> parameter so non-ASCII
+        /// names survive. Exposed via <c>InternalsVisibleTo</c> for unit tests (#1540).
+        /// </summary>
+        internal static string BuildContentDisposition(string filename)
+        {
+            // Quoted-string ASCII fallback (RFC 6266 §4.1 / RFC 7230 qdtext): drop ALL
+            // control chars — CR/LF (header-injection vector) plus TAB/NUL/DEL/C1 which
+            // are invalid in a quoted-string — then escape backslash and double-quote.
+            // char.IsControl covers 0x00–0x1F, 0x7F and the 0x80–0x9F C1 range.
+            var sanitized = new string(filename.Where(c => !char.IsControl(c)).ToArray())
+                .Replace("\\", "\\\\", StringComparison.Ordinal)
+                .Replace("\"", "\\\"", StringComparison.Ordinal);
+
+            var header = $"attachment; filename=\"{sanitized}\"";
+
+            // RFC 5987/8187: for non-ASCII names, add a percent-encoded UTF-8 filename*
+            // so clients render the real name. Uri.EscapeDataString neutralizes CR/LF
+            // (no injection here). It can leave ' ( ) * unescaped depending on runtime,
+            // and those are not valid attr-chars, so percent-encode them explicitly to
+            // keep the parameter RFC 5987-conformant regardless of .NET version.
+            if (filename.Any(c => c > 127))
+            {
+                var encoded = Uri.EscapeDataString(filename)
+                    .Replace("'", "%27", StringComparison.Ordinal)
+                    .Replace("(", "%28", StringComparison.Ordinal)
+                    .Replace(")", "%29", StringComparison.Ordinal)
+                    .Replace("*", "%2A", StringComparison.Ordinal);
+                header += $"; filename*=UTF-8''{encoded}";
+            }
+
+            return header;
         }
 
         [LoggerMessage(EventId = 4001, Level = LogLevel.Information,

--- a/docs/plans/features/quick/1540-s3-content-disposition-escaping.md
+++ b/docs/plans/features/quick/1540-s3-content-disposition-escaping.md
@@ -1,0 +1,48 @@
+# Fix #1540 — Unescaped double-quotes in S3 presigned-URL Content-Disposition
+
+**Branch**: `fix/1540-s3-content-disposition-escaping`
+**Type**: Bug fix (correctness + header-injection hardening), backend (.NET), priority: medium
+**Complexity**: Low (single helper + tests)
+
+## Problem
+
+`S3StorageProvider.GetPresignedUrlAsync` built the `Content-Disposition`
+response-header override by interpolating the filename between double-quotes:
+`$"attachment; filename=\"{downloadFilename}\""`. A filename containing a `"`
+produces an RFC 6266-invalid header → S3 returns HTTP 400 → the presigned
+download silently breaks. CR/LF in the filename is a header-injection vector.
+The `LocalStorageProvider` path is unaffected (ASP.NET builds the header safely).
+
+## Fix
+
+Extract an `internal static BuildContentDisposition(string filename)` helper
+(exposed to tests via the existing `InternalsVisibleTo`):
+
+1. Strip the full control-char range (`char.IsControl` — CR/LF + TAB/NUL/DEL/C1),
+   then escape `\` and `"` per RFC 6266 §4.1 (strip → escape ordering).
+2. For non-ASCII names, append an RFC 5987 `filename*=UTF-8''<percent-encoded>`
+   parameter. `Uri.EscapeDataString` leaves `' ( ) *` raw on .NET, so those are
+   percent-encoded explicitly (`%27 %28 %29 %2A`) to stay attr-char-conformant.
+
+Wired into `GetPresignedUrlAsync` in place of the raw interpolation.
+
+## Tests (new `S3StorageProviderTests.cs`)
+
+- Plain ASCII name → quoted as-is, no `filename*`.
+- `"` → `\"`, `\` → `\\` (exact-string).
+- CR/LF + TAB/NUL/DEL stripped.
+- Non-ASCII → `filename*=UTF-8''` with percent-encoding.
+- Combined non-ASCII + `"` + `'` → `n%C3%A1%22me%27s.fits`.
+
+## Scope check
+
+Verified the other backend Content-Disposition call sites
+(`MosaicController`, `CompositeController`, `JwstDataController`, `JobsController`,
+`DataManagementController`) all use ASP.NET `File(...)`/`FileResult`, which builds
+the header via `ContentDispositionHeaderValue` and is not vulnerable. The S3
+presigned-URL path was the only hand-built header.
+
+## Verification
+
+`dotnet test --filter S3StorageProviderTests` — 12 passed. No new StyleCop warnings.
+Two rounds of code-reviewer.


### PR DESCRIPTION
## Summary

Fixes #1540: `S3StorageProvider.GetPresignedUrlAsync` built the `Content-Disposition` response-header override by interpolating the filename directly between double-quotes (`$"attachment; filename=\"{downloadFilename}\""`). A filename containing a `"` produced an RFC 6266-invalid header, so S3 rejected the presigned URL with **HTTP 400** and the download silently broke. CR/LF in the filename was a **header-injection** vector.

## Changes Made

**`backend/JwstDataAnalysis.API/Services/Storage/S3StorageProvider.cs`**
- Extracted `internal static BuildContentDisposition(string filename)` (exposed to tests via the existing `InternalsVisibleTo`), wired into `GetPresignedUrlAsync` in place of the raw interpolation.
- ASCII fallback: strips the full control-char range (`char.IsControl` — CR/LF, TAB, NUL, DEL, C1) then escapes `\` and `"` per RFC 6266 §4.1 (strip → escape ordering).
- Non-ASCII names: appends an RFC 5987 `filename*=UTF-8''<percent-encoded>` parameter. `Uri.EscapeDataString` leaves `' ( ) *` raw on .NET, so those are explicitly percent-encoded (`%27 %28 %29 %2A`) to stay attr-char-conformant.

**`backend/JwstDataAnalysis.API.Tests/Services/S3StorageProviderTests.cs`** (new)
- 12 tests: plain ASCII, `"`/`\` escaping (exact-string), CR/LF + TAB/NUL/DEL stripping, non-ASCII `filename*`, and a combined non-ASCII + `"` + `'` case asserting `n%C3%A1%22me%27s.fits`.

## Test Plan

- [x] `dotnet test --filter S3StorageProviderTests` — **12 passed**
- [x] Full backend suite — **1123 passed**
- [x] Verified all other backend `Content-Disposition` call sites use ASP.NET `File()`/`FileResult` (safe via `ContentDispositionHeaderValue`) — only the S3 hand-built header was vulnerable
- [x] code-reviewer run twice — round 2 zero MUST FIX / zero SHOULD FIX
- [ ] Reviewer: confirm an S3-backed download of a file whose stored name contains `"` now succeeds (previously HTTP 400)

## Documentation Checklist

- [x] No public API / endpoint / DTO changes — `GetPresignedUrlAsync` signature unchanged.
- [x] Behavior documented inline (helper XML doc) and in the quick plan.
- [x] No user-facing or setup docs affected.

## Tech Debt Impact

- [x] **Reduces** debt: replaces a hand-rolled header string with a single tested helper and adds the first `S3StorageProvider` unit tests.
- [x] No new debt. Note: the pre-commit hook's `dotnet build --warnaserror` currently fails on **pre-existing** transitive-dependency advisories (NU1902 `SharpCompress` 0.30.1, NU1903 `Snappier` 1.0.0), unrelated to this change — flagged separately for a follow-up. CI builds without `--warnaserror`, so this PR is unaffected.

## Risk & Rollback

- **Risk: Low.** Single backend file + new test file. `GetPresignedUrlAsync` signature and behavior for normal filenames unchanged; only malformed/edge filenames change (now correct instead of broken).
- **Rollback:** revert the single commit — no migrations, schema, or config changes.

Closes #1540
