### PR TITLE
chore(ci): skip claude-review on dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Dependabot-triggered runs read secrets from the Dependabot secret store,
+    # where CLAUDE_CODE_OAUTH_TOKEN is not set, so the review action always
+    # fails on dependency-bump PRs. Skip it there (auto-merge tier anyway).
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Every dependabot PR fails the non-required `claude-review` check because dependabot-triggered workflow runs read secrets from the **Dependabot secret store**, where `CLAUDE_CODE_OAUTH_TOKEN` is not configured (`Secret source: Dependabot` in the run logs; the action receives an empty token). This adds an actor guard so the job skips on dependabot PRs instead of failing.

## Changes Made

- `.github/workflows/claude-code-review.yml` — add `if: github.actor != 'dependabot[bot]'` to the `claude-review` job, replacing the commented-out example filter.

## Test Plan

- [x] Confirmed root cause in run logs of PR #1612 (empty `claude_code_oauth_token`, secret source Dependabot).
- [ ] After merge: next dependabot PR shows `claude-review` as skipped, not failed.

## Documentation Checklist

- [x] No docs impact (CI-only change)

## Tech Debt Impact

- [x] Removes recurring red ✗ noise on all dependabot PRs; no new debt

## Risk & Rollback

- **Risk**: Minimal — only skips a non-required job for the dependabot actor; human/agent PRs unaffected.
- **Rollback**: revert the one-line condition.

https://claude.ai/code/session_019QhpARsCtfZrenjm4shej7


No linked issue
