### PR TITLE
fix: clean up auto-generated recipe names — drop /IMAGE suffix, add spacing (#1454)

### DIFF
--- a/docs/plans/features/quick/1454-recipe-name-display.md
+++ b/docs/plans/features/quick/1454-recipe-name-display.md
@@ -1,0 +1,48 @@
+# Fix #1454 — Clean up auto-generated recipe names
+
+**Branch**: `fix/1454-recipe-name-display`
+**Type**: UX bug fix (display strings), processing-engine, priority: nice-to-have
+**Complexity**: Low–medium (helpers + ~14 name sites + test migration)
+
+## Problem
+
+Recipe titles showed raw MAST `instrument` strings:
+`Best 6-filter MIRI/IMAGE+NIRCAM/IMAGE…` — the `/IMAGE` suffix is redundant
+noise, the all-caps reads poorly, and the long name truncates in the UI.
+
+## Fix (`processing-engine/app/discovery/recipe_engine.py`)
+
+Three module-level helpers:
+
+- `normalize_instrument_for_display(raw)` — `"NIRCAM/IMAGE"` → `"NIRCam"`
+  (drop the dataproduct-kind suffix, canonical casing; unknown → title-case).
+- `format_instruments_for_display(instruments)` — normalize + de-dupe + join
+  with `" + "`, ordered short → long wavelength (NIRCam … MIRI).
+- `_filter_count_phrase(n)` — `"1 filter"` / `"3 filters"` (correct plural;
+  the naive `-filter` → ` filters` swap would have produced `"1 filters"`).
+
+Applied at every `name=` site (cross-instrument → `format_instruments_for_display`,
+single → `instrument_display`) and at the instrument-bearing `description=`
+strings. New format: `Best 6 filters · NIRCam + MIRI`.
+
+**The `instruments=[…]` data field stays raw** (MAST form) — only display
+strings changed. Curated recipes (hardcoded names) are untouched.
+
+## Tests (`tests/test_recipe_engine.py`)
+
+- New `TestInstrumentDisplayNames`: helper unit tests (normalize, dedupe,
+  ordering, singular/plural, empty, unknown-append) + integration tests for the
+  single- and cross-instrument name formats.
+- Migrated all existing old-format assertions/selectors (e.g.
+  `"3-filter NIRCAM"` → `"3 filters · NIRCam"`, `"Narrowband NIRCAM"` →
+  `"Narrowband NIRCam"`, `"NIRCAM+MIRI"` → `"NIRCam + MIRI"`).
+
+## Out of scope (tracked)
+
+Frontend recipe/target cards render `recipe.instruments.join(' + ')` (raw) in
+their meta line — a separate display surface from the title #1454 targets.
+Filed as follow-up **#1561** (TS display helper + e2e assertion update).
+
+## Verification
+
+Full processing-engine suite: **1424 passed**. Ruff clean. Two code-review rounds.

--- a/processing-engine/app/discovery/recipe_engine.py
+++ b/processing-engine/app/discovery/recipe_engine.py
@@ -8,6 +8,7 @@ ranked composite recipes with chromatic-ordered color assignments.
 import logging
 import math
 import re
+from collections.abc import Iterable
 from datetime import UTC, datetime
 
 from app.composite.color_mapping import chromatic_order_hues, hue_to_rgb_weights
@@ -18,6 +19,49 @@ from app.instruments import (
 )
 
 from .models import ObservationInput, Recipe
+
+
+# Canonical display names for JWST instruments. MAST reports instruments as
+# e.g. "NIRCAM/IMAGE" (instrument + dataproduct kind); the "/IMAGE" suffix is
+# redundant noise in recipe titles, and the all-caps form reads poorly. (#1454)
+_INSTRUMENT_DISPLAY = {
+    "NIRCAM": "NIRCam",
+    "NIRISS": "NIRISS",
+    "NIRSPEC": "NIRSpec",
+    "MIRI": "MIRI",
+    "FGS": "FGS",
+}
+
+# Order cross-instrument titles short → long wavelength (NIRCam … MIRI) so the
+# title matches the wavelength ribbon users see. (#1454)
+_INSTRUMENT_DISPLAY_ORDER = ["NIRCam", "NIRISS", "NIRSpec", "FGS", "MIRI"]
+
+
+def normalize_instrument_for_display(raw: str) -> str:
+    """Convert a raw MAST instrument string (e.g. ``"NIRCAM/IMAGE"``) into a
+    clean display name (e.g. ``"NIRCam"``), dropping the dataproduct-kind
+    suffix. Unknown instruments fall back to a title-cased base. (#1454)
+    """
+    base = raw.split("/", 1)[0].strip().upper()
+    return _INSTRUMENT_DISPLAY.get(base, base.title())
+
+
+def format_instruments_for_display(instruments: Iterable[str]) -> str:
+    """Normalize, de-duplicate, and join instrument names for a recipe title,
+    ordered short → long wavelength (NIRCam … MIRI). Unrecognized names are
+    appended in sorted order for determinism. (#1454)
+    """
+    seen = {normalize_instrument_for_display(i) for i in instruments}
+    ordered = [d for d in _INSTRUMENT_DISPLAY_ORDER if d in seen]
+    ordered += sorted(seen - set(ordered))
+    return " + ".join(ordered)
+
+
+def _filter_count_phrase(n: int) -> str:
+    """Render a filter count for a recipe title with correct pluralization —
+    ``"1 filter"`` vs ``"3 filters"``. (#1454)
+    """
+    return f"{n} filter{'' if n == 1 else 's'}"
 
 
 # MJD epoch: November 17, 1858
@@ -1222,7 +1266,7 @@ def generate_recipes(
                     best_filter_set = {f.upper() for f in best}
                     all_recipes.append(
                         Recipe(
-                            name=f"Best {len(best)}-filter {'+'.join(group_instruments)}",
+                            name=f"Best {_filter_count_phrase(len(best))} · {format_instruments_for_display(group_instruments)}",
                             rank=1,
                             filters=best,
                             color_mapping=build_cross_instrument_color_mapping(
@@ -1238,7 +1282,7 @@ def generate_recipes(
                     )
                     all_recipes.append(
                         Recipe(
-                            name=f"{len(combined_sorted)}-filter {'+'.join(group_instruments)}",
+                            name=f"{_filter_count_phrase(len(combined_sorted))} · {format_instruments_for_display(group_instruments)}",
                             rank=DEMOTED_ALL_RANK,
                             filters=combined_sorted,
                             color_mapping=build_cross_instrument_color_mapping(
@@ -1257,7 +1301,7 @@ def generate_recipes(
                 else:
                     all_recipes.append(
                         Recipe(
-                            name=f"{len(combined_sorted)}-filter {'+'.join(group_instruments)}",
+                            name=f"{_filter_count_phrase(len(combined_sorted))} · {format_instruments_for_display(group_instruments)}",
                             rank=1,
                             filters=combined_sorted,
                             color_mapping=build_cross_instrument_color_mapping(
@@ -1298,7 +1342,7 @@ def generate_recipes(
                 best_filter_set = {f.upper() for f in best}
                 all_recipes.append(
                     Recipe(
-                        name=f"Best {len(best)}-filter {'+'.join(all_instruments)}",
+                        name=f"Best {_filter_count_phrase(len(best))} · {format_instruments_for_display(all_instruments)}",
                         rank=1,
                         filters=best,
                         color_mapping=build_cross_instrument_color_mapping(
@@ -1315,7 +1359,7 @@ def generate_recipes(
                 )
                 all_recipes.append(
                     Recipe(
-                        name=f"{len(combined_sorted)}-filter {'+'.join(all_instruments)}",
+                        name=f"{_filter_count_phrase(len(combined_sorted))} · {format_instruments_for_display(all_instruments)}",
                         rank=DEMOTED_ALL_RANK,
                         filters=combined_sorted,
                         color_mapping=build_cross_instrument_color_mapping(
@@ -1333,7 +1377,7 @@ def generate_recipes(
             else:
                 all_recipes.append(
                     Recipe(
-                        name=f"{len(combined_sorted)}-filter {'+'.join(all_instruments)}",
+                        name=f"{_filter_count_phrase(len(combined_sorted))} · {format_instruments_for_display(all_instruments)}",
                         rank=1,
                         filters=combined_sorted,
                         color_mapping=build_cross_instrument_color_mapping(
@@ -1349,6 +1393,10 @@ def generate_recipes(
                 )
 
     for instrument, obs_list in instrument_groups.items():
+        # Clean display form for titles/descriptions; `instrument` stays raw for
+        # the data fields and lookups below. (#1454)
+        instrument_display = normalize_instrument_for_display(instrument)
+
         # Deduplicate by filter name and sort by wavelength
         filter_map: dict[str, ObservationInput] = {}
         for obs in obs_list:
@@ -1391,7 +1439,7 @@ def generate_recipes(
                 pruned_filter_set = {f.upper() for f in pruned}
                 all_recipes.append(
                     Recipe(
-                        name=f"{len(pruned)}-filter {instrument}",
+                        name=f"{_filter_count_phrase(len(pruned))} · {instrument_display}",
                         rank=1 + rank_offset,
                         filters=pruned,
                         color_mapping=build_color_mapping(pruned),
@@ -1399,13 +1447,13 @@ def generate_recipes(
                         requires_mosaic=inst_needs_mosaic,
                         estimated_time_seconds=estimate_time(len(pruned), inst_needs_mosaic),
                         observation_ids=_filter_obs_ids(obs_list, pruned_filter_set),
-                        description=f"{len(pruned)} {instrument} filters — redundant wavelengths removed",
+                        description=f"{len(pruned)} {instrument_display} filters — redundant wavelengths removed",
                         overlap_warning=coverage_warning,
                     )
                 )
                 all_recipes.append(
                     Recipe(
-                        name=f"{n_filters}-filter {instrument}",
+                        name=f"{_filter_count_phrase(n_filters)} · {instrument_display}",
                         rank=DEMOTED_ALL_RANK + rank_offset,
                         filters=sorted_filters,
                         color_mapping=build_color_mapping(sorted_filters),
@@ -1413,7 +1461,7 @@ def generate_recipes(
                         requires_mosaic=inst_needs_mosaic,
                         estimated_time_seconds=estimate_time(n_filters, inst_needs_mosaic),
                         observation_ids=obs_ids or None,
-                        description=f"All {n_filters} {instrument} filters for maximum detail",
+                        description=f"All {n_filters} {instrument_display} filters for maximum detail",
                         tag="All data",
                         overlap_warning=coverage_warning,
                     )
@@ -1422,7 +1470,7 @@ def generate_recipes(
                 # Pruning didn't remove anything — keep single recipe
                 all_recipes.append(
                     Recipe(
-                        name=f"{n_filters}-filter {instrument}",
+                        name=f"{_filter_count_phrase(n_filters)} · {instrument_display}",
                         rank=1 + rank_offset,
                         filters=sorted_filters,
                         color_mapping=build_color_mapping(sorted_filters),
@@ -1430,14 +1478,14 @@ def generate_recipes(
                         requires_mosaic=inst_needs_mosaic,
                         estimated_time_seconds=estimate_time(n_filters, inst_needs_mosaic),
                         observation_ids=obs_ids or None,
-                        description=f"All {n_filters} {instrument} filters for maximum detail",
+                        description=f"All {n_filters} {instrument_display} filters for maximum detail",
                         overlap_warning=coverage_warning,
                     )
                 )
         else:
             all_recipes.append(
                 Recipe(
-                    name=f"{n_filters}-filter {instrument}",
+                    name=f"{_filter_count_phrase(n_filters)} · {instrument_display}",
                     rank=1 + rank_offset,
                     filters=sorted_filters,
                     color_mapping=build_color_mapping(sorted_filters),
@@ -1445,7 +1493,7 @@ def generate_recipes(
                     requires_mosaic=inst_needs_mosaic,
                     estimated_time_seconds=estimate_time(n_filters, inst_needs_mosaic),
                     observation_ids=obs_ids or None,
-                    description=f"All {n_filters} {instrument} filters for maximum detail",
+                    description=f"All {n_filters} {instrument_display} filters for maximum detail",
                     overlap_warning=coverage_warning,
                 )
             )
@@ -1468,7 +1516,7 @@ def generate_recipes(
                 classic_filter_set = {f.upper() for f in classic_filters}
                 all_recipes.append(
                     Recipe(
-                        name=f"Classic 3-color {instrument}",
+                        name=f"Classic 3-color {instrument_display}",
                         rank=2 + rank_offset,
                         filters=classic_filters,
                         color_mapping=build_color_mapping(classic_filters),
@@ -1485,7 +1533,7 @@ def generate_recipes(
                 classic_filter_set = {f.upper() for f in classic_filters}
                 all_recipes.append(
                     Recipe(
-                        name=f"2-filter {instrument}",
+                        name=f"2 filters · {instrument_display}",
                         rank=2 + rank_offset,
                         filters=classic_filters,
                         color_mapping=build_color_mapping(classic_filters),
@@ -1504,7 +1552,7 @@ def generate_recipes(
             nb_filter_set = {f.upper() for f in narrowband}
             all_recipes.append(
                 Recipe(
-                    name=f"Narrowband {instrument}",
+                    name=f"Narrowband {instrument_display}",
                     rank=3 + rank_offset,
                     filters=narrowband,
                     color_mapping=build_color_mapping(narrowband),
@@ -1522,7 +1570,7 @@ def generate_recipes(
             bb_filter_set = {f.upper() for f in broadband}
             all_recipes.append(
                 Recipe(
-                    name=f"Broadband {instrument}",
+                    name=f"Broadband {instrument_display}",
                     rank=4 + rank_offset,
                     filters=broadband,
                     color_mapping=build_color_mapping(broadband),

--- a/processing-engine/tests/test_recipe_engine.py
+++ b/processing-engine/tests/test_recipe_engine.py
@@ -10,6 +10,7 @@ from app.discovery.recipe_engine import (
     _angular_separation_arcmin,
     _bandpass_priority,
     _compute_filter_coverage,
+    _filter_count_phrase,
     _inject_curated_recipes,
     _is_c_prefix,
     _is_o_prefix,
@@ -17,6 +18,7 @@ from app.discovery.recipe_engine import (
     build_color_mapping,
     build_cross_instrument_color_mapping,
     deduplicate_mosaic_observations,
+    format_instruments_for_display,
     generate_recipes,
     group_by_spatial_overlap,
     hue_to_hex,
@@ -24,6 +26,7 @@ from app.discovery.recipe_engine import (
     is_broadband,
     is_medium_band,
     is_narrowband,
+    normalize_instrument_for_display,
     prune_redundant_filters,
     resolve_wavelength,
     select_best_n_filters,
@@ -120,7 +123,7 @@ class TestGenerateRecipes:
         obs = [ObservationInput(filter="F444W", instrument="NIRCAM")]
         recipes = generate_recipes(obs)
         assert len(recipes) == 1
-        assert recipes[0].name == "1-filter NIRCAM"
+        assert recipes[0].name == "1 filter · NIRCam"
         assert recipes[0].rank == 1
         assert recipes[0].filters == ["F444W"]
 
@@ -132,8 +135,8 @@ class TestGenerateRecipes:
         ]
         recipes = generate_recipes(obs)
         names = [r.name for r in recipes]
-        assert "3-filter NIRCAM" in names
-        assert "Classic 3-color NIRCAM" in names
+        assert "3 filters · NIRCam" in names
+        assert "Classic 3-color NIRCam" in names
 
     def test_classic_picks_short_mid_long(self):
         obs = [
@@ -156,8 +159,8 @@ class TestGenerateRecipes:
         ]
         recipes = generate_recipes(obs)
         names = [r.name for r in recipes]
-        assert "Narrowband NIRCAM" in names
-        narrow = next(r for r in recipes if r.name == "Narrowband NIRCAM")
+        assert "Narrowband NIRCam" in names
+        narrow = next(r for r in recipes if r.name == "Narrowband NIRCam")
         assert set(narrow.filters) == {"F187N", "F470N"}
 
     def test_broadband_recipe_generated(self):
@@ -169,8 +172,8 @@ class TestGenerateRecipes:
         ]
         recipes = generate_recipes(obs)
         names = [r.name for r in recipes]
-        assert "Broadband NIRCAM" in names
-        broad = next(r for r in recipes if r.name == "Broadband NIRCAM")
+        assert "Broadband NIRCam" in names
+        broad = next(r for r in recipes if r.name == "Broadband NIRCam")
         assert all(is_broadband(f) for f in broad.filters)
 
     def test_multi_instrument_cross_instrument_ranked_first(self):
@@ -181,7 +184,7 @@ class TestGenerateRecipes:
             ObservationInput(filter="F1000W", instrument="MIRI"),
         ]
         recipes = generate_recipes(obs)
-        combined = [r for r in recipes if "MIRI+NIRCAM" in r.name or "NIRCAM+MIRI" in r.name]
+        combined = [r for r in recipes if "NIRCam + MIRI" in r.name]
         assert len(combined) == 1
         # Cross-instrument recipe is rank 1 (recommended) when multiple instruments present
         assert combined[0].rank == 1
@@ -197,7 +200,7 @@ class TestGenerateRecipes:
             ObservationInput(filter="F200W", instrument="NIRCAM"),
         ]
         recipes = generate_recipes(obs)
-        all_recipe = next(r for r in recipes if "2-filter" in r.name)
+        all_recipe = next(r for r in recipes if "2 filters" in r.name)
         assert len(all_recipe.filters) == 2
 
     def test_recipes_have_color_mappings(self):
@@ -289,7 +292,7 @@ class TestGenerateRecipes:
         ]
         recipes = generate_recipes(obs)
         names = [r.name for r in recipes]
-        assert "4-filter MIRI" in names
+        assert "4 filters · MIRI" in names
         assert "Broadband MIRI" not in names
 
     def test_no_duplicate_narrowband_when_all_narrowband(self):
@@ -301,8 +304,8 @@ class TestGenerateRecipes:
         ]
         recipes = generate_recipes(obs)
         names = [r.name for r in recipes]
-        assert "3-filter NIRCAM" in names
-        assert "Narrowband NIRCAM" not in names
+        assert "3 filters · NIRCam" in names
+        assert "Narrowband NIRCam" not in names
 
 
 class TestProprietaryFiltering:
@@ -500,7 +503,7 @@ class TestSingleInstrumentRankingUnchanged:
         ]
         recipes = generate_recipes(obs)
         assert recipes[0].rank == 1
-        assert recipes[0].name == "3-filter NIRCAM"
+        assert recipes[0].name == "3 filters · NIRCam"
 
     def test_single_instrument_classic_rank_2(self):
         obs = [
@@ -699,7 +702,7 @@ class TestSpatialGrouping:
             ),
         ]
         recipes = generate_recipes(obs)
-        all_recipe = next(r for r in recipes if "NIRCAM" in r.name and "filter" in r.name)
+        all_recipe = next(r for r in recipes if "NIRCam" in r.name and "filter" in r.name)
         assert all_recipe.requires_mosaic is True
 
     def test_requires_mosaic_same_pointing(self):
@@ -709,7 +712,7 @@ class TestSpatialGrouping:
             ObservationInput(filter="F444W", instrument="NIRCAM", s_ra=180.0, s_dec=0.0),
         ]
         recipes = generate_recipes(obs)
-        all_recipe = next(r for r in recipes if "NIRCAM" in r.name and "filter" in r.name)
+        all_recipe = next(r for r in recipes if "NIRCam" in r.name and "filter" in r.name)
         assert all_recipe.requires_mosaic is False
 
     def test_chain_overlap_transitive(self):
@@ -1771,7 +1774,7 @@ class TestCoverageAwareClassic3Color:
         recipes = generate_recipes(obs)
         # Should get a 2-filter recipe (only 2 well-covered), not a Classic 3-color
         classic = [r for r in recipes if r.name.startswith("Classic 3-color")]
-        two_filter = [r for r in recipes if r.name.startswith("2-filter")]
+        two_filter = [r for r in recipes if r.name.startswith("2 filters")]
 
         assert len(classic) == 0, "Should not produce Classic 3-color with only 2 well-covered"
         assert len(two_filter) == 1, "Should produce 2-filter recipe"
@@ -1781,7 +1784,7 @@ class TestCoverageAwareClassic3Color:
         """Crab Nebula: 'all' recipe should have a coverage warning about F560W/F2100W."""
         obs = self._make_crab_obs()
         recipes = generate_recipes(obs)
-        all_recipe = [r for r in recipes if "4-filter" in r.name and "MIRI" in r.instruments]
+        all_recipe = [r for r in recipes if "4 filters" in r.name and "MIRI" in r.instruments]
         assert len(all_recipe) >= 1
         assert all_recipe[0].overlap_warning is not None
         assert "F560W" in all_recipe[0].overlap_warning
@@ -2032,3 +2035,65 @@ class TestRecommendedFeatherStrength:
         assert len(mixed_multi) > 0
         assert all(r.recommended_feather_strength is not None for r in mixed_multi)
         assert all(r.recommended_feather_strength is None for r in single_nircam)
+
+
+class TestInstrumentDisplayNames:
+    """Recipe titles use clean instrument display names (#1454)."""
+
+    def test_normalize_drops_dataproduct_suffix(self):
+        assert normalize_instrument_for_display("NIRCAM/IMAGE") == "NIRCam"
+        assert normalize_instrument_for_display("MIRI/IMAGE") == "MIRI"
+        assert normalize_instrument_for_display("NIRISS/IMAGE") == "NIRISS"
+        assert normalize_instrument_for_display("NIRSPEC/IFU") == "NIRSpec"
+        assert normalize_instrument_for_display("FGS") == "FGS"
+
+    def test_normalize_is_case_insensitive_and_strips(self):
+        assert normalize_instrument_for_display(" nircam/image ") == "NIRCam"
+
+    def test_normalize_unknown_falls_back_to_title_case(self):
+        assert normalize_instrument_for_display("NEWCAM/THING") == "Newcam"
+
+    def test_format_orders_short_to_long_wavelength(self):
+        # NIRCam (short) before MIRI (long), regardless of input order.
+        assert format_instruments_for_display(["MIRI/IMAGE", "NIRCAM/IMAGE"]) == "NIRCam + MIRI"
+
+    def test_format_empty_list_returns_empty_string(self):
+        assert format_instruments_for_display([]) == ""
+
+    def test_format_appends_unknown_after_known(self):
+        # Known instruments lead in wavelength order; unknown names follow, sorted.
+        assert format_instruments_for_display(["NEWCAM", "NIRCAM/IMAGE"]) == "NIRCam + Newcam"
+
+    def test_format_deduplicates(self):
+        result = format_instruments_for_display(["NIRCAM/IMAGE", "NIRCAM/IMAGE"])
+        assert result == "NIRCam"
+
+    def test_filter_count_phrase_pluralizes(self):
+        assert _filter_count_phrase(1) == "1 filter"
+        assert _filter_count_phrase(3) == "3 filters"
+
+    def test_single_instrument_recipe_name_format(self):
+        obs = [
+            ObservationInput(filter="F090W", instrument="NIRCAM/IMAGE"),
+            ObservationInput(filter="F200W", instrument="NIRCAM/IMAGE"),
+            ObservationInput(filter="F444W", instrument="NIRCAM/IMAGE"),
+        ]
+        names = [r.name for r in generate_recipes(obs)]
+        # Clean "N filters · NIRCam" form — no "/IMAGE", no all-caps, no "-filter".
+        assert "3 filters · NIRCam" in names
+        assert not any("/IMAGE" in n for n in names)
+        assert not any("-filter" in n for n in names)
+
+    def test_cross_instrument_recipe_name_format(self):
+        # Same sky position so the two instruments form one cross-instrument group.
+        obs = [
+            ObservationInput(filter="F090W", instrument="NIRCAM/IMAGE", s_ra=10.0, s_dec=20.0),
+            ObservationInput(filter="F200W", instrument="NIRCAM/IMAGE", s_ra=10.0, s_dec=20.0),
+            ObservationInput(filter="F770W", instrument="MIRI/IMAGE", s_ra=10.0, s_dec=20.0),
+            ObservationInput(filter="F1500W", instrument="MIRI/IMAGE", s_ra=10.0, s_dec=20.0),
+        ]
+        cross = [r for r in generate_recipes(obs) if len(r.instruments) > 1]
+        assert cross, "expected at least one cross-instrument recipe"
+        # NIRCam listed before MIRI, joined with ' + ', clean form.
+        assert all("NIRCam + MIRI" in r.name for r in cross)
+        assert all(" filters · " in r.name or " filter · " in r.name for r in cross)


### PR DESCRIPTION
## Summary

Fixes #1454: auto-generated recipe titles showed raw MAST instrument strings — `Best 6-filter MIRI/IMAGE+NIRCAM/IMAGE…`. The `/IMAGE` dataproduct-kind suffix is redundant noise, the all-caps reads poorly, and the long name truncates in the UI.

New format: **`Best 6 filters · NIRCam + MIRI`**.

## Changes Made

**`processing-engine/app/discovery/recipe_engine.py`** — three display helpers:
- `normalize_instrument_for_display(raw)` — `"NIRCAM/IMAGE"` → `"NIRCam"` (drop suffix, canonical casing; unknown → title-case).
- `format_instruments_for_display(instruments)` — normalize + de-dupe + join with `" + "`, ordered short → long wavelength (NIRCam … MIRI) to match the wavelength ribbon.
- `_filter_count_phrase(n)` — `"1 filter"` / `"3 filters"` correct pluralization (the naive `-filter`→` filters` swap would have produced `"1 filters"`).

Applied at every auto-generated `name=` site and the instrument-bearing `description=` strings. **The `instruments=[…]` data field stays raw** (MAST form) — only display strings change. Curated recipes (hardcoded names) untouched.

**`processing-engine/tests/test_recipe_engine.py`** — new `TestInstrumentDisplayNames` (helper units + single/cross-instrument format, incl. `"1 filter"` singular, empty-list, unknown-append ordering); migrated all existing old-format assertions/selectors.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_recipe_engine.py` — **183 passed**
- [x] Full processing-engine suite — **1424 passed**
- [x] Mixed NIRCam+MIRI recipe → `… filters · NIRCam + MIRI`; single NIRCam → `N filters · NIRCam`; single-filter → `1 filter · NIRCam` (correct singular)
- [x] Curated recipes (e.g. `NASA NIRCam (NGC 346)`) unchanged
- [x] `ruff check` + `ruff format` clean
- [x] code-reviewer run twice — round 2 zero MUST FIX / zero SHOULD FIX
- [ ] Reviewer: confirm Process step no longer truncates and shows clean instrument names in the title

## Documentation Checklist

- [x] No API / endpoint / DTO changes (recipe `name`/`instruments` schema unchanged).
- [x] Behavior documented inline (helper docstrings) and in the quick plan.
- [x] No user-facing docs reference the recipe-name format.

## Tech Debt Impact

- [x] **Reduces** debt: replaces ad-hoc `'+'.join(raw)` title construction across ~14 sites with three small, tested helpers.
- [x] No new debt. Frontend card meta line still renders raw `instruments` (a separate pre-existing display surface) — tracked as follow-up #1561, not introduced here.

## Risk & Rollback

- **Risk: Low.** Display-only string change in the processing engine; the recipe `name`/`instruments` schema and all data fields are unchanged, and the frontend renders `recipe.name` verbatim. Curated recipes untouched.
- **Rollback:** revert the single commit — no migrations, schema, or config changes.

Closes #1454
