### PR TITLE
feat: global render semaphore — bound concurrent composite/mosaic renders

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -102,6 +102,30 @@ MAST_DOWNLOAD_TIMEOUT=3600
 # COMPOSITE_DOWNSCALE_FAIL_THRESHOLD=0.85
 # MAX_COMPOSITE_ESTIMATE_FILES=500
 
+# -----------------------------------------------------------------------------
+# Render Concurrency Gate (#1645)
+# -----------------------------------------------------------------------------
+# MAX_COMPOSITE_MEMORY_BYTES caps ONE render; the gate caps how many renders
+# run at once (composite + mosaic generation). Requests beyond the limit wait
+# briefly, then receive HTTP 429 with a Retry-After header instead of piling
+# up and OOMing the container.
+#
+# MAX_CONCURRENT_RENDERS: 0 (default) = auto-scale with the memory budget:
+#   clamp(container_memory_limit / MAX_COMPOSITE_MEMORY_BYTES, 1, 4),
+#   falling back to 2 when no container limit is detectable. Set N>0 to pin
+#   an exact slot count — keep N x MAX_COMPOSITE_MEMORY_BYTES <= mem_limit.
+#   Note: the sizing invariant models a slot as one composite budget; mosaic
+#   renders share the same slots but are bounded by MAX_MOSAIC_OUTPUT_PIXELS,
+#   so keep that conservative too.
+# RENDER_QUEUE_WAIT_SECONDS: how long a request may wait for a slot before
+#   429 (absorbs short bursts without unbounded queueing).
+# RENDER_RETRY_AFTER_SECONDS: the Retry-After hint sent with 429.
+#
+# Uncomment to override defaults:
+# MAX_CONCURRENT_RENDERS=0
+# RENDER_QUEUE_WAIT_SECONDS=10
+# RENDER_RETRY_AFTER_SECONDS=30
+
 # =============================================================================
 # Storage Configuration
 # =============================================================================

--- a/docs/plans/features/quick/1645-render-semaphore.md
+++ b/docs/plans/features/quick/1645-render-semaphore.md
@@ -1,0 +1,62 @@
+# 1645 — Global render semaphore (bound concurrent composite/mosaic renders)
+
+**Issue:** #1645 · **Risk:** low · **CE deploy blocker** (plan: `docs/plans/features/community-edition-v1.md` Phase 4)
+
+## Problem
+
+Synchronous renders run in-request with no concurrency bound. The #882 memory
+budget (`MAX_COMPOSITE_MEMORY_BYTES` → 413) is per-request; N parallel renders
+× ~budget bytes each OOM the box. Nothing limits render concurrency anywhere
+in the stack.
+
+## Approach
+
+New `app/render_gate.py`: a process-global `threading.BoundedSemaphore` gating
+the heavy render endpoints. Requests that can't get a slot within a bounded
+wait get **429 + Retry-After** instead of piling up.
+
+**Slot count scales with the memory budget**: when `MAX_CONCURRENT_RENDERS` is
+unset/0, slots = `clamp(container_memory_limit / MAX_COMPOSITE_MEMORY_BYTES,
+1, 4)` (cgroup v2/v1 detection; fallback 2 when no limit is readable).
+Explicit `MAX_CONCURRENT_RENDERS=N` overrides. Startup warns when
+`slots × budget > container limit`.
+
+## Changes
+
+- `processing-engine/app/render_gate.py` — new: `RenderGate`, `render_gated`
+  decorator (sync handlers), `get_render_gate()` lazy singleton +
+  `reset_render_gate()` for tests, cgroup limit detection, env parsing via
+  `app.config` helpers (#1383 pattern).
+- `processing-engine/app/composite/routes.py` — gate `/generate-nchannel`
+  (decorator) and the `/generate-nchannel-stream` worker thread (context
+  manager inside `run_pipeline`; existing `except HTTPException` already emits
+  the 429 as an NDJSON error event).
+- `processing-engine/app/mosaic/routes.py` — gate `/generate` and
+  `/generate-observation` (decorator).
+- `processing-engine/main.py` — resolve the gate at import (fail fast on bad
+  env, log the resolved slot count).
+- `docker/.env.example` — document `MAX_CONCURRENT_RENDERS`,
+  `RENDER_QUEUE_WAIT_SECONDS`, `RENDER_RETRY_AFTER_SECONDS` next to the memory
+  sizing table.
+- `processing-engine/tests/test_render_gate.py` — new (red-green).
+
+Unthrottled by design: `/composite/estimate`, `/composite/analyze-channels`,
+`/mosaic/footprint`, thumbnails/previews — cheap, no reproject+combine work.
+
+## Env knobs
+
+| Var | Default | Meaning |
+|---|---|---|
+| `MAX_CONCURRENT_RENDERS` | 0 (auto) | 0/unset = derive from memory; N>0 = exactly N slots; negative = startup error |
+| `RENDER_QUEUE_WAIT_SECONDS` | 10 | Max wait for a slot before 429 |
+| `RENDER_RETRY_AFTER_SECONDS` | 30 | `Retry-After` header value on 429 |
+
+## Test plan
+
+- Unit: slot resolution (explicit, auto from mocked cgroup limit, clamps,
+  fallback, negative → `EnvVarError`); gate acquire/timeout/release; 429
+  carries `Retry-After`.
+- Integration: `/composite/generate-nchannel` and `/mosaic/generate` return
+  429 when the gate is exhausted (deterministic via patched gate + events);
+  render inside the limit unaffected.
+- Full suite: `docker exec jwst-processing python -m pytest`.

--- a/processing-engine/Dockerfile
+++ b/processing-engine/Dockerfile
@@ -39,4 +39,7 @@ USER appuser
 
 EXPOSE 8000
 
+# --workers 1 is load-bearing: the render concurrency gate (app/render_gate.py,
+# #1645) is per-process, so more workers multiply effective render concurrency
+# and can exceed the container memory limit.
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-keep-alive", "600", "--workers", "1"]

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -44,6 +44,7 @@ from app.processing.enhancement import (
     zscale_stretch,
 )
 from app.processing.filters import astropy_gaussian_filter
+from app.render_gate import get_render_gate, render_gated
 from app.storage.helpers import resolve_fits_path
 
 from .auto_stretch import auto_stretch_params
@@ -1550,6 +1551,7 @@ def _run_nchannel_pipeline(
 
 
 @router.post("/generate-nchannel")
+@render_gated
 def generate_nchannel_composite(request: NChannelCompositeRequest):
     """Generate an RGB composite image from N FITS channels with color mapping.
 
@@ -1597,7 +1599,11 @@ async def generate_nchannel_composite_stream(request: NChannelCompositeRequest):
 
     def run_pipeline() -> None:
         try:
-            response = _run_nchannel_pipeline(request, progress=emit)
+            # Acquire the render slot in the worker thread (not the async
+            # route) so slot exhaustion surfaces as a normal NDJSON error
+            # event via the HTTPException handler below.
+            with get_render_gate().slot():
+                response = _run_nchannel_pipeline(request, progress=emit)
             if cancellation.is_set():
                 return
             image_bytes: bytes = bytes(response.body)

--- a/processing-engine/app/mosaic/routes.py
+++ b/processing-engine/app/mosaic/routes.py
@@ -31,6 +31,7 @@ from app.processing.enhancement import (
     sqrt_stretch,
     zscale_stretch,
 )
+from app.render_gate import render_gated
 from app.storage.helpers import (
     MAX_FITS_FILE_SIZE_BYTES,
     resolve_fits_path,
@@ -342,6 +343,7 @@ def apply_stretch(data: np.ndarray, config: MosaicFileConfig) -> np.ndarray:
 
 
 @router.post("/generate")
+@render_gated
 def generate_mosaic_image(request: MosaicRequest):
     """
     Generate a WCS-aware mosaic image from 2+ FITS files.
@@ -635,6 +637,7 @@ def get_mosaic_footprint(request: FootprintRequest):
 
 
 @router.post("/generate-observation")
+@render_gated
 def generate_observation_mosaic(request: ObservationMosaicRequest):
     """Generate an observation-level mosaic from many per-detector FITS files.
 

--- a/processing-engine/app/render_gate.py
+++ b/processing-engine/app/render_gate.py
@@ -1,0 +1,252 @@
+"""Global render concurrency gate (#1645).
+
+The per-request memory budget (#882, ``MAX_COMPOSITE_MEMORY_BYTES`` -> 413)
+caps how big one render can be, but nothing bounds how many renders run at
+once — N parallel synchronous renders can OOM the container regardless of the
+per-request budget. This module provides a process-global semaphore around
+the heavy render endpoints (composite/mosaic generation): requests that cannot
+get a slot within a bounded wait receive **429 + Retry-After** instead of
+piling up.
+
+Configuration:
+
+- ``MAX_CONCURRENT_RENDERS``: 0/unset = auto (see below); N>0 = exactly N
+  slots; negative or non-integer = startup error.
+- Auto mode scales with the memory budget: ``clamp(container_memory_limit /
+  MAX_COMPOSITE_MEMORY_BYTES, 1, 4)``, falling back to 2 slots when no
+  container limit is readable. The sizing invariant covers the *composite*
+  budget; mosaic renders share the same slots but their per-render memory is
+  governed by ``MAX_MOSAIC_OUTPUT_PIXELS`` — keep that conservative, since a
+  slot's "cost" is modeled as one composite budget.
+- ``RENDER_QUEUE_WAIT_SECONDS`` (default 10): how long a request may wait for
+  a slot before giving up with 429.
+- ``RENDER_RETRY_AFTER_SECONDS`` (default 30): the ``Retry-After`` hint sent
+  with the 429.
+
+Slot counts are resolved once at process start (first use); the memory budget
+itself stays live-tunable per #882.
+
+The gate is per *process*: it is only a true global limit because the engine
+runs uvicorn with ``--workers 1`` (see the Dockerfile CMD). Raising the worker
+count multiplies effective render concurrency by the worker count.
+
+Async route handlers must wait via :meth:`RenderGate.acquire_async` (used by
+the :func:`render_gated` decorator) so waiters park on the event loop; the
+blocking :meth:`RenderGate.slot` is for code already running in a worker
+thread (the streaming pipeline).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException
+from starlette.concurrency import run_in_threadpool
+
+from app.config import EnvVarError, float_env, int_env
+
+
+logger = logging.getLogger(__name__)
+
+# Mirrors the composite pipeline's default budget (app/composite/routes.py).
+# Not imported from there to keep this module dependency-free of the routers
+# that decorate their endpoints with it.
+_DEFAULT_MEMORY_BUDGET_BYTES = 3_000_000_000
+
+_AUTO_SLOT_FALLBACK = 2
+_AUTO_SLOT_MAX = 4
+
+# How often an async waiter re-checks the semaphore. Coarse enough to be
+# cheap, fine enough that a freed slot is picked up promptly relative to
+# render durations (tens of seconds).
+_ASYNC_POLL_SECONDS = 0.1
+
+# cgroup v2 then v1; values above this sentinel mean "no limit set".
+_CGROUP_LIMIT_FILES = (
+    "/sys/fs/cgroup/memory.max",
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+)
+_CGROUP_UNLIMITED_SENTINEL = 1 << 60
+
+
+def detect_container_memory_limit_bytes() -> int | None:
+    """Best-effort read of the container's memory limit from cgroups.
+
+    Returns None outside a limited container (bare metal, "max", unreadable).
+    """
+    for candidate in _CGROUP_LIMIT_FILES:
+        try:
+            raw = Path(candidate).read_text().strip()
+        except OSError:
+            continue
+        if raw.isdigit():
+            value = int(raw)
+            if 0 < value < _CGROUP_UNLIMITED_SENTINEL:
+                return value
+    return None
+
+
+def _configured_slot_count() -> int:
+    """Read and validate MAX_CONCURRENT_RENDERS (0 = auto)."""
+    configured = int_env("MAX_CONCURRENT_RENDERS", 0)
+    if configured < 0:
+        raise EnvVarError(
+            f"Environment variable MAX_CONCURRENT_RENDERS={configured} must be >= 0 "
+            "(0 = auto-derive from container memory and MAX_COMPOSITE_MEMORY_BYTES)."
+        )
+    return configured
+
+
+def resolve_slot_count(detected_limit_bytes: int | None, configured: int | None = None) -> int:
+    """Resolve the render slot count from env + detected container memory.
+
+    Explicit ``MAX_CONCURRENT_RENDERS`` > 0 wins. 0/unset derives the count
+    from the composite memory budget so total worst-case render memory stays
+    within the container: ``clamp(limit / budget, 1, 4)``.
+    """
+    if configured is None:
+        configured = _configured_slot_count()
+    if configured > 0:
+        return configured
+
+    if detected_limit_bytes is None:
+        return _AUTO_SLOT_FALLBACK
+
+    budget = int_env("MAX_COMPOSITE_MEMORY_BYTES", _DEFAULT_MEMORY_BUDGET_BYTES)
+    derived = detected_limit_bytes // max(budget, 1)
+    return max(1, min(_AUTO_SLOT_MAX, derived))
+
+
+class RenderGate:
+    """Bounded semaphore that turns render-slot exhaustion into HTTP 429."""
+
+    def __init__(self, slots: int, wait_seconds: float, retry_after_seconds: int):
+        self.slots = slots
+        self.wait_seconds = wait_seconds
+        self.retry_after_seconds = retry_after_seconds
+        self._semaphore = threading.BoundedSemaphore(slots)
+
+    def _busy_exception(self) -> HTTPException:
+        return HTTPException(
+            status_code=429,
+            detail=(
+                "The server is busy rendering other images right now. Please try again in a moment."
+            ),
+            headers={"Retry-After": str(self.retry_after_seconds)},
+        )
+
+    @contextmanager
+    def slot(self) -> Iterator[None]:
+        """Hold a render slot for the duration of the block, or raise 429.
+
+        Blocking — only for code already running in a worker thread (e.g. the
+        streaming pipeline). Async handlers must use :meth:`acquire_async` so
+        the wait does not pin a threadpool thread.
+        """
+        if not self._semaphore.acquire(timeout=self.wait_seconds):
+            raise self._busy_exception()
+        try:
+            yield
+        finally:
+            self._semaphore.release()
+
+    async def acquire_async(self) -> None:
+        """Acquire a slot from the event loop without blocking any thread.
+
+        Polls the semaphore non-blockingly with short async sleeps up to
+        ``wait_seconds``, so waiters cost the event loop a timer instead of
+        occupying a threadpool thread (which would starve cheap endpoints
+        that share the pool). Raises 429 when the wait window elapses.
+        """
+        deadline = time.monotonic() + self.wait_seconds
+        while True:
+            if self._semaphore.acquire(blocking=False):
+                return
+            if time.monotonic() >= deadline:
+                raise self._busy_exception()
+            await asyncio.sleep(_ASYNC_POLL_SECONDS)
+
+    def release(self) -> None:
+        self._semaphore.release()
+
+
+_gate: RenderGate | None = None
+_gate_lock = threading.Lock()
+
+
+def get_render_gate() -> RenderGate:
+    """Return the process-global gate, resolving configuration on first use."""
+    global _gate
+    if _gate is None:
+        with _gate_lock:
+            if _gate is None:
+                detected = detect_container_memory_limit_bytes()
+                configured = _configured_slot_count()
+                slots = resolve_slot_count(detected, configured)
+                gate = RenderGate(
+                    slots=slots,
+                    wait_seconds=float_env("RENDER_QUEUE_WAIT_SECONDS", 10.0),
+                    retry_after_seconds=int_env("RENDER_RETRY_AFTER_SECONDS", 30),
+                )
+                budget = int_env("MAX_COMPOSITE_MEMORY_BYTES", _DEFAULT_MEMORY_BUDGET_BYTES)
+                if detected is not None and slots * budget > detected:
+                    logger.warning(
+                        "Render gate: %d slots x %d-byte composite budget exceeds the "
+                        "container memory limit (%d bytes) — concurrent worst-case "
+                        "renders can OOM. Lower MAX_CONCURRENT_RENDERS or "
+                        "MAX_COMPOSITE_MEMORY_BYTES.",
+                        slots,
+                        budget,
+                        detected,
+                    )
+                logger.info(
+                    "Render gate ready: %d slot(s) (%s), queue wait %.1fs, Retry-After %ds",
+                    slots,
+                    "explicit MAX_CONCURRENT_RENDERS"
+                    if configured > 0
+                    else "auto from memory budget",
+                    gate.wait_seconds,
+                    gate.retry_after_seconds,
+                )
+                _gate = gate
+                return gate
+    return _gate
+
+
+def reset_render_gate() -> None:
+    """Drop the cached gate so the next use re-reads the environment (tests)."""
+    global _gate
+    with _gate_lock:
+        _gate = None
+
+
+def render_gated(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Gate a synchronous route handler behind a render slot.
+
+    The wrapper is async: it waits for a slot on the event loop (no threadpool
+    thread is pinned while queueing), then runs the sync handler body in the
+    threadpool exactly as Starlette would have.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        gate = get_render_gate()
+        await gate.acquire_async()
+        try:
+            # run_in_threadpool uses anyio's non-abandoning to_thread.run_sync:
+            # even if this task is cancelled, the await does not resume until
+            # the sync render thread completes, so the release below cannot
+            # free a slot while its render is still consuming memory.
+            return await run_in_threadpool(func, *args, **kwargs)
+        finally:
+            gate.release()
+
+    return wrapper

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -33,6 +33,7 @@ from app.processing.enhancement import (
 )
 from app.processing.filters import reduce_noise
 from app.processing.statistics import compute_histogram, compute_percentiles
+from app.render_gate import get_render_gate
 from app.semantic.routes import router as semantic_router
 from app.storage.helpers import resolve_fits_path
 
@@ -98,6 +99,11 @@ app.include_router(semantic_router)
 app.include_router(auth_router)
 app.include_router(library_router)
 app.include_router(jobs_router)
+
+# Resolve the render concurrency gate now rather than on the first render:
+# malformed env (MAX_CONCURRENT_RENDERS etc.) fails startup with a clear
+# message, and the effective slot count is logged for operators (#1645).
+get_render_gate()
 
 
 class ThumbnailRequest(BaseModel):

--- a/processing-engine/tests/test_render_gate.py
+++ b/processing-engine/tests/test_render_gate.py
@@ -1,0 +1,299 @@
+"""Tests for the global render concurrency gate (#1645).
+
+The gate bounds concurrent heavy renders (composite/mosaic generation) so N
+parallel requests cannot OOM the box — the per-request memory budget (#882)
+caps one render, the gate caps how many run at once.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+from fastapi import HTTPException
+
+from app.config import EnvVarError
+from app.render_gate import (
+    RenderGate,
+    get_render_gate,
+    render_gated,
+    reset_render_gate,
+    resolve_slot_count,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_gate_env(monkeypatch):
+    """Isolate each test from ambient env and the module singleton."""
+    for var in (
+        "MAX_CONCURRENT_RENDERS",
+        "RENDER_QUEUE_WAIT_SECONDS",
+        "RENDER_RETRY_AFTER_SECONDS",
+        "MAX_COMPOSITE_MEMORY_BYTES",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    reset_render_gate()
+    yield
+    reset_render_gate()
+
+
+# ---------------------------------------------------------------------------
+# Slot resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSlotCount:
+    def test_explicit_env_wins(self, monkeypatch):
+        monkeypatch.setenv("MAX_CONCURRENT_RENDERS", "3")
+        assert resolve_slot_count(detected_limit_bytes=32_000_000_000) == 3
+
+    def test_auto_derives_from_memory_limit_over_budget(self, monkeypatch):
+        # 8 GB container / 3 GB budget -> 2 slots
+        monkeypatch.setenv("MAX_COMPOSITE_MEMORY_BYTES", "3000000000")
+        assert resolve_slot_count(detected_limit_bytes=8_000_000_000) == 2
+
+    def test_auto_clamps_to_max_four(self, monkeypatch):
+        monkeypatch.setenv("MAX_COMPOSITE_MEMORY_BYTES", "1500000000")
+        assert resolve_slot_count(detected_limit_bytes=64_000_000_000) == 4
+
+    def test_auto_clamps_to_min_one(self, monkeypatch):
+        # Budget larger than the container limit still yields one slot.
+        monkeypatch.setenv("MAX_COMPOSITE_MEMORY_BYTES", "3000000000")
+        assert resolve_slot_count(detected_limit_bytes=2_000_000_000) == 1
+
+    def test_auto_without_detectable_limit_falls_back_to_two(self):
+        assert resolve_slot_count(detected_limit_bytes=None) == 2
+
+    def test_zero_env_means_auto(self, monkeypatch):
+        monkeypatch.setenv("MAX_CONCURRENT_RENDERS", "0")
+        monkeypatch.setenv("MAX_COMPOSITE_MEMORY_BYTES", "3000000000")
+        assert resolve_slot_count(detected_limit_bytes=8_000_000_000) == 2
+
+    def test_negative_env_is_a_startup_error(self, monkeypatch):
+        monkeypatch.setenv("MAX_CONCURRENT_RENDERS", "-1")
+        with pytest.raises(EnvVarError):
+            resolve_slot_count(detected_limit_bytes=None)
+
+    def test_non_integer_env_is_a_startup_error(self, monkeypatch):
+        monkeypatch.setenv("MAX_CONCURRENT_RENDERS", "many")
+        with pytest.raises(EnvVarError):
+            resolve_slot_count(detected_limit_bytes=None)
+
+
+# ---------------------------------------------------------------------------
+# Gate behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRenderGate:
+    def test_render_runs_inside_slot(self):
+        gate = RenderGate(slots=1, wait_seconds=0.05, retry_after_seconds=7)
+        with gate.slot():
+            pass  # acquired and released without error
+
+    def test_second_render_gets_429_when_full(self):
+        gate = RenderGate(slots=1, wait_seconds=0.05, retry_after_seconds=7)
+        holding = threading.Event()
+        release = threading.Event()
+
+        def hold_slot():
+            with gate.slot():
+                holding.set()
+                release.wait(timeout=5)
+
+        worker = threading.Thread(target=hold_slot)
+        worker.start()
+        try:
+            assert holding.wait(timeout=5)
+            with pytest.raises(HTTPException) as excinfo, gate.slot():
+                pass
+            assert excinfo.value.status_code == 429
+            assert excinfo.value.headers["Retry-After"] == "7"
+        finally:
+            release.set()
+            worker.join(timeout=5)
+
+    def test_slot_freed_after_release(self):
+        gate = RenderGate(slots=1, wait_seconds=0.05, retry_after_seconds=7)
+        with gate.slot():
+            pass
+        with gate.slot():
+            pass  # no 429 — the slot was released
+
+    def test_slot_freed_when_render_raises(self):
+        gate = RenderGate(slots=1, wait_seconds=0.05, retry_after_seconds=7)
+        with pytest.raises(RuntimeError), gate.slot():
+            raise RuntimeError("render blew up")
+        with gate.slot():
+            pass  # slot not leaked by the failure
+
+    def test_acquire_async_succeeds_when_slot_free(self):
+        gate = RenderGate(slots=1, wait_seconds=0.05, retry_after_seconds=7)
+        asyncio.run(gate.acquire_async())
+        gate.release()
+        # Released slot is reusable.
+        asyncio.run(gate.acquire_async())
+        gate.release()
+
+    def test_acquire_async_raises_429_when_full(self):
+        gate = RenderGate(slots=1, wait_seconds=0.05, retry_after_seconds=7)
+        gate._semaphore.acquire()  # consume the only slot
+        with pytest.raises(HTTPException) as excinfo:
+            asyncio.run(gate.acquire_async())
+        assert excinfo.value.status_code == 429
+        assert excinfo.value.headers["Retry-After"] == "7"
+
+    def test_acquire_async_gets_slot_freed_within_window(self):
+        gate = RenderGate(slots=1, wait_seconds=5, retry_after_seconds=7)
+        gate._semaphore.acquire()
+
+        async def free_then_acquire():
+            loop = asyncio.get_running_loop()
+            loop.call_later(0.15, gate.release)
+            await gate.acquire_async()  # must pick up the freed slot, not 429
+
+        asyncio.run(free_then_acquire())
+        gate.release()
+
+    def test_waiter_acquires_when_slot_frees_within_window(self):
+        gate = RenderGate(slots=1, wait_seconds=5, retry_after_seconds=7)
+        holding = threading.Event()
+
+        def hold_briefly():
+            with gate.slot():
+                holding.set()
+                time.sleep(0.1)
+
+        worker = threading.Thread(target=hold_briefly)
+        worker.start()
+        try:
+            assert holding.wait(timeout=5)
+            with gate.slot():
+                pass  # waited out the holder instead of 429ing
+        finally:
+            worker.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# render_gated decorator — slot accounting around the wrapped handler
+# ---------------------------------------------------------------------------
+
+
+class TestRenderGatedDecorator:
+    def _install_gate(self, monkeypatch) -> RenderGate:
+        import app.render_gate as render_gate_module
+
+        gate = RenderGate(slots=1, wait_seconds=0.05, retry_after_seconds=7)
+        monkeypatch.setattr(render_gate_module, "_gate", gate)
+        return gate
+
+    def test_success_runs_handler_and_releases_slot(self, monkeypatch):
+        gate = self._install_gate(monkeypatch)
+
+        @render_gated
+        def handler(value: int) -> int:
+            return value + 1
+
+        assert asyncio.run(handler(1)) == 2
+        # Slot was released: it can be acquired again without waiting.
+        asyncio.run(gate.acquire_async())
+        gate.release()
+
+    def test_handler_exception_still_releases_slot(self, monkeypatch):
+        gate = self._install_gate(monkeypatch)
+
+        @render_gated
+        def handler() -> None:
+            raise RuntimeError("render blew up")
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(handler())
+        asyncio.run(gate.acquire_async())
+        gate.release()
+
+    def test_raises_429_without_running_handler_when_busy(self, monkeypatch):
+        gate = self._install_gate(monkeypatch)
+        gate._semaphore.acquire()  # exhaust the only slot
+        ran = False
+
+        @render_gated
+        def handler() -> None:
+            nonlocal ran
+            ran = True
+
+        with pytest.raises(HTTPException) as excinfo:
+            asyncio.run(handler())
+        assert excinfo.value.status_code == 429
+        assert ran is False
+
+
+# ---------------------------------------------------------------------------
+# Singleton + env wiring
+# ---------------------------------------------------------------------------
+
+
+class TestGateSingleton:
+    def test_get_render_gate_reads_env(self, monkeypatch):
+        monkeypatch.setenv("MAX_CONCURRENT_RENDERS", "1")
+        monkeypatch.setenv("RENDER_QUEUE_WAIT_SECONDS", "0.05")
+        monkeypatch.setenv("RENDER_RETRY_AFTER_SECONDS", "11")
+        reset_render_gate()
+        gate = get_render_gate()
+        assert gate.slots == 1
+        assert gate.retry_after_seconds == 11
+        assert get_render_gate() is gate  # cached singleton
+
+
+# ---------------------------------------------------------------------------
+# Endpoint integration — gated routes return 429 when the gate is exhausted
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _exhausted_gate():
+    gate = RenderGate(slots=1, wait_seconds=0.05, retry_after_seconds=7)
+    gate._semaphore.acquire()  # deterministically consume the only slot
+    return gate
+
+
+class TestEndpointIntegration:
+    def test_generate_nchannel_returns_429_when_busy(self, monkeypatch, client):
+        import app.render_gate as render_gate_module
+
+        monkeypatch.setattr(render_gate_module, "_gate", _exhausted_gate())
+        response = client.post(
+            "/composite/generate-nchannel",
+            json={"channels": [{"file_paths": ["nonexistent.fits"], "color": {"hue": 0}}]},
+        )
+        assert response.status_code == 429
+        assert response.headers.get("Retry-After") == "7"
+
+    def test_mosaic_generate_returns_429_when_busy(self, monkeypatch, client):
+        import app.render_gate as render_gate_module
+
+        monkeypatch.setattr(render_gate_module, "_gate", _exhausted_gate())
+        response = client.post(
+            "/mosaic/generate",
+            json={"files": [{"file_path": "a.fits"}, {"file_path": "b.fits"}]},
+        )
+        assert response.status_code == 429
+
+    def test_estimate_stays_unthrottled(self, monkeypatch, client):
+        import app.render_gate as render_gate_module
+
+        monkeypatch.setattr(render_gate_module, "_gate", _exhausted_gate())
+        response = client.post(
+            "/composite/estimate",
+            json={"channels": [{"file_paths": ["nonexistent.fits"], "color": {"hue": 0}}]},
+        )
+        # Not 429: the pre-flight estimate must stay cheap and available even
+        # while renders are saturated (it may 4xx for other reasons here).
+        assert response.status_code != 429


### PR DESCRIPTION
## Summary

Adds a **global render concurrency gate** to the processing engine. The per-request memory budget (#882, `MAX_COMPOSITE_MEMORY_BYTES` → HTTP 413) caps how big one render can be, but nothing bounded how many renders run at once — N parallel synchronous renders could OOM the container regardless of the budget. This is a CE deploy blocker (`docs/plans/features/community-edition-v1.md` Phase 4): a public no-auth instance whose core feature is "burn CPU+RAM for 30–120s per click" needs a concurrency bound before it can face the internet.

**Design highlights:**

- **Slot count scales with the memory budget** (answering the sizing question directly): with `MAX_CONCURRENT_RENDERS=0`/unset, slots = `clamp(container_memory_limit / MAX_COMPOSITE_MEMORY_BYTES, 1, 4)` via cgroup v2/v1 detection, falling back to 2 when no limit is readable. Explicit `MAX_CONCURRENT_RENDERS=N` overrides. Startup warns when `slots × budget > container limit`. Verified live: a 4 GB container with the default 3 GB budget resolves to 1 slot.
- **Bounded wait, then 429 + `Retry-After`** (`RENDER_QUEUE_WAIT_SECONDS`, default 10s; `RENDER_RETRY_AFTER_SECONDS`, default 30s) — short bursts absorb, sustained overload sheds load instead of queueing unboundedly.
- **Async acquisition** — waiters park on the event loop, not on threadpool threads, so saturated renders cannot starve the cheap endpoints (`/composite/estimate`, `/composite/analyze-channels`, `/mosaic/footprint`) that share Starlette's pool. (Round-1 self-review caught the naive blocking version doing exactly that.)
- Gated: `POST /composite/generate-nchannel`, `/composite/generate-nchannel-stream` (slot acquired in its worker thread; exhaustion surfaces as the existing NDJSON error event with status 429), `/mosaic/generate`, `/mosaic/generate-observation`. Deliberately unthrottled: estimate/analyze/footprint/thumbnails.

## Changes Made

- `processing-engine/app/render_gate.py` — new: `RenderGate` (threading.BoundedSemaphore + async poll acquisition), slot resolution with cgroup memory detection, lazy singleton, `render_gated` decorator, env parsing via the #1383 `app.config` helpers.
- `processing-engine/app/composite/routes.py` — gate the sync generate endpoint (decorator) and the streaming pipeline worker (context manager).
- `processing-engine/app/mosaic/routes.py` — gate both mosaic generate endpoints.
- `processing-engine/main.py` — resolve the gate at import: malformed env fails startup with a clear message; effective slot count logged for operators.
- `processing-engine/Dockerfile` — comment marking `--workers 1` as load-bearing (the gate is per-process).
- `docker/.env.example` — document the three knobs next to the memory sizing table, including the mosaic-budget caveat (`MAX_MOSAIC_OUTPUT_PIXELS` governs mosaic slot cost).
- `processing-engine/tests/test_render_gate.py` — 23 tests: slot resolution (explicit/auto/clamps/fallback/invalid env), sync + async gate behavior (429, Retry-After, release-on-exception, waiter-acquires-freed-slot), decorator slot accounting, endpoint integration (429 through the real app, estimate stays unthrottled).
- `docs/plans/features/quick/1645-render-semaphore.md` — plan file.

## Test Plan

- [x] Red-green TDD: tests written first, implementation second
- [x] Full engine suite in container: **1449 passed** (`docker run … docker-processing-engine python -m pytest`)
- [x] Ruff lint + format clean
- [x] Live startup smoke: engine booted in a 4 GB-limited container logs `Render gate ready: 1 slot(s) (auto from memory budget), queue wait 10.0s, Retry-After 30s`
- [x] Two code-reviewer rounds; all MUST/SHOULD FIX findings addressed (round 1: threadpool starvation → async acquisition; round 2: decorator release-path test gap → covered, cancellation semantics pinned via anyio non-abandoning `run_in_threadpool`)
- [ ] Reviewer: sanity-check the auto-derivation policy (clamp ceiling of 4, fallback of 2) against intended CE VPS sizing

## Documentation Checklist

- [x] Env knobs documented in `docker/.env.example`
- [x] Plan file in `docs/plans/features/quick/`
- [x] No new endpoints/controllers/services — no API doc updates needed
- [x] Dockerfile comment documents the single-worker assumption

## Tech Debt Impact

- [x] No new tech debt introduced
- [x] Removes a known gap called out in the CE plan risk register (sync-render DoS)
- [ ] Known limitation (documented, accepted): the gate is per-process; multi-worker deployments would multiply effective concurrency (comment at the Dockerfile CMD)

## Risk & Rollback

- **Risk:** Low. Behavior is unchanged until slots are exhausted; the failure mode changes from "container OOM" to "429 with Retry-After". Frontend impact: the anonymous sync composite path can now receive 429 — surfaced as a normal request error (same handling as existing 4xx); a friendlier busy-state UI is a possible follow-up.
- **Rollback:** revert the single commit; no config/data migrations.

Closes #1645

https://claude.ai/code/session_014zTGLv97yrDz1fscqsBspS
