### PR TITLE
feat: CE Phase 5 — --exclude curation flag for the seed gate

### DIFF
--- a/processing-engine/scripts/seed_ce.py
+++ b/processing-engine/scripts/seed_ce.py
@@ -37,6 +37,7 @@ import os
 import sys
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
+from fnmatch import fnmatchcase
 from pathlib import Path, PurePosixPath
 
 import requests
@@ -70,10 +71,17 @@ class RecipeReport:
     estimate_status: str | None
     data_ids: list[str] = field(default_factory=list)
     total_bytes: int = 0
+    # Curation exclusion: not shipped, but not a gate failure either — the
+    # featured tile still works via its other (e.g. MIRI) recipes.
+    excluded: bool = False
 
     @property
     def passed(self) -> bool:
-        return not self.missing_filters and self.estimate_status in ("ok", "warn")
+        return (
+            not self.excluded
+            and not self.missing_filters
+            and self.estimate_status in ("ok", "warn")
+        )
 
 
 def _entry_filter(obs_id: str, entry: dict, obs_filters: dict | None) -> str:
@@ -342,10 +350,11 @@ def _fetch_docs(collection, data_ids: list[str]) -> list[dict]:
 
 
 def evaluate_all(
-    client: EngineClient, targets: list[dict], collection
+    client: EngineClient, targets: list[dict], collection, exclude: list[str] | None = None
 ) -> tuple[list[RecipeReport], list[dict]]:
     reports: list[RecipeReport] = []
     all_docs: list[dict] = []
+    matched_patterns: set[str] = set()
     for target in targets:
         name = target["name"]
         search_name = (target.get("mastSearchParams") or {}).get("target") or name
@@ -380,6 +389,22 @@ def evaluate_all(
             r.get("obs_id"): str(r.get("filters") or "").upper() for r in rows if r.get("obs_id")
         }
         for recipe in recipes:
+            label = f"{name}/{recipe.get('name', '?')}"
+            hits = [pat for pat in exclude or [] if fnmatchcase(label, pat)]
+            if hits:
+                matched_patterns.update(hits)
+                # skip evaluation entirely — mega-mosaic estimates are slow
+                # and the recipe is deliberately not shipping
+                reports.append(
+                    RecipeReport(
+                        target=name,
+                        recipe=recipe.get("name", "?"),
+                        missing_filters=[],
+                        estimate_status=None,
+                        excluded=True,
+                    )
+                )
+                continue
             availability = client.check_availability(recipe.get("observationIds") or [])
             usable_ids = [
                 data_id
@@ -402,6 +427,11 @@ def evaluate_all(
             reports.append(report)
             if report.passed:
                 all_docs.extend(d for d in docs if str(d["_id"]) in set(report.data_ids))
+    unmatched = [pat for pat in exclude or [] if pat not in matched_patterns]
+    if unmatched:
+        # A stale/typo'd pattern silently re-admits the exact recipes the
+        # curation excluded (recipe names aren't pinned upstream). Refuse.
+        raise SystemExit(f"--exclude pattern(s) matched no recipe: {unmatched}")
     return reports, all_docs
 
 
@@ -411,7 +441,7 @@ def print_report(reports: list[RecipeReport], budget_gb: float) -> None:
     for r in reports:
         print(
             f"{(r.target + ' / ' + r.recipe).ljust(width)}  "
-            f"{'PASS' if r.passed else 'FAIL'}  "
+            f"{'EXCL' if r.excluded else 'PASS' if r.passed else 'FAIL'}  "
             f"estimate={r.estimate_status or '-':4}  "
             f"files={len(r.data_ids):3d}  "
             f"{r.total_bytes / 1e9:6.2f} GB"
@@ -468,6 +498,16 @@ def main(argv: list[str] | None = None) -> int:
         "dev engine running the strict default.",
     )
     parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="TARGET/RECIPE",
+        help="fnmatch pattern against 'Target/Recipe name'; matching recipes "
+        "are excluded from evaluation and the bundle WITHOUT failing the "
+        'gate (e.g. --exclude "Carina Nebula/*NIRCam*"). The featured tile '
+        "still works via its remaining recipes.",
+    )
+    parser.add_argument(
         "--allow-failures",
         action="store_true",
         help="Do not block gate/export on failing recipes; ship only passing "
@@ -499,7 +539,7 @@ def main(argv: list[str] | None = None) -> int:
         client.estimate = lambda channels: apply_threshold(  # type: ignore[method-assign]
             raw_estimate(channels), args.fail_threshold
         )
-    reports, docs = evaluate_all(client, targets, _mongo_collection())
+    reports, docs = evaluate_all(client, targets, _mongo_collection(), exclude=args.exclude)
     print_report(reports, args.budget_gb)
     if args.fail_threshold is not None:
         print(f"(estimates evaluated at fail-threshold {args.fail_threshold:.2f})")
@@ -507,7 +547,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "report":
         return 0
 
-    failed = [r for r in reports if not r.passed]
+    excluded = [r for r in reports if r.excluded]
+    if excluded:
+        logger.info("%d recipe(s) excluded by --exclude patterns", len(excluded))
+    failed = [r for r in reports if not r.passed and not r.excluded]
     if failed and not args.allow_failures:
         logger.error("completeness gate FAILED: %d recipe(s) not fully renderable", len(failed))
         return 1

--- a/processing-engine/tests/test_seed_ce.py
+++ b/processing-engine/tests/test_seed_ce.py
@@ -425,7 +425,7 @@ class TestMainExitCodes:
         targets_file.write_text(json.dumps([{"name": "T", "mastSearchParams": {"target": "T"}}]))
         monkeypatch.setattr(mod, "_mongo_collection", lambda: None)
         monkeypatch.setattr(mod, "EngineClient", lambda _url: None)
-        monkeypatch.setattr(mod, "evaluate_all", lambda _c, _t, _m: (reports, docs))
+        monkeypatch.setattr(mod, "evaluate_all", lambda _c, _t, _m, **_kw: (reports, docs))
         return mod.main([*argv, "--targets", str(targets_file)])
 
     def test_gate_fails_on_failing_recipe(self, monkeypatch, tmp_path):
@@ -510,3 +510,100 @@ class TestApplyThreshold:
         """413s and no-path failures carry no side_factor — never upgraded."""
         v = {"status": "fail", "detail": "over estimate file cap (413)"}
         assert apply_threshold(v, 0.15)["status"] == "fail"
+
+
+class TestExcludePatterns:
+    """Curation: --exclude drops recipes from the bundle without failing the
+    gate (decision 2026-07-08: Carina/Stephan's NIRCam mega-mosaics stay out
+    of the ~100GB budget; their MIRI recipes still ship)."""
+
+    def _fake_client(self):
+        class FakeClient:
+            estimate_calls = []
+
+            def search_target(self, _name):
+                return [
+                    {
+                        "obs_id": "jw0001-o001",
+                        "filters": "F770W",
+                        "instrument_name": "MIRI",
+                        "dataproduct_type": "image",
+                    }
+                ]
+
+            def suggest_recipes(self, _name, _observations):
+                return [
+                    {
+                        "name": "Classic 3-color NIRCam",
+                        "filters": ["F770W"],
+                        "observationIds": ["jw0001-o001"],
+                    },
+                    {
+                        "name": "Classic 3-color MIRI",
+                        "filters": ["F770W"],
+                        "observationIds": ["jw0001-o001"],
+                    },
+                ]
+
+            def check_availability(self, _ids):
+                return {
+                    "jw0001-o001": {
+                        "available": True,
+                        "dataIds": ["c" * 24],
+                        "filter": "F770W",
+                    }
+                }
+
+            def estimate(self, channels):
+                FakeClient.estimate_calls.append(channels)
+                return {"status": "ok"}
+
+        return FakeClient()
+
+    def _fake_collection(self):
+        from bson import ObjectId
+
+        class FakeCollection:
+            def find(self, _query):
+                return [{"_id": ObjectId("c" * 24), "FilePath": "mast/c.fits", "FileSize": 7}]
+
+        return FakeCollection()
+
+    def test_excluded_recipe_skips_evaluation_and_gate(self):
+        client = self._fake_client()
+        targets = [{"name": "Carina Nebula", "mastSearchParams": {"target": "NGC 3324"}}]
+        reports, docs = evaluate_all(
+            client, targets, self._fake_collection(), exclude=["Carina Nebula/*NIRCam*"]
+        )
+        by_name = {r.recipe: r for r in reports}
+        assert by_name["Classic 3-color NIRCam"].excluded is True
+        assert by_name["Classic 3-color NIRCam"].passed is False
+        assert by_name["Classic 3-color MIRI"].passed is True
+        # excluded recipe never evaluated: exactly one estimate call (MIRI)
+        assert len(type(client).estimate_calls) == 1
+        # excluded recipes contribute no docs beyond the passing MIRI ones
+        assert {str(d["_id"]) for d in docs} == {"c" * 24}
+
+    def test_unmatched_exclude_pattern_aborts(self):
+        """A stale pattern would silently re-admit the excluded mega-mosaics
+        — refuse to run instead."""
+        import pytest
+
+        client = self._fake_client()
+        targets = [{"name": "Carina Nebula", "mastSearchParams": {"target": "NGC 3324"}}]
+        with pytest.raises(SystemExit, match="matched no recipe"):
+            evaluate_all(client, targets, self._fake_collection(), exclude=["Tyop Target/*NIRCam*"])
+
+    def test_excluded_does_not_fail_the_gate(self, monkeypatch, tmp_path):
+        import scripts.seed_ce as mod
+
+        reports = [
+            RecipeReport("T", "good MIRI", [], "ok", ["c" * 24], 7),
+            RecipeReport("T", "big NIRCam", [], None, excluded=True),
+        ]
+        targets_file = tmp_path / "featured.json"
+        targets_file.write_text(json.dumps([{"name": "T"}]))
+        monkeypatch.setattr(mod, "_mongo_collection", lambda: None)
+        monkeypatch.setattr(mod, "EngineClient", lambda _url: None)
+        monkeypatch.setattr(mod, "evaluate_all", lambda _c, _t, _m, **_kw: (reports, []))
+        assert mod.main(["gate", "--targets", str(targets_file)]) == 0

--- a/scripts/seed-ce.sh
+++ b/scripts/seed-ce.sh
@@ -94,6 +94,15 @@ docker cp "$CONTAINER:$CONTAINER_OUT/files.txt" "$OUT_DIR/files.txt"
 docker cp "$CONTAINER:$CONTAINER_OUT/manifest.json" "$OUT_DIR/manifest.json"
 
 info "Copying FITS tree (rsync --files-from)..."
+# SEED_HARDLINK=1: hardlink instead of copy (same-filesystem bundles cost
+# ~zero extra space — an 80GB bundle next to a 200GB data dir won't fit
+# twice on most dev disks). Transfer tools (rsync/scp/tar) read hardlinked
+# files normally.
+LINK_ARGS=()
+if [ "${SEED_HARDLINK:-0}" = "1" ]; then
+    LINK_ARGS+=(--link-dest="$DATA_ROOT")
+    info "  (hardlink mode: --link-dest=$DATA_ROOT)"
+fi
 # Defense in depth: seed_ce.py already refuses unsafe FilePaths at export;
 # re-check here because files.txt feeds rsync verbatim and a `..` or
 # absolute entry would read outside the data root.
@@ -101,7 +110,7 @@ if grep -qE '(^/|(^|/)\.\.(/|$))' "$OUT_DIR/files.txt"; then
     die "files.txt contains absolute or parent-traversal paths — refusing to rsync"
 fi
 mkdir -p "$OUT_DIR/data"
-rsync -a --files-from="$OUT_DIR/files.txt" "$DATA_ROOT/" "$OUT_DIR/data/"
+rsync -a ${LINK_ARGS[@]+"${LINK_ARGS[@]}"} --files-from="$OUT_DIR/files.txt" "$DATA_ROOT/" "$OUT_DIR/data/"
 
 MISSING=0
 while IFS= read -r rel; do


### PR DESCRIPTION
## Summary

No linked issue (CE plan Phase 5; tracked by epic #1403). Third seed-tool PR: the **curation mechanism**.

Post-prefetch report at the CE posture (`--fail-threshold 0.15`): **81/93 recipes pass, ~148.5 GB** — over the ~100 GB budget, with the overage concentrated exactly where predicted: Carina NIRCam (~32 GB across 160+ file mosaics whose estimates run past 300 s) and Stephan's Quintet NIRCam (~34 GB, 18k×18k inputs). Decision: exclude those recipe families; their MIRI recipes still ship, so all 12 featured tiles keep working. Result: ~82 GB projected bundle.

`--exclude` takes repeatable `fnmatchcase` patterns against `Target/Recipe name` (e.g. `--exclude "Carina Nebula/*NIRCam*"`). Matches skip evaluation entirely (no availability/estimate calls), print as `EXCL`, ride into `manifest.json` with `excluded: true`, and do not fail the gate. **A pattern that matches nothing aborts the run** (reviewer catch): recipe names aren't pinned upstream, and a stale pattern would otherwise silently re-admit the exact mega-mosaics the curation excluded — with over-budget only a soft warning.

## Changes Made

- `processing-engine/scripts/seed_ce.py`: `RecipeReport.excluded` + `--exclude` flag + unmatched-pattern abort + `EXCL` report row
- `scripts/seed-ce.sh`: `SEED_HARDLINK=1` mode — `rsync --link-dest` against the data root so same-filesystem bundles cost ~zero extra space (an 80GB copy next to the 200GB data dir doesn't fit on the dev disk)
- `processing-engine/tests/test_seed_ce.py`: 3 new tests (exclusion skips evaluation and never calls estimate; gate exits 0 with exclusions present; unmatched pattern aborts) — 34 seed tests

## Test Plan

- [x] Red-green: exclusion tests written first
- [x] Full engine suite in Docker: **1556 passed**
- [x] Live post-prefetch report at 0.15 across all 12 targets (81/93 pass, 148.5 GB) — table in PR comment
- [x] Self-review round: 1 SHOULD (unmatched-pattern silence) + 1 NIT (fnmatchcase) — both fixed
- [x] ruff clean

## Documentation Checklist

- [x] Flag documented in `--help` and the plan's Phase 5 completion notes will record the exclusion list (completion docs PR)

## Tech Debt Impact

- [x] None. Exclusion list lives in the build invocation, not code; unmatched patterns fail loudly.

## Risk & Rollback

- **Risk:** Low — build-time tool only.
- **Rollback:** revert the commit.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
