### PR TITLE
chore: move processing-engine test/lint tooling out of production requirements.txt (#1468)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,9 @@ jobs:
 
     - name: Install Ruff
       if: needs.detect-changes.outputs.code == 'true'
-      run: pip install ruff
+      # Pin to the version in processing-engine/requirements-dev.txt so CI lint
+      # can't drift to a newer ruff than local/Docker. (#1468)
+      run: pip install ruff==0.15.12
 
     - name: Lint Processing Engine (Ruff)
       if: needs.detect-changes.outputs.code == 'true'
@@ -188,12 +190,12 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
-        cache-dependency-path: processing-engine/requirements.txt
+        cache-dependency-path: processing-engine/requirements-dev.txt
 
     - name: Install Python Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
       working-directory: processing-engine
 
     - name: Test Processing Engine

--- a/.github/workflows/composite-memory-test.yml
+++ b/.github/workflows/composite-memory-test.yml
@@ -6,6 +6,7 @@ on:
       - 'processing-engine/app/composite/**'
       - 'processing-engine/tests/test_composite_memory_rss.py'
       - 'processing-engine/requirements.txt'
+      - 'processing-engine/requirements-dev.txt'
       - '.github/workflows/composite-memory-test.yml'
   schedule:
     # Nightly 08:00 UTC — catches dependency drift in numpy/reproject/astropy
@@ -27,13 +28,13 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-          cache-dependency-path: processing-engine/requirements.txt
+          cache-dependency-path: processing-engine/requirements-dev.txt
 
       - name: Install Python dependencies
         working-directory: processing-engine
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Run memory-marked tests
         working-directory: processing-engine

--- a/docker/docker-compose.agent.yml
+++ b/docker/docker-compose.agent.yml
@@ -45,6 +45,8 @@ services:
     build:
       context: ${SOURCE_ROOT}/processing-engine
       dockerfile: Dockerfile
+      args:
+        INSTALL_DEV: "true"  # agent images run pytest (see scripts/agent-docker.sh) (#1468)
     restart: unless-stopped
     environment:
       - PYTHONPATH=/app

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -23,6 +23,9 @@ services:
       - "127.0.0.1:8002:8000"  # Expose MAST proxy for debugging (localhost only)
 
   processing-engine:
+    build:
+      args:
+        INSTALL_DEV: "true"  # local image ships pytest/ruff for `docker exec jwst-processing pytest` (#1468)
     ports:
       - "127.0.0.1:8000:8000"  # Expose processing engine for debugging (localhost only)
 

--- a/docs/architecture/build-pipeline.md
+++ b/docs/architecture/build-pipeline.md
@@ -137,7 +137,7 @@ Uses `dorny/paths-filter` to determine which services changed:
 | **lint** | Node 22 | ESLint, Prettier check, Ruff, docs consistency | Zero warnings |
 | **backend-test** | .NET 10 SDK | `dotnet restore` → `build` → `test` with Coverlet | 40% line coverage |
 | **frontend-test** | Node 22 | `npm ci` → `tsc -b && vite build` → `vitest` | Build must pass |
-| **python-test** | Python 3.12 | `pip install -r requirements.txt` → `pytest` | 60% coverage |
+| **python-test** | Python 3.12 | `pip install -r requirements-dev.txt` → `pytest` | 60% coverage |
 
 #### 3. Docker Build
 

--- a/docs/plans/features/quick/1468-requirements-dev-split.md
+++ b/docs/plans/features/quick/1468-requirements-dev-split.md
@@ -1,0 +1,54 @@
+# Chore #1468 — Move test/lint tooling out of production requirements.txt
+
+**Branch**: `chore/1468-requirements-dev-split`
+**Type**: Chore (dependency hygiene), processing-engine, priority: medium
+**Complexity**: Low–medium (packaging + Docker + CI wiring)
+
+## Problem
+
+`processing-engine/requirements.txt` (installed directly by the production
+`Dockerfile`) carried a `# Testing` block — `pytest`, `pytest-asyncio`,
+`pytest-cov`, `httpx`, `ruff` — so every production image shipped test runners
+and a linter. `requirements-dev.txt` re-declared some of these as floors but the
+pinned versions in `requirements.txt` silently won (drift).
+
+## Constraint the issue missed
+
+The local `jwst-processing` container builds from the **same** production
+`Dockerfile` (base `docker-compose.yml`), and the documented local test workflow
+is `docker exec jwst-processing python -m pytest`. Simply deleting the test tools
+from `requirements.txt` (as the issue suggested, "no Dockerfile change needed")
+would break local testing after a rebuild. So the Dockerfile needs an opt-in.
+
+## Fix
+
+1. **`requirements.txt`** — remove the `# Testing` block (left a pointer comment).
+2. **`requirements-dev.txt`** — single source of truth for test/lint tooling;
+   pin `pytest==9.0.3`, `pytest-asyncio==1.3.0`, `pytest-cov==7.1.0`,
+   `httpx==0.28.1`, `ruff==0.15.12` (the versions previously in requirements.txt,
+   killing the drift). Still `-r requirements.txt` for prod deps.
+3. **`Dockerfile`** — `ARG INSTALL_DEV=false`; when `true`, install
+   `requirements-dev.txt` instead of `requirements.txt`. Default `false` → plain
+   builds and the production stack stay lean.
+4. **`docker-compose.override.yml`** (local-only) — set
+   `processing-engine.build.args.INSTALL_DEV: "true"` so local images keep pytest/ruff.
+   Prod (`docker-compose.prod.yml`) sets no arg → lean image.
+5. **CI** — `ci.yml` (Python Tests) and `composite-memory-test.yml` now
+   `pip install -r requirements-dev.txt` (+ cache-dependency-path + path trigger).
+
+## Consumer matrix (verified)
+
+| Consumer | Builds/installs | Gets test tools? | Correct |
+|---|---|---|---|
+| Local stack (base+override) | `INSTALL_DEV=true` | yes | ✓ keeps `docker exec ... pytest` |
+| Prod stack (base+prod) | no arg → false | no | ✓ lean |
+| CI Docker Build job | plain build, no arg | no | ✓ validates lean image |
+| CI Python Tests / memory-test | `pip -r requirements-dev.txt` | yes | ✓ |
+| E2E | mock processing-engine image | n/a | ✓ unaffected |
+
+## Verification
+
+- `pip install --dry-run -r requirements-dev.txt` resolves cleanly (no conflicts).
+- `docker compose config` confirms `INSTALL_DEV=true` merges locally and is absent in prod.
+- Dev image build (`--build-arg INSTALL_DEV=true`) ships pytest + ruff.
+- CI Docker Build validates the lean (default) image builds.

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -132,7 +132,7 @@ Common patterns, API endpoints, troubleshooting, and MAST usage tips.
 
 **Processing Engine Not Working**:
 - Virtual environment activated?
-- All dependencies installed? (`pip install -r requirements.txt`)
+- All dependencies installed? (`pip install -r requirements.txt`; use `requirements-dev.txt` for the test/lint toolchain)
 - Check Python version (requires 3.10+)
 
 **MAST Proxy Service**:

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -171,7 +171,9 @@ npm run dev                   # Runs on http://localhost:3000
 cd processing-engine
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt      # runtime only
+# To run tests/linters locally, install the dev toolchain instead (pytest, ruff,
+# mypy, …) — it includes requirements.txt:  pip install -r requirements-dev.txt
 uvicorn main:app --reload     # Runs on http://localhost:8000
 ```text
 

--- a/processing-engine/Dockerfile
+++ b/processing-engine/Dockerfile
@@ -9,8 +9,17 @@ RUN apt-get update && apt-get install -y \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Production images install runtime deps only. Set INSTALL_DEV=true (local/CI
+# test images) to additionally install test/lint tooling from requirements-dev.txt
+# (which itself includes requirements.txt). Defaults false so a plain build — and
+# the production stack — never ships pytest/ruff. (#1468)
+ARG INSTALL_DEV=false
+COPY requirements.txt requirements-dev.txt ./
+RUN if [ "$INSTALL_DEV" = "true" ]; then \
+        pip install --no-cache-dir -r requirements-dev.txt; \
+    else \
+        pip install --no-cache-dir -r requirements.txt; \
+    fi
 
 COPY . .
 

--- a/processing-engine/requirements-dev.txt
+++ b/processing-engine/requirements-dev.txt
@@ -1,11 +1,14 @@
 # Development dependencies for JWST Processing Engine
 # Install: pip install -r requirements-dev.txt
+#
+# This is the single source of truth for test/lint tooling — production images
+# install requirements.txt only and must not ship these. (#1468)
 
 # Include production dependencies
 -r requirements.txt
 
 # Linting and formatting
-ruff>=0.15.12
+ruff==0.15.12
 
 # Type checking
 mypy>=2.1.0
@@ -13,7 +16,8 @@ mypy>=2.1.0
 # Pre-commit hooks
 pre-commit>=4.6.0
 
-# Testing (enhanced)
-pytest-asyncio>=1.3.0
-pytest-cov>=4.1.0
-httpx>=0.26.0  # For testing FastAPI with async client
+# Testing (pinned to the versions previously declared in requirements.txt)
+pytest==9.0.3
+pytest-asyncio==1.3.0
+pytest-cov==7.1.0
+httpx==0.28.1  # async client for testing FastAPI

--- a/processing-engine/requirements.txt
+++ b/processing-engine/requirements.txt
@@ -39,9 +39,5 @@ faiss-cpu>=1.13.2,<2.0.0
 # AWS
 boto3>=1.43.9
 
-# Testing
-pytest==9.0.3
-pytest-asyncio==1.3.0
-pytest-cov==7.1.0
-httpx==0.28.1
-ruff==0.15.12
+# NOTE: test/lint tooling (pytest, pytest-asyncio, pytest-cov, httpx, ruff) lives
+# in requirements-dev.txt — production images must not ship test runners. (#1468)


### PR DESCRIPTION
## Summary

Fixes #1468: `processing-engine/requirements.txt` (installed directly by the production `Dockerfile`) carried a `# Testing` block — `pytest`, `pytest-asyncio`, `pytest-cov`, `httpx`, `ruff` — so **every production image shipped test runners and a linter**. `requirements-dev.txt` also re-declared some of these as floors that the `requirements.txt` pins silently overrode (version drift).

**Beyond the issue's scope:** the local `jwst-processing` container builds from the *same* production `Dockerfile` (base `docker-compose.yml`), and the documented local workflow is `docker exec jwst-processing python -m pytest`. Simply deleting the test tools (as the issue suggested, "no Dockerfile change needed") would break local testing after a rebuild — so the Dockerfile gets an `INSTALL_DEV` opt-in instead, keeping prod lean while local/CI/agent keep the tooling.

## Changes Made

- **`requirements.txt`** — removed the `# Testing` block (pointer comment left behind).
- **`requirements-dev.txt`** — single source of truth for test/lint tooling; pinned `pytest==9.0.3`, `pytest-asyncio==1.3.0`, `pytest-cov==7.1.0`, `httpx==0.28.1`, `ruff==0.15.12` (the versions previously in `requirements.txt` — kills the drift).
- **`Dockerfile`** — `ARG INSTALL_DEV=false`; when `true`, installs `requirements-dev.txt` instead of `requirements.txt`. Default `false` → plain builds and the production stack stay lean.
- **`docker-compose.override.yml`** (local) and **`docker-compose.agent.yml`** — set `INSTALL_DEV: "true"` so local/agent images keep pytest/ruff. `docker-compose.prod.yml` / `.staging.yml` set no arg → lean.
- **`ci.yml`** (Python Tests) and **`composite-memory-test.yml`** — `pip install -r requirements-dev.txt` (+ cache-dependency-path + path triggers); `ci.yml` lint job pins `ruff==0.15.12` to match.
- **docs** — `build-pipeline.md` python-test row, `setup-guide.md`, `quick-reference.md` point the test/lint toolchain at `requirements-dev.txt`.

## Test Plan

- [x] Dev image (`docker build --build-arg INSTALL_DEV=true`) ships **pytest 9.0.3 + ruff 0.15.12**
- [x] Lean image (default `docker build`) **omits** pytest/ruff (prod purity)
- [x] `docker compose config` confirms local (base+override) = `INSTALL_DEV=true`, prod (base+prod) = no arg → lean
- [x] `pip install --dry-run -r requirements-dev.txt` resolves with no conflicts; pinned versions already satisfied (no drift)
- [x] `./scripts/check-docs-consistency.sh` passes
- [ ] Reviewer: `docker compose up -d --build` locally, then `docker exec jwst-processing python -m pytest` still works

## Documentation Checklist

- [x] `build-pipeline.md`, `setup-guide.md`, `quick-reference.md` updated to reflect `requirements-dev.txt`.
- [x] No API / endpoint / DTO changes.
- [x] Docs consistency check passes.

## Tech Debt Impact

- [x] **Reduces** debt: production images no longer ship test/lint tooling; eliminates the requirements.txt↔requirements-dev.txt version drift by making the dev file the single source of truth.
- [x] No new debt; the `INSTALL_DEV` arg defaults to the safe (lean) path, so a forgotten arg never ships test tools to prod.

## Risk & Rollback

- **Risk: Low.** Packaging/CI wiring only — no application code changed. Consumer matrix verified (local=dev, prod=lean, CI Docker Build=lean, CI tests=dev, E2E=mock). The default build path is lean, so the failure mode of forgetting the arg is fail-safe.
- **Rollback:** revert the single commit — no migrations, no runtime behavior change.

Closes #1468
