### PR TITLE
fix: CE render timeout 120s → 600s (relaxed-threshold posture)

### DIFF
--- a/docs/architecture/deployment-architecture.md
+++ b/docs/architecture/deployment-architecture.md
@@ -297,7 +297,7 @@ three-container slice with no .NET tier, no mast-proxy, no SeaweedFS:
               ┌───────────────────┐
               │ frontend (nginx)  │  VITE_CE_MODE build · SPA + /api proxy
               │  mem 256m         │  limit_req: api 10r/s · mast 2r/s · render 1r/s
-              └─────────┬─────────┘  timeouts: 120s render (Phase 1 spike)
+              └─────────┬─────────┘  timeouts: 600s render (relaxed-threshold posture)
               ce-edge   │
               ┌─────────▼─────────┐
               │ processing-engine │  CE_MODE deny-by-default /api facade

--- a/docs/architecture/docker-compose.md
+++ b/docs/architecture/docker-compose.md
@@ -65,7 +65,7 @@ three-container slice with no .NET tier, no mast-proxy, no SeaweedFS:
               ┌───────────────────┐
               │ frontend (nginx)  │  VITE_CE_MODE build · SPA + /api proxy
               │  mem 256m         │  limit_req: api 10r/s · mast 2r/s · render 1r/s
-              └─────────┬─────────┘  timeouts: 120s render (Phase 1 spike)
+              └─────────┬─────────┘  timeouts: 600s render (relaxed-threshold posture)
               ce-edge   │
               ┌─────────▼─────────┐
               │ processing-engine │  CE_MODE deny-by-default /api facade

--- a/docs/architecture/network-topology.md
+++ b/docs/architecture/network-topology.md
@@ -234,7 +234,7 @@ three-container slice with no .NET tier, no mast-proxy, no SeaweedFS:
               ┌───────────────────┐
               │ frontend (nginx)  │  VITE_CE_MODE build · SPA + /api proxy
               │  mem 256m         │  limit_req: api 10r/s · mast 2r/s · render 1r/s
-              └─────────┬─────────┘  timeouts: 120s render (Phase 1 spike)
+              └─────────┬─────────┘  timeouts: 600s render (relaxed-threshold posture)
               ce-edge   │
               ┌─────────▼─────────┐
               │ processing-engine │  CE_MODE deny-by-default /api facade

--- a/frontend/jwst-frontend/nginx-ce.conf
+++ b/frontend/jwst-frontend/nginx-ce.conf
@@ -5,9 +5,12 @@
 # engine. Rate limits are the outer DoS layer (the engine's render semaphore
 # + input caps are the inner layer). No /hubs (no SignalR in CE), no backend.
 #
-# Timeout note: 120s on render routes comes from the Phase 1 timing spike —
-# passing featured-recipe renders finish in seconds (5s dev ≈ 10-20s VPS);
-# a render still running at 120s is stuck, not slow.
+# Timeout note: the render route allows 600s. The Phase 1 spike's 120s
+# ("still running at 120s is stuck") was measured under the STRICT downscale
+# threshold; the CE posture (0.15, Phase 5 curation decision) deliberately
+# renders big NIRCam mosaics, and a mid-size passing recipe measured 181s on
+# dev hardware. A 504 would also strand the render server-side, burning a
+# semaphore slot with nobody listening.
 
 # Zones live at http context (conf.d files are included there).
 # 10m zone ≈ 160k tracked client IPs — plenty.
@@ -115,7 +118,7 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # Composite render — 120s ceiling from the Phase 1 timing spike
+    # Composite render — 600s ceiling (see timeout note at the top)
     location = /api/composite/generate-nchannel {
         limit_req zone=ce_render burst=3 nodelay;
         limit_conn ce_conn 4;
@@ -126,7 +129,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 10s;
-        proxy_send_timeout 120s;
-        proxy_read_timeout 120s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
     }
 }


### PR DESCRIPTION
## Summary

No linked issue (CE plan Phase 5; epic #1403). Live-smoke finding from booting the CE stack against the **real 67GB seed bundle**.

The CE render timeout (120s, from the Phase 1 spike) is too low for the Phase 5 relaxed-threshold posture: a mid-size `estimate=ok` recipe (Crab Best-5, NIRCam+MIRI) rendered in **181s**, so nginx 504'd — and the sync render kept running server-side, burning a semaphore slot with nobody listening. The spike's "still running at 120s is stuck" was measured under the strict 0.85 threshold, which the curation decision deliberately relaxed.

Raised to **600s** on the composite location only (general `/api` stays 120s, MAST/preview stay 60s). After the raise, the full stranger flow passes end to end through nginx against the seed bundle: health → featured (12) → MAST search → suggest-recipes → check-availability → render **200** (134.7s NIRCam+MIRI 392KB; 20.7s MIRI 156KB).

## Changes Made

- `frontend/jwst-frontend/nginx-ce.conf`: composite location `proxy_read/send_timeout` 120s → 600s; header timeout note rewritten with the measured data
- `docs/architecture/{deployment-architecture,network-topology,docker-compose}.md`: CE diagram timeout line updated

## Test Plan

- [x] Live stranger smoke against the real bundle through nginx: both render classes 200 (details above); rate limits/deny checks unchanged from the Phase 4 smoke
- [x] Docs-only + config — no engine/frontend code changes

## Documentation Checklist

- [x] Arch docs updated in the same PR

## Tech Debt Impact

- [x] None. Phase 6 deploy smoke should re-time renders on the real VPS and adjust if needed (noted in the plan's Phase 6 stranger-smoke item).

## Risk & Rollback

- **Risk:** Low. CE-only nginx config; longer allowed waits are bounded by the render semaphore (2 slots + queue 4 + instant 429).
- **Rollback:** revert the commit.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
