### PR TITLE
docs: catch up drift from #1520, #1521, #1619

### DIFF
--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -105,6 +105,7 @@ Quick reference for finding important files in the codebase.
 ## Core Frontend Components
 
 - `frontend/jwst-frontend/src/App.tsx` - Root component with routing
+- `frontend/jwst-frontend/src/components/ErrorBoundary.tsx` - Top-level React error boundary (wraps the app in index.tsx, shows reload fallback UI)
 - `frontend/jwst-frontend/src/components/layout/SharedLayout.tsx` - Persistent header + nav layout shell
 - `frontend/jwst-frontend/src/components/layout/MastStatusPill.tsx` - Header pill showing live /api/health status
 - `frontend/jwst-frontend/src/components/layout/ImportProgressPill.tsx` - Header pill showing aggregate MAST import progress (survives navigation, links to `/archive`)

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -85,6 +85,7 @@ Common patterns, API endpoints, troubleshooting, and MAST usage tips.
   - Luminance channel: at most one; blends detail via HSL into the combined color channels (LRGB technique). `weight` controls blend strength (0–1).
   - Optional: `label` (filter name), `wavelength_um` (for metadata)
   - Optional global params: `overall.stretch`, `overall.blackPoint`, `overall.whitePoint`, `overall.gamma`, `overall.asinhA`
+  - Response header `X-Composite-Stretch-Fallbacks`: emitted when a requested stretch failed and fell back to zscale, per channel (e.g. `F444W:asinh->zscale`); lets callers surface "requested asinh, served zscale" (#1394)
 - **Mosaic**:
   - `POST /mosaic/generate` - WCS-aware mosaic from 2+ FITS files (output: png/jpeg/fits)
     - FITS output includes provenance cards in the primary header and a `SRCMETA` extension with source header metadata

--- a/docs/standards/frontend-development.md
+++ b/docs/standards/frontend-development.md
@@ -11,8 +11,9 @@
 
 - Main app: [frontend/jwst-frontend/src/App.tsx](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/App.tsx)
 - Components:
+  - [ErrorBoundary.tsx](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/ErrorBoundary.tsx) - Top-level React error boundary wrapping the app in `index.tsx`; renders a reload fallback on uncaught render errors
   - [JwstDataDashboard.tsx](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx) - Main dashboard with grid, list, grouped, and lineage views
-  - [MastSearch.tsx](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/MastSearch.tsx) - MAST portal search interface with progress tracking
+  - [MastSearch.tsx](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/mast/MastSearch.tsx) - MAST portal search orchestrator on the public `/archive` page (progress tracking, import job wiring)
   - [ImageViewer.tsx](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/ImageViewer.tsx) - FITS image viewer with color maps, stretch controls, and PNG export
 - Types:
   - [JwstDataTypes.ts](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/types/JwstDataTypes.ts) - Core data types, lineage types, processing levels
@@ -29,7 +30,7 @@
 - Styles:
   - [App.css](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/App.css) - Global styles
   - [JwstDataDashboard.css](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/JwstDataDashboard.css) - Dashboard and lineage view styles
-  - [MastSearch.css](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/MastSearch.css) - MAST search and progress styles
+  - [MastSearch.css](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/mast/MastSearch.css) - MAST search and progress styles
   - [FitsViewer.css](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/FitsViewer.css) - FITS viewer styles
   - [ImageViewer.css](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/src/components/ImageViewer.css) - Image viewer modal styles
 - Package config: [frontend/jwst-frontend/package.json](https://github.com/Snoww3d/jwst-data-analysis/blob/main/frontend/jwst-frontend/package.json)


### PR DESCRIPTION
## Summary

Documentation drift catch-up flagged by the doc-drift hook (score was 10/15). Three merged PRs shipped without their doc updates; this PR closes those gaps. Docs-only — no code changes.

No linked issue — drift catch-up across already-closed PRs (#1520, #1521, #1619).

## Changes Made

- **`docs/key-files.md`** — added `ErrorBoundary.tsx` to Core Frontend Components (introduced in #1521 via #1366, never listed).
- **`docs/standards/frontend-development.md`** —
  - added `ErrorBoundary.tsx` to the Key Files component list;
  - fixed `MastSearch.tsx` and `MastSearch.css` GitHub links to the `components/mast/` path they moved to in #1619, and updated the description to reflect the public `/archive` page.
- **`docs/quick-reference.md`** — documented the `X-Composite-Stretch-Fallbacks` response header added in #1520 (closes the doc gap from #1394's fix; header reports per-channel stretch fallbacks like `F444W:asinh->zscale`).

Not changed: `docs/audits/2026-03-08-codebase-review.md` also references the old MastSearch path, but audit docs are dated historical snapshots.

## Test Plan

- [x] `grep -rn 'components/MastSearch' docs/` — only the historical audit snapshot remains; both live-doc links now point to `components/mast/`
- [x] `grep -rln 'ErrorBoundary' docs/standards/ docs/key-files.md` — now present in both key-file lists
- [x] Verified header name against source: `processing-engine/app/composite/routes.py` emits `X-Composite-Stretch-Fallbacks` (commit 3ee7cde)
- [x] Pre-commit documentation consistency check passed

## Documentation Checklist

- [x] This PR is itself the documentation update
- [x] `docs/key-files.md` updated
- [x] `docs/standards/frontend-development.md` updated
- [x] `docs/quick-reference.md` updated

## Tech Debt Impact

- [x] No new tech debt introduced
- [x] Reduces existing debt (clears accumulated doc drift from #1520, #1521, #1619)

## Risk & Rollback

- **Risk**: None — docs-only, no code or config touched. CI takes the docs fast path.
- **Rollback**: revert the single commit.
