### PR TITLE
feat: CE Phase 4 — deployment stack (compose, nginx rate limits, ceReader)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -174,3 +174,20 @@ S3_BACKUP_BUCKET=
 # hour per registered domain).
 # Format: lowercase RFC 1123 hostname (e.g., jwst.example.com).
 DOMAIN_NAME=
+
+# =============================================================================
+# Community Edition (CE) deployment — docker-compose.ce.yml only
+# =============================================================================
+# Password for the read-only Mongo user the CE engine connects as. Created by
+# docker/mongo-init-ce/create-ce-reader.js (auto on first init of an empty
+# volume; run manually for a pre-seeded volume — see docs/deployment.md).
+# IMPORTANT: this value is embedded raw in the Mongo connection URI — it must
+# be URL-safe. Generate with: openssl rand -hex 32  (hex only; base64's
+# + / = characters would silently break engine authentication).
+# CE_MONGO_READER_PASSWORD=
+
+# Host port the CE frontend (the stack's only published port) binds to.
+# CE_HTTP_PORT=80
+
+# Host path holding the CE seed bundle (FITS files), mounted read-only.
+# CE_DATA_DIR=../data

--- a/docker/docker-compose.ce.yml
+++ b/docker/docker-compose.ce.yml
@@ -1,0 +1,131 @@
+# =============================================================================
+# Community Edition (CE) stack — public, anonymous, read-only deployment.
+#
+# CE plan: docs/plans/features/community-edition-v1.md (Phase 4).
+# Three containers only: frontend (nginx, THE sole published port, same-origin
+# /api proxy with rate limits) + processing-engine (CE_MODE deny-by-default,
+# read-only Mongo credentials, read-only data mount) + mongodb (internal
+# network only — unreachable from the host or the edge network).
+#
+#   docker compose -f docker-compose.ce.yml --env-file .env up -d --build
+#
+# Memory math for an ~8GB box: engine 4g (render budget 3e9 + headroom),
+# mongo 1g (WiredTiger cache 0.5GB), frontend 256m, OS/page-cache the rest.
+# Enable swap on the host as a safety net (see docs/deployment.md CE runbook).
+#
+# Covers #745 (per-service resource limits) and #651 (network isolation) for
+# the CE topology.
+# =============================================================================
+
+name: jwst-ce
+
+services:
+  mongodb:
+    image: mongo:8.0
+    container_name: jwst-ce-mongodb
+    restart: unless-stopped
+    mem_limit: 1g
+    # Cap WiredTiger cache well below mem_limit — the seeded catalog is small
+    # and read-only; default cache sizing assumes it owns the machine.
+    command: ["mongod", "--wiredTigerCacheSizeGB", "0.5"]
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME:?Set MONGO_ROOT_USERNAME in .env (see .env.example)}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:?Set MONGO_ROOT_PASSWORD in .env (see .env.example)}
+      # Consumed by mongo-init-ce/create-ce-reader.js on FIRST init of an
+      # empty data volume. For a pre-seeded volume, run the script manually
+      # (see docs/deployment.md CE runbook).
+      MONGO_CE_READER_PASSWORD: ${CE_MONGO_READER_PASSWORD:?Set CE_MONGO_READER_PASSWORD in .env (see .env.example)}
+      MONGO_DATABASE: ${MONGO_DATABASE:-jwst_data_analysis}
+    volumes:
+      - mongodb_ce_data:/data/db
+      - ./mongo-init-ce:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - ce-internal
+
+  processing-engine:
+    build:
+      context: ../processing-engine
+      dockerfile: Dockerfile
+    container_name: jwst-ce-engine
+    restart: unless-stopped
+    mem_limit: 4g
+    environment:
+      - PYTHONPATH=/app
+      - PYTHONUNBUFFERED=1
+      # Deny-by-default: ONLY the /api read/search/render facade mounts; the
+      # middleware 404s everything else. See tests/test_ce_mode_mounting.py.
+      - CE_MODE=true
+      # Read-only credentials: ceReader has the `read` role on the app DB
+      # and nothing else. Created by mongo-init-ce/create-ce-reader.js.
+      # Password is interpolated RAW into the URI — must be URL-safe
+      # (generate with `openssl rand -hex 32`, see .env.example).
+      - MONGODB_URI=mongodb://ceReader:${CE_MONGO_READER_PASSWORD:?Set CE_MONGO_READER_PASSWORD in .env}@mongodb:27017/${MONGO_DATABASE:-jwst_data_analysis}?authSource=${MONGO_DATABASE:-jwst_data_analysis}
+      - MONGODB_DATABASE=${MONGO_DATABASE:-jwst_data_analysis}
+      # Render limits (8GB box): 3GB per-render budget x 2 concurrent slots,
+      # small queue, instant 429 beyond slots+depth.
+      - MAX_COMPOSITE_MEMORY_BYTES=${MAX_COMPOSITE_MEMORY_BYTES:-3000000000}
+      - COMPOSITE_DOWNSCALE_FAIL_THRESHOLD=${COMPOSITE_DOWNSCALE_FAIL_THRESHOLD:-0.85}
+      - MAX_CONCURRENT_COMPOSITES=${MAX_CONCURRENT_COMPOSITES:-2}
+      - COMPOSITE_QUEUE_WAIT_SECONDS=${COMPOSITE_QUEUE_WAIT_SECONDS:-15}
+      - COMPOSITE_QUEUE_DEPTH=${COMPOSITE_QUEUE_DEPTH:-4}
+      - MAX_COMPOSITE_REQUEST_FILES=${MAX_COMPOSITE_REQUEST_FILES:-100}
+      - MAX_FITS_ARRAY_ELEMENTS=${MAX_FITS_ARRAY_ELEMENTS:-200000000}
+      - STORAGE_PROVIDER=local
+      - STORAGE_BASE_PATH=/app/data
+    volumes:
+      # Read-only: CE never writes FITS data (no imports, no uploads) — the
+      # seed bundle is produced offline and shipped to this path.
+      - ${CE_DATA_DIR:-../data}:/app/data:ro
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - ce-internal
+      - ce-edge
+
+  frontend:
+    build:
+      context: ../frontend/jwst-frontend
+      dockerfile: Dockerfile
+      args:
+        # Same-origin: the bundle calls /api/... relative, nginx proxies it.
+        VITE_API_URL: ""
+        VITE_CE_MODE: "true"
+        NGINX_CONF: nginx-ce.conf
+    container_name: jwst-ce-frontend
+    restart: unless-stopped
+    mem_limit: 256m
+    ports:
+      # THE only published port of the stack. TLS terminates in front of
+      # this (certbot/nginx on the host or a provider LB) — Phase 6.
+      - "${CE_HTTP_PORT:-80}:3000"
+    depends_on:
+      # service_started (not healthy): the SPA shell should serve even if the
+      # engine is down — the frontend has its own API error states.
+      processing-engine:
+        condition: service_started
+    networks:
+      - ce-edge
+
+networks:
+  # Mongo lives here alone with the engine: `internal: true` means no
+  # host-published ports and no route out — the DB is unreachable from the
+  # edge network and the internet even by misconfiguration.
+  ce-internal:
+    internal: true
+  ce-edge:
+
+volumes:
+  mongodb_ce_data:

--- a/docker/mongo-init-ce/create-ce-reader.js
+++ b/docker/mongo-init-ce/create-ce-reader.js
@@ -1,0 +1,35 @@
+// Community Edition read-only Mongo user (CE plan Phase 4).
+//
+// Runs from /docker-entrypoint-initdb.d on the FIRST initialization of an
+// empty /data/db volume, authenticated as the root user. For a pre-seeded
+// volume (the normal CE deploy path — the seed bundle ships a populated
+// volume), run this manually once:
+//
+//   docker exec jwst-ce-mongodb mongosh -u "$MONGO_ROOT_USERNAME" \
+//     -p "$MONGO_ROOT_PASSWORD" --authenticationDatabase admin \
+//     /docker-entrypoint-initdb.d/create-ce-reader.js
+//
+// The engine connects as ceReader (read role on the app database only), so
+// even a full application compromise cannot write, drop, or admin the DB.
+
+const dbName = process.env.MONGO_DATABASE || 'jwst_data_analysis';
+const password = process.env.MONGO_CE_READER_PASSWORD;
+
+if (!password) {
+  throw new Error('MONGO_CE_READER_PASSWORD is not set — refusing to create ceReader');
+}
+
+const appDb = db.getSiblingDB(dbName);
+
+const existing = appDb.getUser('ceReader');
+if (existing) {
+  print(`ceReader already exists in ${dbName} — updating password/roles`);
+  appDb.updateUser('ceReader', { pwd: password, roles: [{ role: 'read', db: dbName }] });
+} else {
+  appDb.createUser({
+    user: 'ceReader',
+    pwd: password,
+    roles: [{ role: 'read', db: dbName }],
+  });
+  print(`created ceReader with read-only access to ${dbName}`);
+}

--- a/docs/architecture/deployment-architecture.md
+++ b/docs/architecture/deployment-architecture.md
@@ -285,6 +285,43 @@ flowchart LR
 | **Phase 1** | DB performance or durability needs | Managed MongoDB (Atlas/DocumentDB); app stays on EC2 |
 | **Phase 2** | Compute bottleneck or HA requirements | ECS/EKS orchestration, ALB, Redis for SignalR backplane, AWS S3 for storage |
 
+## Community Edition (CE) Topology
+
+The CE deployment (`docker/docker-compose.ce.yml`, CE plan Phase 4) is a
+three-container slice with no .NET tier, no mast-proxy, no SeaweedFS:
+
+```text
+                     Internet
+                        │  :80 (the ONLY published port; TLS in front — Phase 6)
+                        ▼
+              ┌───────────────────┐
+              │ frontend (nginx)  │  VITE_CE_MODE build · SPA + /api proxy
+              │  mem 256m         │  limit_req: api 10r/s · mast 2r/s · render 1r/s
+              └─────────┬─────────┘  timeouts: 120s render (Phase 1 spike)
+              ce-edge   │
+              ┌─────────▼─────────┐
+              │ processing-engine │  CE_MODE deny-by-default /api facade
+              │  mem 4g           │  render semaphore 2 slots + queue 4
+              └─────────┬─────────┘  data mount READ-ONLY
+              ce-internal (internal: true — no host ports, no egress)
+              ┌─────────▼─────────┐
+              │ mongodb           │  ceReader (read role only)
+              │  mem 1g · WT 0.5g │  seeded catalog, IsPublic data
+              └───────────────────┘
+```
+
+Defense layers, outermost first: nginx rate limits → engine deny-by-default
+route mounting + default-deny middleware → render semaphore + input caps +
+per-request memory budget → read-only Mongo credentials → read-only FITS
+mount → internal-only DB network. Covers #651 (network isolation) and #745
+(resource limits) for the CE topology.
+
+Known residual: the single-image data views (`preview`/`histogram`/
+`pixeldata`/`cubeinfo`) are capped per-IP at nginx (3r/s, 4 conns) but have
+no engine-side concurrency gate — aggregate cross-IP load is unbounded
+below the container memory limit. Tracked in #1664.
+
 ---
 
 [Back to Architecture Overview](index.md)
+

--- a/docs/architecture/docker-compose.md
+++ b/docs/architecture/docker-compose.md
@@ -53,6 +53,43 @@ flowchart TB
     MongoContainer --> MongoData
 ```
 
+## Community Edition (CE) Topology
+
+The CE deployment (`docker/docker-compose.ce.yml`, CE plan Phase 4) is a
+three-container slice with no .NET tier, no mast-proxy, no SeaweedFS:
+
+```text
+                     Internet
+                        │  :80 (the ONLY published port; TLS in front — Phase 6)
+                        ▼
+              ┌───────────────────┐
+              │ frontend (nginx)  │  VITE_CE_MODE build · SPA + /api proxy
+              │  mem 256m         │  limit_req: api 10r/s · mast 2r/s · render 1r/s
+              └─────────┬─────────┘  timeouts: 120s render (Phase 1 spike)
+              ce-edge   │
+              ┌─────────▼─────────┐
+              │ processing-engine │  CE_MODE deny-by-default /api facade
+              │  mem 4g           │  render semaphore 2 slots + queue 4
+              └─────────┬─────────┘  data mount READ-ONLY
+              ce-internal (internal: true — no host ports, no egress)
+              ┌─────────▼─────────┐
+              │ mongodb           │  ceReader (read role only)
+              │  mem 1g · WT 0.5g │  seeded catalog, IsPublic data
+              └───────────────────┘
+```
+
+Defense layers, outermost first: nginx rate limits → engine deny-by-default
+route mounting + default-deny middleware → render semaphore + input caps +
+per-request memory budget → read-only Mongo credentials → read-only FITS
+mount → internal-only DB network. Covers #651 (network isolation) and #745
+(resource limits) for the CE topology.
+
+Known residual: the single-image data views (`preview`/`histogram`/
+`pixeldata`/`cubeinfo`) are capped per-IP at nginx (3r/s, 4 conns) but have
+no engine-side concurrency gate — aggregate cross-IP load is unbounded
+below the container memory limit. Tracked in #1664.
+
 ---
 
 [Back to Architecture Overview](index.md)
+

--- a/docs/architecture/network-topology.md
+++ b/docs/architecture/network-topology.md
@@ -222,6 +222,43 @@ All services within `jwst-network` can reach each other by container name (e.g.,
 
 **Recommendation for production**: Restrict SSH to specific IP ranges.
 
+## Community Edition (CE) Topology
+
+The CE deployment (`docker/docker-compose.ce.yml`, CE plan Phase 4) is a
+three-container slice with no .NET tier, no mast-proxy, no SeaweedFS:
+
+```text
+                     Internet
+                        │  :80 (the ONLY published port; TLS in front — Phase 6)
+                        ▼
+              ┌───────────────────┐
+              │ frontend (nginx)  │  VITE_CE_MODE build · SPA + /api proxy
+              │  mem 256m         │  limit_req: api 10r/s · mast 2r/s · render 1r/s
+              └─────────┬─────────┘  timeouts: 120s render (Phase 1 spike)
+              ce-edge   │
+              ┌─────────▼─────────┐
+              │ processing-engine │  CE_MODE deny-by-default /api facade
+              │  mem 4g           │  render semaphore 2 slots + queue 4
+              └─────────┬─────────┘  data mount READ-ONLY
+              ce-internal (internal: true — no host ports, no egress)
+              ┌─────────▼─────────┐
+              │ mongodb           │  ceReader (read role only)
+              │  mem 1g · WT 0.5g │  seeded catalog, IsPublic data
+              └───────────────────┘
+```
+
+Defense layers, outermost first: nginx rate limits → engine deny-by-default
+route mounting + default-deny middleware → render semaphore + input caps +
+per-request memory budget → read-only Mongo credentials → read-only FITS
+mount → internal-only DB network. Covers #651 (network isolation) and #745
+(resource limits) for the CE topology.
+
+Known residual: the single-image data views (`preview`/`histogram`/
+`pixeldata`/`cubeinfo`) are capped per-IP at nginx (3r/s, 4 conns) but have
+no engine-side concurrency gate — aggregate cross-IP load is unbounded
+below the container memory limit. Tracked in #1664.
+
 ---
 
 [Back to Architecture Overview](index.md)
+

--- a/frontend/jwst-frontend/Dockerfile
+++ b/frontend/jwst-frontend/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:22-alpine AS build
 
 ARG VITE_API_URL
+ARG VITE_CE_MODE
 ENV VITE_API_URL=${VITE_API_URL}
+ENV VITE_CE_MODE=${VITE_CE_MODE}
 
 WORKDIR /app
 
@@ -12,8 +14,10 @@ COPY . .
 RUN npm run build
 
 FROM nginx:1.29-alpine
+# Which nginx config to bake (nginx.conf | nginx-staging.conf | nginx-ce.conf)
+ARG NGINX_CONF=nginx.conf
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY ${NGINX_CONF} /etc/nginx/conf.d/default.conf
 
 # Create non-root user and ensure nginx directories are writable
 RUN addgroup -S -g 1001 appgroup && \

--- a/frontend/jwst-frontend/nginx-ce.conf
+++ b/frontend/jwst-frontend/nginx-ce.conf
@@ -1,0 +1,132 @@
+# Community Edition nginx configuration (CE plan Phase 4).
+#
+# The frontend container is the ONLY published port of the CE stack; this
+# config is both the SPA server and the /api reverse proxy to the Python
+# engine. Rate limits are the outer DoS layer (the engine's render semaphore
+# + input caps are the inner layer). No /hubs (no SignalR in CE), no backend.
+#
+# Timeout note: 120s on render routes comes from the Phase 1 timing spike —
+# passing featured-recipe renders finish in seconds (5s dev ≈ 10-20s VPS);
+# a render still running at 120s is stuck, not slow.
+
+# Zones live at http context (conf.d files are included there).
+# 10m zone ≈ 160k tracked client IPs — plenty.
+limit_req_zone $binary_remote_addr zone=ce_api:10m rate=10r/s;
+# MAST passthrough is the only per-request OUTBOUND call CE makes — cheap for
+# the caller, a real MAST query for us. Tighter than the general API.
+limit_req_zone $binary_remote_addr zone=ce_mast:10m rate=2r/s;
+# Composite render: the engine 429s beyond its semaphore anyway; this keeps
+# hammering clients from even reaching it.
+limit_req_zone $binary_remote_addr zone=ce_render:10m rate=1r/s;
+# Single-image data views (preview/histogram/pixeldata/cubeinfo) load full
+# FITS arrays but are NOT behind the engine's render semaphore — cap them
+# tighter than the general API so parallel viewers can't stack memory.
+limit_req_zone $binary_remote_addr zone=ce_preview:10m rate=3r/s;
+limit_conn_zone $binary_remote_addr zone=ce_conn:10m;
+
+server {
+    listen 3000;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # limit_req/limit_conn reject with 503 by default — surface them as 429
+    # so clients (and the frontend's ApiError parser) see the real semantics.
+    limit_req_status 429;
+    limit_conn_status 429;
+
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Rate-limited responses as JSON the frontend's ApiError parser reads.
+    # NOTE: any add_header in a location DROPS inherited server-level headers
+    # — every location that adds one must re-declare the security trio.
+    error_page 429 = @rate_limited;
+    location @rate_limited {
+        default_type application/json;
+        add_header Retry-After 5 always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        return 429 '{"error": "Too many requests — please slow down.", "detail": "rate limited"}';
+    }
+
+    # SPA routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Immutable hashed assets
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        try_files $uri =404;
+    }
+
+    # ---- API proxy (deny-by-default lives in the engine; these are limits) ----
+
+    location /api/ {
+        limit_req zone=ce_api burst=20 nodelay;
+        limit_conn ce_conn 10;
+        proxy_pass http://processing-engine:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
+    }
+
+    # MAST search passthrough — tighter limit (outbound amplification vector)
+    location /api/mast/ {
+        limit_req zone=ce_mast burst=5 nodelay;
+        limit_conn ce_conn 5;
+        proxy_pass http://processing-engine:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # Single-image data views — full FITS loads with no engine-side
+    # semaphore; regex location outranks the /api/ prefix match.
+    location ~ ^/api/jwstdata/[^/]+/(preview|histogram|pixeldata|cubeinfo)$ {
+        limit_req zone=ce_preview burst=10 nodelay;
+        limit_conn ce_conn 4;
+        proxy_pass http://processing-engine:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # Composite render — 120s ceiling from the Phase 1 timing spike
+    location = /api/composite/generate-nchannel {
+        limit_req zone=ce_render burst=3 nodelay;
+        limit_conn ce_conn 4;
+        proxy_pass http://processing-engine:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
+    }
+}

--- a/processing-engine/app/mast/download_state_manager.py
+++ b/processing-engine/app/mast/download_state_manager.py
@@ -3,6 +3,7 @@ Download state persistence for resume capability.
 Stores download job state to JSON files for recovery after interruption.
 """
 
+import errno
 import json
 import logging
 import os
@@ -34,7 +35,17 @@ class DownloadStateManager:
         """
         self.base_download_dir = base_download_dir
         self.state_dir = os.path.join(base_download_dir, STATE_DIR_NAME)
-        os.makedirs(self.state_dir, exist_ok=True)
+        try:
+            os.makedirs(self.state_dir, exist_ok=True)
+        except OSError as exc:
+            # Read-only data mount (CE deployment): no downloads, no resume
+            # state. Anything other than EROFS should still fail loudly.
+            if exc.errno != errno.EROFS:
+                raise
+            logger.warning(
+                "Download state dir %s is read-only — resume state disabled",
+                self.state_dir,
+            )
 
     def _get_state_path(self, job_id: str) -> str:
         """Get the file path for a job's state file."""

--- a/processing-engine/app/mast/mast_service.py
+++ b/processing-engine/app/mast/mast_service.py
@@ -5,6 +5,7 @@ Uses astroquery.mast for all MAST portal interactions.
 
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import re
@@ -224,7 +225,19 @@ class MastService:
 
     def __init__(self, download_dir: str = "/app/data/mast"):
         self.download_dir = download_dir
-        os.makedirs(download_dir, exist_ok=True)
+        try:
+            os.makedirs(download_dir, exist_ok=True)
+        except OSError as exc:
+            # Read-only data mount (CE deployment): searches still work, and
+            # the download routes never mount there anyway. Anything other
+            # than EROFS (e.g. bad perms on a writable box) should still
+            # fail loudly at startup.
+            if exc.errno != errno.EROFS:
+                raise
+            logger.warning(
+                "MAST download dir %s is read-only — downloads disabled",
+                download_dir,
+            )
 
     def search_by_target(
         self,


### PR DESCRIPTION
## Summary

No linked issue (CE plan Phase 4, PR 2 of 2; tracked by epic #1403). Delivers #651 (network isolation) and #745 (per-service resource limits) for the CE topology.

The **Community Edition deployment stack**: `docker compose -f docker-compose.ce.yml up -d --build` boots the full public, anonymous, read-only three-container slice — frontend nginx (the stack's ONLY published port, SPA + same-origin `/api` proxy with rate limits) → FastAPI engine (`CE_MODE` deny-by-default, read-only Mongo credentials, read-only data mount) → MongoDB (internal-only network, unreachable from host/edge/internet).

### Defense layers (outermost first)

nginx rate limits → engine deny-by-default route mounting + default-deny middleware → render semaphore (#1663) + input caps + per-request memory budget → read-only Mongo user (`ceReader`, `read` role only) → read-only FITS mount → `internal: true` DB network.

### Memory math (~8GB box)

engine 4g (3GB render budget × headroom), mongo 1g (WiredTiger cache capped at 0.5g), frontend 256m, remainder for OS/page cache.

### nginx zones

| zone | rate | burst | applies to |
|---|---|---|---|
| ce_api | 10r/s | 20 | `/api/` general |
| ce_mast | 2r/s | 5 | `/api/mast/` (outbound amplification) |
| ce_render | 1r/s | 3 | `= /api/composite/generate-nchannel` |
| ce_preview | 3r/s | 10 | `~ /api/jwstdata/{id}/(preview\|histogram\|pixeldata\|cubeinfo)` |

Rejections surface as **429 + `Retry-After: 5` + JSON body** (`limit_req_status 429` + `error_page 429 = @rate_limited`) so the frontend's `ApiError` parser and the Phase 3 "busy" copy work end-to-end. Render timeout 120s from the Phase 1 timing spike.

### Boot fix discovered by the smoke test

The engine crash-looped on the read-only data mount: `MastService`/`DownloadStateManager` run `os.makedirs` at import time (module-level instantiation in `app/mast/routes.py`). Both now warn-and-continue **only on `EROFS`** (expected in CE; downloads never mount there) and still fail loudly on any other `OSError` (e.g. bad perms on a writable box).

### Review round 1 hardening

- nginx `add_header` inheritance footgun: locations with their own `add_header` silently drop the server-level security trio — re-declared in `/assets/` and `@rate_limited` (live-verified on hashed bundle responses)
- Single-image data views (full FITS loads, no engine semaphore) got the `ce_preview` zone; residual aggregate cross-IP exposure documented in the arch docs and tracked as **#1664**
- `CE_MONGO_READER_PASSWORD` is interpolated raw into the Mongo URI — `.env.example` now mandates URL-safe generation (`openssl rand -hex 32`)
- frontend `depends_on` relaxed to `service_started` so the SPA shell serves even if the engine is down

## Changes Made

- `docker/docker-compose.ce.yml` (new): 3-container CE stack — mem limits, `ce-internal` (`internal: true`) + `ce-edge` networks, `ceReader` URI, `:ro` data mount, all render-limit env knobs, healthchecks
- `docker/mongo-init-ce/create-ce-reader.js` (new): idempotent read-only Mongo user creation from `MONGO_CE_READER_PASSWORD`; refuses to run without the password; documented manual-run path for pre-seeded volumes
- `frontend/jwst-frontend/nginx-ce.conf` (new): SPA + `/api` proxy, 4 limit_req zones + limit_conn, 429-as-JSON, security headers, immutable asset caching
- `frontend/jwst-frontend/Dockerfile`: `ARG VITE_CE_MODE` (build flag) + `ARG NGINX_CONF=nginx.conf` (default keeps the dev image byte-identical; CE passes `nginx-ce.conf`)
- `docker/.env.example`: `CE_MONGO_READER_PASSWORD` (with URL-safe generation guidance), `CE_HTTP_PORT`, `CE_DATA_DIR`
- `processing-engine/app/mast/mast_service.py`, `download_state_manager.py`: EROFS-tolerant init (see above)
- `docs/architecture/deployment-architecture.md`, `network-topology.md`, `docker-compose.md`: CE topology section — ASCII diagram, defense layers, #1664 residual note

## Test Plan

- [x] `docker compose -f docker-compose.ce.yml config --quiet` validates
- [x] Full live boot smoke on `:8080` with scratch creds: all three containers healthy; `/api/health` Healthy (engine + Mongo checks); `/api/discovery/featured` 200
- [x] Deny checks: `/api/auth/login`, `/api/mast/download`, `/api/admin` → 404; `/docs` + `/openapi.json` → SPA fallback at edge AND 404 from the engine directly (CE middleware)
- [x] Rate limits: 40-request burst → 10×200 + 30×429; 429 body is JSON `{"error", "detail"}` with `Retry-After: 5`; preview zone burst 20 → 14×429
- [x] Security headers present on hashed asset responses (the add_header-inheritance fix)
- [x] `ceReader`: role list is exactly `[{role: "read"}]`; live write attempt → `Unauthorized`
- [x] Engine boots healthy on the `:ro` data mount (EROFS fix); teardown with `down -v` clean
- [x] Full engine suite in Docker: **1522 passed**
- [x] Self-review round 1 (0 MUST / 3 SHOULD — all fixed, residual tracked as #1664) + round 2 verification
- [x] ruff clean

Reviewer walkthrough: copy `.env.example` values (`MONGO_ROOT_USERNAME/PASSWORD`, `CE_MONGO_READER_PASSWORD=$(openssl rand -hex 32)`, `CE_HTTP_PORT=8080`), run `docker compose -f docker/docker-compose.ce.yml up -d --build`, then: `curl localhost:8080/api/health`, burst `seq 1 40 | xargs -P20 -I{} curl -s -o /dev/null -w '%{http_code}\n' localhost:8080/api/health | sort | uniq -c`, `curl localhost:8080/docs` (SPA html, not swagger), `docker compose -f docker/docker-compose.ce.yml down -v`.

## Documentation Checklist

- [x] Architecture docs updated in the same PR (3 files, CE topology + diagram)
- [x] `.env.example` documents every new knob
- [ ] CE runbook (ops/deploy steps) — Phase 6 per plan

## Tech Debt Impact

- [x] Follow-up tracked: #1664 (engine-side concurrency gate for single-image render endpoints — nginx per-IP caps are the current mitigation)
- [x] No other new debt; proxy-header block duplication in nginx-ce.conf is intentional (an include file would complicate the single-ARG Dockerfile COPY)

## Risk & Rollback

- **Risk:** Low for existing deployments — the dev/prod compose files are untouched; the frontend Dockerfile change is default-preserving (`NGINX_CONF=nginx.conf`); the mast EROFS handling only changes behavior on read-only mounts (previously: crash loop). CE stack itself is new surface, not yet deployed anywhere.
- **Rollback:** revert the commit; no data migrations, no schema changes.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
