### PR TITLE
docs: ADR 0001 + Python backend scaffolding for single-backend migration (Phase 0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,13 @@ JWST Data Analysis Application — a microservices-based platform for analyzing 
 
 **Architecture**: Frontend (React TypeScript) → Backend (.NET 10 API) → MongoDB + Processing Engine (Python FastAPI) → MAST Portal (STScI)
 
+> **Migration in progress (ADR 0001):** collapsing to a two-service architecture —
+> the React frontend will talk directly to the Python FastAPI backend (which absorbs
+> auth, MongoDB persistence, jobs, and WebSocket progress) and the `.NET` gateway is
+> removed. New backend code goes in `processing-engine/app/` (`auth/`, `db/`,
+> `library/`, `jobs/`). See
+> [`docs/architecture/adr/0001-collapse-to-python-single-backend.md`](docs/architecture/adr/0001-collapse-to-python-single-backend.md).
+
 | Service           | URL    | Tech                      |
 | ----------------- | ------ | ------------------------- |
 | Frontend          | :3000  | React + Vite + TypeScript |

--- a/docs/architecture/adr/0001-collapse-to-python-single-backend.md
+++ b/docs/architecture/adr/0001-collapse-to-python-single-backend.md
@@ -1,0 +1,95 @@
+# ADR 0001 — Collapse to a Two-Service Architecture (Python single backend)
+
+- **Status:** Accepted (in progress)
+- **Date:** 2026-06-07
+- **Supersedes:** the three-tier polyglot architecture described in `system-overview.md`
+
+## Context
+
+The application runs a three-tier polyglot stack:
+
+```
+React frontend (31k LOC)
+      │  only ever talks to :5001
+      ▼
+.NET gateway (21k LOC + 23k test)  ──HTTP proxy──►  Python engine (17.5k LOC + 16k test)
+  auth · MongoDB · jobs · SignalR ·                   ALL real compute (astropy):
+  storage · + proxies Composite/Mosaic/               composite, mosaic, mast,
+  Mast/Analysis/Semantic to Python                    analysis, discovery, semantic
+      │                                                       │
+      ▼                                                       ▼
+  MongoDB (2 collections)                          MAST + shared storage (SeaweedFS = 4 containers)
+```
+
+A full-stack review surfaced that the `.NET` `CompositeService`, `MosaicService`,
+`MastService`, `AnalysisService`, and `SemanticSearchService` are **HTTP proxies**
+(`_httpClient` → Python). The Python engine already owns every one of those domains
+end-to-end. The `.NET` tier's only *non-duplicated* responsibilities are:
+
+- **Auth** (JWT issue/validate, register/login/refresh)
+- **MongoDB persistence** — only two collections: `jwst_data` and `users`
+- **Job tracking + SignalR push** (`/hubs/job-progress`) and its background workers
+  (composite/mosaic/thumbnail/embedding/scan/reaper)
+- **Storage abstraction** — already duplicated by Python's `app/storage/provider.py`
+
+Astropy and the scientific stack must stay in Python. The middle tier therefore adds
+a second language, a second service, and a `snake_case ↔ camelCase` boundary while
+mostly forwarding requests.
+
+## Decision
+
+Make the **Python FastAPI service the single backend** and **delete the .NET gateway**.
+The Python backend absorbs auth, MongoDB persistence, job tracking, and real-time
+progress (WebSocket replacing SignalR). The React frontend talks to one backend over
+HTTP + WebSocket.
+
+### Target architecture
+
+```
+React frontend  ──HTTP + WebSocket──►  Python FastAPI (single backend)
+                                          compute + auth + persistence + jobs + WS
+                                                │
+                                                ▼
+                                        MongoDB · storage (volume/real S3) · MAST
+```
+
+## Consequences
+
+**Positive**
+
+- One backend instead of two; one language deleted (~44k lines of C# incl. tests).
+- No more cross-language DTO/casing boundary.
+- Far fewer containers and compose files; simpler local and prod topology.
+- Each ported responsibility carries its security fix from the review
+  (JWT-secret-from-env, password complexity, no seed passwords, locked job state,
+  `asyncio.to_thread` for blocking `fits.open`, no `str(e)` leakage).
+
+**Negative / risks**
+
+- Auth, persistence, and job orchestration must be reimplemented in Python.
+- SignalR is replaced by a WebSocket protocol; the frontend client is rewritten once.
+- A single frontend cutover (Phase 5) is the riskiest step; it is reversible by
+  reverting the API base URL while both backends still run.
+
+## Migration roadmap (strangler-fig)
+
+The system stays shippable after every phase. Phases 1–4 add Python capability behind
+the scenes while .NET still serves the frontend; Phase 5 is the one switchover; Phase 6
+deletes the gateway.
+
+| Phase | Scope |
+|-------|-------|
+| 0 | This ADR + Python backend package scaffolding (`auth/`, `db/`, `library/`, `jobs/`) + deps |
+| 1 | MongoDB (`motor`) + Auth (`pyjwt`, `passlib`) in Python |
+| 2 | Library / persistence endpoints (`jwst_data` CRUD, upload, scan) |
+| 3 | Jobs + WebSocket progress + background workers |
+| 4 | MAST import + discovery wired to persistence/jobs |
+| 5 | Frontend cutover to Python + WebSocket |
+| 6 | Delete the `.NET` tier (`backend/`, CI jobs, compose services) |
+| 7 | Infrastructure simplification (SeaweedFS → volume/S3, collapse compose files) |
+| 8 | In-tier cleanup (god-files, duplication) |
+
+## References
+
+- `CODEBASE_REVIEW.md` — full-stack review and issue inventory
+- `system-overview.md` — current (pre-migration) architecture

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -2,6 +2,17 @@
 
 Architecture documentation for the JWST Data Analysis Application, organized using the [4+1 Architectural View Model](https://en.wikipedia.org/wiki/4%2B1_architectural_view_model).
 
+> **In progress:** the system is migrating from the three-tier polyglot stack to a
+> two-service architecture (Python single backend). See
+> [ADR 0001 — Collapse to a Python single backend](adr/0001-collapse-to-python-single-backend.md).
+> Documents below describe the current (pre-migration) state until each phase lands.
+
+---
+
+## Decisions (ADRs)
+
+- **[ADR 0001 — Collapse to a Python single backend](adr/0001-collapse-to-python-single-backend.md)** — delete the .NET gateway; Python/FastAPI becomes the one backend
+
 ---
 
 ## +1 Scenarios (Use Cases)

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -2,6 +2,12 @@
 
 High-level view of the microservices architecture and their communication patterns.
 
+> **Migration in progress (ADR 0001).** The diagram below is the current state. The
+> target is a two-service architecture where the React frontend talks directly to the
+> Python FastAPI backend (compute + auth + persistence + jobs + WebSocket) and the
+> `.NET` gateway is removed. See
+> [ADR 0001 — Collapse to a Python single backend](adr/0001-collapse-to-python-single-backend.md).
+
 ```mermaid
 flowchart TB
     subgraph Client["Client Layer"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,8 @@ nav:
     - Architecture:
       - Overview: architecture/index.md
       - System Overview: architecture/system-overview.md
+      - Decisions (ADRs):
+        - "ADR 0001 — Python Single Backend": architecture/adr/0001-collapse-to-python-single-backend.md
       - "+1 Scenarios":
         - Use Case Catalog: architecture/use-case-catalog.md
         - Quality Attributes: architecture/quality-attributes.md

--- a/processing-engine/app/auth/__init__.py
+++ b/processing-engine/app/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Authentication package — JWT issue/validate, register/login/refresh.
+
+Scaffolding for the Python single-backend migration. Logic lands in Phase 1;
+see docs/architecture/adr/0001-collapse-to-python-single-backend.md.
+"""

--- a/processing-engine/app/auth/routes.py
+++ b/processing-engine/app/auth/routes.py
@@ -1,0 +1,13 @@
+"""Authentication routes (scaffold).
+
+Endpoints land in Phase 1 of the single-backend migration
+(docs/architecture/adr/0001-collapse-to-python-single-backend.md):
+``/api/auth/register``, ``/api/auth/login``, ``/api/auth/refresh``.
+
+The router is intentionally empty for now so the import graph and OpenAPI tag
+are established without changing runtime behavior.
+"""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/auth", tags=["Auth"])

--- a/processing-engine/app/db/__init__.py
+++ b/processing-engine/app/db/__init__.py
@@ -1,0 +1,6 @@
+"""Database package — async MongoDB access (motor).
+
+Scaffolding for the Python single-backend migration. The repository and client
+factory land in Phases 1-2; see
+docs/architecture/adr/0001-collapse-to-python-single-backend.md.
+"""

--- a/processing-engine/app/jobs/__init__.py
+++ b/processing-engine/app/jobs/__init__.py
@@ -1,0 +1,6 @@
+"""Jobs package — async job tracking, workers, and WebSocket progress.
+
+Scaffolding for the Python single-backend migration. The tracker, queue workers,
+reaper, and WebSocket endpoint land in Phase 3; see
+docs/architecture/adr/0001-collapse-to-python-single-backend.md.
+"""

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -1,0 +1,14 @@
+"""Jobs routes (scaffold).
+
+Endpoints land in Phase 3 of the single-backend migration
+(docs/architecture/adr/0001-collapse-to-python-single-backend.md):
+``/api/jobs`` status queries plus the ``/ws/jobs`` WebSocket that replaces the
+``.NET`` SignalR ``/hubs/job-progress`` hub.
+
+The router is intentionally empty for now so the import graph and OpenAPI tag
+are established without changing runtime behavior.
+"""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/jobs", tags=["Jobs"])

--- a/processing-engine/app/library/__init__.py
+++ b/processing-engine/app/library/__init__.py
@@ -1,0 +1,5 @@
+"""Library package — jwst_data persistence, upload, and data scan.
+
+Scaffolding for the Python single-backend migration. Endpoints land in Phase 2;
+see docs/architecture/adr/0001-collapse-to-python-single-backend.md.
+"""

--- a/processing-engine/app/library/routes.py
+++ b/processing-engine/app/library/routes.py
@@ -1,0 +1,14 @@
+"""Library routes (scaffold).
+
+Endpoints land in Phase 2 of the single-backend migration
+(docs/architecture/adr/0001-collapse-to-python-single-backend.md):
+``/api/jwstdata`` CRUD, ``/api/jwstdata/upload``, ``/api/upload``,
+``/api/datamanagement/import/scan``.
+
+The router is intentionally empty for now so the import graph and OpenAPI tag
+are established without changing runtime behavior.
+"""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api", tags=["Library"])

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -11,6 +11,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 
 from app.analysis.routes import router as analysis_router
+from app.auth.routes import router as auth_router
 from app.composite.routes import router as composite_router
 from app.discovery.routes import router as discovery_router
 from app.exceptions import (
@@ -18,6 +19,8 @@ from app.exceptions import (
     generic_error_handler,
     processing_engine_error_handler,
 )
+from app.jobs.routes import router as jobs_router
+from app.library.routes import router as library_router
 from app.mosaic.routes import router as mosaic_router
 from app.processing.enhancement import (
     asinh_stretch,
@@ -89,6 +92,12 @@ app.include_router(discovery_router)
 
 # Include Semantic Search routes
 app.include_router(semantic_router)
+
+# Single-backend migration scaffolding (ADR 0001). These routers are empty
+# until their respective phases land auth, persistence, and job tracking.
+app.include_router(auth_router)
+app.include_router(library_router)
+app.include_router(jobs_router)
 
 
 class ThumbnailRequest(BaseModel):

--- a/processing-engine/requirements.txt
+++ b/processing-engine/requirements.txt
@@ -39,5 +39,12 @@ faiss-cpu>=1.13.2,<2.0.0
 # AWS
 boto3>=1.43.9
 
+# Single-backend migration (ADR 0001): persistence + auth move into Python.
+# Async MongoDB driver, JWT, and password hashing.
+motor==3.6.0
+pyjwt==2.10.1
+passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
+
 # NOTE: test/lint tooling (pytest, pytest-asyncio, pytest-cov, httpx, ruff) lives
 # in requirements-dev.txt — production images must not ship test runners. (#1468)


### PR DESCRIPTION
No linked issue

## Summary

Kicks off a phased architecture simplification: collapse the three-tier polyglot stack (React → .NET gateway → Python engine) into a **two-service architecture** — React frontend talking directly to a **Python FastAPI single backend** — and delete the `.NET` gateway.

This PR is **Phase 0**: the decision record plus backend scaffolding. It is **additive with zero runtime behavior change** — the empty routers add no endpoints, and `.NET` still serves the frontend exactly as before.

## Why

A full-stack review (`CODEBASE_REVIEW.md`) confirmed the `.NET` `Composite`/`Mosaic`/`Mast`/`Analysis`/`SemanticSearch` services are **HTTP proxies** to the Python engine, which already owns those domains end-to-end. The gateway's only non-duplicated responsibilities are auth, MongoDB persistence (just 2 collections), job tracking + SignalR, and a storage abstraction Python already has. Astropy must stay in Python, so the natural simplification is to make Python the single backend.

Outcome of the full migration: one backend instead of two, ~44k fewer lines of C# (incl. tests), no `snake_case ↔ camelCase` boundary, and far fewer containers/compose files. The system stays shippable after every phase (strangler-fig).

## Changes Made

- **ADR** `docs/architecture/adr/0001-collapse-to-python-single-backend.md` — context, decision, consequences, and the 8-phase roadmap. Linked from the architecture index and mkdocs nav.
- **Scaffolding packages** under `processing-engine/app/`: `auth/`, `db/`, `library/`, `jobs/`. Empty `APIRouter`s wired into `main.py` to establish the import graph and OpenAPI tags ahead of Phases 1–3.
- **`requirements.txt`** — adds `motor` (async MongoDB), `pyjwt`, `passlib[bcrypt]`, `bcrypt` for the upcoming persistence + auth phases.
- **Docs** — `AGENTS.md` and `docs/architecture/system-overview.md` note the in-progress target architecture and where new backend code lives.

## Test Plan

- [x] New Python files parse cleanly (`ast.parse`); router wiring is mechanically identical to the five existing routers.
- [x] No endpoints added — empty routers are valid to include; OpenAPI gains only the new tags.
- [ ] Full `docker exec jwst-processing python -m pytest` in CI (fastapi/deps run in Docker, not in this environment).

## Documentation Checklist

- [x] `docs/architecture/` (new ADR + system-overview note)
- [x] No other doc updates needed for Phase 0

## Tech Debt Impact

- [x] Existing tech debt reduced — establishes the path to remove the redundant `.NET` proxy tier and the duplicated storage abstraction.

## Risk & Rollback

- **Risk:** Minimal. Additive only; no behavior change. New deps are unused until Phase 1.
- **Rollback:** Revert this commit — removes the scaffolding packages, deps, and docs with no impact on the running system.

## Follow-up phases

Each lands as its own PR: (1) Mongo + Auth, (2) Library/persistence, (3) Jobs + WebSocket, (4) MAST/discovery wiring, (5) frontend cutover, (6) delete `.NET`, (7) infra simplification, (8) in-tier god-file cleanup.

https://claude.ai/code/session_01MWMesVhoX13SVmCcgjWrDF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWMesVhoX13SVmCcgjWrDF)_