### PR TITLE
feat: CE Phase 2 read-slice — /api facade, db read layer, CE_MODE deny-by-default

### DIFF
--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -196,6 +196,13 @@ Quick reference for finding important files in the codebase.
 - `processing-engine/main.py` - FastAPI application entry point (image processing: composites, mosaics, analysis)
 - `processing-engine/main_mast.py` - FastAPI entry point for MAST proxy service (search, download)
 - `processing-engine/app/exceptions.py` - Custom exception hierarchy and error handler middleware
+- `processing-engine/app/db/client.py` - Lazy motor (MongoDB) client for the single-backend migration (ADR 0001)
+- `processing-engine/app/db/repository.py` - Read-only jwst_data repository (anonymous/IsPublic semantics)
+- `processing-engine/app/db/projection.py` - Mongo doc -> camelCase DataResponse projection (.NET MapToDataResponse parity)
+- `processing-engine/app/db/casing.py` - PascalCase/camelCase/snake_case wire-contract converters
+- `processing-engine/app/library/routes.py` - CE read endpoints: /api/jwstdata list, thumbnail, check-availability
+- `processing-engine/app/discovery/api_routes.py` - CE /api/discovery facade: featured targets, camelCase suggest-recipes
+- `processing-engine/app/discovery/featured_targets.json` - Featured targets config (engine copy; .NET Configuration copy is canonical until gateway retires)
 - `processing-engine/Dockerfile` - Main processing engine Docker image
 - `processing-engine/Dockerfile.mast` - Lightweight Docker image for MAST proxy service
 - `processing-engine/app/mast/mast_service.py` - MAST API wrapper (astroquery)

--- a/processing-engine/app/db/casing.py
+++ b/processing-engine/app/db/casing.py
@@ -1,0 +1,86 @@
+"""Key-casing converters for the CE /api facade.
+
+The wire contract is pinned by the Phase 1 golden fixtures
+(tests/contract/fixtures/): Mongo documents are PascalCase (.NET-written),
+the frontend wire is camelCase (System.Text.Json CamelCase policy), and the
+recipe engine speaks snake_case. Dict subtrees keyed by DATA (Metadata mast_*
+keys, colorMapping filter names) must never be case-mangled — Metadata is
+skipped by name, and snake_to_camel only rewrites keys containing an
+underscore.
+"""
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+
+_CAMEL_BOUNDARY = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def pascal_to_camel(key: str) -> str:
+    """PascalCase -> camelCase, matching System.Text.Json: a LEADING RUN of
+    capitals is lowercased as a unit (WCS -> wcs, WCSInfo -> wcsInfo)."""
+    if not key or key[0].islower():
+        return key
+    run = 1
+    while run < len(key) and key[run].isupper():
+        run += 1
+    # If the run is followed by a lowercase letter, the last capital starts
+    # the next word and stays (WCSInfo -> wcs + Info).
+    if run < len(key) and run > 1:
+        run -= 1
+    return key[:run].lower() + key[run:]
+
+
+def snake_to_camel(key: str) -> str:
+    """snake_case -> camelCase. Keys without underscores pass through
+    verbatim so data-keyed dicts (filter names like F444W) are untouched."""
+    if "_" not in key:
+        return key
+    head, *rest = key.split("_")
+    return head + "".join(part.title() for part in rest)
+
+
+def camel_to_snake(key: str) -> str:
+    return _CAMEL_BOUNDARY.sub("_", key).lower()
+
+
+def _iso_z(dt: datetime) -> str:
+    """Serialize like System.Text.Json: ISO-8601 UTC with the fractional part
+    trailing-zero-trimmed and omitted entirely when zero (verified against the
+    live .NET API, which emits .9Z/.99Z/.999Z variants). Mongo datetimes are
+    naive UTC."""
+    if dt.tzinfo is not None:  # motor default is naive UTC; normalize if not
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    base = dt.isoformat(timespec="microseconds")
+    head, frac = base.split(".")
+    frac = frac.rstrip("0")
+    return head + (f".{frac}" if frac else "") + "Z"
+
+
+def _walk(obj: Any, key_fn, verbatim_keys: set[str]) -> Any:
+    if isinstance(obj, datetime):
+        return _iso_z(obj)
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            if k in verbatim_keys:
+                out[key_fn(k)] = v  # rename the container key, keep subtree
+            else:
+                out[key_fn(k)] = _walk(v, key_fn, verbatim_keys)
+        return out
+    if isinstance(obj, list):
+        return [_walk(v, key_fn, verbatim_keys) for v in obj]
+    return obj
+
+
+def pascal_to_camel_keys(obj: Any, verbatim_keys: set[str] | frozenset[str] = frozenset()) -> Any:
+    return _walk(obj, pascal_to_camel, set(verbatim_keys))
+
+
+def snake_to_camel_keys(obj: Any) -> Any:
+    return _walk(obj, snake_to_camel, set())
+
+
+def camel_to_snake_keys(obj: Any) -> Any:
+    return _walk(obj, camel_to_snake, set())

--- a/processing-engine/app/db/client.py
+++ b/processing-engine/app/db/client.py
@@ -1,0 +1,40 @@
+"""Lazy motor client for the single-backend migration (ADR 0001 Phase 2).
+
+CE runs with read-only Mongo credentials; the URI comes from the environment.
+Fail-fast validation of these settings is tracked in #1653.
+"""
+
+import os
+
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
+
+
+_client: AsyncIOMotorClient | None = None
+
+DEFAULT_DATABASE = "jwst_data_analysis"
+
+
+class MongoNotConfiguredError(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__(
+            "MONGODB_URI is not set. The CE read layer requires a MongoDB "
+            "connection string (read-only credentials are sufficient)."
+        )
+
+
+def get_database() -> AsyncIOMotorDatabase:
+    global _client
+    uri = os.environ.get("MONGODB_URI")
+    if not uri:
+        raise MongoNotConfiguredError()
+    if _client is None:
+        _client = AsyncIOMotorClient(uri, serverSelectionTimeoutMS=5000)
+    return _client[os.environ.get("MONGODB_DATABASE", DEFAULT_DATABASE)]
+
+
+def reset_client() -> None:
+    """Drop the cached client (tests / URI rotation)."""
+    global _client
+    if _client is not None:
+        _client.close()
+    _client = None

--- a/processing-engine/app/db/deps.py
+++ b/processing-engine/app/db/deps.py
@@ -1,0 +1,21 @@
+"""FastAPI dependencies for the CE read layer (overridable in tests)."""
+
+from collections.abc import Callable
+
+from app.db.client import get_database
+from app.db.repository import JwstDataReadRepository
+
+
+def get_repository() -> JwstDataReadRepository:
+    return JwstDataReadRepository(get_database()["jwst_data"])
+
+
+def get_file_exists() -> Callable[[str], bool]:
+    """Existence check for a relative storage key (check-availability).
+
+    Imported lazily so unit tests never touch the storage factory.
+    """
+    from app.storage.factory import get_storage_provider
+
+    provider = get_storage_provider()
+    return provider.exists

--- a/processing-engine/app/db/projection.py
+++ b/processing-engine/app/db/projection.py
@@ -1,0 +1,97 @@
+"""Mongo document -> wire DTO projections (parity with .NET MapToDataResponse,
+JwstDataController.cs:2322). The golden fixture get_jwstdata_list.json pins
+the exact key set."""
+
+from typing import Any
+
+from app.db.casing import pascal_to_camel_keys
+
+
+# PascalCase source fields copied through 1:1 (then camelized). Order matches
+# the .NET DTO for reviewer diffing; JSON key order is not part of the contract.
+_COPIED_FIELDS = [
+    "FileName",
+    "DataType",
+    "UploadDate",
+    "Description",
+    "Metadata",
+    "FileSize",
+    "ProcessingStatus",
+    "Tags",
+    "UserId",
+    "IsPublic",
+    "Version",
+    "FileFormat",
+    "IsValidated",
+    "LastAccessed",
+    "IsArchived",
+    "ArchivedDate",
+    "ImageInfo",
+    "SensorInfo",
+    "SpectralInfo",
+    "CalibrationInfo",
+    "ProcessingLevel",
+    "ObservationBaseId",
+    "ExposureId",
+    "ParentId",
+    "DerivedFrom",
+    "IsViewable",
+    "SharedWith",
+]
+
+_LIST_DEFAULTS = {"Tags", "SharedWith", "DerivedFrom"}
+
+# .NET Dictionary<string,...> fields serialize with DictionaryKeyPolicy=null —
+# keys pass through AS STORED (only POCO property names camelize). These are
+# the data-keyed dict fields in the JwstDataModel graph; their subtrees must
+# not be case-mangled (e.g. WCS keys are FITS keywords like CRPIX1).
+_VERBATIM_SUBTREES = {
+    "Metadata",
+    "WCS",
+    "Statistics",
+    "InstrumentSettings",
+    "NoiseCharacteristics",
+    "LineMeasurements",
+    "CalibrationParameters",
+    "Properties",
+}
+
+
+def _unwrap_bson_discriminators(obj: Any) -> Any:
+    """Unwrap .NET BSON type discriminators: object-typed fields serialize as
+    {"_t": "System.Collections...", "_v": <value>} and the .NET deserializer
+    unwraps them invisibly. Found empirically on mosaic-generator Metadata
+    (source_ids) during the live .NET-vs-Python list diff."""
+    if isinstance(obj, dict):
+        if set(obj.keys()) == {"_t", "_v"}:
+            return _unwrap_bson_discriminators(obj["_v"])
+        return {k: _unwrap_bson_discriminators(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_unwrap_bson_discriminators(v) for v in obj]
+    return obj
+
+
+def to_data_response(doc: dict) -> dict[str, Any]:
+    """Project a raw jwst_data document to the camelCase DataResponse shape.
+
+    Notable semantics from the .NET mapper:
+    - thumbnail bytes are NEVER inlined; only hasThumbnail is derived
+    - processingResultsCount / lastProcessed are computed from ProcessingResults
+    - Metadata subtree passes through verbatim (mast_* keys)
+    """
+    src: dict[str, Any] = {}
+    for field in _COPIED_FIELDS:
+        default: Any = [] if field in _LIST_DEFAULTS else None
+        src[field] = doc.get(field, default)
+    if src["Metadata"] is None:
+        src["Metadata"] = {}
+
+    results = doc.get("ProcessingResults") or []
+    processed_dates = [r.get("ProcessedDate") for r in results if r.get("ProcessedDate")]
+    src["ProcessingResultsCount"] = len(results)
+    src["LastProcessed"] = max(processed_dates) if processed_dates else None
+    src["HasThumbnail"] = doc.get("ThumbnailData") is not None
+
+    out = pascal_to_camel_keys(_unwrap_bson_discriminators(src), verbatim_keys=_VERBATIM_SUBTREES)
+    out["id"] = str(doc["_id"])
+    return out

--- a/processing-engine/app/db/repository.py
+++ b/processing-engine/app/db/repository.py
@@ -1,0 +1,47 @@
+"""Read-only repository over the .NET-era ``jwst_data`` collection.
+
+Documents are PascalCase (no BsonElement attrs, no convention pack — Phase 1
+spike). Anonymous/CE visibility is IsPublic only, mirroring the .NET
+FilterAccessibleData anonymous branch; every accessor here enforces it, so a
+route cannot forget the filter.
+"""
+
+from bson import ObjectId
+from bson.errors import InvalidId
+
+
+class JwstDataReadRepository:
+    def __init__(self, collection) -> None:
+        self._col = collection
+
+    async def get_public_list(self, *, include_archived: bool) -> list[dict]:
+        docs = [d async for d in self._col.find({"IsPublic": True})]
+        if not include_archived:
+            docs = [d for d in docs if not d.get("IsArchived")]
+        return docs
+
+    async def get_public_by_id(self, data_id: str) -> dict | None:
+        try:
+            oid = ObjectId(data_id)
+        except (InvalidId, TypeError):
+            return None
+        return await self._col.find_one({"_id": oid, "IsPublic": True})
+
+    async def get_public_thumbnail(self, data_id: str) -> bytes | None:
+        doc = await self.get_public_by_id(data_id)
+        if doc is None:
+            return None
+        thumb = doc.get("ThumbnailData")
+        return bytes(thumb) if thumb is not None else None
+
+    async def get_public_by_observation_base_id(self, obs_id: str) -> list[dict]:
+        """ObservationBaseId lookup with the .NET mast_obs_id fallback.
+
+        Mirrors MongoDBService.cs:609 exactly: the fallback fires only when
+        the UNFILTERED base-id query is empty; the anonymous IsPublic filter
+        is applied afterwards (FilterAccessibleData order).
+        """
+        docs = [d async for d in self._col.find({"ObservationBaseId": obs_id})]
+        if not docs:
+            docs = [d async for d in self._col.find({"Metadata.mast_obs_id": obs_id})]
+        return [d for d in docs if d.get("IsPublic")]

--- a/processing-engine/app/discovery/api_routes.py
+++ b/processing-engine/app/discovery/api_routes.py
@@ -1,0 +1,78 @@
+"""CE /api facade for discovery (ADR 0001 Phase 2).
+
+Two concerns live here that the unprefixed engine routes don't have:
+
+1. ``/api/discovery/featured`` — serves featured_targets.json, which moved
+   from the .NET Configuration dir (the .NET copy remains canonical for the
+   main app until the gateway retires; keep them in sync).
+2. ``/api/discovery/suggest-recipes`` — the frontend speaks camelCase (the
+   .NET wire contract) while the engine models are snake_case. This facade
+   converts request/response casing; the existing ``/discovery/suggest-recipes``
+   route keeps its snake_case wire because the .NET proxy depends on it.
+"""
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from app.db.casing import camel_to_snake_keys, snake_to_camel_keys
+from app.discovery.models import SuggestRecipesRequest
+from app.discovery.routes import suggest_recipes as engine_suggest_recipes
+
+
+router = APIRouter(prefix="/api/discovery", tags=["Discovery API"])
+
+_FEATURED_PATH = Path(__file__).parent / "featured_targets.json"
+
+
+@lru_cache(maxsize=1)
+def load_featured_targets() -> list[dict[str, Any]]:
+    """Load and normalize featured targets to the .NET DTO shape.
+
+    The .NET serializer emits mastSearchParams.searchRadius as an explicit
+    null when absent; the fixture pins that, so the facade adds it.
+    """
+    targets = json.loads(_FEATURED_PATH.read_text())
+    for target in targets:
+        params = target.setdefault("mastSearchParams", {})
+        params.setdefault("searchRadius", None)
+    return targets
+
+
+def resolve_target_alias(name: str) -> str:
+    """Map display names to catalog ids (e.g. 'Pillars of Creation' -> 'M16').
+
+    Parity with DiscoveryService.ResolveTargetAlias — used by the MAST target
+    search facade (next Phase 2 PR).
+    """
+    lowered = name.strip().lower()
+    for target in load_featured_targets():
+        if target.get("name", "").lower() == lowered:
+            return target.get("catalogId") or name
+    return name
+
+
+@router.get("/featured")
+async def get_featured_targets() -> list[dict[str, Any]]:
+    return load_featured_targets()
+
+
+@router.post("/suggest-recipes")
+async def suggest_recipes_api(request: dict) -> JSONResponse:
+    """camelCase wrapper around the engine recipe route.
+
+    Deliberately reuses the engine handler (including its 400 on empty
+    observations) so recipe behavior can never drift between the two wires.
+    """
+    engine_request = SuggestRecipesRequest.model_validate(camel_to_snake_keys(request))
+    response = engine_suggest_recipes(engine_request)
+    payload = response.model_dump(mode="json")
+    for recipe in payload.get("recipes", []):
+        # exact .NET wire parity: SuggestRecipesResponseDto has no
+        # recommended_feather_strength field, so the .NET tier drops it
+        recipe.pop("recommended_feather_strength", None)
+    return JSONResponse(content=snake_to_camel_keys(payload))

--- a/processing-engine/app/discovery/featured_targets.json
+++ b/processing-engine/app/discovery/featured_targets.json
@@ -1,0 +1,158 @@
+[
+  {
+    "name": "Carina Nebula",
+    "catalogId": "NGC 3324",
+    "category": "nebula",
+    "description": "Massive star-forming region, one of JWST's first images. Reveals hundreds of previously hidden young stars.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 9,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/07/STScI-01GA6KKWG229B16K4Q38CH3BXS.png?w=600",
+    "mastSearchParams": {
+      "target": "NGC 3324"
+    }
+  },
+  {
+    "name": "Pillars of Creation",
+    "catalogId": "M16",
+    "category": "nebula",
+    "description": "Iconic columns of gas and dust in the Eagle Nebula where new stars are forming.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 8,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/10/STScI-01GGF8H15VZ09MET9HFBRQX4S3.png?w=600",
+    "mastSearchParams": {
+      "target": "M16"
+    }
+  },
+  {
+    "name": "Southern Ring Nebula",
+    "catalogId": "NGC 3132",
+    "category": "nebula",
+    "description": "Planetary nebula showing shells of gas expelled by a dying star. JWST revealed a hidden companion star.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 8,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/07/STScI-01G8GZQ3ZFJRD8YF8YZWMAXCE3.png?w=600",
+    "mastSearchParams": {
+      "target": "NGC 3132"
+    }
+  },
+  {
+    "name": "Stephan's Quintet",
+    "catalogId": "HCG 92",
+    "category": "galaxy",
+    "description": "Compact galaxy group showing interactions and mergers. Largest JWST image at release covering 1/5 of the Moon's diameter.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 11,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/07/STScI-01G8H49RQ0E48YDM8WKW9PP5XS.png?w=600",
+    "mastSearchParams": {
+      "target": "Stephan's Quintet"
+    }
+  },
+  {
+    "name": "SMACS 0723",
+    "catalogId": "SMACS J0723.3-7327",
+    "category": "galaxy",
+    "description": "Deep field showing thousands of galaxies including some of the most distant ever observed via gravitational lensing.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 11,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/07/STScI-01G8H1K2BCNATEZSKVRN9Z69SR.png?w=600",
+    "mastSearchParams": {
+      "target": "SMACS J0723.3-7327"
+    }
+  },
+  {
+    "name": "Tarantula Nebula",
+    "catalogId": "NGC 2070",
+    "category": "nebula",
+    "description": "Largest and brightest star-forming region in the Local Group, in the Large Magellanic Cloud.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 13,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/09/STScI-01GA76Q01D09HFEV174SVMQDMV.png?w=600",
+    "mastSearchParams": {
+      "target": "NGC 2070"
+    }
+  },
+  {
+    "name": "Cartwheel Galaxy",
+    "catalogId": "ESO 350-40",
+    "category": "galaxy",
+    "description": "Ring galaxy formed by a high-speed collision. JWST reveals new details in dust and star formation.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 13,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2022/08/STScI-01G9G4J23CDPVNGCYDJRZTTJQN.png?w=600",
+    "mastSearchParams": {
+      "target": "Cartwheel Galaxy"
+    }
+  },
+  {
+    "name": "Cassiopeia A",
+    "catalogId": "Cas A",
+    "category": "nebula",
+    "description": "Supernova remnant from a star that exploded ~340 years ago. JWST reveals intricate debris structures.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 11,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/12/STScI-01HGGZBZ1WK06H9NMB5WZTZPXD.png?w=600",
+    "mastSearchParams": {
+      "target": "Cassiopeia A"
+    }
+  },
+  {
+    "name": "NGC 346",
+    "catalogId": "NGC 346",
+    "category": "nebula",
+    "description": "Brightest star-forming region in the Small Magellanic Cloud. JWST revealed protostars still accreting gas and dust.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 21,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/01/STScI-01GNYMD5RCRF1S01A8M2S5M0Z1.png?w=600",
+    "mastSearchParams": {
+      "target": "NGC 346"
+    }
+  },
+  {
+    "name": "Phantom Galaxy",
+    "catalogId": "M74",
+    "category": "galaxy",
+    "description": "Face-on spiral galaxy showing exquisite detail in spiral arms and star-forming regions.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 18,
+    "compositePotential": "great",
+    "thumbnail": "https://cdn.esawebb.org/archives/images/wallpaper1/potm2208a.jpg",
+    "mastSearchParams": {
+      "target": "M74"
+    }
+  },
+  {
+    "name": "Horsehead Nebula",
+    "catalogId": "Barnard 33",
+    "category": "nebula",
+    "description": "Iconic dark nebula in Orion. JWST reveals the sharpest infrared view ever of its edge.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 19,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2024/04/STScI-01HV4CG0EACM1MC07E10X19KNX.png?w=600",
+    "mastSearchParams": {
+      "target": "Horsehead Nebula"
+    }
+  },
+  {
+    "name": "Crab Nebula",
+    "catalogId": "M1",
+    "category": "nebula",
+    "description": "Supernova remnant powered by a pulsar. JWST reveals synchrotron radiation and dust emission.",
+    "instruments": ["NIRCam", "MIRI"],
+    "filterCount": 8,
+    "compositePotential": "great",
+    "thumbnail": "https://assets.science.nasa.gov/dynamicimage/assets/science/missions/webb/science/2023/10/STScI-01HBBMF6GFYQG7ECGX1WD3W92B.png?w=600",
+    "mastSearchParams": {
+      "target": "M1"
+    }
+  }
+]

--- a/processing-engine/app/library/routes.py
+++ b/processing-engine/app/library/routes.py
@@ -1,15 +1,102 @@
-"""Library routes (scaffold).
+"""Library read endpoints (ADR 0001 Phase 2 — CE read-slice).
 
-Endpoints land in Phase 2 of the single-backend migration
-(docs/architecture/adr/0001-collapse-to-python-single-backend.md):
-``/api/jwstdata`` CRUD, ``/api/jwstdata/upload``, ``/api/upload``,
-``/api/datamanagement/import/scan``.
+Anonymous-only semantics: everything here serves IsPublic data, matching the
+.NET controller's anonymous branch. Wire shapes are pinned by the golden
+fixtures in tests/contract/fixtures/ — see docs/plans/features/
+ce-phase1-spike-report.md for the contract rules.
 
-The router is intentionally empty for now so the import graph and OpenAPI tag
-are established without changing runtime behavior.
+Writes (upload/archive/delete/scan) intentionally do not exist in this router;
+CE mounts are deny-by-default (docs/plans/features/ce-phase1-route-allowlist.md).
 """
 
-from fastapi import APIRouter
+import logging
+from collections.abc import Callable
+from typing import Annotated
 
+from fastapi import APIRouter, Depends, HTTPException, Response
+from pydantic import BaseModel, Field
+
+from app.db.deps import get_file_exists, get_repository
+from app.db.projection import to_data_response
+from app.db.repository import JwstDataReadRepository
+
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["Library"])
+
+# Usable calibration levels for guided creation (JwstDataController.cs:2139)
+_USABLE_LEVELS = {"L2a", "L2b", "L3"}
+_DATA_PREFIX = "/app/data/"
+
+RepoDep = Annotated[JwstDataReadRepository, Depends(get_repository)]
+FileExistsDep = Annotated[Callable[[str], bool], Depends(get_file_exists)]
+
+
+def _to_relative_key(file_path: str) -> str:
+    """StorageKeyHelper.ToRelativeKey parity: strip the container data prefix."""
+    if file_path.lower().startswith(_DATA_PREFIX):
+        return file_path[len(_DATA_PREFIX) :]
+    return file_path
+
+
+class CheckAvailabilityRequest(BaseModel):
+    observation_ids: list[str] = Field(alias="observationIds")
+
+
+@router.get("/jwstdata")
+async def list_jwst_data(repo: RepoDep, includeArchived: bool = False) -> list[dict]:  # noqa: N803 -- camelCase query param is the .NET wire contract
+    docs = await repo.get_public_list(include_archived=includeArchived)
+    return [to_data_response(d) for d in docs]
+
+
+@router.get("/jwstdata/{data_id}/thumbnail")
+async def get_thumbnail(data_id: str, repo: RepoDep) -> Response:
+    doc = await repo.get_public_by_id(data_id)
+    if doc is None:
+        # 404 (not 403) to prevent ID enumeration — .NET parity
+        raise HTTPException(status_code=404)
+    thumb = doc.get("ThumbnailData")
+    if thumb is None:
+        return Response(status_code=204)
+    return Response(
+        content=bytes(thumb),
+        media_type="image/png",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+@router.post("/jwstdata/check-availability")
+async def check_availability(
+    request: CheckAvailabilityRequest, repo: RepoDep, file_exists: FileExistsDep
+) -> dict:
+    obs_ids = request.observation_ids
+    if not obs_ids:
+        raise HTTPException(status_code=400, detail="ObservationIds is required")
+    if len(obs_ids) > 50:
+        raise HTTPException(status_code=400, detail="Maximum 50 observation IDs per request")
+
+    results: dict[str, dict] = {}
+    for obs_id in obs_ids:
+        if not obs_id or not obs_id.strip():
+            continue
+        records = await repo.get_public_by_observation_base_id(obs_id)
+        usable = [
+            r
+            for r in records
+            if not r.get("IsArchived")
+            and r.get("FilePath")
+            and r.get("ProcessingLevel") in _USABLE_LEVELS
+        ]
+        # Mongo records can outlive deleted files — verify on disk.
+        # file_exists is a sync local-stat under CE (STORAGE_PROVIDER=local);
+        # wrap in a thread if S3 storage is ever used behind this route.
+        verified = [r for r in usable if file_exists(_to_relative_key(r["FilePath"]))]
+        if verified:
+            image_info = verified[0].get("ImageInfo") or {}
+            results[obs_id] = {
+                "available": True,
+                "dataIds": [str(r["_id"]) for r in verified],
+                "filter": image_info.get("Filter"),
+            }
+    return {"results": results}

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -13,6 +13,8 @@ from pydantic import BaseModel
 from app.analysis.routes import router as analysis_router
 from app.auth.routes import router as auth_router
 from app.composite.routes import router as composite_router
+from app.db.client import MongoNotConfiguredError, get_database
+from app.discovery.api_routes import router as discovery_api_router
 from app.discovery.routes import router as discovery_router
 from app.exceptions import (
     ProcessingEngineError,
@@ -78,30 +80,64 @@ app = FastAPI(title="JWST Data Processing Engine", version="1.0.0")
 app.add_exception_handler(ProcessingEngineError, processing_engine_error_handler)
 app.add_exception_handler(Exception, generic_error_handler)
 
-# Include Composite routes
-app.include_router(composite_router)
+# Community Edition mode: deny-by-default route mounting (ADR 0001 / CE plan).
+# When CE_MODE is truthy, ONLY the /api facade surface mounts — no mosaic, no
+# semantic search, no unprefixed engine routers, and the auth/jobs scaffolds
+# never mount. The route-table test (tests/test_ce_mode_mounting.py) is the
+# regression guard for this block.
+CE_MODE = os.environ.get("CE_MODE", "").strip().lower() in {"1", "true", "yes"}
 
-# Include Mosaic routes
-app.include_router(mosaic_router)
+if CE_MODE:
+    app.include_router(library_router)  # /api/jwstdata reads only
+    app.include_router(discovery_api_router)  # /api/discovery facade
 
-# Include Analysis routes
-app.include_router(analysis_router)
+    # True default-deny: any request outside /api/* (plus bare liveness for
+    # container healthchecks) is 404'd BEFORE routing/validation. This covers
+    # the module-level render routes — which register regardless of CE_MODE —
+    # and anything added in the future, uniformly.
+    from fastapi.responses import JSONResponse as _JSONResponse
 
-# Include Discovery routes
-app.include_router(discovery_router)
+    @app.middleware("http")
+    async def ce_deny_non_api(request, call_next):
+        path = request.url.path
+        if path not in ("/", "/health") and not path.startswith("/api/"):
+            # note: also blocks /docs and /openapi.json — CE does not expose
+            # interactive API docs publicly
+            return _JSONResponse({"detail": "Not Found"}, status_code=404)
+        return await call_next(request)
 
-# Include Semantic Search routes
-app.include_router(semantic_router)
+else:
+    # Full engine surface (the .NET gateway depends on these routes)
+    app.include_router(composite_router)
+    app.include_router(mosaic_router)
+    app.include_router(analysis_router)
+    app.include_router(discovery_router)
+    app.include_router(semantic_router)
 
-# Single-backend migration scaffolding (ADR 0001). These routers are empty
-# until their respective phases land auth, persistence, and job tracking.
-app.include_router(auth_router)
-app.include_router(library_router)
-app.include_router(jobs_router)
+    # Single-backend migration scaffolding (ADR 0001). auth/jobs are empty
+    # until their phases land; library now carries the CE read endpoints,
+    # mounted in dev too so they can be exercised against the full stack.
+    app.include_router(auth_router)
+    app.include_router(library_router)
+    app.include_router(jobs_router)
+    app.include_router(discovery_api_router)
 
 
 class ThumbnailRequest(BaseModel):
     file_path: str
+
+
+def _deny_bare_route_in_ce() -> None:
+    """Deny-by-default guard for the module-level render routes.
+
+    These @app decorators register regardless of CE_MODE (they predate the
+    router split — folding them into a router is tracked for the next Phase 2
+    PR). They take raw file paths with no IsPublic gate, so in CE they must
+    not answer even though the nginx proxy only forwards /api/*. 404 keeps
+    parity with the deny-by-default posture.
+    """
+    if CE_MODE:
+        raise HTTPException(status_code=404, detail="Not Found")
 
 
 @app.get("/")
@@ -112,6 +148,37 @@ async def root():
 @app.get("/health")
 async def health_check():
     return {"status": "healthy", "service": "jwst-processing-engine"}
+
+
+@app.get("/api/health")
+async def api_health_check():
+    """Aggregated health in the .NET HealthChecks response shape.
+
+    In the CE topology the engine IS the backend, so the .NET version's two
+    proxy checks collapse to engine liveness + a MongoDB ping. The frontend
+    MastStatusPill polls this endpoint.
+    """
+    checks = [
+        {
+            "name": "processing_engine",
+            "status": "Healthy",
+            "description": "Processing engine is reachable",
+        }
+    ]
+    mongo = {"name": "mongodb", "status": "Healthy", "description": "MongoDB ping ok"}
+    try:
+        await get_database().command("ping")
+    except MongoNotConfiguredError:
+        mongo = {
+            "name": "mongodb",
+            "status": "Unhealthy",
+            "description": "MONGODB_URI is not configured",
+        }
+    except Exception as exc:  # noqa: BLE001 -- health endpoints must degrade, never raise
+        mongo = {"name": "mongodb", "status": "Unhealthy", "description": str(exc)}
+    checks.append(mongo)
+    overall = "Healthy" if all(c["status"] == "Healthy" for c in checks) else "Unhealthy"
+    return {"status": overall, "checks": checks}
 
 
 def _extract_thumbnail_data(file_path: str, *, use_memmap: bool = True) -> np.ndarray | None:
@@ -151,6 +218,7 @@ def _extract_thumbnail_data(file_path: str, *, use_memmap: bool = True) -> np.nd
 
 @app.post("/thumbnail")
 def generate_thumbnail(request: ThumbnailRequest):
+    _deny_bare_route_in_ce()
     """
     Generate a 256x256 PNG thumbnail from a FITS file.
 
@@ -225,6 +293,7 @@ def generate_preview(
     smooth_sigma: float = 1.0,  # Gaussian smoothing sigma: 0.1 to 10.0
     smooth_size: int = 3,  # Kernel size for median/box smoothing: 1 to 25 (odd)
 ):
+    _deny_bare_route_in_ce()
     """
     Generate a preview image for a FITS file with configurable stretch and level controls.
 
@@ -528,6 +597,7 @@ def get_histogram(
     smooth_sigma: float = 1.0,  # Gaussian smoothing sigma: 0.1 to 10.0
     smooth_size: int = 3,  # Kernel size for median/box smoothing: 1 to 25 (odd)
 ):
+    _deny_bare_route_in_ce()
     """
     Get histogram data for a FITS file with stretch applied.
 
@@ -731,6 +801,7 @@ def get_pixel_data(
     max_size: int = 1200,
     slice_index: int = -1,
 ):
+    _deny_bare_route_in_ce()
     """
     Get pixel data array for hover coordinate display.
 
@@ -873,6 +944,7 @@ def get_pixel_data(
 
 @app.get("/cubeinfo/{data_id}")
 def get_cube_info(data_id: str, file_path: str):
+    _deny_bare_route_in_ce()
     """
     Get 3D cube metadata including slice count and wavelength info.
 

--- a/processing-engine/tests/contract/test_ce_api_contracts.py
+++ b/processing-engine/tests/contract/test_ce_api_contracts.py
@@ -1,0 +1,191 @@
+"""CE /api facade contract tests against the Phase 1 golden .NET fixtures.
+
+The fixtures capture what the frontend receives from the .NET tier today;
+these tests pin the FastAPI facade to the same shapes (key names + casing).
+Values are environment-specific, so assertions are structural.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from bson import ObjectId
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.db.deps import get_file_exists, get_repository
+from app.db.repository import JwstDataReadRepository
+from app.discovery.api_routes import router as discovery_api_router
+from app.library.routes import router as library_router
+from tests.db.fakes import FakeCollection
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def fixture(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def full_doc(oid: ObjectId) -> dict:
+    """A Mongo doc with every field MapToDataResponse projects, PascalCase."""
+    return {
+        "_id": oid,
+        "FileName": "jw1_i2d.fits",
+        "DataType": "image",
+        "UploadDate": datetime(2026, 7, 1, 10, 0, 0),
+        "Description": None,
+        "Metadata": {"mast_obs_id": "jw1-o001", "source": "mast"},
+        "FilePath": "mast/jw1/jw1_i2d.fits",
+        "FileSize": 123,
+        "ProcessingStatus": "completed",
+        "Tags": ["mast"],
+        "UserId": None,
+        "ImageInfo": {"Filter": "F770W", "BitDepth": 16},
+        "SensorInfo": None,
+        "SpectralInfo": None,
+        "CalibrationInfo": None,
+        "ProcessingResults": [{"ProcessedDate": datetime(2026, 7, 2, 9, 0, 0)}],
+        "FileFormat": "fits",
+        "IsValidated": True,
+        "LastAccessed": None,
+        "IsPublic": True,
+        "SharedWith": [],
+        "IsArchived": False,
+        "ArchivedDate": None,
+        "Version": 1,
+        "ParentId": None,
+        # DerivedFrom deliberately ABSENT — .NET's non-nullable List default
+        # means the wire always shows []; the projection must default it
+        "ProcessingLevel": "L3",
+        "ObservationBaseId": "jw01",
+        "ExposureId": None,
+        "IsViewable": True,
+        "ThumbnailData": b"\x89PNG",
+    }
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(library_router)
+    app.include_router(discovery_api_router)
+
+    oid = ObjectId()
+    docs = [full_doc(oid)]
+    repo = JwstDataReadRepository(FakeCollection(docs))
+    app.dependency_overrides[get_repository] = lambda: repo
+    app.dependency_overrides[get_file_exists] = lambda: lambda _key: True
+    c = TestClient(app)
+    c.test_oid = str(oid)
+    return c
+
+
+class TestFeaturedContract:
+    def test_matches_fixture_exactly_in_shape(self, client):
+        resp = client.get("/api/discovery/featured")
+        assert resp.status_code == 200
+        body = resp.json()
+        fix = fixture("get_discovery_featured.json")
+        assert isinstance(body, list) and len(body) == len(fix)
+        assert set(body[0].keys()) == set(fix[0].keys())
+        # .NET adds searchRadius: null to mastSearchParams — facade must too
+        assert set(body[0]["mastSearchParams"].keys()) == {"target", "searchRadius"}
+
+
+class TestJwstDataListContract:
+    def test_item_keys_match_fixture(self, client):
+        resp = client.get("/api/jwstdata?includeArchived=false")
+        assert resp.status_code == 200
+        items = resp.json()
+        assert len(items) == 1
+        fix_keys = set(fixture("get_jwstdata_list.json")[0].keys())
+        assert set(items[0].keys()) == fix_keys
+
+    def test_projection_semantics(self, client):
+        item = client.get("/api/jwstdata").json()[0]
+        assert item["id"] == client.test_oid
+        assert item["hasThumbnail"] is True  # ThumbnailData present but NOT inlined
+        assert "thumbnailData" not in item
+        assert item["processingResultsCount"] == 1
+        # whole-second timestamps: System.Text.Json omits the fraction entirely
+        assert item["lastProcessed"] == "2026-07-02T09:00:00Z"
+        assert item["uploadDate"].endswith("Z")
+        assert item["derivedFrom"] == []  # absent in doc -> .NET emits []
+        assert item["imageInfo"] == {"filter": "F770W", "bitDepth": 16}
+        assert item["metadata"] == {"mast_obs_id": "jw1-o001", "source": "mast"}
+
+
+class TestCheckAvailabilityContract:
+    def test_shape_matches_fixture(self, client):
+        resp = client.post("/api/jwstdata/check-availability", json={"observationIds": ["jw01"]})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == {"results"}
+        item = body["results"]["jw01"]
+        assert set(item.keys()) == {"available", "dataIds", "filter"}
+        assert item["available"] is True and item["filter"] == "F770W"
+
+    def test_missing_obs_absent_from_results(self, client):
+        body = client.post(
+            "/api/jwstdata/check-availability", json={"observationIds": ["nope"]}
+        ).json()
+        assert body["results"] == {}
+
+    def test_validation_empty_and_cap(self, client):
+        assert (
+            client.post("/api/jwstdata/check-availability", json={"observationIds": []}).status_code
+            == 400
+        )
+        too_many = {"observationIds": [f"o{i}" for i in range(51)]}
+        assert client.post("/api/jwstdata/check-availability", json=too_many).status_code == 400
+
+    def test_file_missing_on_disk_excludes(self, client):
+        client.app.dependency_overrides[get_file_exists] = lambda: lambda _key: False
+        body = client.post(
+            "/api/jwstdata/check-availability", json={"observationIds": ["jw01"]}
+        ).json()
+        assert body["results"] == {}
+
+
+class TestThumbnailRoute:
+    def test_png_with_cache_header(self, client):
+        resp = client.get(f"/api/jwstdata/{client.test_oid}/thumbnail")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/png"
+        assert resp.headers["cache-control"] == "public, max-age=86400"
+
+    def test_unknown_id_404(self, client):
+        resp = client.get(f"/api/jwstdata/{ObjectId()}/thumbnail")
+        assert resp.status_code == 404
+
+
+class TestSuggestRecipesContract:
+    def test_camel_request_and_camel_response(self, client):
+        req = {
+            "targetName": "NGC 3132",
+            "observations": [
+                {"filter": "F770W", "instrument": "MIRI", "observationId": "o1"},
+                {"filter": "F1130W", "instrument": "MIRI", "observationId": "o2"},
+                {"filter": "F1800W", "instrument": "MIRI", "observationId": "o3"},
+            ],
+        }
+        resp = client.post("/api/discovery/suggest-recipes", json=req)
+        assert resp.status_code == 200
+        body = resp.json()
+        fix = fixture("post_discovery_suggest_recipes.json")
+        assert set(body.keys()) == set(fix.keys())  # {target, recipes}
+        assert body["recipes"], "expected at least one recipe for 3 MIRI filters"
+        recipe = body["recipes"][0]
+        # exact .NET wire parity, including dropping recommended_feather_strength
+        assert set(recipe.keys()) == set(fix["recipes"][0].keys())
+        assert "colorMapping" in recipe and "color_mapping" not in recipe
+        # colorMapping is keyed by FILTER NAMES — must not be case-mangled
+        assert all(k.startswith("F") for k in recipe["colorMapping"])
+
+    def test_empty_observations_400(self, client):
+        resp = client.post(
+            "/api/discovery/suggest-recipes", json={"targetName": "x", "observations": []}
+        )
+        assert resp.status_code == 400

--- a/processing-engine/tests/db/fakes.py
+++ b/processing-engine/tests/db/fakes.py
@@ -1,0 +1,58 @@
+"""In-memory fake of the (tiny) motor collection surface the repository uses.
+
+Supports the exact query shapes the read repository issues: equality matches,
+dotted paths (``Metadata.mast_obs_id``), ``$ne``, and ``_id`` ObjectId lookups.
+Deliberately minimal — extend only when the repository grows a new query.
+"""
+
+from typing import Any
+
+
+def _matches(doc: dict, query: dict) -> bool:
+    for key, expected in query.items():
+        value: Any = doc
+        for part in key.split("."):
+            value = value.get(part) if isinstance(value, dict) else None
+        if isinstance(expected, dict):
+            if "$ne" in expected:
+                if value == expected["$ne"]:
+                    return False
+            else:  # unsupported operator — fail loudly, not silently
+                raise NotImplementedError(f"FakeCollection: operator in {expected}")
+        elif value != expected:
+            return False
+    return True
+
+
+class _FakeCursor:
+    def __init__(self, docs: list[dict]):
+        self._docs = docs
+
+    async def to_list(self, length=None):
+        return self._docs if length is None else self._docs[:length]
+
+    def __aiter__(self):
+        self._it = iter(self._docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+class FakeCollection:
+    def __init__(self, docs: list[dict]):
+        self.docs = docs
+
+    def find(self, query: dict, projection: dict | None = None) -> _FakeCursor:
+        found = [d for d in self.docs if _matches(d, query)]
+        if projection:
+            keep = {k for k, v in projection.items() if v} | {"_id"}
+            found = [{k: v for k, v in d.items() if k in keep} for d in found]
+        return _FakeCursor(found)
+
+    async def find_one(self, query: dict, projection: dict | None = None) -> dict | None:
+        docs = await self.find(query, projection).to_list()
+        return docs[0] if docs else None

--- a/processing-engine/tests/db/test_casing.py
+++ b/processing-engine/tests/db/test_casing.py
@@ -1,0 +1,99 @@
+"""Casing converters — the CE /api facade must match the .NET wire contract.
+
+Rules pinned by the Phase 1 golden fixtures (tests/contract/fixtures/):
+- Mongo docs are PascalCase; the wire is camelCase (System.Text.Json policy,
+  which lowercases a LEADING RUN of capitals: WCS -> wcs, WCSInfo -> wcsInfo).
+- The Metadata subtree passes through verbatim (mast_* keys untouched).
+- The recipe-engine facade converts camelCase requests to snake_case and
+  snake_case responses to camelCase.
+"""
+
+from datetime import datetime
+
+from app.db.casing import (
+    camel_to_snake_keys,
+    pascal_to_camel,
+    pascal_to_camel_keys,
+    snake_to_camel,
+    snake_to_camel_keys,
+)
+
+
+class TestPascalToCamel:
+    def test_simple(self):
+        assert pascal_to_camel("FileName") == "fileName"
+        assert pascal_to_camel("IsPublic") == "isPublic"
+
+    def test_leading_acronym_run(self):
+        # System.Text.Json CamelCase policy behavior
+        assert pascal_to_camel("WCS") == "wcs"
+        assert pascal_to_camel("WCSInfo") == "wcsInfo"
+
+    def test_already_camel_or_single(self):
+        assert pascal_to_camel("id") == "id"
+        assert pascal_to_camel("A") == "a"
+
+    def test_bit_depth(self):
+        assert pascal_to_camel("BitDepth") == "bitDepth"
+        assert pascal_to_camel("ProposalPi") == "proposalPi"
+
+
+class TestPascalToCamelKeys:
+    def test_recursive_with_verbatim_subtrees(self):
+        # WCS is a Dictionary<string,object> in .NET — DictionaryKeyPolicy is
+        # null, so its keys (FITS keywords like CRPIX1) pass through verbatim;
+        # only the container property name camelizes.
+        doc = {
+            "FileName": "a.fits",
+            "ImageInfo": {"BitDepth": 16, "WCS": {"CRPIX1": 1.0}},
+            "Metadata": {"mast_obs_id": "jw1", "source": "mast"},
+            "Tags": ["X"],
+        }
+        out = pascal_to_camel_keys(doc, verbatim_keys={"Metadata", "WCS"})
+        assert out["fileName"] == "a.fits"
+        assert out["imageInfo"]["bitDepth"] == 16
+        assert out["imageInfo"]["wcs"] == {"CRPIX1": 1.0}
+        # Metadata keys untouched, but renamed to camel itself
+        assert out["metadata"] == {"mast_obs_id": "jw1", "source": "mast"}
+        assert out["tags"] == ["X"]
+
+    def test_datetimes_become_utc_iso_z(self):
+        doc = {"UploadDate": datetime(2026, 7, 6, 12, 0, 0, 123000)}
+        out = pascal_to_camel_keys(doc, verbatim_keys=set())
+        assert out["uploadDate"] == "2026-07-06T12:00:00.123Z"
+
+    def test_datetime_trailing_zeros_trimmed_like_dotnet(self):
+        # System.Text.Json trims trailing zeros (verified against live API:
+        # .9Z / .99Z / .999Z variants on the wire)
+        doc = {"A": datetime(2026, 7, 6, 12, 0, 0, 360000)}
+        assert pascal_to_camel_keys(doc, verbatim_keys=set())["a"] == "2026-07-06T12:00:00.36Z"
+
+    def test_datetime_whole_second_omits_fraction(self):
+        doc = {"A": datetime(2026, 7, 6, 12, 0, 0)}
+        assert pascal_to_camel_keys(doc, verbatim_keys=set())["a"] == "2026-07-06T12:00:00Z"
+
+    def test_lists_of_dicts(self):
+        doc = {"Items": [{"SubKey": 1}, {"SubKey": 2}]}
+        out = pascal_to_camel_keys(doc, verbatim_keys=set())
+        assert out["items"] == [{"subKey": 1}, {"subKey": 2}]
+
+
+class TestSnakeCamelRoundtrip:
+    def test_snake_to_camel(self):
+        assert snake_to_camel("color_mapping") == "colorMapping"
+        assert snake_to_camel("t_obs_release") == "tObsRelease"
+        assert snake_to_camel("name") == "name"
+
+    def test_snake_to_camel_keys_recursive(self):
+        out = snake_to_camel_keys(
+            {"color_mapping": {"F444W": "#ff0000"}, "recipes": [{"observation_ids": ["a"]}]}
+        )
+        # dict VALUES keyed by data (filter names) must be untouched
+        assert out["colorMapping"] == {"F444W": "#ff0000"}
+        assert out["recipes"] == [{"observationIds": ["a"]}]
+
+    def test_camel_to_snake_keys(self):
+        out = camel_to_snake_keys(
+            {"targetName": "M16", "observations": [{"tObsRelease": 1.0, "sRa": 2.0}]}
+        )
+        assert out == {"target_name": "M16", "observations": [{"t_obs_release": 1.0, "s_ra": 2.0}]}

--- a/processing-engine/tests/db/test_projection.py
+++ b/processing-engine/tests/db/test_projection.py
@@ -1,0 +1,35 @@
+"""Projection edge cases found by the live .NET-vs-Python parity diff."""
+
+from bson import ObjectId
+
+from app.db.projection import to_data_response
+
+
+def test_bson_type_discriminators_unwrapped():
+    # mosaic-generator docs store Metadata.source_ids as a typed .NET
+    # collection: {"_t": "System.Collections.Generic.List`1[...]", "_v": [...]}
+    doc = {
+        "_id": ObjectId(),
+        "FileName": "m.fits",
+        "IsPublic": True,
+        "Metadata": {
+            "source": "mosaic-generator",
+            "source_ids": {
+                "_t": "System.Collections.Generic.List`1[[System.String]]",
+                "_v": ["a", "b"],
+            },
+        },
+    }
+    out = to_data_response(doc)
+    assert out["metadata"]["source_ids"] == ["a", "b"]
+
+
+def test_literal_t_v_dict_with_extra_keys_untouched():
+    doc = {
+        "_id": ObjectId(),
+        "FileName": "x.fits",
+        "IsPublic": True,
+        "Metadata": {"weird": {"_t": 1, "_v": 2, "other": 3}},
+    }
+    out = to_data_response(doc)
+    assert out["metadata"]["weird"] == {"_t": 1, "_v": 2, "other": 3}

--- a/processing-engine/tests/db/test_repository.py
+++ b/processing-engine/tests/db/test_repository.py
@@ -1,0 +1,147 @@
+"""Read-repository semantics — mirrors the .NET anonymous-access suite.
+
+Anonymous (CE) visibility = IsPublic only; the .NET SetupAnonymousUser tests
+are the reference behavior. Uses an in-memory fake motor collection so no
+Mongo instance is needed.
+"""
+
+import pytest
+from bson import ObjectId
+
+from app.db.repository import JwstDataReadRepository
+from tests.db.fakes import FakeCollection
+
+
+def make_doc(
+    *,
+    oid=None,
+    public=True,
+    archived=False,
+    file_path="mast/jw1/f1.fits",
+    level="L3",
+    obs_base="jw01",
+    user_id=None,
+    thumb=None,
+    mast_obs_id=None,
+):
+    doc = {
+        "_id": oid or ObjectId(),
+        "FileName": "f1.fits",
+        "DataType": "image",
+        "IsPublic": public,
+        "IsArchived": archived,
+        "FilePath": file_path,
+        "ProcessingLevel": level,
+        "ObservationBaseId": obs_base,
+        "UserId": user_id,
+        "ThumbnailData": thumb,
+        "Metadata": {"mast_obs_id": mast_obs_id} if mast_obs_id else {},
+        "ImageInfo": {"Filter": "F770W"},
+        "ProcessingResults": [],
+        "Tags": [],
+        "SharedWith": [],
+        "Version": 1,
+    }
+    return doc
+
+
+@pytest.fixture
+def repo_with(request):
+    def _build(docs):
+        return JwstDataReadRepository(FakeCollection(docs))
+
+    return _build
+
+
+class TestPublicList:
+    @pytest.mark.asyncio
+    async def test_anonymous_sees_only_public(self, repo_with):
+        docs = [make_doc(public=True), make_doc(public=False), make_doc(public=True)]
+        repo = repo_with(docs)
+        out = await repo.get_public_list(include_archived=True)
+        assert len(out) == 2
+        assert all(d["IsPublic"] for d in out)
+
+    @pytest.mark.asyncio
+    async def test_owned_private_docs_excluded(self, repo_with):
+        # a doc owned by some user and not public must never surface anonymously
+        docs = [make_doc(public=False, user_id="u1")]
+        repo = repo_with(docs)
+        assert await repo.get_public_list(include_archived=True) == []
+
+    @pytest.mark.asyncio
+    async def test_archived_excluded_by_default(self, repo_with):
+        docs = [make_doc(archived=True), make_doc(archived=False)]
+        repo = repo_with(docs)
+        out = await repo.get_public_list(include_archived=False)
+        assert len(out) == 1
+        assert out[0]["IsArchived"] is False
+
+    @pytest.mark.asyncio
+    async def test_include_archived_true(self, repo_with):
+        docs = [make_doc(archived=True), make_doc(archived=False)]
+        repo = repo_with(docs)
+        assert len(await repo.get_public_list(include_archived=True)) == 2
+
+
+class TestGetByIdPublic:
+    @pytest.mark.asyncio
+    async def test_returns_public_doc(self, repo_with):
+        oid = ObjectId()
+        repo = repo_with([make_doc(oid=oid)])
+        doc = await repo.get_public_by_id(str(oid))
+        assert doc is not None and doc["_id"] == oid
+
+    @pytest.mark.asyncio
+    async def test_private_doc_hidden(self, repo_with):
+        oid = ObjectId()
+        repo = repo_with([make_doc(oid=oid, public=False)])
+        assert await repo.get_public_by_id(str(oid)) is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_id_returns_none(self, repo_with):
+        repo = repo_with([])
+        assert await repo.get_public_by_id("not-an-objectid") is None
+
+
+class TestThumbnail:
+    @pytest.mark.asyncio
+    async def test_thumbnail_bytes(self, repo_with):
+        oid = ObjectId()
+        repo = repo_with([make_doc(oid=oid, thumb=b"\x89PNG...")])
+        assert await repo.get_public_thumbnail(str(oid)) == b"\x89PNG..."
+
+    @pytest.mark.asyncio
+    async def test_no_thumbnail_returns_none(self, repo_with):
+        oid = ObjectId()
+        repo = repo_with([make_doc(oid=oid, thumb=None)])
+        assert await repo.get_public_thumbnail(str(oid)) is None
+
+    @pytest.mark.asyncio
+    async def test_private_thumbnail_hidden(self, repo_with):
+        oid = ObjectId()
+        repo = repo_with([make_doc(oid=oid, public=False, thumb=b"png")])
+        assert await repo.get_public_thumbnail(str(oid)) is None
+
+
+class TestByObservationBase:
+    @pytest.mark.asyncio
+    async def test_finds_by_observation_base_id(self, repo_with):
+        repo = repo_with([make_doc(obs_base="jw02733002001")])
+        out = await repo.get_public_by_observation_base_id("jw02733002001")
+        assert len(out) == 1
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_mast_obs_id(self, repo_with):
+        # .NET MongoDBService.cs:609 fallback semantics
+        repo = repo_with([make_doc(obs_base="other", mast_obs_id="jw02733-o002_t001")])
+        out = await repo.get_public_by_observation_base_id("jw02733-o002_t001")
+        assert len(out) == 1
+
+    @pytest.mark.asyncio
+    async def test_private_records_filtered(self, repo_with):
+        repo = repo_with(
+            [make_doc(obs_base="jw01", public=False), make_doc(obs_base="jw01", public=True)]
+        )
+        out = await repo.get_public_by_observation_base_id("jw01")
+        assert len(out) == 1 and out[0]["IsPublic"]

--- a/processing-engine/tests/test_ce_mode_mounting.py
+++ b/processing-engine/tests/test_ce_mode_mounting.py
@@ -1,0 +1,130 @@
+"""CE_MODE deny-by-default route-table tests — the security posture's regression guard.
+
+CE_MODE mounts ONLY the /api facade surface (the Phase 1 allowlist as far as
+this PR implements it). Everything else — mosaic, semantic search, unprefixed
+engine routers, auth/jobs scaffolds — must be absent. Non-CE mode must keep
+serving today's full route set (the .NET tier depends on it).
+
+main.py builds the app at import time, so these tests reload it under a
+patched environment.
+"""
+
+import importlib
+import os
+from unittest import mock
+
+
+def load_app(ce_mode: str | None):
+    env = dict(os.environ)
+    env.pop("CE_MODE", None)
+    if ce_mode is not None:
+        env["CE_MODE"] = ce_mode
+    with mock.patch.dict(os.environ, env, clear=True):
+        import main
+
+        importlib.reload(main)
+        return main.app
+
+
+def teardown_module():
+    """Restore the module-level app for other test files."""
+    import main
+
+    importlib.reload(main)
+
+
+def paths(app) -> set[str]:
+    # FastAPI ≥0.139 defers include_router (routes sit inside _IncludedRouter
+    # wrappers), so app.routes doesn't flatten; the OpenAPI schema does.
+    return set(app.openapi()["paths"].keys())
+
+
+# The /api surface this PR implements (grows in later Phase 2 PRs, and the
+# allowlist doc is the target end state).
+CE_API_SURFACE = {
+    "/api/health",
+    "/api/discovery/featured",
+    "/api/discovery/suggest-recipes",
+    "/api/jwstdata",
+    "/api/jwstdata/{data_id}/thumbnail",
+    "/api/jwstdata/check-availability",
+}
+
+# Bare @app render routes defined in main.py. They remain registered in CE
+# (module-level decorators) but are NOT part of the /api surface and are
+# unreachable through the CE nginx proxy, which forwards /api/* only.
+# Folding them behind CE_MODE is tracked for the next Phase 2 PR.
+ENGINE_INTERNAL = {
+    "/",
+    "/health",
+    "/thumbnail",
+    "/preview/{data_id}",
+    "/histogram/{data_id}",
+    "/pixeldata/{data_id}",
+    "/cubeinfo/{data_id}",
+}
+
+
+class TestCeMode:
+    def test_api_surface_is_exactly_the_allowlist(self):
+        app = load_app("true")
+        api_paths = {p for p in paths(app) if p.startswith("/api")}
+        assert api_paths == CE_API_SURFACE
+
+    def test_denied_routers_not_mounted(self):
+        app = load_app("true")
+        p = paths(app)
+        for denied in (
+            "/composite/generate-nchannel",
+            "/composite/generate-nchannel-stream",
+            "/mosaic/generate",
+            "/semantic/search",
+            "/discovery/suggest-recipes",  # unprefixed engine route
+        ):
+            assert denied not in p, f"{denied} must not mount in CE_MODE"
+
+    def test_no_unexpected_routes_outside_api(self):
+        app = load_app("true")
+        non_api = {p for p in paths(app) if not p.startswith("/api")}
+        assert non_api <= ENGINE_INTERNAL, f"unexpected non-api routes: {non_api - ENGINE_INTERNAL}"
+
+
+class TestCeBareRouteGuard:
+    def test_bare_render_routes_404_in_ce(self):
+        """The module-level render routes stay registered (decorators) but
+        must refuse to answer in CE — they take raw file paths with no
+        IsPublic gate."""
+        from fastapi.testclient import TestClient
+
+        app = load_app("true")
+        client = TestClient(app)
+        assert client.get("/preview/abc123").status_code == 404
+        assert client.get("/pixeldata/abc123").status_code == 404
+        assert client.get("/cubeinfo/abc123").status_code == 404
+        assert client.get("/histogram/abc123").status_code == 404
+        assert client.post("/thumbnail", json={"file_path": "x.fits"}).status_code == 404
+
+
+class TestNonCeMode:
+    def test_legacy_surface_unchanged(self):
+        app = load_app(None)
+        p = paths(app)
+        for legacy in (
+            "/composite/generate-nchannel",
+            "/mosaic/generate",
+            "/discovery/suggest-recipes",
+            "/preview/{data_id}",
+            "/health",
+        ):
+            assert legacy in p, f"{legacy} missing in non-CE mode"
+
+    def test_api_facade_also_available_in_dev(self):
+        # additive: the facade mounts in dev too, so it can be exercised
+        # against the full stack before the CE cutover
+        app = load_app(None)
+        assert paths(app) >= CE_API_SURFACE
+
+    def test_ce_mode_falsy_values(self):
+        for v in ("0", "false", "", "no"):
+            app = load_app(v)
+            assert "/composite/generate-nchannel" in paths(app), f"CE_MODE={v!r} must be off"


### PR DESCRIPTION
## Summary

No linked issue (CE plan Phase 2, PR 1 of N; tracked by epic #1403).

First slice of the **CE Python read layer** (ADR 0001 Phase 2): a FastAPI `/api` facade over the engine that reproduces the .NET wire contract byte-for-byte, plus **`CE_MODE` deny-by-default mounting** — the CE security posture.

**Live parity proof:** with the branch running in the engine container against the real dev Mongo (1407 public docs), `GET /api/jwstdata?includeArchived=true` from this code and from the live .NET API were diffed record-by-record: **1407/1407 byte-identical** (after fixing two real divergences the diff itself surfaced — see below).

### What's implemented (allowlist subset)

| Route | Implementation |
|---|---|
| `GET /api/health` | .NET HealthChecks shape; engine liveness + Mongo ping |
| `GET /api/discovery/featured` | serves `featured_targets.json` (engine copy) + `searchRadius: null` normalization |
| `POST /api/discovery/suggest-recipes` | camelCase facade over the engine recipe route (snake_case wire preserved for the .NET proxy); drops `recommended_feather_strength` for exact .NET DTO parity |
| `GET /api/jwstdata` | public list + full `MapToDataResponse` projection parity |
| `GET /api/jwstdata/{id}/thumbnail` | Mongo binary read; 404-on-private (anti-enumeration), 204-no-thumbnail, Cache-Control |
| `POST /api/jwstdata/check-availability` | obs-id lookup with `mast_obs_id` fallback (MongoDBService.cs:609 order), L2a/L2b/L3 filter, on-disk existence check, 50-id cap |

### CE_MODE security posture

- `CE_MODE=true`: ONLY the facade routers mount — no composite/mosaic/analysis/semantic/unprefixed-discovery, auth/jobs scaffolds never mount.
- **Default-deny middleware**: any request outside `/api/*` (except `/` and `/health` liveness) is 404'd before routing — covers the module-level render routes (which register regardless) and anything future. Interactive docs (`/docs`, `/openapi.json`) are blocked in CE.
- Per-handler guards on the 5 bare render routes as belt-and-suspenders.
- Route-table pytest asserts the `/api` surface equals the allowlist exactly, denied routes absent, and non-CE mode unchanged.
- Anonymous access enforced in the repository layer (`IsPublic` on every accessor) so a route cannot forget the filter.

### Contract findings fixed along the way (each now pinned by a test)

- **Date serialization**: System.Text.Json trims trailing fractional zeros and omits zero fractions (`.36Z`, `:00Z`) — verified empirically against the live API; `_iso_z` replicates it.
- **Dictionary keys are never camelized** (`DictionaryKeyPolicy=null`): `WCS` (FITS keywords like `CRPIX1`), `Statistics`, `InstrumentSettings`, etc. pass through verbatim; only POCO property names camelize.
- **`derivedFrom` defaults to `[]`** (non-nullable .NET list), never `null`.
- **BSON type discriminators** (`{"_t": "System.Collections...", "_v": [...]}` on mosaic-generator Metadata) are unwrapped like the .NET deserializer does — found by the live 1407-record diff.
- **`colorMapping` is keyed by filter names** (`F444W`) — the snake→camel converter only rewrites keys containing underscores, so data keys are never mangled.

### Non-CE behavior

Zero change: full engine surface mounts exactly as before; the facade also mounts in dev (additive) so it can be exercised against the full stack pre-cutover.

## Changes Made

- New `app/db/`: `client.py` (lazy motor), `repository.py` (IsPublic-enforcing reads), `projection.py` (MapToDataResponse parity), `casing.py` (wire-contract converters), `deps.py`
- `app/library/routes.py`: scaffold → real read endpoints
- New `app/discovery/api_routes.py` + `featured_targets.json` (engine copy; .NET Configuration copy stays canonical for the main app until gateway retires)
- `main.py`: `CE_MODE` mounting switch, default-deny middleware, `/api/health`, bare-route guards
- Tests: 45 new (casing, projection, repository, contract-vs-fixtures, route-table, bare-route guard). Full suite: **1471 passed** in Docker.
- `docs/key-files.md`: new module entries

## Test Plan

- [x] Red-green: contract/repo/casing tests written first, verified failing, then implementation
- [x] Full engine suite in Docker: 1471 passed, 1 deselected (`docker exec … python -m pytest`)
- [x] **Live end-to-end smoke** (CE_MODE app on :8055 in the engine container against real Mongo): health Healthy, 12 featured targets, 1407-doc list, check-availability finds real NGC-3132 MIRI obs, composite/mosaic/preview/semantic/docs all 404, liveness 200
- [x] **Live parity diff vs .NET**: 1407/1407 records identical
- [x] Self-review: code-reviewer round 1 (1 MUST + 4 SHOULD — all fixed), round 2 clean (0 MUST/SHOULD; 2 of 3 nits taken, third deferred to the router-fold PR)
- [x] ruff check + format clean
- [ ] Reviewer: sanity-check the CE_MODE test's allowlist constant against `docs/plans/features/ce-phase1-route-allowlist.md`

## Documentation Checklist

- [x] `docs/key-files.md` updated with new modules
- [x] Contract rules documented in module docstrings + spike report cross-references
- [ ] `docs/quick-reference.md` CE endpoint section — deferred to the Phase 2 completion PR (surface still growing)

## Tech Debt Impact

- [x] No weakened tests; 45 added
- [x] Known deferred items called out in code comments: bare render routes fold into a router (next Phase 2 PR); `featured_targets.json` dual-source until gateway retires; sync `file_exists` fine for CE local storage
- [ ] Follow-up (#1653): fail-fast config validation wires into `app/db/client.py`

## Risk & Rollback

- **Risk:** Low-medium. All changes are additive; `CE_MODE` defaults off, so the deployed engine behavior is unchanged (verified by the non-CE route-table test + full suite). The new surface only activates in the future CE compose.
- **Rollback:** revert the commit; no data or schema changes.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
