### PR TITLE
feat: CE Phase 4 — global render semaphore (two-stage queue-or-429)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -97,10 +97,22 @@ MAST_DOWNLOAD_TIMEOUT=3600
 # MAX_COMPOSITE_ESTIMATE_FILES caps total inputs to /composite/estimate to
 # prevent file-resolution amplification. 500 is generous for most recipes.
 #
+# MAX_CONCURRENT_COMPOSITES caps SIMULTANEOUS composite renders (the memory
+# budget above is per-request; N parallel renders can still sum past physical
+# RAM). Requests beyond the cap queue up to COMPOSITE_QUEUE_WAIT_SECONDS for a
+# free slot, then get 429 + Retry-After. COMPOSITE_QUEUE_DEPTH bounds how many
+# requests may WAIT (beyond those rendering) — everyone past slots+depth 429s
+# instantly so waiters can never exhaust the worker thread pools. Mandatory
+# posture for the public CE deployment; 2 slots is right for an ~8GB box with
+# a ~3GB per-render budget.
+#
 # Uncomment to override defaults:
 # MAX_COMPOSITE_MEMORY_BYTES=3000000000
 # COMPOSITE_DOWNSCALE_FAIL_THRESHOLD=0.85
 # MAX_COMPOSITE_ESTIMATE_FILES=500
+# MAX_CONCURRENT_COMPOSITES=2
+# COMPOSITE_QUEUE_WAIT_SECONDS=15
+# COMPOSITE_QUEUE_DEPTH=4
 
 # =============================================================================
 # Storage Configuration

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -11,6 +11,7 @@ import json
 import logging
 import re
 import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -103,6 +104,75 @@ COMPOSITE_DOWNSCALE_FAIL_THRESHOLD = float_env("COMPOSITE_DOWNSCALE_FAIL_THRESHO
 # pre-flight endpoint. Body-size protection lives at the .NET gateway.
 _MAX_ESTIMATE_TOTAL_FILES = int_env("MAX_COMPOSITE_ESTIMATE_FILES", 500)
 BYTES_PER_PIXEL = np.dtype(np.float64).itemsize  # 8 bytes
+
+# ---------------------------------------------------------------------------
+# Global render semaphore (CE plan Phase 4).
+#
+# The memory budget above is PER-REQUEST; nothing bounded render concurrency.
+# On a public no-auth deployment, N parallel composites each within budget can
+# still sum past physical memory. Every composite render — the sync route, the
+# NDJSON stream route, and the CE /api facade — funnels through
+# _run_nchannel_pipeline, so the slot is acquired there: queue briefly for a
+# free slot, then fail fast with 429 + Retry-After. Values are read at module
+# load; docker/.env.example documents them.
+# ---------------------------------------------------------------------------
+MAX_CONCURRENT_COMPOSITES = int_env("MAX_CONCURRENT_COMPOSITES", 2)
+COMPOSITE_QUEUE_WAIT_SECONDS = float_env("COMPOSITE_QUEUE_WAIT_SECONDS", 15.0)
+# How many renders may WAIT for a slot (beyond the ones rendering). Waiters
+# occupy worker threads, so this must stay small — an unbounded queue would
+# let a request flood exhaust the shared thread pools and starve every other
+# sync endpoint (the exact DoS this gate exists to prevent).
+COMPOSITE_QUEUE_DEPTH = int_env("COMPOSITE_QUEUE_DEPTH", 4)
+_render_slots = threading.BoundedSemaphore(MAX_CONCURRENT_COMPOSITES)
+_admission = threading.BoundedSemaphore(MAX_CONCURRENT_COMPOSITES + COMPOSITE_QUEUE_DEPTH)
+
+_AT_CAPACITY = "The image renderer is at capacity. Please retry in a few seconds."
+
+
+def _busy(retry_after: float) -> HTTPException:
+    return HTTPException(
+        status_code=429,
+        detail=_AT_CAPACITY,
+        headers={"Retry-After": str(max(1, int(retry_after)))},
+    )
+
+
+@contextlib.contextmanager
+def _render_slot(cancelled: threading.Event | None = None):
+    """Hold one global render slot; 429 when saturated.
+
+    Two-stage gate:
+    1. ADMISSION (non-blocking): at most slots+queue_depth requests are in
+       the building — everyone else 429s IMMEDIATELY, so waiters can never
+       pile up and exhaust the shared worker pools.
+    2. SLOT (sliced blocking): admitted requests wait up to
+       COMPOSITE_QUEUE_WAIT_SECONDS for a render slot in 0.5s slices,
+       observing ``cancelled`` between slices so a disconnected streaming
+       client stops waiting instead of holding a thread for the full window.
+
+    Callers run in worker threads (sync routes use the Starlette threadpool,
+    the stream route + CE facade use asyncio's executor), so blocking here
+    never stalls the event loop.
+    """
+    wait = COMPOSITE_QUEUE_WAIT_SECONDS
+    if not _admission.acquire(blocking=False):
+        raise _busy(wait)
+    try:
+        deadline = time.monotonic() + wait
+        while True:
+            if cancelled is not None and cancelled.is_set():
+                raise PipelineCancelled()
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise _busy(wait)
+            if _render_slots.acquire(timeout=min(0.5, remaining)):
+                break
+        try:
+            yield
+        finally:
+            _render_slots.release()
+    finally:
+        _admission.release()
 
 
 def _current_max_memory_bytes() -> int:
@@ -1490,6 +1560,7 @@ def _encode_and_respond(
 def _run_nchannel_pipeline(
     request: NChannelCompositeRequest,
     progress: ProgressCallback = None,
+    cancelled: threading.Event | None = None,
 ) -> Response:
     """Run the full N-channel composite pipeline.
 
@@ -1498,55 +1569,56 @@ def _run_nchannel_pipeline(
     to emit per-channel events to the streaming response; pass `None` for
     the buffered sync path (no events emitted, no overhead).
     """
-    input_budget = min(
-        MAX_INPUT_PIXELS,
-        max(request.width * request.height * PREVIEW_OVERSAMPLE, MIN_PREVIEW_PIXELS),
-    )
-    log_memory("composite-start")
-    logger.info(
-        f"Generating N-channel composite ({len(request.channels)} channels, "
-        f"output={request.width}x{request.height}, "
-        f"input_budget={input_budget:,} px)"
-    )
-
-    instruments = _detect_channel_instruments(request.channels)
-    reprojected, verdict = _load_reprojected_channels(
-        request, instruments, input_budget, progress=progress
-    )
-    feather, auto_feathered = _resolve_feather_strength(request, instruments)
-
-    if request.debug_masks:
-        return _render_debug_masks_response(request, reprojected, instruments, feather)
-
-    if request.background_neutralization:
-        emit_progress(
-            progress,
-            stage="background_neutralize",
-            message="Applying background neutralization",
+    with _render_slot(cancelled=cancelled):
+        input_budget = min(
+            MAX_INPUT_PIXELS,
+            max(request.width * request.height * PREVIEW_OVERSAMPLE, MIN_PREVIEW_PIXELS),
         )
-        logger.info("Applying cross-channel background neutralization (pre-stretch)")
-        stretch_input = neutralize_raw_backgrounds(reprojected)
-    else:
-        stretch_input = reprojected
-
-    mapped = _stretch_and_map_channels(request, stretch_input, instruments, progress=progress)
-    emit_progress(progress, stage="combine", message="Combining color channels")
-    rgb = _combine_to_rgb(mapped, reprojected, request, feather, instruments)
-    if request.sharpening is not None and request.sharpening.amount > 0.0:
-        rgb = apply_sharpening(
-            rgb, request.sharpening, coverage_mask=_build_coverage_mask(reprojected)
+        log_memory("composite-start")
+        logger.info(
+            f"Generating N-channel composite ({len(request.channels)} channels, "
+            f"output={request.width}x{request.height}, "
+            f"input_budget={input_budget:,} px)"
         )
-    if request.saturation is not None:
-        rgb = apply_saturation_vibrancy(rgb, request.saturation)
-    emit_progress(progress, stage="encode", message="Encoding image")
-    return _encode_and_respond(
-        rgb,
-        request,
-        auto_feathered,
-        feather,
-        verdict,
-        stretch_fallbacks=mapped.stretch_fallbacks,
-    )
+
+        instruments = _detect_channel_instruments(request.channels)
+        reprojected, verdict = _load_reprojected_channels(
+            request, instruments, input_budget, progress=progress
+        )
+        feather, auto_feathered = _resolve_feather_strength(request, instruments)
+
+        if request.debug_masks:
+            return _render_debug_masks_response(request, reprojected, instruments, feather)
+
+        if request.background_neutralization:
+            emit_progress(
+                progress,
+                stage="background_neutralize",
+                message="Applying background neutralization",
+            )
+            logger.info("Applying cross-channel background neutralization (pre-stretch)")
+            stretch_input = neutralize_raw_backgrounds(reprojected)
+        else:
+            stretch_input = reprojected
+
+        mapped = _stretch_and_map_channels(request, stretch_input, instruments, progress=progress)
+        emit_progress(progress, stage="combine", message="Combining color channels")
+        rgb = _combine_to_rgb(mapped, reprojected, request, feather, instruments)
+        if request.sharpening is not None and request.sharpening.amount > 0.0:
+            rgb = apply_sharpening(
+                rgb, request.sharpening, coverage_mask=_build_coverage_mask(reprojected)
+            )
+        if request.saturation is not None:
+            rgb = apply_saturation_vibrancy(rgb, request.saturation)
+        emit_progress(progress, stage="encode", message="Encoding image")
+        return _encode_and_respond(
+            rgb,
+            request,
+            auto_feathered,
+            feather,
+            verdict,
+            stretch_fallbacks=mapped.stretch_fallbacks,
+        )
 
 
 @router.post("/generate-nchannel")
@@ -1597,7 +1669,7 @@ async def generate_nchannel_composite_stream(request: NChannelCompositeRequest):
 
     def run_pipeline() -> None:
         try:
-            response = _run_nchannel_pipeline(request, progress=emit)
+            response = _run_nchannel_pipeline(request, progress=emit, cancelled=cancellation)
             if cancellation.is_set():
                 return
             image_bytes: bytes = bytes(response.body)
@@ -1616,7 +1688,11 @@ async def generate_nchannel_composite_stream(request: NChannelCompositeRequest):
             # nobody is listening on the other side of the queue.
             logger.info("Streaming composite cancelled by client disconnect")
         except HTTPException as e:
-            emit({"event": "error", "detail": str(e.detail), "status_code": e.status_code})
+            error_event = {"event": "error", "detail": str(e.detail), "status_code": e.status_code}
+            retry_after = (e.headers or {}).get("Retry-After")
+            if retry_after is not None:
+                error_event["retry_after"] = retry_after
+            emit(error_event)
         except Exception as e:  # noqa: BLE001 - surface arbitrary engine failures
             logger.exception("Streaming composite failed")
             emit({"event": "error", "detail": str(e), "status_code": 500})

--- a/processing-engine/tests/test_render_semaphore.py
+++ b/processing-engine/tests/test_render_semaphore.py
@@ -1,0 +1,208 @@
+"""Global render semaphore (CE plan Phase 4).
+
+The #882 memory budget is per-request; nothing bounded render CONCURRENCY
+before this. On a public no-auth box, N parallel composites each within
+budget can still sum past physical memory — the semaphore caps concurrent
+renders (queue briefly, then 429 + Retry-After).
+"""
+
+import json
+import threading
+import time
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import app.composite.routes as routes
+
+
+@pytest.fixture
+def exhausted_semaphore(monkeypatch):
+    """Render slots exhausted (admission open) and a near-zero queue wait."""
+    sem = threading.BoundedSemaphore(1)
+    assert sem.acquire(blocking=False)
+    monkeypatch.setattr(routes, "_render_slots", sem)
+    monkeypatch.setattr(routes, "_admission", threading.BoundedSemaphore(8))
+    monkeypatch.setattr(routes, "COMPOSITE_QUEUE_WAIT_SECONDS", 0.05)
+    return sem
+
+
+VALID_BODY = {
+    "channels": [{"file_paths": ["mast/x/y.fits"], "color": {"hue": 120.0}}],
+    "width": 200,
+    "height": 200,
+}
+
+
+class TestRenderSlot:
+    @pytest.mark.usefixtures("exhausted_semaphore")
+    def test_exhausted_raises_429_with_retry_after(self):
+        with pytest.raises(HTTPException) as exc, routes._render_slot():
+            pass
+        assert exc.value.status_code == 429
+        # clamped to >= 1 even when the queue wait is sub-second
+        assert int(exc.value.headers["Retry-After"]) >= 1
+        assert "renderer is at capacity" in str(exc.value.detail)
+
+    def test_admission_full_fails_immediately_without_waiting(self, monkeypatch):
+        """Beyond slots+queue_depth, callers must NOT block a thread at all."""
+        monkeypatch.setattr(routes, "_render_slots", threading.BoundedSemaphore(1))
+        adm = threading.BoundedSemaphore(1)
+        assert adm.acquire(blocking=False)
+        monkeypatch.setattr(routes, "_admission", adm)
+        monkeypatch.setattr(routes, "COMPOSITE_QUEUE_WAIT_SECONDS", 30.0)
+        start = time.monotonic()
+        with pytest.raises(HTTPException) as exc, routes._render_slot():
+            pass
+        assert exc.value.status_code == 429
+        assert time.monotonic() - start < 1.0  # no 30s wait
+
+    def test_cancelled_while_waiting_raises_pipeline_cancelled(self, monkeypatch):
+        from app.composite.progress import PipelineCancelled
+
+        sem = threading.BoundedSemaphore(1)
+        assert sem.acquire(blocking=False)
+        monkeypatch.setattr(routes, "_render_slots", sem)
+        monkeypatch.setattr(routes, "_admission", threading.BoundedSemaphore(8))
+        monkeypatch.setattr(routes, "COMPOSITE_QUEUE_WAIT_SECONDS", 30.0)
+        cancelled = threading.Event()
+        cancelled.set()
+        start = time.monotonic()
+        with pytest.raises(PipelineCancelled), routes._render_slot(cancelled=cancelled):
+            pass
+        assert time.monotonic() - start < 1.0  # bails on the first slice
+
+    def test_exactly_slot_count_succeeds_under_contention(self, monkeypatch):
+        monkeypatch.setattr(routes, "_render_slots", threading.BoundedSemaphore(2))
+        monkeypatch.setattr(routes, "_admission", threading.BoundedSemaphore(10))
+        monkeypatch.setattr(routes, "COMPOSITE_QUEUE_WAIT_SECONDS", 0.3)
+        inside = threading.Semaphore(0)
+        release_renders = threading.Event()
+        outcomes = []
+
+        def render():
+            try:
+                with routes._render_slot():
+                    inside.release()
+                    release_renders.wait(timeout=5)
+                    outcomes.append("ok")
+            except HTTPException as e:
+                outcomes.append(e.status_code)
+
+        threads = [threading.Thread(target=render) for _ in range(5)]
+        for t in threads:
+            t.start()
+        inside.acquire()
+        inside.acquire()  # two renders hold slots
+        # give the other three time to exhaust their 0.3s window
+        time.sleep(0.6)
+        release_renders.set()
+        for t in threads:
+            t.join(timeout=5)
+        assert outcomes.count("ok") == 2
+        assert outcomes.count(429) == 3
+
+    def test_slot_released_after_use(self, monkeypatch):
+        sem = threading.BoundedSemaphore(1)
+        monkeypatch.setattr(routes, "_render_slots", sem)
+        monkeypatch.setattr(routes, "COMPOSITE_QUEUE_WAIT_SECONDS", 0.05)
+        with routes._render_slot():
+            assert not sem.acquire(blocking=False)  # held
+        assert sem.acquire(blocking=False)  # released
+        sem.release()
+
+    def test_slot_released_when_body_raises(self, monkeypatch):
+        sem = threading.BoundedSemaphore(1)
+        monkeypatch.setattr(routes, "_render_slots", sem)
+        with pytest.raises(RuntimeError), routes._render_slot():
+            raise RuntimeError("pipeline exploded")
+        assert sem.acquire(blocking=False)
+        sem.release()
+
+    def test_queued_caller_proceeds_when_slot_frees(self, monkeypatch):
+        """A waiter inside the queue window gets the slot instead of 429ing."""
+        sem = threading.BoundedSemaphore(1)
+        monkeypatch.setattr(routes, "_render_slots", sem)
+        monkeypatch.setattr(routes, "COMPOSITE_QUEUE_WAIT_SECONDS", 2.0)
+        assert sem.acquire(blocking=False)
+        result = {}
+
+        def waiter():
+            with routes._render_slot():
+                result["entered"] = True
+
+        t = threading.Thread(target=waiter)
+        t.start()
+        time.sleep(0.1)
+        sem.release()  # first render finishes
+        t.join(timeout=3)
+        assert result.get("entered") is True
+
+
+class TestRoutesGuarded:
+    @pytest.mark.usefixtures("exhausted_semaphore")
+    def test_sync_route_429_before_any_pipeline_work(self):
+        from main import app
+
+        client = TestClient(app)
+        resp = client.post("/composite/generate-nchannel", json=VALID_BODY)
+        assert resp.status_code == 429
+        assert resp.headers.get("retry-after")
+
+    @pytest.mark.usefixtures("exhausted_semaphore")
+    def test_stream_route_emits_429_error_event_with_retry_hint(self):
+        from main import app
+
+        client = TestClient(app)
+        with client.stream("POST", "/composite/generate-nchannel-stream", json=VALID_BODY) as resp:
+            events = [json.loads(line) for line in resp.iter_lines() if line]
+        terminal = events[-1]
+        assert terminal["event"] == "error"
+        assert terminal["status_code"] == 429
+        # NDJSON responses are HTTP 200, so the backoff hint must ride in-band
+        assert int(terminal["retry_after"]) >= 1
+
+    @pytest.mark.usefixtures("exhausted_semaphore")
+    def test_ce_facade_429_with_retry_after(self):
+        """The public CE edge: 429 must propagate out of asyncio.to_thread
+        with the Retry-After header and the /api error-shim body shape."""
+        from bson import ObjectId
+        from fastapi import FastAPI
+
+        import app.composite.api_routes as facade
+        from app.db.deps import get_repository
+        from app.db.repository import JwstDataReadRepository
+        from app.exceptions import register_api_error_shim
+        from tests.db.fakes import FakeCollection
+
+        oid = ObjectId()
+        api = FastAPI()
+        register_api_error_shim(api)
+        api.include_router(facade.router)
+        repo = JwstDataReadRepository(
+            FakeCollection(
+                [{"_id": oid, "FileName": "x.fits", "IsPublic": True, "FilePath": "mast/x.fits"}]
+            )
+        )
+        api.dependency_overrides[get_repository] = lambda: repo
+        client = TestClient(api)
+        resp = client.post(
+            "/api/composite/generate-nchannel",
+            json={"channels": [{"dataIds": [str(oid)], "color": {"hue": 1.0}}]},
+        )
+        assert resp.status_code == 429
+        assert resp.headers.get("retry-after")
+        assert "renderer is at capacity" in resp.json()["error"]
+
+    @pytest.mark.usefixtures("exhausted_semaphore")
+    def test_estimate_and_analyze_bypass_the_gate(self):
+        """Pre-flight endpoints deliberately do NOT take a render slot —
+        they must keep answering while renderers are saturated."""
+        from main import app
+
+        client = TestClient(app)
+        resp = client.post("/composite/estimate", json=VALID_BODY)
+        assert resp.status_code != 429
+        resp = client.post("/composite/analyze-channels", json=VALID_BODY)
+        assert resp.status_code != 429


### PR DESCRIPTION
## Summary

No linked issue (CE plan Phase 4, PR 1 of 2; tracked by epic #1403).

**Global render semaphore** — the plan's "mandatory for any public no-auth deploy" item. The #882 memory budget is per-request; nothing bounded render *concurrency*, so N parallel composites each within budget could still sum past physical RAM.

### Design (hardened through review round 1)

Two-stage gate at the single choke point (`_run_nchannel_pipeline` — covers the sync route, the NDJSON stream route, and the CE `/api` facade):

1. **Admission (non-blocking)**: at most `MAX_CONCURRENT_COMPOSITES + COMPOSITE_QUEUE_DEPTH` requests in the building; everyone else 429s **immediately**. This was the round-1 catch: a naive blocking acquire would let a request flood park up to 15s × N on the shared worker pools and starve every other sync endpoint — the DoS control becoming its own DoS vector.
2. **Slot (sliced blocking)**: admitted requests wait up to `COMPOSITE_QUEUE_WAIT_SECONDS` (15s) in 0.5s slices, observing the stream route's cancellation event between slices — a disconnected client stops waiting instead of pinning a thread and stealing a slot.

429s carry `Retry-After`; the NDJSON stream (HTTP 200) carries the hint in-band as `retry_after` on the error event. Pre-flight endpoints (`/estimate`, `/analyze-channels`) deliberately bypass the gate (test-pinned) so preflight stays live while renderers are saturated.

Defaults: 2 slots / depth 4 / 15s — right for an ~8GB box with a ~3GB per-render budget. All env-tunable, documented in `docker/.env.example`.

**Live smoke:** 3 parallel real renders against a 1-slot config → one 200 (real 117KB JPEG, 10.7s), two 429s after the queue window with `Retry-After` — and the 429 bodies flow through the `/api` error shim into the frontend's Phase 3 "renderer busy" copy. The full CE ladder (semaphore → shim → friendly UX) composes.

## Changes Made

- `app/composite/routes.py`: gate + `_render_slot(cancelled=)` + pipeline wrap + stream `retry_after`
- `tests/test_render_semaphore.py`: 11 tests (slot lifecycle, immediate-429 admission bound, cancel-while-waiting, exact-slot-count contention, sync/stream/facade 429s, preflight bypass)
- `docker/.env.example`: `MAX_CONCURRENT_COMPOSITES` / `COMPOSITE_QUEUE_WAIT_SECONDS` / `COMPOSITE_QUEUE_DEPTH`

## Test Plan

- [x] Red-green: semaphore tests written first
- [x] Full engine suite in Docker: **1522 passed** (mechanical pipeline-body re-indent verified — only implicit f-string concatenations inside, no semantics change; reviewer-verified all release paths incl. `PipelineCancelled`)
- [x] Live smoke: parallel renders → 429/queue, not OOM (the plan's stranger-smoke bullet)
- [x] Self-review round 1 (0 MUST; 3 SHOULD: threadpool starvation, cancel-while-waiting, stream backoff hint — all fixed; 5 test gaps closed), round 2 verification requested
- [x] ruff clean

## Documentation Checklist

- [x] `.env.example` documents the knobs
- [ ] CE compose wires the values — PR2 (next)

## Tech Debt Impact

- [x] No new debt. Noted follow-up from review (not blocking): `/analyze-channels` low-res reproject has no concurrency cap of its own — revisit if analyze traffic grows.

## Risk & Rollback

- **Risk:** Low-medium. Applies in all modes (dev included) — but 2 concurrent renders + 4 queued exceeds any realistic single-user dev load, and the main app's wizard uses the async job path for authenticated users anyway.
- **Rollback:** revert the commit.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
