### PR TITLE
feat: CE Phase 3 — VITE_CE_MODE flag + route/nav/library gating

### DIFF
--- a/frontend/jwst-frontend/src/App.ce.test.tsx
+++ b/frontend/jwst-frontend/src/App.ce.test.tsx
@@ -1,0 +1,73 @@
+import type React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from './App';
+
+/**
+ * CE routing contract: auth pages, wizard pages, and semantic search are not
+ * routed at all (unknown paths fall through to Discover); /library is public.
+ * Pages are stubbed — this tests the route table, not the pages.
+ */
+vi.mock('./config/ce', () => ({ CE_MODE: true }));
+
+vi.mock('./pages/LoginPage', () => ({ LoginPage: () => <div data-testid="page-login" /> }));
+vi.mock('./pages/RegisterPage', () => ({
+  RegisterPage: () => <div data-testid="page-register" />,
+}));
+vi.mock('./pages/DiscoveryHome', () => ({
+  DiscoveryHome: () => <div data-testid="page-discover" />,
+}));
+vi.mock('./pages/MyLibrary', () => ({ MyLibrary: () => <div data-testid="page-library" /> }));
+vi.mock('./pages/TargetDetail', () => ({ TargetDetail: () => <div data-testid="page-target" /> }));
+vi.mock('./pages/GuidedCreate', () => ({ GuidedCreate: () => <div data-testid="page-create" /> }));
+vi.mock('./pages/CompositePage', () => ({
+  CompositePage: () => <div data-testid="page-composite" />,
+}));
+vi.mock('./pages/MosaicPage', () => ({ MosaicPage: () => <div data-testid="page-mosaic" /> }));
+vi.mock('./pages/SearchPage', () => ({ SearchPage: () => <div data-testid="page-search" /> }));
+vi.mock('./pages/ArchivePage', () => ({ ArchivePage: () => <div data-testid="page-archive" /> }));
+vi.mock('./components/layout/SharedLayout', async () => {
+  const { Outlet } = await import('react-router-dom');
+  return { SharedLayout: () => <Outlet /> };
+});
+vi.mock('./context/ActiveImportsContext', () => ({
+  ActiveImportsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="protected">{children}</div>
+  ),
+}));
+
+async function renderAt(path: string) {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>
+  );
+  // lazy routes resolve async even when mocked
+  return screen.findByTestId(/page-/);
+}
+
+describe('App routing in CE mode', () => {
+  it('serves the golden path + archive + library publicly', async () => {
+    expect((await renderAt('/')).dataset.testid).toBe('page-discover');
+  });
+
+  it('routes /library without ProtectedRoute', async () => {
+    const page = await renderAt('/library');
+    expect(page.dataset.testid).toBe('page-library');
+    expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['/login', 'page-discover'],
+    ['/register', 'page-discover'],
+    ['/search', 'page-discover'],
+    ['/composite', 'page-discover'],
+    ['/mosaic', 'page-discover'],
+  ])('%s falls through to Discover (route not registered)', async (path, expected) => {
+    expect((await renderAt(path)).dataset.testid).toBe(expected);
+  });
+});

--- a/frontend/jwst-frontend/src/App.tsx
+++ b/frontend/jwst-frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import './App.css';
 import { ProtectedRoute } from './components/ProtectedRoute';
+import { CE_MODE } from './config/ce';
 import { SharedLayout } from './components/layout/SharedLayout';
 import { ToastProvider } from './components/ui/toast';
 import { ActiveImportsProvider } from './context/ActiveImportsContext';
@@ -76,29 +77,36 @@ function App() {
       <ActiveImportsProvider>
         <Suspense fallback={<PageLoadingFallback />}>
           <Routes>
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/register" element={<RegisterPage />} />
+            {/* CE has no accounts: auth pages are not routed at all */}
+            {!CE_MODE && <Route path="/login" element={<LoginPage />} />}
+            {!CE_MODE && <Route path="/register" element={<RegisterPage />} />}
             {/* Public discovery pages — no login required to browse */}
             <Route element={<SharedLayout />}>
               <Route index element={<DiscoveryHome />} />
               <Route path="target/:name" element={<TargetDetail />} />
               <Route path="create" element={<GuidedCreate />} />
-              <Route path="search" element={<SearchPage />} />
+              {/* semantic search is out of CE v1 (its API never mounts) */}
+              {!CE_MODE && <Route path="search" element={<SearchPage />} />}
               <Route path="archive" element={<ArchivePage />} />
+              {/* CE review decision 2026-07-06: /library is a public
+                  read-only view — mutations are gated inside the dashboard */}
+              {CE_MODE && <Route path="library" element={<MyLibrary />} />}
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
-            {/* Protected pages — login required */}
-            <Route
-              element={
-                <ProtectedRoute>
-                  <SharedLayout />
-                </ProtectedRoute>
-              }
-            >
-              <Route path="library" element={<MyLibrary />} />
-              <Route path="composite" element={<CompositePage />} />
-              <Route path="mosaic" element={<MosaicPage />} />
-            </Route>
+            {/* Protected pages — login required (never routed in CE) */}
+            {!CE_MODE && (
+              <Route
+                element={
+                  <ProtectedRoute>
+                    <SharedLayout />
+                  </ProtectedRoute>
+                }
+              >
+                <Route path="library" element={<MyLibrary />} />
+                <Route path="composite" element={<CompositePage />} />
+                <Route path="mosaic" element={<MosaicPage />} />
+              </Route>
+            )}
           </Routes>
         </Suspense>
       </ActiveImportsProvider>

--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.ce.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.ce.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DashboardToolbar from './DashboardToolbar';
+
+// CE build: no uploads, no composite/mosaic wizards (auth'd async endpoints)
+vi.mock('../../config/ce', () => ({ CE_MODE: true }));
+
+describe('DashboardToolbar in CE mode', () => {
+  const defaultProps = {
+    searchTerm: '',
+    selectedDataType: 'all',
+    selectedProcessingLevel: 'all',
+    selectedViewability: 'all',
+    selectedInstrument: 'all',
+    selectedTag: 'all',
+    onSearchChange: vi.fn(),
+    onDataTypeChange: vi.fn(),
+    onProcessingLevelChange: vi.fn(),
+    onViewabilityChange: vi.fn(),
+    onInstrumentChange: vi.fn(),
+    onTagChange: vi.fn(),
+    baseFilteredCount: 10,
+    afterTypeFilterCount: 10,
+    afterLevelFilterCount: 10,
+    afterInstrumentFilterCount: 10,
+    availableTypes: {
+      dataTypeCounts: new Map<string, number>(),
+      viewableCount: 5,
+      tableCount: 2,
+    },
+    availableLevels: new Map<string, number>(),
+    availableInstruments: {
+      groupCounts: new Map<string, number>(),
+      modeCounts: new Map<string, number>(),
+    },
+    availableTags: [],
+    viewMode: 'lineage' as const,
+    onViewModeChange: vi.fn(),
+    showArchived: false,
+    onToggleArchived: vi.fn(),
+    onShowUpload: vi.fn(),
+    selectedCount: 0,
+    onOpenCompositeWizard: vi.fn(),
+    onOpenMosaicWizard: vi.fn(),
+    onOpenComparisonPicker: vi.fn(),
+  };
+
+  const renderToolbar = () =>
+    render(
+      <MemoryRouter>
+        <DashboardToolbar {...defaultProps} />
+      </MemoryRouter>
+    );
+
+  it('hides Upload Data and the composite/mosaic wizard buttons', () => {
+    renderToolbar();
+    expect(screen.queryByRole('button', { name: 'Upload Data' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Composite/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /WCS Mosaic/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps the read-only affordances (MAST search link, Compare, view toggles)', () => {
+    renderToolbar();
+    expect(screen.getByRole('link', { name: 'Search MAST' })).toHaveAttribute('href', '/archive');
+    expect(screen.getByRole('button', { name: /Compare/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Lineage/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Show Archived/ })).toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DashboardToolbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { CE_MODE } from '../../config/ce';
 import { LineageIcon, TargetIcon } from '../icons/DashboardIcons';
 import './DashboardToolbar.css';
 
@@ -244,9 +245,11 @@ const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
         </div>
 
         <div className="controls-row controls-row-primary-actions">
-          <button className="btn-base btn-large upload-btn" onClick={onShowUpload}>
-            Upload Data
-          </button>
+          {!CE_MODE && (
+            <button className="btn-base btn-large upload-btn" onClick={onShowUpload}>
+              Upload Data
+            </button>
+          )}
           <Link to="/archive" className="btn-base btn-large mast-search-btn">
             Search MAST
           </Link>
@@ -280,36 +283,41 @@ const DashboardToolbar: React.FC<DashboardToolbarProps> = ({
           </button>
         </div>
 
+        {/* CE: composite/mosaic wizards use auth'd async endpoints — hidden */}
         <div className="controls-row controls-row-analysis-actions" ref={analysisRowRef}>
-          <button
-            className="btn-base composite-btn"
-            onClick={onOpenCompositeWizard}
-            title="Create composite image"
-          >
-            <span className="composite-icon">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                <circle cx="8" cy="8" r="4" fill="#ff4444" opacity="0.8" />
-                <circle cx="16" cy="8" r="4" fill="#44ff44" opacity="0.8" />
-                <circle cx="12" cy="14" r="4" fill="#4488ff" opacity="0.8" />
-              </svg>
-            </span>
-            Composite{selectedCount > 0 ? ` (${selectedCount})` : ''}
-          </button>
-          <button
-            className={`btn-base mosaic-open-btn ${selectedCount >= 2 ? 'ready' : ''}`}
-            onClick={onOpenMosaicWizard}
-            title="Create a WCS-aligned mosaic from multiple FITS images"
-          >
-            <span className="mosaic-icon">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                <rect x="2" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#4488ff" />
-                <rect x="13" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#44ddff" />
-                <rect x="2" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#8844ff" />
-                <rect x="13" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#44ff88" />
-              </svg>
-            </span>
-            WCS Mosaic{selectedCount > 0 ? ` (${selectedCount})` : ''}
-          </button>
+          {!CE_MODE && (
+            <>
+              <button
+                className="btn-base composite-btn"
+                onClick={onOpenCompositeWizard}
+                title="Create composite image"
+              >
+                <span className="composite-icon">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                    <circle cx="8" cy="8" r="4" fill="#ff4444" opacity="0.8" />
+                    <circle cx="16" cy="8" r="4" fill="#44ff44" opacity="0.8" />
+                    <circle cx="12" cy="14" r="4" fill="#4488ff" opacity="0.8" />
+                  </svg>
+                </span>
+                Composite{selectedCount > 0 ? ` (${selectedCount})` : ''}
+              </button>
+              <button
+                className={`btn-base mosaic-open-btn ${selectedCount >= 2 ? 'ready' : ''}`}
+                onClick={onOpenMosaicWizard}
+                title="Create a WCS-aligned mosaic from multiple FITS images"
+              >
+                <span className="mosaic-icon">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                    <rect x="2" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#4488ff" />
+                    <rect x="13" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#44ddff" />
+                    <rect x="2" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#8844ff" />
+                    <rect x="13" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#44ff88" />
+                  </svg>
+                </span>
+                WCS Mosaic{selectedCount > 0 ? ` (${selectedCount})` : ''}
+              </button>
+            </>
+          )}
           <button
             className="btn-base compare-open-btn"
             onClick={onOpenComparisonPicker}

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.ce.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.ce.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { JwstDataModel } from '../../types/JwstDataTypes';
+import DataCard from './DataCard';
+
+// CE build: library is a public read-only view — no mutations, no selection
+vi.mock('../../config/ce', () => ({ CE_MODE: true }));
+vi.mock('../../config/api', () => ({ API_BASE_URL: 'http://test:5001' }));
+vi.mock('../../utils/fitsUtils', () => ({
+  getFitsFileInfo: () => ({
+    type: 'image',
+    label: 'CAL',
+    viewable: true,
+    description: 'Calibrated image',
+  }),
+  isSpectralFile: () => false,
+}));
+vi.mock('../../utils/statusUtils', () => ({ getStatusColor: () => 'green' }));
+
+const item: JwstDataModel = {
+  id: '507f1f77bcf86cd799439011',
+  fileName: 'test_cal.fits',
+  dataType: 'image',
+  fileSize: 5242880,
+  processingStatus: 'completed',
+  filePath: '/app/data/mast/test/test_cal.fits',
+  uploadDate: '2026-01-01T00:00:00Z',
+  tags: [],
+  description: '',
+  isArchived: false,
+  hasThumbnail: false,
+  metadata: {},
+  processingResults: [],
+};
+
+describe('DataCard in CE mode', () => {
+  it('renders View but no Archive and no composite-select', () => {
+    render(
+      <DataCard
+        item={item}
+        isSelected={false}
+        isArchiving={false}
+        selectedTag=""
+        onFileSelect={vi.fn()}
+        onView={vi.fn()}
+        onArchive={vi.fn()}
+        onTagClick={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /archive/i })).not.toBeInTheDocument();
+    expect(document.querySelector('.composite-select-btn')).toBeNull();
+  });
+});

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -3,6 +3,7 @@ import { JwstDataModel } from '../../types/JwstDataTypes';
 import { getFitsFileInfo, isSpectralFile } from '../../utils/fitsUtils';
 import { getStatusColor } from '../../utils/statusUtils';
 import { API_BASE_URL } from '../../config/api';
+import { CE_MODE } from '../../config/ce';
 import { TelescopeIcon, ImageIcon, TableIcon, CheckIcon, PlusIcon } from '../icons/DashboardIcons';
 import './DataCard.css';
 
@@ -54,7 +55,7 @@ const DataCard: React.FC<DataCardProps> = ({
         </div>
       )}
       <div className="card-header">
-        {fitsInfo.viewable && (
+        {!CE_MODE && fitsInfo.viewable && (
           <button
             className={`btn-base composite-select-btn ${isSelected ? 'selected' : ''}`}
             onClick={(e) => onFileSelect(item.id, e)}
@@ -151,19 +152,21 @@ const DataCard: React.FC<DataCardProps> = ({
         >
           {isSpectralFile(item.fileName) ? 'Spectrum' : fitsInfo.viewable ? 'View' : 'Table'}
         </button>
-        <button
-          className="btn-base btn-compact archive-btn"
-          onClick={() => onArchive(item.id, item.isArchived)}
-          disabled={isArchiving}
-        >
-          {isArchiving
-            ? item.isArchived
-              ? 'Unarchiving...'
-              : 'Archiving...'
-            : item.isArchived
-              ? 'Unarchive'
-              : 'Archive'}
-        </button>
+        {!CE_MODE && (
+          <button
+            className="btn-base btn-compact archive-btn"
+            onClick={() => onArchive(item.id, item.isArchived)}
+            disabled={isArchiving}
+          >
+            {isArchiving
+              ? item.isArchived
+                ? 'Unarchiving...'
+                : 'Archiving...'
+              : item.isArchived
+                ? 'Unarchive'
+                : 'Archive'}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.ce.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.ce.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import FloatingAnalysisBar from './FloatingAnalysisBar';
+
+// CE: the floating mirror of the toolbar's analysis row must not resurface
+// the Composite/Mosaic wizards (round-1 review catch)
+vi.mock('../../config/ce', () => ({ CE_MODE: true }));
+
+describe('FloatingAnalysisBar in CE mode', () => {
+  it('renders only the read-only Compare action', () => {
+    render(
+      <FloatingAnalysisBar
+        visible={true}
+        selectedCount={0}
+        onOpenCompositeWizard={vi.fn()}
+        onOpenMosaicWizard={vi.fn()}
+        onOpenComparisonPicker={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button', { name: /Composite/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /WCS Mosaic/ })).not.toBeInTheDocument();
+    expect(screen.queryByText(/files? selected/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Compare/ })).toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/FloatingAnalysisBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { CE_MODE } from '../../config/ce';
 import './FloatingAnalysisBar.css';
 
 interface FloatingAnalysisBarProps {
@@ -19,40 +20,46 @@ const FloatingAnalysisBar: React.FC<FloatingAnalysisBarProps> = ({
   return (
     <div className={`floating-analysis-bar ${visible ? 'visible' : ''}`} aria-hidden={!visible}>
       <div className="floating-analysis-inner">
-        <span className="floating-selection-context">
-          {selectedCount === 0
-            ? 'No files selected'
-            : `${selectedCount} file${selectedCount === 1 ? '' : 's'} selected`}
-        </span>
-        <button
-          className={`btn-base composite-btn ${selectedCount >= 2 ? 'ready' : ''}`}
-          onClick={onOpenCompositeWizard}
-          title="Create composite image"
-        >
-          <span className="composite-icon">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-              <circle cx="8" cy="8" r="4" fill="#ff4444" opacity="0.8" />
-              <circle cx="16" cy="8" r="4" fill="#44ff44" opacity="0.8" />
-              <circle cx="12" cy="14" r="4" fill="#4488ff" opacity="0.8" />
-            </svg>
+        {!CE_MODE && (
+          <span className="floating-selection-context">
+            {selectedCount === 0
+              ? 'No files selected'
+              : `${selectedCount} file${selectedCount === 1 ? '' : 's'} selected`}
           </span>
-          Composite{selectedCount > 0 ? ` (${selectedCount})` : ''}
-        </button>
-        <button
-          className={`btn-base mosaic-open-btn ${selectedCount >= 2 ? 'ready' : ''}`}
-          onClick={onOpenMosaicWizard}
-          title="Create a WCS-aligned mosaic from multiple FITS images"
-        >
-          <span className="mosaic-icon">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-              <rect x="2" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#4488ff" />
-              <rect x="13" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#44ddff" />
-              <rect x="2" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#8844ff" />
-              <rect x="13" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#44ff88" />
-            </svg>
-          </span>
-          WCS Mosaic{selectedCount > 0 ? ` (${selectedCount})` : ''}
-        </button>
+        )}
+        {!CE_MODE && (
+          <>
+            <button
+              className={`btn-base composite-btn ${selectedCount >= 2 ? 'ready' : ''}`}
+              onClick={onOpenCompositeWizard}
+              title="Create composite image"
+            >
+              <span className="composite-icon">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                  <circle cx="8" cy="8" r="4" fill="#ff4444" opacity="0.8" />
+                  <circle cx="16" cy="8" r="4" fill="#44ff44" opacity="0.8" />
+                  <circle cx="12" cy="14" r="4" fill="#4488ff" opacity="0.8" />
+                </svg>
+              </span>
+              Composite{selectedCount > 0 ? ` (${selectedCount})` : ''}
+            </button>
+            <button
+              className={`btn-base mosaic-open-btn ${selectedCount >= 2 ? 'ready' : ''}`}
+              onClick={onOpenMosaicWizard}
+              title="Create a WCS-aligned mosaic from multiple FITS images"
+            >
+              <span className="mosaic-icon">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                  <rect x="2" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#4488ff" />
+                  <rect x="13" y="2" width="9" height="9" rx="1" opacity="0.7" fill="#44ddff" />
+                  <rect x="2" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#8844ff" />
+                  <rect x="13" y="13" width="9" height="9" rx="1" opacity="0.7" fill="#44ff88" />
+                </svg>
+              </span>
+              WCS Mosaic{selectedCount > 0 ? ` (${selectedCount})` : ''}
+            </button>
+          </>
+        )}
         <button
           className="btn-base compare-open-btn"
           onClick={onOpenComparisonPicker}

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.ce.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.ce.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { JwstDataModel } from '../../types/JwstDataTypes';
+import LineageFileCard from './LineageFileCard';
+
+// CE: read-only file rows — no archive, no composite selection
+vi.mock('../../config/ce', () => ({ CE_MODE: true }));
+vi.mock('../../config/api', () => ({ API_BASE_URL: 'http://test:5001' }));
+vi.mock('../../utils/fitsUtils', () => ({
+  getFitsFileInfo: () => ({
+    type: 'image',
+    label: 'I2D',
+    viewable: true,
+    description: 'Resampled image',
+  }),
+  isSpectralFile: () => false,
+}));
+vi.mock('../../utils/statusUtils', () => ({ getStatusColor: () => 'green' }));
+
+const item: JwstDataModel = {
+  id: 'abc123',
+  fileName: 'test_i2d.fits',
+  dataType: 'image',
+  fileSize: 1048576,
+  processingStatus: 'completed',
+  filePath: 'mast/x/test_i2d.fits',
+  uploadDate: '2026-01-01T00:00:00Z',
+  tags: [],
+  description: '',
+  isArchived: false,
+  hasThumbnail: false,
+  metadata: {},
+  processingResults: [],
+};
+
+describe('LineageFileCard in CE mode', () => {
+  it('renders View but hides Archive and composite-select', () => {
+    render(
+      <LineageFileCard
+        item={item}
+        isSelected={false}
+        isArchiving={false}
+        onFileSelect={vi.fn()}
+        onView={vi.fn()}
+        onArchive={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /archive/i })).not.toBeInTheDocument();
+    expect(document.querySelector('.composite-select-btn')).toBeNull();
+  });
+});

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.tsx
@@ -3,6 +3,7 @@ import { JwstDataModel } from '../../types/JwstDataTypes';
 import { getFitsFileInfo, isSpectralFile } from '../../utils/fitsUtils';
 import { getStatusColor } from '../../utils/statusUtils';
 import { API_BASE_URL } from '../../config/api';
+import { CE_MODE } from '../../config/ce';
 import { TelescopeIcon, ImageIcon, TableIcon, CheckIcon, PlusIcon } from '../icons/DashboardIcons';
 import './LineageFileCard.css';
 
@@ -51,7 +52,7 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
       )}
       <div className="lineage-file-content">
         <div className="file-header">
-          {fitsInfo.viewable && (
+          {!CE_MODE && fitsInfo.viewable && (
             <button
               className={`btn-base composite-select-btn small ${isSelected ? 'selected' : ''}`}
               onClick={(e) => onFileSelect(item.id, e)}
@@ -123,19 +124,21 @@ const LineageFileCard: React.FC<LineageFileCardProps> = ({
           >
             {isSpectralFile(item.fileName) ? 'Spectrum' : fitsInfo.viewable ? 'View' : 'Table'}
           </button>
-          <button
-            className="btn-base archive-btn"
-            onClick={() => onArchive(item.id, item.isArchived)}
-            disabled={isArchiving}
-          >
-            {isArchiving
-              ? item.isArchived
-                ? 'Unarchiving...'
-                : 'Archiving...'
-              : item.isArchived
-                ? 'Unarchive'
-                : 'Archive'}
-          </button>
+          {!CE_MODE && (
+            <button
+              className="btn-base archive-btn"
+              onClick={() => onArchive(item.id, item.isArchived)}
+              disabled={isArchiving}
+            >
+              {isArchiving
+                ? item.isArchived
+                  ? 'Unarchiving...'
+                  : 'Archiving...'
+                : item.isArchived
+                  ? 'Unarchive'
+                  : 'Archive'}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/jwst-frontend/src/components/dashboard/LineageView.ce.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageView.ce.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LineageView from './LineageView';
+import type { JwstDataModel } from '../../types/JwstDataTypes';
+
+// CE: no delete-observation / archive-level / delete-level controls
+vi.mock('../../config/ce', () => ({ CE_MODE: true }));
+vi.mock('./LineageFileCard', () => ({
+  default: (props: { item: { id: string } }) => (
+    <div data-testid={`lineage-file-card-${props.item.id}`} />
+  ),
+}));
+
+const item: JwstDataModel = {
+  id: '1',
+  fileName: 'test_i2d.fits',
+  fileSize: 1024,
+  uploadDate: '2024-01-01T00:00:00Z',
+  processingLevel: 'L3',
+  observationBaseId: 'jw01234-o001',
+  dataType: 'image',
+  processingStatus: 'completed',
+  filePath: 'mast/x/test_i2d.fits',
+  tags: [],
+  description: '',
+  isArchived: false,
+  hasThumbnail: false,
+  metadata: {},
+  processingResults: [],
+};
+
+describe('LineageView in CE mode', () => {
+  const props = {
+    filteredData: [item],
+    collapsedLineages: new Set<string>(),
+    expandedLevels: new Set<string>(['jw01234-o001-L3']),
+    selectedFiles: new Set<string>(),
+    archivingIds: new Set<string>(),
+    onToggleLineage: vi.fn(),
+    onToggleLevel: vi.fn(),
+    onDeleteObservation: vi.fn(),
+    onDeleteLevel: vi.fn(),
+    onArchiveLevel: vi.fn(),
+    isArchivingLevel: false,
+    onFileSelect: vi.fn(),
+    onView: vi.fn(),
+    onArchive: vi.fn(),
+    hasActiveFilters: false,
+    totalCount: 1,
+    onClearFilters: vi.fn(),
+  };
+
+  it('hides observation delete and level archive/delete controls', () => {
+    render(<LineageView {...props} />);
+    expect(screen.getByTestId('lineage-file-card-1')).toBeInTheDocument();
+    expect(screen.queryByTitle('Delete this observation')).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/Archive all/)).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/Delete all/)).not.toBeInTheDocument();
+  });
+
+  it('empty state does not advertise uploads', () => {
+    render(<LineageView {...props} filteredData={[]} totalCount={0} />);
+    expect(screen.getByText('Search MAST to get started.')).toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/components/dashboard/LineageView.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageView.tsx
@@ -7,6 +7,7 @@ import {
 import { formatFileSize } from '../../utils/formatUtils';
 import { TrashIcon, ArchiveIcon, TelescopeIcon } from '../icons/DashboardIcons';
 import LineageFileCard from './LineageFileCard';
+import { CE_MODE } from '../../config/ce';
 import './LineageView.css';
 
 interface LineageViewProps {
@@ -163,7 +164,7 @@ const LineageView: React.FC<LineageViewProps> = ({
                 <span className="group-count">
                   {totalFiles} file{totalFiles !== 1 ? 's' : ''}
                 </span>
-                {obsId !== 'Manual Uploads' && (
+                {!CE_MODE && obsId !== 'Manual Uploads' && (
                   <button
                     className="btn-base delete-observation-btn"
                     onClick={(e) => onDeleteObservation(obsId, e)}
@@ -206,7 +207,7 @@ const LineageView: React.FC<LineageViewProps> = ({
                           ({filesAtLevel.length} files, {formatFileSize(levelTotalSize)})
                         </span>
                         <span className="expand-icon">{isExpanded ? '−' : '+'}</span>
-                        {obsId !== 'Manual Uploads' && (
+                        {!CE_MODE && obsId !== 'Manual Uploads' && (
                           <div className="level-actions">
                             <button
                               className="btn-base level-action-btn archive-btn"
@@ -268,7 +269,11 @@ const LineageView: React.FC<LineageViewProps> = ({
           ) : (
             <>
               <h3>Your library is empty</h3>
-              <p>Upload FITS files or search MAST to get started.</p>
+              <p>
+                {CE_MODE
+                  ? 'Search MAST to get started.'
+                  : 'Upload FITS files or search MAST to get started.'}
+              </p>
             </>
           )}
         </div>

--- a/frontend/jwst-frontend/src/components/dashboard/TargetGroupView.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/TargetGroupView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { JwstDataModel } from '../../types/JwstDataTypes';
 import DataCard from './DataCard';
 import { TelescopeIcon } from '../icons/DashboardIcons';
+import { CE_MODE } from '../../config/ce';
 import './TargetGroupView.css';
 
 interface TargetGroupViewProps {
@@ -130,7 +131,11 @@ const TargetGroupView: React.FC<TargetGroupViewProps> = ({
           ) : (
             <>
               <h3>Your library is empty</h3>
-              <p>Upload FITS files or search MAST to get started.</p>
+              <p>
+                {CE_MODE
+                  ? 'Search MAST to get started.'
+                  : 'Upload FITS files or search MAST to get started.'}
+              </p>
             </>
           )}
         </div>

--- a/frontend/jwst-frontend/src/components/layout/SharedLayout.ce.test.tsx
+++ b/frontend/jwst-frontend/src/components/layout/SharedLayout.ce.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SharedLayout } from './SharedLayout';
+
+// CE build: no accounts, no imports, no semantic search
+vi.mock('../../config/ce', () => ({ CE_MODE: true }));
+vi.mock('../UserMenu', () => ({ UserMenu: () => <div data-testid="user-menu" /> }));
+vi.mock('./MastStatusPill', () => ({ MastStatusPill: () => <div data-testid="mast-pill" /> }));
+vi.mock('./ImportProgressPill', () => ({
+  ImportProgressPill: () => <div data-testid="import-pill" />,
+}));
+
+describe('SharedLayout in CE mode', () => {
+  function renderLayout() {
+    return render(
+      <MemoryRouter>
+        <SharedLayout />
+      </MemoryRouter>
+    );
+  }
+
+  it('hides the UserMenu and ImportProgressPill', () => {
+    renderLayout();
+    expect(screen.queryByTestId('user-menu')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('import-pill')).not.toBeInTheDocument();
+  });
+
+  it('keeps the MAST status pill', () => {
+    renderLayout();
+    expect(screen.getByTestId('mast-pill')).toBeInTheDocument();
+  });
+
+  it('hides the semantic Search nav link and de-personalizes Library', () => {
+    renderLayout();
+    expect(screen.queryByRole('link', { name: 'Search' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute('href', '/library');
+    expect(screen.queryByRole('link', { name: 'My Library' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/components/layout/SharedLayout.test.tsx
+++ b/frontend/jwst-frontend/src/components/layout/SharedLayout.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SharedLayout } from './SharedLayout';
+
+// Regression guard: with CE off (the default build), the full chrome renders.
+vi.mock('../UserMenu', () => ({ UserMenu: () => <div data-testid="user-menu" /> }));
+vi.mock('./MastStatusPill', () => ({ MastStatusPill: () => <div data-testid="mast-pill" /> }));
+vi.mock('./ImportProgressPill', () => ({
+  ImportProgressPill: () => <div data-testid="import-pill" />,
+}));
+
+describe('SharedLayout (full build)', () => {
+  it('renders UserMenu, ImportProgressPill, Search link, and My Library', () => {
+    render(
+      <MemoryRouter>
+        <SharedLayout />
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('user-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('import-pill')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Search' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'My Library' })).toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/components/layout/SharedLayout.tsx
+++ b/frontend/jwst-frontend/src/components/layout/SharedLayout.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet } from 'react-router-dom';
+import { CE_MODE } from '../../config/ce';
 import { UserMenu } from '../UserMenu';
 import { MastStatusPill } from './MastStatusPill';
 import { ImportProgressPill } from './ImportProgressPill';
@@ -40,18 +41,21 @@ export function SharedLayout() {
               <NavLink to="/" className="nav-link" end>
                 Discover
               </NavLink>
-              <NavLink to="/search" className="nav-link">
-                Search
-              </NavLink>
+              {!CE_MODE && (
+                <NavLink to="/search" className="nav-link">
+                  Search
+                </NavLink>
+              )}
               <NavLink to="/library" className="nav-link">
-                My Library
+                {CE_MODE ? 'Library' : 'My Library'}
               </NavLink>
             </nav>
           </div>
           <div className="header-right">
-            <ImportProgressPill />
+            {/* CE: no imports and no accounts — pills/menu never render */}
+            {!CE_MODE && <ImportProgressPill />}
             <MastStatusPill />
-            <UserMenu />
+            {!CE_MODE && <UserMenu />}
           </div>
         </div>
       </header>

--- a/frontend/jwst-frontend/src/config/ce.test.ts
+++ b/frontend/jwst-frontend/src/config/ce.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+/**
+ * CE_MODE is read from import.meta.env at module evaluation, so each case
+ * stubs the env and re-imports the module fresh.
+ */
+describe('CE_MODE flag', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('is false when VITE_CE_MODE is unset', async () => {
+    vi.stubEnv('VITE_CE_MODE', undefined as unknown as string);
+    const { CE_MODE } = await import('./ce');
+    expect(CE_MODE).toBe(false);
+  });
+
+  it('is true only for the literal string "true"', async () => {
+    vi.stubEnv('VITE_CE_MODE', 'true');
+    vi.resetModules();
+    expect((await import('./ce')).CE_MODE).toBe(true);
+  });
+
+  it.each(['1', 'TRUE', 'yes', ''])('is false for %j', async (value) => {
+    vi.stubEnv('VITE_CE_MODE', value);
+    vi.resetModules();
+    expect((await import('./ce')).CE_MODE).toBe(false);
+  });
+});

--- a/frontend/jwst-frontend/src/config/ce.ts
+++ b/frontend/jwst-frontend/src/config/ce.ts
@@ -1,0 +1,18 @@
+/**
+ * Community Edition build flag (CE plan Phase 3 — progressive capability gate).
+ *
+ * `VITE_CE_MODE=true` at build time produces the public, anonymous, read-only
+ * CE bundle: no auth surfaces, no library mutations, no job-queue/SignalR
+ * paths, pointed at the Python backend (`VITE_API_URL`). The flag is a
+ * build-time constant, so Vite dead-code-eliminates the gated branches from
+ * the CE bundle.
+ *
+ * UI gating here is a UX concern only — the security boundary is the
+ * backend's CE_MODE deny-by-default route mounting (the corresponding
+ * server-side flag), which 404s everything outside the read allowlist.
+ *
+ * Capabilities intentionally OFF in CE v1 (flip on as the Python tier grows):
+ * accounts, MAST imports, uploads, delete/archive mutations, composite/mosaic
+ * wizard pages, async jobs + SignalR progress, semantic search (/search).
+ */
+export const CE_MODE = import.meta.env.VITE_CE_MODE === 'true';

--- a/frontend/jwst-frontend/src/pages/MyLibrary.tsx
+++ b/frontend/jwst-frontend/src/pages/MyLibrary.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import JwstDataDashboard from '../components/JwstDataDashboard';
 import { jwstDataService, ApiError } from '../services';
 import { JwstDataModel } from '../types/JwstDataTypes';
+import { CE_MODE } from '../config/ce';
 import './MyLibrary.css';
 
 /**
@@ -42,7 +43,7 @@ export function MyLibrary() {
   };
 
   useEffect(() => {
-    document.title = 'My Library — JWST Discovery';
+    document.title = CE_MODE ? 'Library — JWST Discovery' : 'My Library — JWST Discovery';
   }, []);
 
   useEffect(() => {
@@ -73,8 +74,12 @@ export function MyLibrary() {
   return (
     <div className="my-library">
       <div className="library-header">
-        <h1 className="library-title">My Library</h1>
-        <p className="library-subtitle">Your imported FITS files, composites, and mosaics</p>
+        <h1 className="library-title">{CE_MODE ? 'Library' : 'My Library'}</h1>
+        <p className="library-subtitle">
+          {CE_MODE
+            ? 'Browse the curated JWST data behind the featured targets'
+            : 'Your imported FITS files, composites, and mosaics'}
+        </p>
       </div>
       <JwstDataDashboard data={data} onDataUpdate={refreshData} />
     </div>

--- a/frontend/jwst-frontend/src/vite-env.d.ts
+++ b/frontend/jwst-frontend/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
+  readonly VITE_CE_MODE?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

No linked issue (CE plan Phase 3, PR 1 of 2; tracked by epic #1403).

**`VITE_CE_MODE`** — the frontend's build-time Community Edition flag (the plan's "progressive capability gate") — plus the route/nav/library gating it drives. With the flag off (every existing build), rendering is byte-identical to main; with it on, the app becomes the public, anonymous, read-only CE surface.

### What CE mode changes

- **Routing (`App.tsx`)**: `/login`, `/register`, `/search` (semantic — its API never mounts in CE), `/composite`, `/mosaic` are simply not routed (unknown paths fall through to Discover). **`/library` routes publicly without `ProtectedRoute`** (review decision 2026-07-06).
- **Layout (`SharedLayout`)**: no `UserMenu`, no `ImportProgressPill`, no Search nav link; "My Library" → "Library".
- **Library surface, read-only** (UI/UX gating — the security boundary is the backend's `CE_MODE` deny-by-default): Upload button, composite/mosaic wizard launchers (toolbar **and** the floating analysis bar — review catch, see below), per-card Archive, composite-select buttons, lineage delete-observation / archive-level / delete-level controls all gone. Compare (read-only) and the MAST search link stay.
- **Chrome/copy**: `MyLibrary` title/subtitle de-personalized in CE; empty states no longer advertise uploads.

### Review catch worth reading

Round 1 found that `FloatingAnalysisBar` — the scroll-following mirror of the toolbar's analysis row — still exposed live Composite/WCS Mosaic buttons in CE (the gating had only been applied to the toolbar). Fixed + regression test. This is exactly the multi-consumer trap the self-review pipeline exists for.

### Deliberately NOT in this PR (Phase 3 PR2, next)

In-page auth affordances and UX copy: GuidedCreate sign-in wall, RecipeCard "Login required" pill, `/login` links in WhatsNewPanel/ResultsTable, ResultStep `/composite` handoff, admin Re-index button, 429/timeout friendly renderer-busy state, de-jargon pass (MastStatusPill, NO_PRODUCTS/S3_UNAVAILABLE). These are plan lines 178–186 and land next.

## Changes Made

- New `src/config/ce.ts` (+ `vite-env.d.ts` typing)
- `App.tsx`, `SharedLayout.tsx` — CE routing/nav
- `DashboardToolbar`, `FloatingAnalysisBar`, `DataCard`, `LineageFileCard`, `LineageView`, `TargetGroupView`, `MyLibrary` — read-only gating + copy
- 8 new test files / 24 new tests: flag parsing, CE route table (incl. `/library` public + fall-throughs), layout both modes, every gated affordance

## Test Plan

- [x] Full unit suite: **1126 passed** (includes a non-CE `SharedLayout` regression test pinning the full chrome)
- [x] `npx tsc --noEmit` clean; eslint 0 errors
- [x] **CE production build compiles** (`VITE_CE_MODE=true npm run build`) — flag is a build-time constant, so gated branches dead-code-eliminate; unused lazy chunks may still be emitted but are never fetched (backend deny-by-default is the real boundary)
- [x] Self-review round 1 (1 MUST: FloatingAnalysisBar; 3 SHOULD: MyLibrary chrome, empty states, test gaps — all fixed), round 2 verification requested
- [x] Non-CE behavior: with the flag unset, every gate renders the original element — verified by review + full suite
- [ ] E2E: runs in CI (frontend changed). Local E2E intentionally skipped: the running dev containers serve the pre-branch build, and flag-off rendering is unchanged (pinned by unit tests)

## Documentation Checklist

- [x] `src/config/ce.ts` docstring documents the capability-gate contract and the UI-vs-backend security split
- [ ] CE build/deploy docs (`VITE_CE_MODE` in compose) — Phase 4 compose PR

## Tech Debt Impact

- [x] No new tech debt; gates are single-constant conditionals that vanish from non-CE builds
- [x] Multi-consumer sweep done (toolbar + floating bar + cards + lineage + nav)

## Risk & Rollback

- **Risk:** Low. All changes are behind a build flag that no existing build sets; flag-off DOM is unchanged.
- **Rollback:** revert the commit.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
