### PR TITLE
feat: CE Phase 5 — seed bundle tool with completeness gate

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -94,6 +94,10 @@ services:
     environment:
       - PYTHONPATH=/app
       - PYTHONUNBUFFERED=1
+      # The Python /api read layer (CE plan Phase 2) needs Mongo in dev too —
+      # root credentials here; CE uses the read-only ceReader instead.
+      - MONGODB_URI=mongodb://${MONGO_ROOT_USERNAME:?Set MONGO_ROOT_USERNAME in .env}:${MONGO_ROOT_PASSWORD:?Set MONGO_ROOT_PASSWORD in .env}@mongodb:27017/${MONGO_DATABASE:-jwst_data_analysis}?authSource=admin
+      - MONGODB_DATABASE=${MONGO_DATABASE:-jwst_data_analysis}
       - MAX_MOSAIC_OUTPUT_PIXELS=${MAX_MOSAIC_OUTPUT_PIXELS:-64000000}
       - MAX_COMPOSITE_MEMORY_BYTES=${MAX_COMPOSITE_MEMORY_BYTES:-3000000000}
       - COMPOSITE_DOWNSCALE_FAIL_THRESHOLD=${COMPOSITE_DOWNSCALE_FAIL_THRESHOLD:-0.85}

--- a/processing-engine/scripts/seed_ce.py
+++ b/processing-engine/scripts/seed_ce.py
@@ -1,0 +1,489 @@
+"""CE seed bundle tool (CE plan Phase 5).
+
+Builds and gates the Community Edition seed bundle by replaying the exact
+stranger flow against a running engine:
+
+    /api/mast/search/target  →  /api/discovery/suggest-recipes
+        →  /api/jwstdata/check-availability   (frontend needsDownload logic)
+        →  /composite/estimate                (memory-budget preflight)
+
+Subcommands:
+    report  — per-target/per-recipe table: filter coverage, estimate verdict,
+              bytes; totals against the disk budget. Never fails the build.
+    gate    — same evaluation; exit 1 if ANY recipe is missing filters or its
+              estimate says "fail". This is the plan's completeness gate:
+              files-on-disk ≠ renderable (Phase 1 spike), so both checks run.
+    export  — gate first, then write the bundle inputs to --out:
+                jwst_data.extjson  one canonical Extended JSON doc per line
+                                   (mongoimport-ready; IsPublic=true,
+                                   UserId=null — casing stays PascalCase per
+                                   the Phase 1 BSON spike)
+                files.txt          relative FITS paths for rsync
+                manifest.json      targets/recipes/sizes/verdicts
+
+Runs inside the engine container (like prefetch_discovery.py):
+    docker exec jwst-processing python scripts/seed_ce.py report
+
+/composite/estimate is called engine-direct (no /api facade exists — the CE
+edge doesn't need one; this tool runs at build time against the dev stack).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+
+import requests
+from bson import ObjectId, json_util
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("seed_ce")
+
+DEFAULT_BASE_URL = "http://localhost:8000"
+DEFAULT_TARGETS = (
+    Path(__file__).resolve().parents[1] / "app" / "discovery" / "featured_targets.json"
+)
+# GuidedCreate's slow path searches with calibLevel [3] and the model-default
+# radius; keep identical so the gate sees what a stranger sees.
+SEARCH_RADIUS = 0.2
+CHECK_AVAILABILITY_BATCH = 50  # facade caps observationIds per request
+
+# Estimate needs a syntactically valid channel color; hue value is irrelevant
+# to the memory math. Spread hues just to keep payloads distinguishable.
+_HUE_STEP = 47.0
+
+
+@dataclass
+class RecipeReport:
+    target: str
+    recipe: str
+    missing_filters: list[str]
+    estimate_status: str | None
+    data_ids: list[str] = field(default_factory=list)
+    total_bytes: int = 0
+
+    @property
+    def passed(self) -> bool:
+        return not self.missing_filters and self.estimate_status in ("ok", "warn")
+
+
+def _entry_filter(obs_id: str, entry: dict, obs_filters: dict | None) -> str:
+    """Availability entry's filter, falling back to the MAST observation's
+    filter when the entry carries none (GuidedCreate: item.filter ?? obs.filters)."""
+    raw = entry.get("filter")
+    # GuidedCreate uses ??, not || — fall back ONLY on null/absent. An empty
+    # string stays empty (treated as uncovered), matching the stranger flow.
+    flt = raw if raw is not None else (obs_filters or {}).get(obs_id) or ""
+    return str(flt).upper()
+
+
+def missing_filters(recipe: dict, availability: dict, obs_filters: dict | None = None) -> list[str]:
+    """Filters of ``recipe`` with no locally-available files.
+
+    Mirrors GuidedCreate: an obsId absent from the results map, or present
+    with no dataIds, provides nothing; coverage is keyed by uppercased
+    filter name with the observation's filter as fallback.
+    """
+    covered = {
+        _entry_filter(obs_id, entry, obs_filters)
+        for obs_id, entry in availability.items()
+        if entry.get("available") and entry.get("dataIds")
+    }
+    return [f for f in recipe.get("filters", []) if str(f).upper() not in covered]
+
+
+def build_estimate_channels(
+    recipe: dict, availability: dict, paths_by_id: dict, obs_filters: dict | None = None
+) -> list[dict]:
+    """One estimate channel per recipe filter, carrying that filter's files.
+
+    Channels omit width/height on purpose: the estimate verdict keys off the
+    WCS-derived original shape and the memory budget, not the output size.
+    """
+    by_filter: dict[str, list[str]] = {}
+    for obs_id, entry in availability.items():
+        if not (entry.get("available") and entry.get("dataIds")):
+            continue
+        flt = _entry_filter(obs_id, entry, obs_filters)
+        for data_id in entry["dataIds"]:
+            path = paths_by_id.get(data_id)
+            if path:
+                by_filter.setdefault(flt, []).append(path)
+    channels = []
+    for i, flt in enumerate(f.upper() for f in recipe.get("filters", [])):
+        paths = by_filter.get(flt)
+        if paths:
+            channels.append({"file_paths": paths, "color": {"hue": (i * _HUE_STEP) % 360.0}})
+    return channels
+
+
+def evaluate_recipe(
+    recipe: dict,
+    availability: dict,
+    paths_by_id: dict,
+    estimate: Callable[[list[dict]], dict],
+    target: str = "",
+    obs_filters: dict | None = None,
+) -> RecipeReport:
+    """Gate one recipe: filter coverage first, then the estimate preflight."""
+    missing = missing_filters(recipe, availability, obs_filters)
+    if missing:
+        return RecipeReport(
+            target=target,
+            recipe=recipe.get("name", "?"),
+            missing_filters=missing,
+            estimate_status=None,
+        )
+
+    wanted = {str(f).upper() for f in recipe.get("filters", [])}
+    data_ids = sorted(
+        {
+            data_id
+            for obs_id, entry in availability.items()
+            if entry.get("available")
+            and entry.get("dataIds")
+            and _entry_filter(obs_id, entry, obs_filters) in wanted
+            for data_id in entry["dataIds"]
+        }
+    )
+    channels = build_estimate_channels(recipe, availability, paths_by_id, obs_filters)
+    if not channels:
+        # availability said yes but no doc resolved a path — treat as fail,
+        # never send an empty channel list (the estimate model 422s on it)
+        verdict = {"status": "fail", "detail": "no file paths resolved"}
+    else:
+        verdict = estimate(channels)
+    return RecipeReport(
+        target=target,
+        recipe=recipe.get("name", "?"),
+        missing_filters=[],
+        estimate_status=verdict.get("status"),
+        data_ids=data_ids,
+    )
+
+
+def transform_doc(doc: dict) -> dict:
+    """Seed docs are anonymous-public: force IsPublic, clear ownership.
+
+    _id is preserved so re-running the import is an idempotent upsert.
+    """
+    out = dict(doc)
+    out["IsPublic"] = True
+    out["UserId"] = None
+    return out
+
+
+def export_bundle(
+    docs: list[dict], reports: list[RecipeReport], out_dir, generated_at: str
+) -> None:
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    seen: set[str] = set()
+    unique_docs = []
+    for doc in docs:
+        key = str(doc["_id"])
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_docs.append(transform_doc(doc))
+
+    with open(out / "jwst_data.extjson", "w") as fh:
+        for doc in unique_docs:
+            fh.write(json_util.dumps(doc, json_options=json_util.CANONICAL_JSON_OPTIONS))
+            fh.write("\n")
+
+    files = sorted({d["FilePath"] for d in unique_docs if d.get("FilePath")})
+    # files.txt feeds rsync --files-from on the host; a corrupt FilePath with
+    # an absolute or parent-traversal component would read outside the data
+    # root and silently pull host files into the bundle. Refuse loudly.
+    unsafe = [f for f in files if PurePosixPath(f).is_absolute() or ".." in PurePosixPath(f).parts]
+    if unsafe:
+        raise ValueError(f"unsafe FilePath values in export set: {unsafe[:5]}")
+    (out / "files.txt").write_text("\n".join(files) + ("\n" if files else ""))
+
+    total_bytes = sum(int(d.get("FileSize") or 0) for d in unique_docs)
+    manifest = {
+        "generatedAt": generated_at,
+        "documentCount": len(unique_docs),
+        "fileCount": len(files),
+        "totalBytes": total_bytes,
+        "recipes": [{**asdict(r), "passed": r.passed} for r in reports],
+    }
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    logger.info(
+        "bundle inputs written to %s (%d docs, %d files, %.1f GB)",
+        out,
+        len(unique_docs),
+        len(files),
+        total_bytes / 1e9,
+    )
+
+
+# --------------------------------------------------------------------------
+# Live evaluation against a running engine
+# --------------------------------------------------------------------------
+
+
+class EngineClient:
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        # A 12-target run is long and MAST is the flakiest hop — retry
+        # transient upstream errors instead of losing the whole pass.
+        retry = Retry(
+            total=3,
+            backoff_factor=2.0,
+            status_forcelist=(429, 502, 503, 504),
+            allowed_methods=("POST",),
+        )
+        self.session.mount("http://", HTTPAdapter(max_retries=retry))
+
+    def _post(self, path: str, payload: dict) -> dict:
+        resp = self.session.post(f"{self.base_url}{path}", json=payload, timeout=300)
+        resp.raise_for_status()
+        return resp.json()
+
+    def search_target(self, target_name: str) -> list[dict]:
+        body = {"targetName": target_name, "radius": SEARCH_RADIUS, "calibLevel": [3]}
+        return self._post("/api/mast/search/target", body).get("results") or []
+
+    def suggest_recipes(self, target_name: str, observations: list[dict]) -> list[dict]:
+        body = {"targetName": target_name, "observations": observations}
+        return self._post("/api/discovery/suggest-recipes", body).get("recipes") or []
+
+    def check_availability(self, observation_ids: list[str]) -> dict:
+        results: dict = {}
+        for i in range(0, len(observation_ids), CHECK_AVAILABILITY_BATCH):
+            batch = observation_ids[i : i + CHECK_AVAILABILITY_BATCH]
+            results.update(
+                self._post("/api/jwstdata/check-availability", {"observationIds": batch}).get(
+                    "results"
+                )
+                or {}
+            )
+        return results
+
+    def estimate(self, channels: list[dict]) -> dict:
+        try:
+            return self._post("/composite/estimate", {"channels": channels})
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 413:
+                # over the estimate file cap — too big for CE, a normal
+                # failing verdict rather than a crashed run
+                return {"status": "fail", "detail": "over estimate file cap (413)"}
+            raise
+
+
+def _to_observation_inputs(rows: list[dict]) -> list[dict]:
+    """frontend observationUtils.toObservationInputs, verbatim semantics."""
+    inputs = []
+    for obs in rows:
+        if not obs.get("filters") or not obs.get("instrument_name"):
+            continue
+        inputs.append(
+            {
+                "filter": obs["filters"],
+                "instrument": obs["instrument_name"],
+                "observationId": obs.get("obs_id"),
+                "tObsRelease": obs.get("t_obs_release"),
+                "dataProductType": obs.get("dataproduct_type"),
+                "sRa": obs.get("s_ra"),
+                "sDec": obs.get("s_dec"),
+            }
+        )
+    return inputs
+
+
+def _mongo_collection():
+    from pymongo import MongoClient
+
+    uri = os.environ.get("MONGODB_URI", "mongodb://localhost:27017")
+    db_name = os.environ.get("MONGODB_DATABASE", "jwst_data_analysis")
+    return MongoClient(uri)[db_name]["jwst_data"]
+
+
+def _fetch_docs(collection, data_ids: list[str]) -> list[dict]:
+    oids = [ObjectId(d) for d in data_ids]
+    return list(collection.find({"_id": {"$in": oids}}))
+
+
+def evaluate_all(
+    client: EngineClient, targets: list[dict], collection
+) -> tuple[list[RecipeReport], list[dict]]:
+    reports: list[RecipeReport] = []
+    all_docs: list[dict] = []
+    for target in targets:
+        name = target["name"]
+        search_name = (target.get("mastSearchParams") or {}).get("target") or name
+        logger.info("evaluating %s (search: %s)", name, search_name)
+        rows = [
+            r for r in client.search_target(search_name) if r.get("dataproduct_type") == "image"
+        ]
+        if not rows:
+            reports.append(
+                RecipeReport(
+                    target=name,
+                    recipe="(no observations)",
+                    missing_filters=["<no MAST results>"],
+                    estimate_status=None,
+                )
+            )
+            continue
+        recipes = client.suggest_recipes(name, _to_observation_inputs(rows))
+        if not recipes:
+            # a featured tile with zero recipes is the worst dead end —
+            # fail the gate exactly like a target with no MAST results
+            reports.append(
+                RecipeReport(
+                    target=name,
+                    recipe="(no recipes suggested)",
+                    missing_filters=["<no recipes>"],
+                    estimate_status=None,
+                )
+            )
+            continue
+        obs_filters = {
+            r.get("obs_id"): str(r.get("filters") or "").upper() for r in rows if r.get("obs_id")
+        }
+        for recipe in recipes:
+            availability = client.check_availability(recipe.get("observationIds") or [])
+            usable_ids = [
+                data_id
+                for entry in availability.values()
+                if entry.get("available") and entry.get("dataIds")
+                for data_id in entry["dataIds"]
+            ]
+            docs = _fetch_docs(collection, usable_ids) if usable_ids else []
+            paths_by_id = {str(d["_id"]): d.get("FilePath") for d in docs}
+            sizes_by_id = {str(d["_id"]): int(d.get("FileSize") or 0) for d in docs}
+            report = evaluate_recipe(
+                recipe,
+                availability,
+                paths_by_id,
+                client.estimate,
+                target=name,
+                obs_filters=obs_filters,
+            )
+            report.total_bytes = sum(sizes_by_id.get(d, 0) for d in report.data_ids)
+            reports.append(report)
+            if report.passed:
+                all_docs.extend(d for d in docs if str(d["_id"]) in set(report.data_ids))
+    return reports, all_docs
+
+
+def print_report(reports: list[RecipeReport], budget_gb: float) -> None:
+    width = max((len(f"{r.target} / {r.recipe}") for r in reports), default=20)
+    unique: dict[str, int] = {}
+    for r in reports:
+        print(
+            f"{(r.target + ' / ' + r.recipe).ljust(width)}  "
+            f"{'PASS' if r.passed else 'FAIL'}  "
+            f"estimate={r.estimate_status or '-':4}  "
+            f"files={len(r.data_ids):3d}  "
+            f"{r.total_bytes / 1e9:6.2f} GB"
+            + (f"  missing: {', '.join(r.missing_filters)}" if r.missing_filters else "")
+        )
+        for d in r.data_ids:
+            unique[d] = 1
+    passed = [r for r in reports if r.passed]
+    print(
+        f"\n{len(passed)}/{len(reports)} recipes pass; "
+        f"{len(unique)} unique files across passing recipes"
+    )
+    total = _unique_bytes(reports)
+    print(
+        f"total unique bytes, approx (passing recipes): {total / 1e9:.1f} GB "
+        f"(budget {budget_gb:.0f} GB; export's manifest.json totalBytes is exact)"
+    )
+    if total > budget_gb * 1e9:
+        print("WARNING: over budget — curate targets or trim recipes")
+
+
+def _unique_bytes(reports: list[RecipeReport]) -> int:
+    # per-recipe totals double-count shared files; approximate the unique sum
+    # by attributing each data_id's bytes once (first recipe that lists it).
+    seen: set[str] = set()
+    total = 0
+    for r in reports:
+        if not r.passed or not r.data_ids:
+            continue
+        fresh = [d for d in r.data_ids if d not in seen]
+        if fresh and len(r.data_ids) > 0:
+            total += int(r.total_bytes * (len(fresh) / len(r.data_ids)))
+        seen.update(fresh)
+    return total
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("command", choices=["report", "gate", "export"])
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--targets", default=str(DEFAULT_TARGETS))
+    parser.add_argument("--target", help="limit to a single featured target name")
+    parser.add_argument("--out", default="/tmp/ce-seed", help="export output directory")
+    parser.add_argument("--budget-gb", type=float, default=100.0, help="disk budget for the report")
+    parser.add_argument("--generated-at", help="ISO timestamp stamped into manifest.json (export)")
+    parser.add_argument(
+        "--allow-failures",
+        action="store_true",
+        help="Do not block gate/export on failing recipes; ship only passing "
+        "recipes' files (failures stay in manifest.json with passed=false). "
+        "CAUTION: failing recipes still show in the CE UI and will error for "
+        "strangers — use only for curated/partial bundles while the featured "
+        "list is being trimmed to match.",
+    )
+    args = parser.parse_args(argv)
+
+    with open(args.targets) as fh:
+        targets = json.load(fh)
+    if args.target:
+        targets = [t for t in targets if t["name"].lower() == args.target.lower()]
+        if not targets:
+            logger.error("no featured target named %r", args.target)
+            return 2
+
+    client = EngineClient(args.base_url)
+    reports, docs = evaluate_all(client, targets, _mongo_collection())
+    print_report(reports, args.budget_gb)
+
+    if args.command == "report":
+        return 0
+
+    failed = [r for r in reports if not r.passed]
+    if failed and not args.allow_failures:
+        logger.error("completeness gate FAILED: %d recipe(s) not fully renderable", len(failed))
+        return 1
+    if failed:
+        logger.warning(
+            "--allow-failures: %d failing recipe(s) EXCLUDED from the bundle "
+            "(they will still show in the CE UI — trim the featured list to match)",
+            len(failed),
+        )
+    if not any(r.passed for r in reports):
+        logger.error("no recipe passed at all — refusing to build an empty bundle")
+        return 1
+
+    if args.command == "export":
+        from datetime import datetime, timezone
+
+        generated_at = args.generated_at or datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        export_bundle(docs, reports, args.out, generated_at=generated_at)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/processing-engine/tests/test_seed_ce.py
+++ b/processing-engine/tests/test_seed_ce.py
@@ -1,0 +1,478 @@
+"""CE seed bundle tool (CE plan Phase 5).
+
+The completeness gate replicates the stranger flow end to end: MAST search →
+suggest-recipes → check-availability (the frontend's ``needsDownload === 0``
+branch in GuidedCreate) → /composite/estimate. A seed bundle only ships when
+every featured recipe is fully renderable from local files — files-on-disk
+alone is NOT the bar (Phase 1 spike: files can exist yet the render can fail
+the memory budget).
+"""
+
+import json
+
+from bson import ObjectId
+
+from scripts.seed_ce import (
+    RecipeReport,
+    build_estimate_channels,
+    evaluate_all,
+    evaluate_recipe,
+    export_bundle,
+    missing_filters,
+    transform_doc,
+)
+
+
+RECIPE = {
+    "name": "NASA NIRCam (Southern Ring)",
+    "filters": ["F090W", "F187N"],
+    "observationIds": [
+        "jw02733-o001_t001_nircam_clear-f090w",
+        "jw02733-o001_t001_nircam_clear-f187n",
+    ],
+}
+
+
+def _availability(*entries):
+    """results map as the /api/jwstdata/check-availability facade returns it."""
+    return dict(entries)
+
+
+class TestMissingFilters:
+    def test_all_covered_returns_empty(self):
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": "F090W"},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24], "filter": "F187N"},
+            ),
+        )
+        assert missing_filters(RECIPE, avail) == []
+
+    def test_absent_obs_id_means_missing(self):
+        """The facade simply omits obsIds with no verified files."""
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": "F090W"},
+            ),
+        )
+        assert missing_filters(RECIPE, avail) == ["F187N"]
+
+    def test_empty_data_ids_means_missing(self):
+        """GuidedCreate requires available && dataIds non-empty."""
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": [], "filter": "F090W"},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24], "filter": "F187N"},
+            ),
+        )
+        assert missing_filters(RECIPE, avail) == ["F090W"]
+
+    def test_filter_match_is_case_insensitive(self):
+        """GuidedCreate uppercases filter keys on both sides."""
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": "f090w"},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24], "filter": "F187N"},
+            ),
+        )
+        assert missing_filters(RECIPE, avail) == []
+
+
+class TestBuildEstimateChannels:
+    def test_groups_paths_per_filter(self):
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": "F090W"},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24, "c" * 24], "filter": "F187N"},
+            ),
+        )
+        paths = {
+            "a" * 24: "mast/obs1/f090w_i2d.fits",
+            "b" * 24: "mast/obs2/f187n_i2d.fits",
+            "c" * 24: "mast/obs3/f187n_seg2_i2d.fits",
+        }
+        channels = build_estimate_channels(RECIPE, avail, paths)
+        by_paths = [sorted(c["file_paths"]) for c in channels]
+        assert ["mast/obs1/f090w_i2d.fits"] in by_paths
+        assert sorted(["mast/obs2/f187n_i2d.fits", "mast/obs3/f187n_seg2_i2d.fits"]) in by_paths
+        assert len(channels) == 2
+        for c in channels:
+            assert c["color"]["hue"] is not None  # estimate model requires a color
+
+
+class TestEvaluateRecipe:
+    def test_missing_filter_fails_without_estimate_call(self):
+        calls = []
+
+        def estimate(_channels):
+            calls.append(1)
+            return {"status": "ok"}
+
+        report = evaluate_recipe(RECIPE, _availability(), {}, estimate)
+        assert report.missing_filters == ["F090W", "F187N"]
+        assert not report.passed
+        assert report.estimate_status is None
+        assert calls == []
+
+    def test_estimate_fail_fails_the_recipe(self):
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": "F090W"},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24], "filter": "F187N"},
+            ),
+        )
+        paths = {"a" * 24: "mast/a.fits", "b" * 24: "mast/b.fits"}
+        report = evaluate_recipe(
+            RECIPE, avail, paths, lambda _c: {"status": "fail", "detail": "too big"}
+        )
+        assert report.missing_filters == []
+        assert report.estimate_status == "fail"
+        assert not report.passed
+
+    def test_warn_passes(self):
+        """A downscaled-but-renderable recipe is acceptable for CE."""
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": "F090W"},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24], "filter": "F187N"},
+            ),
+        )
+        paths = {"a" * 24: "mast/a.fits", "b" * 24: "mast/b.fits"}
+        report = evaluate_recipe(RECIPE, avail, paths, lambda _c: {"status": "warn"})
+        assert report.passed
+        assert report.data_ids == sorted(["a" * 24, "b" * 24])
+
+
+class TestTransformDoc:
+    def test_forces_public_and_clears_user(self):
+        doc = {
+            "_id": ObjectId(),
+            "FileName": "x_i2d.fits",
+            "FilePath": "mast/obs/x_i2d.fits",
+            "IsPublic": False,
+            "UserId": "someone",
+        }
+        out = transform_doc(doc)
+        assert out["IsPublic"] is True
+        assert out["UserId"] is None
+        assert out["_id"] == doc["_id"]  # identity preserved for idempotent re-import
+
+    def test_does_not_mutate_input(self):
+        doc = {"_id": ObjectId(), "IsPublic": False, "UserId": "u"}
+        transform_doc(doc)
+        assert doc["UserId"] == "u"
+
+
+class TestExportBundle:
+    def test_writes_extjson_manifest_and_file_list(self, tmp_path):
+        oid = ObjectId()
+        docs = [
+            {
+                "_id": oid,
+                "FileName": "x_i2d.fits",
+                "FilePath": "mast/obs/x_i2d.fits",
+                "FileSize": 123,
+                "IsPublic": False,
+                "UserId": "u",
+            }
+        ]
+        reports = [
+            RecipeReport(
+                target="Southern Ring Nebula",
+                recipe="NASA NIRCam (Southern Ring)",
+                missing_filters=[],
+                estimate_status="ok",
+                data_ids=[str(oid)],
+                total_bytes=123,
+            )
+        ]
+        export_bundle(docs, reports, tmp_path, generated_at="2026-07-08T00:00:00Z")
+
+        raw = (tmp_path / "jwst_data.extjson").read_text().strip().splitlines()
+        assert len(raw) == 1  # one document per line (mongoimport-friendly)
+        parsed = json.loads(raw[0])
+        assert parsed["_id"] == {"$oid": str(oid)}  # canonical Extended JSON
+        assert parsed["IsPublic"] is True
+        assert parsed["UserId"] is None
+
+        files = (tmp_path / "files.txt").read_text().splitlines()
+        assert files == ["mast/obs/x_i2d.fits"]
+
+        manifest = json.loads((tmp_path / "manifest.json").read_text())
+        assert manifest["generatedAt"] == "2026-07-08T00:00:00Z"
+        assert manifest["documentCount"] == 1
+        assert manifest["totalBytes"] == 123
+        assert manifest["recipes"][0]["recipe"] == "NASA NIRCam (Southern Ring)"
+        assert manifest["recipes"][0]["passed"] is True
+
+    def test_deduplicates_shared_files_across_recipes(self, tmp_path):
+        oid = ObjectId()
+        doc = {
+            "_id": oid,
+            "FilePath": "mast/obs/shared_i2d.fits",
+            "FileSize": 10,
+            "IsPublic": True,
+            "UserId": None,
+        }
+        reports = [
+            RecipeReport("T", "r1", [], "ok", [str(oid)], 10),
+            RecipeReport("T", "r2", [], "ok", [str(oid)], 10),
+        ]
+        export_bundle([doc, doc], reports, tmp_path, generated_at="2026-07-08T00:00:00Z")
+        files = (tmp_path / "files.txt").read_text().splitlines()
+        assert files == ["mast/obs/shared_i2d.fits"]
+        manifest = json.loads((tmp_path / "manifest.json").read_text())
+        assert manifest["documentCount"] == 1
+        assert manifest["totalBytes"] == 10  # shared file counted once
+
+
+class TestReviewHardening:
+    """Round-1 review catches: null-filter fallback, traversal guard,
+    empty-channel guard, zero-recipe sentinel."""
+
+    def test_null_entry_filter_falls_back_to_observation_filter(self):
+        """GuidedCreate keys coverage as item.filter ?? obs.filters — an
+        availability entry with a null filter must not read as missing."""
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": None},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24], "filter": "F187N"},
+            ),
+        )
+        obs_filters = {"jw02733-o001_t001_nircam_clear-f090w": "F090W"}
+        assert missing_filters(RECIPE, avail, obs_filters) == []
+        # without the fallback map the strict behavior remains
+        assert missing_filters(RECIPE, avail) == ["F090W"]
+
+    def test_export_refuses_traversal_file_paths(self, tmp_path):
+        import pytest
+        from bson import ObjectId
+
+        docs = [
+            {
+                "_id": ObjectId(),
+                "FilePath": "mast/../../etc/passwd",
+                "FileSize": 1,
+                "IsPublic": True,
+                "UserId": None,
+            }
+        ]
+        with pytest.raises(ValueError, match="unsafe FilePath"):
+            export_bundle(docs, [], tmp_path, generated_at="2026-07-08T00:00:00Z")
+
+    def test_export_refuses_absolute_file_paths(self, tmp_path):
+        import pytest
+        from bson import ObjectId
+
+        docs = [
+            {
+                "_id": ObjectId(),
+                "FilePath": "/etc/passwd",
+                "FileSize": 1,
+                "IsPublic": True,
+                "UserId": None,
+            }
+        ]
+        with pytest.raises(ValueError, match="unsafe FilePath"):
+            export_bundle(docs, [], tmp_path, generated_at="2026-07-08T00:00:00Z")
+
+    def test_unresolvable_paths_fail_without_calling_estimate(self):
+        """Availability says yes but no doc resolves a path: never POST an
+        empty channel list (the estimate model 422s on it)."""
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": "F090W"},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24], "filter": "F187N"},
+            ),
+        )
+        calls = []
+
+        def estimate(channels):
+            calls.append(channels)
+            return {"status": "ok"}
+
+        report = evaluate_recipe(RECIPE, avail, {}, estimate)
+        assert report.estimate_status == "fail"
+        assert not report.passed
+        assert calls == []
+
+    def test_zero_recipe_target_fails_the_gate(self):
+        """A featured tile whose suggest-recipes comes back empty is a dead
+        end and must produce a failing sentinel report."""
+
+        class FakeClient:
+            def search_target(self, _name):
+                return [
+                    {
+                        "obs_id": "jw0001-o001",
+                        "filters": "F770W",
+                        "instrument_name": "MIRI",
+                        "dataproduct_type": "image",
+                    }
+                ]
+
+            def suggest_recipes(self, _name, _observations):
+                return []
+
+        class FakeCollection:
+            def find(self, _query):
+                return []
+
+        targets = [{"name": "Ghost Target", "mastSearchParams": {"target": "GHOST"}}]
+        reports, docs = evaluate_all(FakeClient(), targets, FakeCollection())
+        assert len(reports) == 1
+        assert not reports[0].passed
+        assert reports[0].recipe == "(no recipes suggested)"
+        assert docs == []
+
+
+class TestEntryFilterEmptyString:
+    def test_empty_string_filter_does_not_fall_back(self):
+        """GuidedCreate uses ?? (nullish), not || — an empty-string filter
+        stays empty and reads as uncovered, so the gate must match."""
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": ""},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24], "filter": "F187N"},
+            ),
+        )
+        obs_filters = {"jw02733-o001_t001_nircam_clear-f090w": "F090W"}
+        assert missing_filters(RECIPE, avail, obs_filters) == ["F090W"]
+
+
+class TestEstimate413:
+    def test_413_maps_to_fail_verdict(self, monkeypatch):
+        from scripts.seed_ce import EngineClient
+
+        client = EngineClient("http://example.invalid")
+
+        class Resp:
+            status_code = 413
+
+        def boom(_path, _payload):
+            import requests
+
+            raise requests.HTTPError(response=Resp())
+
+        monkeypatch.setattr(client, "_post", boom)
+        assert client.estimate([{"file_paths": ["x"], "color": {"hue": 1}}])["status"] == "fail"
+
+    def test_other_http_errors_re_raise(self, monkeypatch):
+        import pytest
+        import requests
+
+        from scripts.seed_ce import EngineClient
+
+        client = EngineClient("http://example.invalid")
+
+        class Resp:
+            status_code = 500
+
+        def boom(_path, _payload):
+            raise requests.HTTPError(response=Resp())
+
+        monkeypatch.setattr(client, "_post", boom)
+        with pytest.raises(requests.HTTPError):
+            client.estimate([{"file_paths": ["x"], "color": {"hue": 1}}])
+
+
+class TestMainExitCodes:
+    """The gate's actual contract: exit codes and what ships."""
+
+    @staticmethod
+    def _run_main(monkeypatch, tmp_path, reports, docs, argv):
+        import scripts.seed_ce as mod
+
+        targets_file = tmp_path / "featured.json"
+        targets_file.write_text(json.dumps([{"name": "T", "mastSearchParams": {"target": "T"}}]))
+        monkeypatch.setattr(mod, "_mongo_collection", lambda: None)
+        monkeypatch.setattr(mod, "EngineClient", lambda _url: None)
+        monkeypatch.setattr(mod, "evaluate_all", lambda _c, _t, _m: (reports, docs))
+        return mod.main([*argv, "--targets", str(targets_file)])
+
+    def test_gate_fails_on_failing_recipe(self, monkeypatch, tmp_path):
+        reports = [RecipeReport("T", "r", ["F090W"], None)]
+        assert self._run_main(monkeypatch, tmp_path, reports, [], ["gate"]) == 1
+
+    def test_gate_passes_when_all_pass(self, monkeypatch, tmp_path):
+        reports = [RecipeReport("T", "r", [], "ok", ["a" * 24], 1)]
+        assert self._run_main(monkeypatch, tmp_path, reports, [], ["gate"]) == 0
+
+    def test_allow_failures_exports_passing_only(self, monkeypatch, tmp_path):
+        oid = ObjectId()
+        reports = [
+            RecipeReport("T", "good", [], "ok", [str(oid)], 5),
+            RecipeReport("T", "bad", ["F444W"], None),
+        ]
+        docs = [{"_id": oid, "FilePath": "mast/x.fits", "FileSize": 5}]
+        out = tmp_path / "bundle"
+        rc = self._run_main(
+            monkeypatch,
+            tmp_path,
+            reports,
+            docs,
+            [
+                "export",
+                "--allow-failures",
+                "--out",
+                str(out),
+                "--generated-at",
+                "2026-07-08T00:00:00Z",
+            ],
+        )
+        assert rc == 0
+        manifest = json.loads((out / "manifest.json").read_text())
+        assert manifest["documentCount"] == 1  # only the passing recipe's doc
+        assert {r["recipe"]: r["passed"] for r in manifest["recipes"]} == {
+            "good": True,
+            "bad": False,
+        }
+
+    def test_allow_failures_still_refuses_empty_bundle(self, monkeypatch, tmp_path):
+        reports = [RecipeReport("T", "bad", ["F444W"], None)]
+        rc = self._run_main(
+            monkeypatch,
+            tmp_path,
+            reports,
+            [],
+            ["export", "--allow-failures", "--out", str(tmp_path / "b")],
+        )
+        assert rc == 1
+        assert not (tmp_path / "b").exists()

--- a/scripts/restore-seed.sh
+++ b/scripts/restore-seed.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Import the CE seed bundle's Mongo metadata into the CE stack's MongoDB.
+# Ships inside the bundle produced by scripts/seed-ce.sh; run it on the CE
+# host from the bundle directory AFTER `docker compose -f docker-compose.ce.yml
+# up -d` has started the mongodb container.
+#
+#   MONGO_ROOT_USERNAME=... MONGO_ROOT_PASSWORD=... ./restore-seed.sh
+#
+# Idempotent: documents keep their _id, so re-running upserts in place.
+# CE is re-seedable by design — "restore" is re-running this script (plus
+# re-pointing CE_DATA_DIR at the bundle's data/); no backup cron needed.
+#
+# NOTE: the engine connects as the read-only ceReader user, which cannot
+# import. This script uses the root credentials, and (re)creates ceReader
+# afterwards for pre-seeded volumes where the init script never ran.
+
+set -euo pipefail
+
+BUNDLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINER="${CE_MONGO_CONTAINER:-jwst-ce-mongodb}"
+DB_NAME="${MONGO_DATABASE:-jwst_data_analysis}"
+
+err() { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
+die() { err "$@"; exit 1; }
+
+[ -f "$BUNDLE_DIR/jwst_data.extjson" ] || die "jwst_data.extjson not found next to this script"
+[ -n "${MONGO_ROOT_USERNAME:-}" ] || die "MONGO_ROOT_USERNAME is not set"
+[ -n "${MONGO_ROOT_PASSWORD:-}" ] || die "MONGO_ROOT_PASSWORD is not set"
+docker inspect "$CONTAINER" &>/dev/null || die "Container '$CONTAINER' is not running"
+
+echo "Importing jwst_data documents into $DB_NAME..."
+docker cp "$BUNDLE_DIR/jwst_data.extjson" "$CONTAINER:/tmp/jwst_data.extjson"
+# Credentials and the db name travel via -e (never interpolated into the
+# command string). The password does appear on mongoimport's in-container
+# argv — accepted residual risk: the CE host is single-tenant and the
+# container's PID namespace has no other workloads. (Same applies to the
+# mongosh call below.)
+docker exec -e MONGO_ROOT_USERNAME -e MONGO_ROOT_PASSWORD -e MONGO_DATABASE="$DB_NAME" \
+    "$CONTAINER" bash -c '
+    mongoimport --username "$MONGO_ROOT_USERNAME" --password "$MONGO_ROOT_PASSWORD" \
+        --authenticationDatabase admin --db "$MONGO_DATABASE" --collection jwst_data \
+        --file /tmp/jwst_data.extjson --mode upsert
+    rm -f /tmp/jwst_data.extjson
+'
+
+if [ -n "${CE_MONGO_READER_PASSWORD:-}" ]; then
+    echo "Ensuring ceReader user exists (pre-seeded volumes skip the init script)..."
+    docker exec -e MONGO_ROOT_USERNAME -e MONGO_ROOT_PASSWORD \
+        -e MONGO_CE_READER_PASSWORD="$CE_MONGO_READER_PASSWORD" \
+        -e MONGO_DATABASE="$DB_NAME" "$CONTAINER" bash -c '
+        mongosh --username "$MONGO_ROOT_USERNAME" --password "$MONGO_ROOT_PASSWORD" \
+            --authenticationDatabase admin --quiet /docker-entrypoint-initdb.d/create-ce-reader.js
+    '
+else
+    echo "CE_MONGO_READER_PASSWORD not set — skipping ceReader creation (fine if the volume was initialized by compose)."
+fi
+
+echo "Seed import complete. Restart the engine to pick up fresh data: docker restart jwst-ce-engine"

--- a/scripts/seed-ce.sh
+++ b/scripts/seed-ce.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Build the Community Edition seed bundle (CE plan Phase 5).
+#
+# Runs against the DEV stack (jwst-processing + its Mongo), which owns the
+# authoritative metadata: the .NET scan pipeline wrote the jwst_data docs and
+# prefetch-discovery.sh downloaded the FITS. This script replays the stranger
+# flow (search → recipes → availability → render estimate) via
+# processing-engine/scripts/seed_ce.py, refuses to build a bundle with dead
+# ends, then assembles:
+#
+#   <out>/data/...            curated FITS tree (rsync'd per files.txt)
+#   <out>/jwst_data.extjson   matching Mongo docs (IsPublic=true, UserId=null)
+#   <out>/files.txt           relative FITS paths in the bundle
+#   <out>/manifest.json       recipes, verdicts, sizes
+#   <out>/restore-seed.sh     import script to run next to the CE stack
+#
+# Usage:
+#   ./scripts/seed-ce.sh report                   # sizing/coverage survey only
+#   ./scripts/seed-ce.sh gate                     # completeness gate, no bundle
+#   ./scripts/seed-ce.sh build --out /tmp/ce-seed # gate + assemble the bundle
+#   ./scripts/seed-ce.sh build --target "Carina Nebula" --out /tmp/ce-seed
+#
+# Extra flags after the command are passed through to seed_ce.py
+# (--target, --budget-gb, --base-url).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+info()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
+ok()    { printf '\033[0;32m%s\033[0m\n' "$*"; }
+err()   { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
+die()   { err "$@"; exit 1; }
+
+CONTAINER="jwst-processing"
+# Override when the repo checkout is not where the FITS live (e.g. worktrees)
+DATA_ROOT="${JWST_DATA_DIR:-$PROJECT_ROOT/data}"
+ENGINE_TARGETS="$PROJECT_ROOT/processing-engine/app/discovery/featured_targets.json"
+DOTNET_TARGETS="$PROJECT_ROOT/backend/JwstDataAnalysis.API/Configuration/featured-targets.json"
+CONTAINER_OUT="/tmp/ce-seed-out"
+
+COMMAND="${1:-}"
+case "$COMMAND" in
+    report|gate|build) shift ;;
+    *) die "Usage: $0 report|gate|build [seed_ce.py flags]" ;;
+esac
+
+# --- Preflight ---
+if ! docker inspect "$CONTAINER" &>/dev/null; then
+    die "Container '$CONTAINER' is not running. Start with: docker compose up -d"
+fi
+
+# The engine serves its own copy of the featured list while prefetch reads
+# the .NET copy — a drifted pair would gate against one list and serve
+# another. Refuse to build until they match.
+if ! diff -q "$ENGINE_TARGETS" "$DOTNET_TARGETS" >/dev/null; then
+    die "featured target lists have drifted: $ENGINE_TARGETS vs $DOTNET_TARGETS — sync them first"
+fi
+ok "Featured target lists in sync"
+
+OUT_DIR=""
+PASSTHROUGH=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --out) [ $# -ge 2 ] || die "--out requires a directory argument"; OUT_DIR="$2"; shift 2 ;;
+        *) PASSTHROUGH+=("$1"); shift ;;
+    esac
+done
+
+if [ "$COMMAND" = "build" ]; then
+    [ -n "$OUT_DIR" ] || die "build requires --out <dir>"
+    mkdir -p "$OUT_DIR"
+fi
+
+# --- Evaluate (and export bundle inputs when building) ---
+GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+if [ "$COMMAND" = "build" ]; then
+    info "Running completeness gate + export in $CONTAINER..."
+    docker exec "$CONTAINER" python scripts/seed_ce.py export \
+        --out "$CONTAINER_OUT" --generated-at "$GENERATED_AT" ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
+else
+    info "Running seed_ce.py $COMMAND in $CONTAINER..."
+    docker exec "$CONTAINER" python scripts/seed_ce.py "$COMMAND" \
+        ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
+    ok "$COMMAND completed"
+    exit 0
+fi
+
+# --- Assemble the bundle on the host ---
+info "Collecting bundle inputs..."
+docker cp "$CONTAINER:$CONTAINER_OUT/jwst_data.extjson" "$OUT_DIR/jwst_data.extjson"
+docker cp "$CONTAINER:$CONTAINER_OUT/files.txt" "$OUT_DIR/files.txt"
+docker cp "$CONTAINER:$CONTAINER_OUT/manifest.json" "$OUT_DIR/manifest.json"
+
+info "Copying FITS tree (rsync --files-from)..."
+# Defense in depth: seed_ce.py already refuses unsafe FilePaths at export;
+# re-check here because files.txt feeds rsync verbatim and a `..` or
+# absolute entry would read outside the data root.
+if grep -qE '(^/|(^|/)\.\.(/|$))' "$OUT_DIR/files.txt"; then
+    die "files.txt contains absolute or parent-traversal paths — refusing to rsync"
+fi
+mkdir -p "$OUT_DIR/data"
+rsync -a --files-from="$OUT_DIR/files.txt" "$DATA_ROOT/" "$OUT_DIR/data/"
+
+MISSING=0
+while IFS= read -r rel; do
+    [ -f "$OUT_DIR/data/$rel" ] || { err "missing from bundle: $rel"; MISSING=1; }
+done < "$OUT_DIR/files.txt"
+[ "$MISSING" -eq 0 ] || die "bundle is incomplete — files listed in Mongo are absent on disk"
+
+cp "$SCRIPT_DIR/restore-seed.sh" "$OUT_DIR/restore-seed.sh"
+chmod +x "$OUT_DIR/restore-seed.sh"
+
+BUNDLE_GB=$(du -sh "$OUT_DIR" | cut -f1)
+ok "Seed bundle assembled at $OUT_DIR ($BUNDLE_GB)"
+info "Next: transfer to the CE host, point CE_DATA_DIR at $OUT_DIR/data, and run restore-seed.sh (see script header)."


### PR DESCRIPTION
## Summary

No linked issue (CE plan Phase 5, PR 1; tracked by epic #1403).

The **CE seed bundle tool** — the plan's "one genuinely new tool". `scripts/seed-ce.sh` + `processing-engine/scripts/seed_ce.py` build and gate the Community Edition seed bundle by replaying the exact stranger flow against a running engine:

`/api/mast/search/target` → `/api/discovery/suggest-recipes` → `/api/jwstdata/check-availability` (the frontend's `needsDownload === 0` logic, replicated verbatim from GuidedCreate incl. the `item.filter ?? obs.filters` fallback) → `/composite/estimate` (memory-budget preflight — files-on-disk ≠ renderable, per the Phase 1 spike).

**This PR delivers BOTH Phase 5 checklist items**: the seed exporter *and* the completeness gate (they turned out to be one flow — the gate is what selects the export set).

### Subcommands

- `report` — per-target/per-recipe coverage + estimate verdict + sizes vs a disk budget
- `gate` — exit 1 if any featured recipe is missing filters or fails the estimate
- `export`/`build` — gate, then write `jwst_data.extjson` (canonical Extended JSON, one doc/line, mongoimport-ready; `IsPublic=true`, `UserId=null`, `_id` preserved for idempotent re-import, PascalCase per the Phase 1 BSON spike) + `files.txt` + `manifest.json`; the shell wrapper rsyncs the FITS subset and ships `restore-seed.sh` into the bundle
- `--allow-failures` — explicit escape hatch for curated/partial bundles: failing recipes are excluded (never silently shipped) and loudly warned about; refuses to build an empty bundle

### Review round 1 hardening (2 MUST / 5 SHOULD — all fixed)

- **Zero-recipe featured target now fails the gate** (was: silently passed — the worst dead end)
- **Path-traversal guard**: export refuses absolute/`..` FilePaths; seed-ce.sh re-checks before `rsync --files-from`
- Estimate over-cap (413) recorded as a failing verdict instead of crashing the run; transient MAST errors retried (urllib3 Retry, POST-safe — all calls are read-only queries)
- `restore-seed.sh`: DB name via `-e` (no string interpolation into the container command); password-on-argv residual risk documented (single-tenant CE host)

### Found & fixed along the way

- **Dev compose never wired `MONGODB_URI` into the engine** — the Phase 2 `/api` read layer 500'd in dev (`MongoNotConfiguredError`). Tests used fakes and the Phase 2 live smokes injected env by hand, so it went unnoticed. Now wired (root creds in dev; CE uses `ceReader`).

### Live sizing data (dev stack, all 12 featured targets, 3GB budget)

22/93 recipes pass: every MIRI recipe with files on disk passes (~4.8 GB total); **every NIRCam recipe fails the estimate** at the default `COMPOSITE_DOWNSCALE_FAIL_THRESHOLD=0.85` (side factors 0.20–0.62 — outputs would still be 3.5–5k px), and SMACS 0723 / Cas A / Tarantula-NIRCam / Phantom-NIRCam files were never prefetched (MIRI-only default). Forced-downscale renders of the worst cases succeed in 69–91s (vs the 120s nginx timeout). Full table in the PR comment / curation decision pending — this PR is the measurement tool and is decision-independent.

## Changes Made

- `processing-engine/scripts/seed_ce.py` (new): gate/report/export tool
- `processing-engine/tests/test_seed_ce.py` (new): 24 tests (needsDownload semantics incl. case-insensitivity, absent-obsId, null-filter ??-fidelity incl. empty-string; estimate channel grouping; fail/warn verdicts; empty-channel guard; doc transform immutability; export dedup + traversal rejection; zero-recipe sentinel; main() gate exit-code contract; estimate 413 mapping)
- `scripts/seed-ce.sh` (new): host orchestrator — featured-list parity check (engine vs .NET copy), container exec, rsync, bundle assembly + verification
- `scripts/restore-seed.sh` (new): CE-host import (mongoimport upsert + optional ceReader creation), ships inside the bundle
- `docker/docker-compose.yml`: dev engine gains `MONGODB_URI`/`MONGODB_DATABASE` (fixes the Phase 2 dev gap)

## Test Plan

- [x] Red-green: coverage/gate tests written first; 24 pass
- [x] Full engine suite in Docker: **1546 passed**
- [x] Live report across all 12 featured targets end-to-end against the dev stack (MAST search → recipes → availability → estimate)
- [x] Live export smoke (Crab Nebula, `--allow-failures`): 14 docs / 14 files / 1.5 GB; extjson line count == manifest documentCount; strict mode correctly refuses when recipes fail
- [x] Full host `seed-ce.sh build`: 1.4G bundle assembled (data/ + extjson + files.txt + manifest.json + restore-seed.sh); missing-file verification loop passes
- [x] Self-review round 1 (2 MUST / 5 SHOULD — all fixed) + round 2 (2 SHOULD: ??-fidelity on empty-string filters, main() exit-code tests — fixed) + round 3 verification clean (0/0)
- [x] ruff clean; `bash -n` on both shell scripts

Reviewer walkthrough: `docker compose up -d --build processing-engine`, then `./scripts/seed-ce.sh report` (needs no writes; ~4 min against MAST), then `./scripts/seed-ce.sh build --target "Crab Nebula" --allow-failures --out /tmp/crab-bundle` and inspect the bundle contents.

## Documentation Checklist

- [x] Tool usage documented in script headers (report/gate/build, flags, bundle layout)
- [ ] CE runbook section in `docs/deployment.md` — Phase 6 per plan (restore-seed.sh header carries the interim instructions)

## Tech Debt Impact

- [x] No new debt. `--allow-failures` is an explicit, loudly-warned escape hatch pending the curation decision (featured-list trim vs threshold relax — user decision, next step in Phase 5).

## Risk & Rollback

- **Risk:** Low. New build-time tooling only — nothing ships in any runtime image; the only runtime-adjacent change is the dev-compose env wiring, which fixes a 500 (no behavior change for the .NET path).
- **Rollback:** revert the commit.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
