### PR TITLE
feat: CE Phase 5 — relaxed downscale threshold for CE + gate posture flag

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -93,6 +93,9 @@ MAST_DOWNLOAD_TIMEOUT=3600
 # sqrt(max_pixels / total_pixels). 0.85 = strict (refuse if output side would
 # shrink below 85%, ≈ 28% area loss). 1.0 = refuse all downscaling. Lower
 # toward 0.0 to allow more silent downscaling.
+# NOTE: the CE stack (docker-compose.ce.yml) defaults this to 0.15 so big
+# NIRCam mosaics render (3.5-5k px outputs) instead of being refused; keep
+# seed_ce.py --fail-threshold in sync when building seed bundles.
 #
 # MAX_COMPOSITE_ESTIMATE_FILES caps total inputs to /composite/estimate to
 # prevent file-resolution amplification. 500 is generous for most recipes.

--- a/docker/docker-compose.ce.yml
+++ b/docker/docker-compose.ce.yml
@@ -70,7 +70,12 @@ services:
       # Render limits (8GB box): 3GB per-render budget x 2 concurrent slots,
       # small queue, instant 429 beyond slots+depth.
       - MAX_COMPOSITE_MEMORY_BYTES=${MAX_COMPOSITE_MEMORY_BYTES:-3000000000}
-      - COMPOSITE_DOWNSCALE_FAIL_THRESHOLD=${COMPOSITE_DOWNSCALE_FAIL_THRESHOLD:-0.85}
+      # Relaxed vs the dev default (0.85) — curation decision 2026-07-08:
+      # big NIRCam mosaics render at 3.5-5k px output instead of being
+      # refused. The memory budget above is still the hard bound; this only
+      # allows deeper downscales. Keep the seed gate in sync:
+      # seed_ce.py --fail-threshold must match this value.
+      - COMPOSITE_DOWNSCALE_FAIL_THRESHOLD=${COMPOSITE_DOWNSCALE_FAIL_THRESHOLD:-0.15}
       - MAX_CONCURRENT_COMPOSITES=${MAX_CONCURRENT_COMPOSITES:-2}
       - COMPOSITE_QUEUE_WAIT_SECONDS=${COMPOSITE_QUEUE_WAIT_SECONDS:-15}
       - COMPOSITE_QUEUE_DEPTH=${COMPOSITE_QUEUE_DEPTH:-4}

--- a/processing-engine/scripts/seed_ce.py
+++ b/processing-engine/scripts/seed_ce.py
@@ -171,6 +171,30 @@ def evaluate_recipe(
     )
 
 
+def apply_threshold(verdict: dict, fail_threshold: float | None) -> dict:
+    """Re-verdict an estimate for a different downscale-fail threshold.
+
+    CE runs a relaxed COMPOSITE_DOWNSCALE_FAIL_THRESHOLD (curation decision
+    2026-07-08: NIRCam recipes render at 3.5-5k px instead of being refused),
+    but the gate usually runs against a dev engine with the strict default.
+    side_factor is threshold-independent, so the CE verdict can be derived
+    client-side. Verdicts without a side_factor (413 cap, unresolved paths)
+    pass through untouched — they can never be upgraded.
+    """
+    if fail_threshold is None:
+        return verdict
+    side = verdict.get("side_factor")
+    if side is None:
+        return verdict
+    if side >= 1.0:
+        status = "ok"
+    elif side >= fail_threshold:
+        status = "warn"
+    else:
+        status = "fail"
+    return {**verdict, "status": status}
+
+
 def transform_doc(doc: dict) -> dict:
     """Seed docs are anonymous-public: force IsPublic, clear ownership.
 
@@ -436,6 +460,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--budget-gb", type=float, default=100.0, help="disk budget for the report")
     parser.add_argument("--generated-at", help="ISO timestamp stamped into manifest.json (export)")
     parser.add_argument(
+        "--fail-threshold",
+        type=float,
+        help="Evaluate estimates at this downscale-fail threshold instead of "
+        "the engine's (e.g. 0.15 to match the CE compose). side_factor is "
+        "threshold-independent, so the gate can mirror CE posture against a "
+        "dev engine running the strict default.",
+    )
+    parser.add_argument(
         "--allow-failures",
         action="store_true",
         help="Do not block gate/export on failing recipes; ship only passing "
@@ -455,8 +487,22 @@ def main(argv: list[str] | None = None) -> int:
             return 2
 
     client = EngineClient(args.base_url)
+    if args.fail_threshold is not None:
+        # visible, not silent: a gate that validated the wrong posture is
+        # worse than no gate (green light for recipes strangers can't render)
+        logger.info(
+            "evaluating estimates at fail-threshold %.2f (engine default overridden "
+            "client-side — must match the CE compose value)",
+            args.fail_threshold,
+        )
+        raw_estimate = client.estimate
+        client.estimate = lambda channels: apply_threshold(  # type: ignore[method-assign]
+            raw_estimate(channels), args.fail_threshold
+        )
     reports, docs = evaluate_all(client, targets, _mongo_collection())
     print_report(reports, args.budget_gb)
+    if args.fail_threshold is not None:
+        print(f"(estimates evaluated at fail-threshold {args.fail_threshold:.2f})")
 
     if args.command == "report":
         return 0

--- a/processing-engine/tests/test_seed_ce.py
+++ b/processing-engine/tests/test_seed_ce.py
@@ -14,6 +14,7 @@ from bson import ObjectId
 
 from scripts.seed_ce import (
     RecipeReport,
+    apply_threshold,
     build_estimate_channels,
     evaluate_all,
     evaluate_recipe,
@@ -476,3 +477,36 @@ class TestMainExitCodes:
         )
         assert rc == 1
         assert not (tmp_path / "b").exists()
+
+
+class TestApplyThreshold:
+    """CE runs a relaxed COMPOSITE_DOWNSCALE_FAIL_THRESHOLD (curation
+    decision 2026-07-08); the gate re-verdicts estimates client-side so it
+    can evaluate CE's posture against a dev engine running the default."""
+
+    def test_none_threshold_is_identity(self):
+        v = {"status": "fail", "side_factor": 0.5}
+        assert apply_threshold(v, None) is v
+
+    def test_reverdicts_fail_to_warn_above_threshold(self):
+        v = {"status": "fail", "side_factor": 0.20}
+        assert apply_threshold(v, 0.15)["status"] == "warn"
+
+    def test_still_fail_below_threshold(self):
+        v = {"status": "fail", "side_factor": 0.10}
+        assert apply_threshold(v, 0.15)["status"] == "fail"
+
+    def test_full_scale_is_ok(self):
+        v = {"status": "warn", "side_factor": 1.0}
+        assert apply_threshold(v, 0.15)["status"] == "ok"
+
+    def test_boundary_equal_to_threshold_is_warn(self):
+        assert apply_threshold({"status": "fail", "side_factor": 0.15}, 0.15)["status"] == "warn"
+
+    def test_just_under_full_scale_is_warn_not_ok(self):
+        assert apply_threshold({"status": "warn", "side_factor": 0.99}, 0.15)["status"] == "warn"
+
+    def test_missing_side_factor_passes_through(self):
+        """413s and no-path failures carry no side_factor — never upgraded."""
+        v = {"status": "fail", "detail": "over estimate file cap (413)"}
+        assert apply_threshold(v, 0.15)["status"] == "fail"


### PR DESCRIPTION
## Summary

No linked issue (CE plan Phase 5; tracked by epic #1403). Implements the curation decision (2026-07-08): **relax threshold + curate**.

CE relaxes `COMPOSITE_DOWNSCALE_FAIL_THRESHOLD` to **0.15** so big NIRCam mosaics render at 3.5–5k px output instead of being refused — at the strict 0.85 default, every NIRCam featured recipe failed the estimate (PR #1669's sizing report). `MAX_COMPOSITE_MEMORY_BYTES` (3GB) remains the hard memory bound; this only permits deeper downscales. Probed renders at this posture: 69–91s, 200 OK, ~770KB JPEGs.

`seed_ce.py --fail-threshold` re-verdicts estimates client-side from `side_factor` (threshold-independent), so the completeness gate can evaluate CE's posture while running against the dev engine's strict default. The override is logged and stamped in the report footer (reviewer catch: a silent posture mismatch would green-light recipes strangers can't render); verdicts without a `side_factor` (413 file-cap, unresolved paths) can never be upgraded. Boundary semantics (`>=` at threshold, `ok` only at 1.0) verified to match the engine's `_compute_memory_budget` exactly.

## Changes Made

- `processing-engine/scripts/seed_ce.py`: `apply_threshold()` + `--fail-threshold` flag + visibility logging
- `processing-engine/tests/test_seed_ce.py`: 7 new tests (verdict mapping incl. both `>=` boundaries, passthrough rules) — 31 seed tests total
- `docker/docker-compose.ce.yml`: CE threshold default 0.15 with decision rationale
- `docker/.env.example`: CE-differs note + keep-gate-in-sync warning

## Test Plan

- [x] Red-green: apply_threshold tests written first
- [x] Full engine suite in Docker: **1553 passed**
- [x] CE compose `config --quiet` validates
- [x] Self-review: 0 MUST / 1 SHOULD (visibility) + boundary-test NIT — both fixed
- [x] ruff clean

## Documentation Checklist

- [x] Compose + .env.example document the posture and the sync requirement

## Tech Debt Impact

- [x] None. Compose↔gate sync is convention with loud visibility (an env-based hard guard is impossible: the gate deliberately runs against a dev engine with a different threshold).

## Risk & Rollback

- **Risk:** Low. CE-only env default (dev/prod unchanged); render memory budget unchanged. Worst case: deep-downscaled renders look softer — preferable to refusal for a public gallery.
- **Rollback:** revert the commit (CE returns to MIRI-only posture).

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
