### PR TITLE
fix: honor dev rate-limit whitelist for IPv6-mapped IPv4 addresses

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Configuration/Ipv4MappedRateLimitConfigurationTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Configuration/Ipv4MappedRateLimitConfigurationTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+
+using AspNetCoreRateLimit;
+using JwstDataAnalysis.API.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace JwstDataAnalysis.API.Tests.Configuration
+{
+    /// <summary>
+    /// Tests for <see cref="Ipv4MappedIpResolveContributor"/> and
+    /// <see cref="Ipv4MappedRateLimitConfiguration"/> (#1615): IPv6-mapped IPv4
+    /// client addresses must normalize to plain IPv4 so the dev IP whitelist matches.
+    /// </summary>
+    public class Ipv4MappedRateLimitConfigurationTests
+    {
+        [Theory]
+        [InlineData("::ffff:172.18.0.1", "172.18.0.1")] // Docker bridge (Linux)
+        [InlineData("::ffff:192.168.65.1", "192.168.65.1")] // Docker Desktop (macOS)
+        [InlineData("::ffff:127.0.0.1", "127.0.0.1")] // mapped loopback
+        public void ResolveIp_Ipv6MappedIpv4_ReturnsPlainIpv4(string mapped, string expected)
+        {
+            var contributor = WrapFixedResult(mapped);
+
+            var result = contributor.ResolveIp(new DefaultHttpContext());
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("172.18.0.1")] // plain IPv4
+        [InlineData("::1")] // plain IPv6 loopback
+        [InlineData("2001:db8::1")] // plain IPv6
+        [InlineData("203.0.113.7, 172.18.0.1")] // X-Forwarded-For list, not a single IP
+        [InlineData("not-an-ip")]
+        public void ResolveIp_NonMappedValues_PassThroughUnchanged(string value)
+        {
+            var contributor = WrapFixedResult(value);
+
+            var result = contributor.ResolveIp(new DefaultHttpContext());
+
+            Assert.Equal(value, result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ResolveIp_NullOrEmpty_PassesThrough(string? value)
+        {
+            var contributor = WrapFixedResult(value);
+
+            var result = contributor.ResolveIp(new DefaultHttpContext());
+
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public void ResolveIp_UsesConnectionRemoteIpAddress_NormalizesMappedAddress()
+        {
+            var configuration = CreateConfiguration();
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = IPAddress.Parse("::ffff:172.18.0.1");
+
+            var resolved = ResolveThroughConfiguration(configuration, context);
+
+            Assert.Equal("172.18.0.1", resolved);
+        }
+
+        [Fact]
+        public void RegisterResolvers_WrapsEveryResolver()
+        {
+            var configuration = CreateConfiguration();
+
+            Assert.NotEmpty(configuration.IpResolvers);
+            Assert.All(
+                configuration.IpResolvers,
+                resolver => Assert.IsType<Ipv4MappedIpResolveContributor>(resolver));
+        }
+
+        [Fact]
+        public void RegisterResolvers_WithRealIpHeader_KeepsConnectionAndHeaderResolvers()
+        {
+            var stock = new RateLimitConfiguration(
+                CreateIpOptions(),
+                Options.Create(new ClientRateLimitOptions()));
+            stock.RegisterResolvers();
+            var configuration = CreateConfiguration();
+
+            Assert.Equal(stock.IpResolvers.Count, configuration.IpResolvers.Count);
+        }
+
+        [Fact]
+        public void RegisterResolvers_InvokedTwice_DoesNotDuplicateResolvers()
+        {
+            var configuration = CreateConfiguration();
+            var ipCount = configuration.IpResolvers.Count;
+            var clientCount = configuration.ClientResolvers.Count;
+
+            configuration.RegisterResolvers();
+
+            Assert.Equal(ipCount, configuration.IpResolvers.Count);
+            Assert.Equal(clientCount, configuration.ClientResolvers.Count);
+        }
+
+        private static Ipv4MappedIpResolveContributor WrapFixedResult(string? value)
+        {
+            var inner = new Mock<IIpResolveContributor>();
+            inner.Setup(x => x.ResolveIp(It.IsAny<HttpContext>())).Returns(value!);
+            return new Ipv4MappedIpResolveContributor(inner.Object);
+        }
+
+        private static IOptions<IpRateLimitOptions> CreateIpOptions()
+        {
+            return Options.Create(new IpRateLimitOptions
+            {
+                RealIpHeader = "X-Forwarded-For",
+                IpWhitelist = new List<string> { "127.0.0.1", "::1", "172.16.0.0/12" },
+            });
+        }
+
+        private static Ipv4MappedRateLimitConfiguration CreateConfiguration()
+        {
+            var configuration = new Ipv4MappedRateLimitConfiguration(
+                CreateIpOptions(),
+                Options.Create(new ClientRateLimitOptions()));
+
+            // Mirror the rate limit middleware, which invokes RegisterResolvers()
+            configuration.RegisterResolvers();
+            return configuration;
+        }
+
+        private static string? ResolveThroughConfiguration(
+            Ipv4MappedRateLimitConfiguration configuration,
+            HttpContext context)
+        {
+            foreach (var resolver in configuration.IpResolvers)
+            {
+                var ip = resolver.ResolveIp(context);
+                if (!string.IsNullOrEmpty(ip))
+                {
+                    return ip;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/backend/JwstDataAnalysis.API/Configuration/Ipv4MappedIpResolveContributor.cs
+++ b/backend/JwstDataAnalysis.API/Configuration/Ipv4MappedIpResolveContributor.cs
@@ -1,0 +1,47 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+
+using AspNetCoreRateLimit;
+
+namespace JwstDataAnalysis.API.Configuration
+{
+    /// <summary>
+    /// Decorates an <see cref="IIpResolveContributor"/> so IPv6-mapped IPv4
+    /// addresses (<c>::ffff:a.b.c.d</c>) resolve to their plain IPv4 form.
+    /// Anything that doesn't parse as a single mapped address (plain IPv4,
+    /// plain IPv6, comma-separated X-Forwarded-For lists) passes through
+    /// unchanged.
+    /// </summary>
+    public sealed class Ipv4MappedIpResolveContributor : IIpResolveContributor
+    {
+        private readonly IIpResolveContributor inner;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ipv4MappedIpResolveContributor"/> class.
+        /// </summary>
+        /// <param name="inner">The resolver to decorate.</param>
+        public Ipv4MappedIpResolveContributor(IIpResolveContributor inner)
+        {
+            this.inner = inner;
+        }
+
+        /// <inheritdoc/>
+        public string? ResolveIp(HttpContext httpContext)
+        {
+            var ip = this.inner.ResolveIp(httpContext);
+            if (string.IsNullOrEmpty(ip))
+            {
+                return ip;
+            }
+
+            if (IPAddress.TryParse(ip, out var parsed) && parsed.IsIPv4MappedToIPv6)
+            {
+                return parsed.MapToIPv4().ToString();
+            }
+
+            return ip;
+        }
+    }
+}

--- a/backend/JwstDataAnalysis.API/Configuration/Ipv4MappedRateLimitConfiguration.cs
+++ b/backend/JwstDataAnalysis.API/Configuration/Ipv4MappedRateLimitConfiguration.cs
@@ -1,0 +1,53 @@
+// Copyright (c) JWST Data Analysis. All rights reserved.
+// Licensed under the MIT License.
+
+using AspNetCoreRateLimit;
+using Microsoft.Extensions.Options;
+
+namespace JwstDataAnalysis.API.Configuration
+{
+    /// <summary>
+    /// Rate limit configuration that normalizes IPv6-mapped IPv4 client addresses
+    /// (e.g. <c>::ffff:172.18.0.1</c> from the Docker bridge) to their plain IPv4
+    /// form before whitelist matching and counter keying. AspNetCoreRateLimit's
+    /// CIDR matching is address-family sensitive, so without this the IPv4
+    /// whitelist entries in <c>appsettings.Development.json</c> never match
+    /// Docker traffic and dev/E2E requests get rate limited (issue #1615).
+    /// </summary>
+    public class Ipv4MappedRateLimitConfiguration : RateLimitConfiguration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ipv4MappedRateLimitConfiguration"/> class.
+        /// </summary>
+        /// <param name="ipOptions">IP rate limit options.</param>
+        /// <param name="clientOptions">Client rate limit options.</param>
+        public Ipv4MappedRateLimitConfiguration(
+            IOptions<IpRateLimitOptions> ipOptions,
+            IOptions<ClientRateLimitOptions> clientOptions)
+            : base(ipOptions, clientOptions)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void RegisterResolvers()
+        {
+            // base.RegisterResolvers() appends, so clear both lists first to keep
+            // re-invocation idempotent (no duplicate or double-wrapped resolvers)
+            IpResolvers.Clear();
+            ClientResolvers.Clear();
+            base.RegisterResolvers();
+
+            var wrapped = new List<IIpResolveContributor>(IpResolvers.Count);
+            foreach (var resolver in IpResolvers)
+            {
+                wrapped.Add(new Ipv4MappedIpResolveContributor(resolver));
+            }
+
+            IpResolvers.Clear();
+            foreach (var resolver in wrapped)
+            {
+                IpResolvers.Add(resolver);
+            }
+        }
+    }
+}

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -36,7 +36,10 @@ builder.Services.Configure<MongoDBSettings>(
 // Configure rate limiting
 builder.Services.AddMemoryCache();
 builder.Services.Configure<IpRateLimitOptions>(builder.Configuration.GetSection("IpRateLimiting"));
-builder.Services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
+
+// Ipv4MappedRateLimitConfiguration normalizes IPv6-mapped IPv4 client addresses
+// (::ffff:a.b.c.d from the Docker bridge) so IPv4 whitelist CIDRs match (#1615)
+builder.Services.AddSingleton<IRateLimitConfiguration, Ipv4MappedRateLimitConfiguration>();
 builder.Services.AddInMemoryRateLimiting();
 
 // Storage provider: conditional registration based on configuration

--- a/docs/plans/features/quick/1615-rate-limit-ipv6-mapped-whitelist.md
+++ b/docs/plans/features/quick/1615-rate-limit-ipv6-mapped-whitelist.md
@@ -1,0 +1,40 @@
+# #1615 — Honor rate-limit IP whitelist for IPv6-mapped IPv4 addresses
+
+**Issue**: [#1615](https://github.com/Snoww3d/jwst-data-analysis/issues/1615)
+**Complexity**: Low (quick plan)
+
+## Problem
+
+`appsettings.Development.json` whitelists IPv4 CIDRs (`127.0.0.1`, `172.16.0.0/12`, …),
+but traffic from the Docker bridge reaches Kestrel as IPv6-mapped IPv4
+(`::ffff:172.18.0.1`). AspNetCoreRateLimit's whitelist matching is address-family
+sensitive, so the entries never match and dev/E2E traffic is rate limited like
+production — `post:/api/auth/register` (5/hour) breaks local E2E runs with 429s.
+
+## Fix
+
+Normalize the resolved client IP before it reaches whitelist matching and counter
+keying:
+
+- New `Configuration/Ipv4MappedIpResolveContributor.cs` — decorates any
+  `IIpResolveContributor`; if the resolved string parses as an IPv4-mapped IPv6
+  address, returns `MapToIPv4()`.
+- New `Configuration/Ipv4MappedRateLimitConfiguration.cs` — overrides
+  `RegisterResolvers()` to wrap every registered IP resolver (connection + real-IP
+  header) with the normalizer; clears resolver lists first so re-invocation is
+  idempotent.
+- `Program.cs`: register `Ipv4MappedRateLimitConfiguration` as the
+  `IRateLimitConfiguration` singleton instead of the stock one.
+
+No whitelist/config changes; production behavior unchanged (non-mapped addresses
+pass through untouched, and normalization also makes counter keys consistent).
+
+## Tests
+
+`JwstDataAnalysis.API.Tests/Configuration/Ipv4MappedRateLimitConfigurationTests.cs`:
+
+- Mapped connection IP (`::ffff:172.18.0.1`) resolves to `172.18.0.1`.
+- Plain IPv4 and plain IPv6 (`::1`) pass through unchanged.
+- Non-IP resolver output (e.g. XFF list string) passes through unchanged.
+- Null/empty resolver output passes through.
+- Configuration wraps all base resolvers (connection + header when `RealIpHeader` set).


### PR DESCRIPTION
## Summary

Fixes #1615 — the dev rate-limit IP whitelist was never honored because Docker traffic reaches Kestrel as IPv6-mapped IPv4 addresses (`::ffff:172.18.0.1`), and AspNetCoreRateLimit's CIDR whitelist matching is address-family sensitive. The IPv4 entries in `appsettings.Development.json` never matched, so local E2E runs hit the 5/hour `post:/api/auth/register` limit and flaked with 429s.

The fix normalizes the resolved client IP to plain IPv4 before whitelist matching and counter keying. No config changes; production is unaffected (prod whitelist is empty, and normalization only touches single mapped addresses).

## Changes Made

- **`Configuration/Ipv4MappedIpResolveContributor.cs`** (new) — decorator over any `IIpResolveContributor`: if the resolved string parses as an IPv4-mapped IPv6 address, returns `MapToIPv4()`. Plain IPv4/IPv6, comma-separated `X-Forwarded-For` lists, unparseable, and null/empty values pass through unchanged.
- **`Configuration/Ipv4MappedRateLimitConfiguration.cs`** (new) — derives from `RateLimitConfiguration`, overrides `RegisterResolvers()` to wrap every registered IP resolver (connection + real-IP header) with the normalizer. Clears both resolver lists first so re-invocation is idempotent.
- **`Program.cs`** — registers `Ipv4MappedRateLimitConfiguration` as the `IRateLimitConfiguration` singleton (before `AddInMemoryRateLimiting()`, whose `TryAddSingleton` then no-ops).
- **`Ipv4MappedRateLimitConfigurationTests.cs`** (new) — 14 unit tests covering mapped normalization, pass-through cases, resolver wrapping, resolver-count parity with the stock configuration, and double-invocation idempotency.
- **Plan**: `docs/plans/features/quick/1615-rate-limit-ipv6-mapped-whitelist.md`

## Test Plan

- [x] Unit tests: 14 new tests pass; full backend suite 1137/1137 green.
- [x] Repro before fix: with the pre-fix backend running (`ASPNETCORE_ENVIRONMENT=Development`), `curl -X POST http://localhost:5001/api/auth/register` 7×; the 6th and 7th returned **429**.
- [x] After fix: rebuilt backend container from this branch (`docker compose up -d --build backend`), sent 10 consecutive register requests — all returned **400** (validation error, as expected for the intentionally invalid payload), **no 429** → whitelist honored.
- [ ] Reviewer: run the full E2E suite locally (`npx playwright test`) and confirm no 429-related flakes past the 5th registration.

## Documentation Checklist

- [x] Quick plan file added (`docs/plans/features/quick/1615-rate-limit-ipv6-mapped-whitelist.md`)
- [x] No API/endpoint/model changes — no docs updates required
- [x] Inline XML docs on both new public classes

## Tech Debt Impact

- [x] No new tech debt introduced
- [x] Follow-up filed: #1620 — rate limiter reads `X-Forwarded-For` directly via `RealIpHeader`, bypassing the ForwardedHeaders trust list (pre-existing, surfaced in code review, out of scope here)

## Risk & Rollback

- **Risk**: Low. Behavior change is confined to IP-string normalization inside the rate limiter. Production whitelist is empty, so no address can newly bypass limits there; counter keying only improves (mapped and plain forms of the same client now share one counter). Non-mapped values are byte-for-byte untouched.
- **Rollback**: revert the single commit — the registration swap in `Program.cs` returns to the stock `RateLimitConfiguration`.

Closes #1615

https://claude.ai/code/session_019QhpARsCtfZrenjm4shej7
