### PR TITLE
fix: guard missing 'Local Path' column in progressive download path (#1523)

### DIFF
--- a/docs/plans/features/quick/1523-progressive-download-manifest-guard.md
+++ b/docs/plans/features/quick/1523-progressive-download-manifest-guard.md
@@ -1,0 +1,52 @@
+# Fix #1523 — Missing 'Local Path' manifest guard in progressive download
+
+**Branch**: `fix/1523-progressive-download-manifest-guard`
+**Type**: Bug fix (defensive guard consistency), processing-engine, priority: medium
+**Complexity**: Low (single per-file loop guard + tests)
+
+## Problem
+
+#1516 added a defensive manifest check to `download_product` and
+`download_observation`:
+
+```python
+if manifest is None or "Local Path" not in manifest.colnames:
+    raise MASTServiceError(...)
+```
+
+The sibling `download_observation_with_progress` (the SSE progress path) was not
+updated. Its per-file loop only checked `if manifest and len(manifest) > 0`, then
+indexed `manifest["Local Path"][0]`. When astroquery returns a non-`None` table
+missing the `"Local Path"` column (the exact failure mode #1516 defends against),
+the index raises `KeyError`, which the surrounding `except Exception as file_error`
+swallows as a generic warning — silently dropping the file. The caller gets
+`status: "completed"` with fewer files and no clear root cause.
+
+## Fix
+
+Add the same guard inside the per-file loop, using `continue` (per-file semantics)
++ a clear warning instead of raising:
+
+```python
+if manifest is None or "Local Path" not in manifest.colnames:
+    logger.warning("Download manifest for %s is missing 'Local Path' — skipping file", filename)
+    continue
+if len(manifest) > 0:
+    filepath = str(manifest["Local Path"][0])
+    ...
+```
+
+Guard sits *before* the length check so a column-less non-empty table can't reach
+the index.
+
+## Tests (new `tests/mast/test_download_progress_guard.py`)
+
+- Missing-column manifest → file skipped, `status: completed`, 0 files, and the
+  warning is the guard's "missing 'Local Path'" message (not the swallowed
+  `except`-path "Failed to download" message — the fixed-vs-buggy discriminator).
+- Valid manifest → file still downloaded and returned.
+
+## Verification
+
+`docker exec jwst-processing python -m pytest tests/mast/ tests/test_mast_service_security.py`
+— 133 passed. Ruff clean. Two rounds of code-reviewer.

--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -683,7 +683,17 @@ class MastService:
                     manifest = Observations.download_products(
                         single_product, download_dir=obs_dir, cache=True
                     )
-                    if manifest and len(manifest) > 0:
+                    # Same defensive guard as download_product / download_observation
+                    # (#1516): a non-None manifest can still lack the 'Local Path'
+                    # column, in which case indexing it raises KeyError and the file
+                    # would be silently dropped. Skip it with a clear reason instead. (#1523)
+                    if manifest is None or "Local Path" not in manifest.colnames:
+                        logger.warning(
+                            "Download manifest for %s is missing 'Local Path' — skipping file",
+                            filename,
+                        )
+                        continue
+                    if len(manifest) > 0:
                         filepath = str(manifest["Local Path"][0])
                         downloaded_files.append(filepath)
                         logger.info(f"Downloaded: {filepath}")

--- a/processing-engine/tests/mast/test_download_progress_guard.py
+++ b/processing-engine/tests/mast/test_download_progress_guard.py
@@ -1,0 +1,80 @@
+"""Regression tests for the manifest 'Local Path' guard in the progressive
+download path (#1523).
+
+`download_observation_with_progress` previously did `manifest["Local Path"][0]`
+guarded only by `if manifest and len(manifest) > 0`. When astroquery returned a
+non-None table missing the `"Local Path"` column (the failure mode #1516 already
+defends against in the sibling `download_product` / `download_observation`), the
+indexing raised KeyError, which the broad `except Exception` swallowed as a
+generic warning — silently dropping the file with no clear root cause.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from astropy.table import Table
+
+from app.mast.mast_service import MastService
+
+
+@pytest.fixture()
+def service(tmp_path):
+    return MastService(download_dir=str(tmp_path))
+
+
+def _patch_observations(monkeypatch_target, *, manifest):
+    """Patch the module-level Observations so the progressive loop reaches one
+    file whose download returns the given manifest."""
+    obs = MagicMock()
+    obs.query_criteria.return_value = Table({"obs_id": ["jw001"]})
+    obs.get_product_list.return_value = Table({"productFilename": ["file1.fits"]})
+    obs.filter_products.return_value = Table(
+        {"productFilename": ["file1.fits"], "productType": ["SCIENCE"]}
+    )
+    obs.download_products.return_value = manifest
+    return patch.object(monkeypatch_target, "Observations", obs)
+
+
+def test_manifest_missing_local_path_column_is_skipped_with_clear_warning(service, caplog):
+    import app.mast.mast_service as mod
+
+    # Non-None manifest, but no "Local Path" column — the #1516 failure mode.
+    bad_manifest = Table({"Status": ["COMPLETE"]})
+
+    with (
+        _patch_observations(mod, manifest=bad_manifest),
+        patch.object(MastService, "_safe_obs_dir", return_value=str(service.download_dir)),
+        caplog.at_level(logging.WARNING),
+    ):
+        result = service.download_observation_with_progress("jw001")
+
+    # File is skipped (not indexed) and the call still completes cleanly.
+    assert result["status"] == "completed"
+    assert result["files"] == []
+    assert result["file_count"] == 0
+
+    # The real fixed-vs-buggy discriminator: the fix drops the file via the
+    # explicit guard ("missing 'Local Path'"), whereas the buggy code dropped it
+    # via the broad `except Exception` handler ("Failed to download ...: 'Local Path'",
+    # the str() of the swallowed KeyError).
+    # getMessage() renders %-style args so the assertion is independent of style.
+    warnings = " ".join(r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+    assert "missing 'Local Path'" in warnings
+    assert "Failed to download" not in warnings
+
+
+def test_manifest_with_local_path_still_downloads(service, caplog):
+    import app.mast.mast_service as mod
+
+    good_manifest = Table({"Local Path": [str(service.download_dir) + "/file1.fits"]})
+
+    with (
+        _patch_observations(mod, manifest=good_manifest),
+        patch.object(MastService, "_safe_obs_dir", return_value=str(service.download_dir)),
+    ):
+        result = service.download_observation_with_progress("jw001")
+
+    assert result["status"] == "completed"
+    assert result["file_count"] == 1
+    assert result["files"] == [str(service.download_dir) + "/file1.fits"]


### PR DESCRIPTION
## Summary

Fixes #1523: `download_observation_with_progress` (the SSE progressive-download path) indexed `manifest["Local Path"][0]` guarded only by `if manifest and len(manifest) > 0`. When astroquery returns a non-`None` table missing the `"Local Path"` column — the exact failure mode #1516 already defends against in the sibling `download_product` / `download_observation` — the index raises `KeyError`, which the surrounding `except Exception as file_error` swallows as a generic warning, **silently dropping the file**. The caller gets `status: "completed"` with fewer files and no clear root cause.

## Changes Made

**`processing-engine/app/mast/mast_service.py`** — `download_observation_with_progress` per-file loop
- Added the same guard the siblings use (`if manifest is None or "Local Path" not in manifest.colnames`), placed **before** the length check so a column-less non-empty table can't reach the index.
- Uses `continue` + a clear warning (per-file semantics) rather than raising, preserving the progressive path's per-file-skip behavior.

**`processing-engine/tests/mast/test_download_progress_guard.py`** (new)
- Missing-column manifest → file skipped, `status: completed`, 0 files, and the warning is the guard's `"missing 'Local Path'"` message — explicitly **not** the old swallowed `"Failed to download"` except-path message (the genuine fixed-vs-buggy discriminator).
- Valid manifest → file still downloaded and returned.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/mast/test_download_progress_guard.py` — **2 passed**
- [x] New missing-column test fails on pre-fix source (logged `Failed to download ...: 'Local Path'`, no `missing`) and passes after — TDD red→green
- [x] `docker exec jwst-processing python -m pytest tests/mast/ tests/test_mast_service_security.py` — **133 passed**
- [x] `ruff check` + `ruff format` clean
- [x] code-reviewer run twice — round 2 zero MUST FIX / zero SHOULD FIX

## Documentation Checklist

- [x] No public API / endpoint / DTO changes — internal method behavior only.
- [x] Guard rationale documented inline (cross-refs #1516) and in the quick plan.
- [x] No user-facing or setup docs affected.

## Tech Debt Impact

- [x] **Reduces** debt: closes the last unguarded `Local Path` index path (the other two were fixed in #1516), making the three download methods consistent.
- [x] No new debt; adds the first test coverage for the progressive download loop.

## Risk & Rollback

- **Risk: Low.** Single-method guard mirroring an established, reviewed pattern. Happy path unchanged; only the previously-`KeyError`-dropped edge case changes (now skipped with a clear log).
- **Rollback:** revert the single commit — no migrations, schema, or config changes.

Closes #1523
