### PR TITLE
fix: normalize instrument names in recipe/target card meta lines (#1561)

### DIFF
--- a/docs/plans/features/quick/1561-normalize-instrument-display.md
+++ b/docs/plans/features/quick/1561-normalize-instrument-display.md
@@ -1,0 +1,45 @@
+# Plan: Normalize instrument names in recipe/target card meta line
+
+**Issue**: #1561
+**Complexity**: Quick (presentational display helper, follow-up to #1454)
+
+## Problem
+
+#1454 cleaned up auto-generated recipe **titles** via display normalization in
+`recipe_engine.py` (`normalize_instrument_for_display` / `format_instruments_for_display`).
+But the recipe/target **cards render the raw `instruments` field directly** in their
+meta line, so users still see the `/IMAGE` suffix and all-caps form (e.g.
+`NIRCAM/IMAGE + MIRI/IMAGE`).
+
+The `instruments` field is intentionally kept raw on the backend (data field for
+downstream consumers), so normalization belongs at the render site.
+
+## Fix
+
+Add a small TS display helper mirroring the backend helpers, then apply it at the
+two render sites.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/jwst-frontend/src/utils/instrumentDisplay.ts` | New `formatInstruments(raw: string[]): string` + `normalizeInstrument(raw: string): string`, mirroring the backend (`NIRCAM/IMAGE` → `NIRCam`, ordered NIRCam → NIRISS → NIRSpec → FGS → MIRI, ` + ` joined, dedup, unknown title-cased + sorted). |
+| `frontend/jwst-frontend/src/utils/instrumentDisplay.test.ts` | Unit tests mirroring `test_recipe_engine.py` cases. |
+| `frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx` | Replace `recipe.instruments.join(' + ')` with `formatInstruments(recipe.instruments)`. |
+| `frontend/jwst-frontend/src/components/discovery/TargetCard.tsx` | Replace `target.instruments.join(' + ')` with `formatInstruments(target.instruments)`. |
+| `frontend/jwst-frontend/e2e/target-detail.spec.ts` | Update pinned raw form `NIRCAM/IMAGE + MIRI/IMAGE` → `NIRCam + MIRI`. |
+
+## Implementation Notes
+
+- Ordering and normalization map kept identical to the backend `_INSTRUMENT_DISPLAY`
+  / `_INSTRUMENT_DISPLAY_ORDER` so the cards match recipe titles exactly.
+- Unknown instruments fall back to title-cased base and are appended in sorted order
+  for determinism (mirrors backend).
+- `TargetCard` uses the formatted text for both the visible meta line and the
+  `aria-label`, so the accessible name stays clean too.
+
+## Acceptance
+
+- [x] Recipe and target cards show clean instrument names (no `/IMAGE`, proper casing).
+- [x] E2E assertion updated.
+- [x] Ordering matches the backend display helper.

--- a/frontend/jwst-frontend/e2e/target-detail.spec.ts
+++ b/frontend/jwst-frontend/e2e/target-detail.spec.ts
@@ -144,7 +144,7 @@ test.describe('Target detail page', () => {
     await expect(swatches).toHaveCount(3);
 
     // Instruments
-    await expect(firstCard.locator('.recipe-card-meta')).toContainText('NIRCAM/IMAGE + MIRI/IMAGE');
+    await expect(firstCard.locator('.recipe-card-meta')).toContainText('NIRCam + MIRI');
 
     // Estimated time
     await expect(firstCard.locator('.recipe-card-meta')).toContainText('~24 seconds');

--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../context/useAuth';
 import { checkDataAvailability } from '../../services/jwstDataService';
+import { formatInstruments } from '../../utils/instrumentDisplay';
 import type { CompositeRecipe } from '../../types/DiscoveryTypes';
 import type { MastObservationResult } from '../../types/MastTypes';
 import './RecipeCard.css';
@@ -127,7 +128,7 @@ export function RecipeCard({
       </div>
 
       <div className="recipe-card-meta">
-        <span>{recipe.instruments.join(' + ')}</span>
+        <span>{formatInstruments(recipe.instruments)}</span>
         <span className="recipe-card-dot">&middot;</span>
         <span>{formatTime(recipe.estimatedTimeSeconds)}</span>
         {recipe.requiresMosaic && (

--- a/frontend/jwst-frontend/src/components/discovery/TargetCard.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/TargetCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import type { FeaturedTarget } from '../../types/DiscoveryTypes';
 import { TelescopeIcon } from '../icons/DashboardIcons';
+import { formatInstruments } from '../../utils/instrumentDisplay';
 import './TargetCard.css';
 
 interface TargetCardProps {
@@ -39,7 +40,7 @@ export function TargetCard({ target }: TargetCardProps) {
   const radiusParam = target.mastSearchParams.searchRadius
     ? `?radius=${target.mastSearchParams.searchRadius}`
     : '';
-  const instrumentsText = target.instruments.join(' + ');
+  const instrumentsText = formatInstruments(target.instruments);
   const potential = POTENTIAL_CONFIG[target.compositePotential] ?? POTENTIAL_CONFIG.good;
   const gradient = CATEGORY_GRADIENTS[target.category.toLowerCase()] ?? DEFAULT_GRADIENT;
 

--- a/frontend/jwst-frontend/src/utils/instrumentDisplay.test.ts
+++ b/frontend/jwst-frontend/src/utils/instrumentDisplay.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeInstrument, formatInstruments } from './instrumentDisplay';
+
+// Mirrors processing-engine/tests/test_recipe_engine.py::TestInstrumentDisplayNames
+// to keep the frontend display helper in sync with the backend. (#1561 / #1454)
+describe('normalizeInstrument', () => {
+  it('drops the dataproduct-kind suffix', () => {
+    expect(normalizeInstrument('NIRCAM/IMAGE')).toBe('NIRCam');
+    expect(normalizeInstrument('MIRI/IMAGE')).toBe('MIRI');
+    expect(normalizeInstrument('NIRISS/IMAGE')).toBe('NIRISS');
+    expect(normalizeInstrument('NIRSPEC/IFU')).toBe('NIRSpec');
+    expect(normalizeInstrument('FGS')).toBe('FGS');
+  });
+
+  it('is case-insensitive and strips whitespace', () => {
+    expect(normalizeInstrument(' nircam/image ')).toBe('NIRCam');
+  });
+
+  it('falls back to title case for unknown instruments', () => {
+    expect(normalizeInstrument('NEWCAM/THING')).toBe('Newcam');
+  });
+});
+
+describe('formatInstruments', () => {
+  it('orders short → long wavelength regardless of input order', () => {
+    expect(formatInstruments(['MIRI/IMAGE', 'NIRCAM/IMAGE'])).toBe('NIRCam + MIRI');
+  });
+
+  it('returns an empty string for an empty list', () => {
+    expect(formatInstruments([])).toBe('');
+  });
+
+  it('appends unknown instruments after known ones, sorted', () => {
+    expect(formatInstruments(['NEWCAM', 'NIRCAM/IMAGE'])).toBe('NIRCam + Newcam');
+  });
+
+  it('de-duplicates', () => {
+    expect(formatInstruments(['NIRCAM/IMAGE', 'NIRCAM/IMAGE'])).toBe('NIRCam');
+  });
+});

--- a/frontend/jwst-frontend/src/utils/instrumentDisplay.ts
+++ b/frontend/jwst-frontend/src/utils/instrumentDisplay.ts
@@ -1,0 +1,46 @@
+/**
+ * Instrument display-name helpers — frontend mirror of the backend
+ * `normalize_instrument_for_display` / `format_instruments_for_display` in
+ * `processing-engine/app/discovery/recipe_engine.py`.
+ *
+ * The `instruments` field on recipes/targets is kept raw (e.g. `"NIRCAM/IMAGE"`)
+ * because downstream consumers depend on the raw MAST form, so normalization
+ * happens at the render site. Keep the map and ordering in sync with the backend
+ * so card meta lines match auto-generated recipe titles. (#1561, follow-up to #1454)
+ */
+
+/** Canonical display names for JWST instruments. */
+const INSTRUMENT_DISPLAY: Record<string, string> = {
+  NIRCAM: 'NIRCam',
+  NIRISS: 'NIRISS',
+  NIRSPEC: 'NIRSpec',
+  MIRI: 'MIRI',
+  FGS: 'FGS',
+};
+
+/** Order cross-instrument names short → long wavelength (NIRCam … MIRI). */
+const INSTRUMENT_DISPLAY_ORDER = ['NIRCam', 'NIRISS', 'NIRSpec', 'FGS', 'MIRI'];
+
+/**
+ * Convert a raw MAST instrument string (e.g. `"NIRCAM/IMAGE"`) into a clean
+ * display name (e.g. `"NIRCam"`), dropping the dataproduct-kind suffix. Unknown
+ * instruments fall back to a title-cased base.
+ */
+export function normalizeInstrument(raw: string): string {
+  const base = raw.split('/', 1)[0].trim().toUpperCase();
+  if (base in INSTRUMENT_DISPLAY) return INSTRUMENT_DISPLAY[base];
+  // Title-case fallback: "NEWCAM" → "Newcam" (mirrors Python str.title()).
+  return base.charAt(0) + base.slice(1).toLowerCase();
+}
+
+/**
+ * Normalize, de-duplicate, and join instrument names for display, ordered short
+ * → long wavelength (NIRCam … MIRI). Unrecognized names are appended in sorted
+ * order for determinism.
+ */
+export function formatInstruments(raw: string[]): string {
+  const seen = new Set(raw.map(normalizeInstrument));
+  const ordered = INSTRUMENT_DISPLAY_ORDER.filter((d) => seen.has(d));
+  const unknown = [...seen].filter((d) => !ordered.includes(d)).sort();
+  return [...ordered, ...unknown].join(' + ');
+}


### PR DESCRIPTION
## Summary

Follow-up to #1454. That PR normalized auto-generated recipe **titles** in `recipe_engine.py`, but the recipe/target discovery **cards** render the raw `instruments` field directly in their meta line — so users still saw the `/IMAGE` suffix and all-caps form (e.g. `NIRCAM/IMAGE + MIRI/IMAGE`).

The `instruments` field is intentionally kept raw on the backend (downstream consumers depend on the raw MAST form), so normalization belongs at the render site.

## Changes Made

- **New** `frontend/jwst-frontend/src/utils/instrumentDisplay.ts` — `formatInstruments(raw: string[])` and `normalizeInstrument(raw: string)`, a faithful mirror of the backend `format_instruments_for_display` / `normalize_instrument_for_display`:
  - drops the dataproduct-kind suffix (`NIRCAM/IMAGE` → `NIRCam`)
  - de-duplicates, orders short → long wavelength (`NIRCam → NIRISS → NIRSpec → FGS → MIRI`)
  - title-cases unknown instruments and appends them sorted, for determinism
- **New** `instrumentDisplay.test.ts` — 7 unit tests mirroring the backend `TestInstrumentDisplayNames` cases.
- `RecipeCard.tsx` — `recipe.instruments.join(' + ')` → `formatInstruments(recipe.instruments)`.
- `TargetCard.tsx` — `target.instruments.join(' + ')` → `formatInstruments(target.instruments)`; the formatted text also flows into the card `aria-label`, so the accessible name is clean too.
- `e2e/target-detail.spec.ts` — updated the pinned assertion from `NIRCAM/IMAGE + MIRI/IMAGE` to `NIRCam + MIRI`.

## Out of scope (follow-up noted)

`dashboard/TargetGroupView.tsx:79` also renders raw instruments (`instruments.join(', ')`), but with a different comma-separated layout in the data-library group header. #1561 is scoped to the discovery cards, so I left that component unchanged rather than silently altering its format. Happy to file a follow-up issue if we want library group headers normalized too.

## Test Plan

- [x] `npx vitest run src/utils/instrumentDisplay.test.ts` — 7/7 pass
- [x] Full pre-commit unit suite — 1036/1036 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open Discovery → a target with NIRCam + MIRI data; confirm recipe and target cards show `NIRCam + MIRI` (no `/IMAGE`, proper casing) in the meta line.
- [ ] Manual: confirm ordering matches the recipe title (short → long wavelength).

## Documentation Checklist

- [x] No API/endpoint/model changes — no doc updates required.
- [x] Plan file added: `docs/plans/features/quick/1561-normalize-instrument-display.md`.

## Tech Debt Impact

- [x] Reduces drift risk: the new helper documents the backend mirror and the issue numbers, so the two stay in sync.
- [ ] No new tech debt introduced.

## Risk & Rollback

**Risk**: Very low. Presentational-only display helper applied at two render sites; no data, API, or state changes. The raw `instruments` field is untouched.

**Rollback**: Revert this commit — cards fall back to rendering the raw joined string. Fully reversible.

Closes #1561
