### PR TITLE
feat: group target-page recipes into Ready to render / Not in library

### DIFF
--- a/docs/plans/features/quick/recipe-grouping-and-fetch-cli.md
+++ b/docs/plans/features/quick/recipe-grouping-and-fetch-cli.md
@@ -1,0 +1,61 @@
+# Recipe grouping + admin fetch-recipe CLI
+
+Issues: #1674 (grouping), #1675 (fetch CLI). CEO review: Mode C, proceed with
+changes (2026-07-08). Eng review: sound, medium complexity, no unresolved
+decisions. Context: post-Phase 5, the CE seed bundle ships 71/93 recipes, so
+"Not in library" is a permanent state on target pages.
+
+## PR 1 — #1674 TargetDetail grouping (frontend)
+
+**`src/services/jwstDataService.ts`**
+- `checkDataAvailability` chunks requests at 50 observationIds (facade cap),
+  merges `results` maps. All callers inherit the fix.
+
+**`src/pages/TargetDetail.tsx`**
+- After recipes load: one chunked `checkDataAvailability` over the union of
+  all recipes' obsIds → `readyByRecipe: Map<recipeName, boolean> | null`.
+- `null` (pending or check failed) → render today's flat list, pills
+  suppressed. Never present a renderable page as dead; single reflow only.
+- Resolved → two sections: **Ready to render** then **Not in library**
+  (reuse `target-detail-section-header`; never render an empty header;
+  Recommended badge logic keyed to the first READY recipe).
+- Readiness per recipe = same boolean the pill uses
+  (`dataReady || isAuthenticated`) — auth users see one section, no change.
+
+**`src/components/discovery/RecipeCard.tsx`**
+- Optional `dataReady?: boolean` prop; when provided, skip the per-card
+  availability effect (spy-tested); when absent, behavior unchanged
+  (regression-tested). Pill suppressed while parent availability is pending.
+
+**Tests**: vitest for chunking, degradation states, grouping branches,
+RecipeCard prop contract; update `e2e/target-detail.spec.ts` (mock
+check-availability, assert section headers + `.recipe-card` counts).
+
+## PR 2 — #1675 fetch subcommand (engine/scripts)
+
+**`processing-engine/scripts/seed_ce.py`**
+- New `fetch` subcommand: `--target` + `--recipe` (exact name; on miss, list
+  available recipe names), optional `--max-file-size` (default 6GB) and
+  `--dry-run`.
+- Resolve recipe via the existing stranger-flow helpers → missing filters →
+  MAST product list for those filters (reuse prefetch_discovery selection
+  logic: combined L3 mosaic, smallest per filter) → download via MastService
+  with disk guards.
+- A needed file over the cap: abort BEFORE downloading anything, print file
+  sizes and the exact `--max-file-size N` re-run command.
+- Post-fetch: estimate preflight at `--fail-threshold` (CE posture); print
+  verdict; exit non-zero if still `fail`. Print next-steps checklist:
+  .NET scan → `seed-ce.sh gate` → bundle rebuild → `restore-seed.sh`.
+
+**`scripts/fetch-recipe.sh`**: thin wrapper (seed-ce.sh conventions,
+featured-list parity check, container exec).
+
+**Tests**: pytest for the missing→download-list diff, cap-abort message,
+estimate-verdict exit codes (mocked client, existing fakes pattern).
+
+## Out of scope
+Why-unavailable explanations; fetch-all-gaps mode; any in-app admin surface
+(CE stays anonymous/read-only); #1676 (pre-existing scan DuplicateKey noise).
+
+## Docs
+`scripts/README.md` entry for fetch-recipe.sh. No architecture diagrams.

--- a/frontend/jwst-frontend/e2e/target-detail.spec.ts
+++ b/frontend/jwst-frontend/e2e/target-detail.spec.ts
@@ -86,6 +86,26 @@ async function mockTargetDetailAPIs(page: import('@playwright/test').Page): Prom
   });
 }
 
+/** Availability mock: F444W+F200W in the library, F560W missing — so the
+ *  2-filter recipe is ready and the 3-filter one is not. */
+async function mockPartialAvailability(page: import('@playwright/test').Page): Promise<void> {
+  await page.route('**/api/jwstdata/check-availability', async (route: Route) => {
+    const body = route.request().postDataJSON() as { observationIds: string[] };
+    const results: Record<string, unknown> = {};
+    for (const id of body.observationIds) {
+      const obs = MOCK_OBSERVATIONS.results.find((o) => o.obs_id === id);
+      if (obs && obs.filters !== 'F560W') {
+        results[id] = { available: true, dataIds: ['0'.repeat(24)], filter: obs.filters };
+      }
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ results }),
+    });
+  });
+}
+
 test.describe('Target detail page', () => {
   test.beforeAll(async ({ request }) => {
     auth = await apiRegisterUser(request, 'tgt');
@@ -250,5 +270,26 @@ test.describe('Target detail — no recipes state', () => {
     await expect(page.locator('.target-detail-no-recipes')).toContainText(
       'No composite recipes could be generated'
     );
+  });
+});
+
+test.describe('Target detail page — anonymous recipe grouping', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTargetDetailAPIs(page);
+    await mockPartialAvailability(page);
+    await page.goto('/target/Carina%20Nebula');
+    await page.waitForSelector('.target-detail-summary', { state: 'visible', timeout: 15_000 });
+  });
+
+  test('groups recipes into Ready to render and Not in library sections', async ({ page }) => {
+    const headers = page.locator('.target-detail-section-header');
+    await expect(headers.first()).toHaveText('Ready to render', { timeout: 15_000 });
+    await expect(headers.nth(1)).toHaveText('Not in library');
+    // every card still renders, just distributed across the two sections
+    await expect(page.locator('.recipe-card')).toHaveCount(2);
+    // the de-emphasized section holds the unavailable recipe
+    await expect(
+      page.locator('.target-detail-recipes-unavailable .recipe-card')
+    ).toHaveCount(1);
   });
 });

--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.availability.test.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.availability.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { RecipeCard } from './RecipeCard';
+import { checkDataAvailability } from '../../services/jwstDataService';
+import type { CompositeRecipe } from '../../types/DiscoveryTypes';
+import type { MastObservationResult } from '../../types/MastTypes';
+
+vi.mock('../../config/ce', () => ({ CE_MODE: true }));
+vi.mock('../../context/useAuth', () => ({ useAuth: () => ({ isAuthenticated: false }) }));
+vi.mock('../../services/jwstDataService', () => ({
+  checkDataAvailability: vi.fn().mockResolvedValue({ results: {} }),
+}));
+
+const recipe: CompositeRecipe = {
+  name: 'Classic RGB',
+  rank: 1,
+  filters: ['F770W'],
+  colorMapping: { F770W: '#0000ff' },
+  instruments: ['MIRI'],
+  requiresMosaic: false,
+  estimatedTimeSeconds: 30,
+  observationIds: ['o1'],
+  description: 'test',
+};
+
+const observations = [
+  { obs_id: 'o1', filters: 'F770W', instrument_name: 'MIRI', dataproduct_type: 'image' },
+] as MastObservationResult[];
+
+function renderCard(availability?: 'ready' | 'missing' | 'pending') {
+  return render(
+    <MemoryRouter>
+      <RecipeCard
+        recipe={recipe}
+        targetName="Crab Nebula"
+        observations={observations}
+        availability={availability}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('RecipeCard availability prop (parent-controlled mode)', () => {
+  beforeEach(() => {
+    vi.mocked(checkDataAvailability).mockClear();
+  });
+
+  it('availability="ready" shows Ready and fires NO availability fetch', () => {
+    renderCard('ready');
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+    expect(checkDataAvailability).not.toHaveBeenCalled();
+  });
+
+  it('availability="missing" shows the pill and fires NO availability fetch', () => {
+    renderCard('missing');
+    expect(screen.getByText('Not in library')).toBeInTheDocument();
+    expect(checkDataAvailability).not.toHaveBeenCalled();
+  });
+
+  it('availability="pending" suppresses the status pill entirely', () => {
+    renderCard('pending');
+    expect(screen.queryByText('Ready')).not.toBeInTheDocument();
+    expect(screen.queryByText('Not in library')).not.toBeInTheDocument();
+    expect(checkDataAvailability).not.toHaveBeenCalled();
+  });
+
+  it('prop absent keeps the standalone self-check behavior (regression)', async () => {
+    renderCard(undefined);
+    // self-check fires and, with empty results, resolves to Not in library
+    expect(await screen.findByText('Not in library')).toBeInTheDocument();
+    expect(checkDataAvailability).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
@@ -3,10 +3,14 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../../context/useAuth';
 import { checkDataAvailability } from '../../services/jwstDataService';
 import { formatInstruments } from '../../utils/instrumentDisplay';
+import { observationIdsForFilters } from '../../utils/observationUtils';
 import type { CompositeRecipe } from '../../types/DiscoveryTypes';
 import type { MastObservationResult } from '../../types/MastTypes';
 import { CE_MODE } from '../../config/ce';
 import './RecipeCard.css';
+
+/** Parent-controlled availability: 'pending' hides the status pill. */
+export type RecipeAvailability = 'ready' | 'missing' | 'pending';
 
 interface RecipeCardProps {
   recipe: CompositeRecipe;
@@ -16,6 +20,12 @@ interface RecipeCardProps {
   observations?: MastObservationResult[];
   /** Optional search radius override to thread through to the guided create page */
   radius?: number;
+  /**
+   * When provided, the parent owns the availability check (one batched call
+   * for the whole page) and the card fires no request of its own. When
+   * absent, the card self-checks — standalone behavior unchanged.
+   */
+  availability?: RecipeAvailability;
 }
 
 function formatTime(seconds: number): string {
@@ -34,30 +44,24 @@ export function RecipeCard({
   isRecommended,
   observations,
   radius,
+  availability,
 }: RecipeCardProps) {
   const { isAuthenticated } = useAuth();
   const radiusParam = radius ? `&radius=${radius}` : '';
   const createUrl = `/create?target=${encodeURIComponent(targetName)}&recipe=${encodeURIComponent(recipe.name)}${radiusParam}`;
   const [dataReady, setDataReady] = useState(false);
 
-  // Find MAST obs_ids that match this recipe's filters
-  const obsIds = useMemo(() => {
-    if (!observations || observations.length === 0) return [];
-    const recipeFilterSet = new Set(recipe.filters.map((f) => f.toUpperCase()));
-    const seen = new Set<string>();
-    const ids: string[] = [];
-    for (const obs of observations) {
-      const filterKey = obs.filters?.toUpperCase();
-      if (filterKey && recipeFilterSet.has(filterKey) && !seen.has(filterKey) && obs.obs_id) {
-        seen.add(filterKey);
-        ids.push(obs.obs_id);
-      }
-    }
-    return ids;
-  }, [observations, recipe.filters]);
+  // Find MAST obs_ids that match this recipe's filters (shared with
+  // TargetDetail's grouped availability map so both agree)
+  const obsIds = useMemo(
+    () => (observations ? observationIdsForFilters(observations, recipe.filters) : []),
+    [observations, recipe.filters]
+  );
 
   // Check if all recipe filters have existing data in the library
+  // (self-check mode only — skipped when the parent owns availability)
   useEffect(() => {
+    if (availability !== undefined) return;
     if (obsIds.length === 0) return;
 
     const controller = new AbortController();
@@ -87,9 +91,11 @@ export function RecipeCard({
     return () => {
       controller.abort();
     };
-  }, [obsIds, recipe.filters]);
+  }, [obsIds, recipe.filters, availability]);
 
-  const showReady = dataReady || isAuthenticated;
+  const resolvedReady = availability !== undefined ? availability === 'ready' : dataReady;
+  const showReady = resolvedReady || isAuthenticated;
+  const statusPending = availability === 'pending';
 
   return (
     <div
@@ -138,13 +144,17 @@ export function RecipeCard({
             <span className="recipe-card-mosaic">Mosaic needed</span>
           </>
         )}
-        <span className="recipe-card-dot">&middot;</span>
-        {showReady ? (
-          <span className="recipe-card-auth recipe-card-auth-ready">Ready</span>
-        ) : CE_MODE ? (
-          <span className="recipe-card-auth recipe-card-auth-login">Not in library</span>
-        ) : (
-          <span className="recipe-card-auth recipe-card-auth-login">Login required</span>
+        {!statusPending && (
+          <>
+            <span className="recipe-card-dot">&middot;</span>
+            {showReady ? (
+              <span className="recipe-card-auth recipe-card-auth-ready">Ready</span>
+            ) : CE_MODE ? (
+              <span className="recipe-card-auth recipe-card-auth-login">Not in library</span>
+            ) : (
+              <span className="recipe-card-auth recipe-card-auth-login">Login required</span>
+            )}
+          </>
         )}
       </div>
 

--- a/frontend/jwst-frontend/src/pages/TargetDetail.css
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.css
@@ -166,3 +166,13 @@
     font-size: var(--text-2xl);
   }
 }
+
+/* Recipes whose data isn't in the library — visibly secondary to the
+   ready-to-render group but still fully readable. */
+.target-detail-recipes-unavailable {
+  opacity: 0.75;
+}
+
+.target-detail-recipes-unavailable .target-detail-section-header {
+  color: var(--text-muted);
+}

--- a/frontend/jwst-frontend/src/pages/TargetDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, Link } from 'react-router-dom';
+import { TargetDetail } from './TargetDetail';
+import { checkDataAvailability } from '../services/jwstDataService';
+import { searchByTarget } from '../services/mastService';
+import { suggestRecipes } from '../services/discoveryService';
+import type { CompositeRecipe } from '../types/DiscoveryTypes';
+
+vi.mock('../config/ce', () => ({ CE_MODE: true }));
+const authState = { isAuthenticated: false };
+vi.mock('../context/useAuth', () => ({ useAuth: () => authState }));
+vi.mock('../services/mastService', () => ({ searchByTarget: vi.fn() }));
+vi.mock('../services/discoveryService', () => ({ suggestRecipes: vi.fn() }));
+vi.mock('../services/jwstDataService', () => ({ checkDataAvailability: vi.fn() }));
+
+function makeRecipe(name: string, filters: string[]): CompositeRecipe {
+  return {
+    name,
+    rank: 1,
+    filters,
+    colorMapping: {},
+    instruments: ['MIRI'],
+    requiresMosaic: false,
+    estimatedTimeSeconds: 30,
+    observationIds: filters.map((f) => `obs-${f.toLowerCase()}`),
+    description: '',
+  };
+}
+
+const observations = [
+  { obs_id: 'obs-f770w', filters: 'F770W', instrument_name: 'MIRI', dataproduct_type: 'image' },
+  { obs_id: 'obs-f090w', filters: 'F090W', instrument_name: 'NIRCAM', dataproduct_type: 'image' },
+];
+
+function mockHappyPath(availability: Record<string, unknown> | Error) {
+  vi.mocked(searchByTarget).mockResolvedValue({ results: observations } as never);
+  vi.mocked(suggestRecipes).mockResolvedValue({
+    recipes: [makeRecipe('MIRI recipe', ['F770W']), makeRecipe('NIRCam recipe', ['F090W'])],
+  } as never);
+  if (availability instanceof Error) {
+    vi.mocked(checkDataAvailability).mockRejectedValue(availability);
+  } else {
+    vi.mocked(checkDataAvailability).mockResolvedValue({ results: availability } as never);
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/target/Crab%20Nebula']}>
+      <Routes>
+        <Route path="/target/:name" element={<TargetDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('TargetDetail recipe grouping', () => {
+  beforeEach(() => {
+    // resetAllMocks (not clearAllMocks): mockImplementation set inside a
+    // test — e.g. the never-resolving availability promise — must not leak
+    vi.resetAllMocks();
+    authState.isAuthenticated = false;
+  });
+
+  it('authenticated users keep the flat layout and no page-level availability call (regression)', async () => {
+    authState.isAuthenticated = true;
+    mockHappyPath({});
+    renderPage();
+    await screen.findByText('Suggested Composites');
+    expect(screen.queryByText('Ready to render')).not.toBeInTheDocument();
+    expect(screen.queryByText('Not in library', { selector: 'h3' })).not.toBeInTheDocument();
+    // page-level batched call is anonymous-only; cards self-check as before
+    expect(checkDataAvailability).toHaveBeenCalledTimes(2);
+  });
+
+  it('mixed availability renders Ready section first, then Not in library', async () => {
+    mockHappyPath({
+      'obs-f770w': { available: true, dataIds: ['a'.repeat(24)], filter: 'F770W' },
+    });
+    renderPage();
+    const ready = await screen.findByText('Ready to render');
+    const missing = await screen.findByText('Not in library', { selector: 'h3' });
+    // Ready section comes first in document order
+    // DOCUMENT_POSITION_FOLLOWING === 4 (Node global is not in the lint env)
+    expect(ready.compareDocumentPosition(missing) & 4).toBeTruthy();
+    // the recommended badge belongs to the first READY recipe
+    const readySection = ready.closest('section');
+    expect(readySection?.textContent).toContain('MIRI recipe');
+    expect(readySection?.textContent).toContain('Recommended');
+  });
+
+  it('all recipes ready renders a single section without an empty "Not in library" header', async () => {
+    mockHappyPath({
+      'obs-f770w': { available: true, dataIds: ['a'.repeat(24)], filter: 'F770W' },
+      'obs-f090w': { available: true, dataIds: ['b'.repeat(24)], filter: 'F090W' },
+    });
+    renderPage();
+    await screen.findByText('Ready to render');
+    expect(screen.queryByText('Not in library', { selector: 'h3' })).not.toBeInTheDocument();
+  });
+
+  it('no recipes ready renders only the Not in library section header', async () => {
+    mockHappyPath({});
+    renderPage();
+    await screen.findByText('Not in library', { selector: 'h3' });
+    expect(screen.queryByText('Ready to render')).not.toBeInTheDocument();
+  });
+
+  it('availability failure degrades to the flat ungrouped list with no pills', async () => {
+    mockHappyPath(new Error('availability down'));
+    renderPage();
+    // flat header, both recipes rendered, no grouping headers, no status pills
+    await screen.findByText('Suggested Composites');
+    expect(screen.getByText('MIRI recipe')).toBeInTheDocument();
+    expect(screen.getByText('NIRCam recipe')).toBeInTheDocument();
+    expect(screen.queryByText('Ready to render')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('Not in library')).not.toBeInTheDocument();
+      expect(screen.queryByText('Ready')).not.toBeInTheDocument();
+    });
+  });
+
+  it('navigating to a new target never groups with the previous target map (regression)', async () => {
+    // Target A resolves: its recipe (shared name!) is READY.
+    mockHappyPath({
+      'obs-f770w': { available: true, dataIds: ['a'.repeat(24)], filter: 'F770W' },
+      'obs-f090w': { available: true, dataIds: ['b'.repeat(24)], filter: 'F090W' },
+    });
+    render(
+      <MemoryRouter initialEntries={['/target/Target%20A']}>
+        <Link to="/target/Target%20B">go-to-b</Link>
+        <Routes>
+          <Route path="/target/:name" element={<TargetDetail />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await screen.findByText('Ready to render');
+
+    // Target B: same recipe names, but availability never resolves.
+    vi.mocked(checkDataAvailability).mockImplementation(() => new Promise(() => {}));
+    screen.getByText('go-to-b').click();
+    await screen.findByText('Suggested Composites');
+    // B must be flat/pending — never "Ready to render" borrowed from A's map
+    expect(screen.queryByText('Ready to render')).not.toBeInTheDocument();
+  });
+
+  it('makes exactly one chunked availability pass for the whole page (not per card)', async () => {
+    mockHappyPath({
+      'obs-f770w': { available: true, dataIds: ['a'.repeat(24)], filter: 'F770W' },
+    });
+    renderPage();
+    await screen.findByText('Ready to render');
+    expect(checkDataAvailability).toHaveBeenCalledTimes(1);
+    const calledIds = vi.mocked(checkDataAvailability).mock.calls[0][0];
+    expect([...calledIds].sort()).toEqual(['obs-f090w', 'obs-f770w']);
+  });
+});

--- a/frontend/jwst-frontend/src/pages/TargetDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.tsx
@@ -1,15 +1,17 @@
 import { useState, useEffect } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router-dom';
 import { RecipeCard } from '../components/discovery/RecipeCard';
+import { checkDataAvailability } from '../services/jwstDataService';
 import { ObservationList } from '../components/discovery/ObservationList';
 import { TargetDetailSkeleton } from '../components/discovery/TargetDetailSkeleton';
 import { TelescopeIcon } from '../components/icons/DashboardIcons';
 import { searchByTarget } from '../services/mastService';
 import { suggestRecipes } from '../services/discoveryService';
-import { toObservationInputs } from '../utils/observationUtils';
+import { toObservationInputs, observationIdsForFilters } from '../utils/observationUtils';
 import type { MastObservationResult } from '../types/MastTypes';
 import type { CompositeRecipe } from '../types/DiscoveryTypes';
 import { CE_MODE } from '../config/ce';
+import { useAuth } from '../context/useAuth';
 import './TargetDetail.css';
 
 type LoadState = 'loading' | 'ready' | 'error' | 'empty';
@@ -24,6 +26,11 @@ type LoadState = 'loading' | 'ready' | 'error' | 'empty';
  */
 export function TargetDetail() {
   const { name } = useParams<{ name: string }>();
+  // Grouping is for anonymous visitors (CE strangers): an authenticated
+  // user's status pill is always "Ready" (they can download missing data),
+  // so grouping would be meaningless — they keep today's flat layout and
+  // per-card behavior untouched.
+  const { isAuthenticated } = useAuth();
   const [searchParams] = useSearchParams();
   const displayName = name ? decodeURIComponent(name) : 'Unknown Target';
   const radiusParam = searchParams.get('radius');
@@ -39,6 +46,10 @@ export function TargetDetail() {
   // it during the pending window.
   const [recipesLoaded, setRecipesLoaded] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
+  // recipe name -> all filters available locally. null = pending or check
+  // failed: render the flat ungrouped list (never present a renderable page
+  // as dead because one availability call hiccuped).
+  const [readyByRecipe, setReadyByRecipe] = useState<Map<string, boolean> | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -47,6 +58,9 @@ export function TargetDetail() {
       setLoadState('loading');
       setErrorMessage(null);
       setRecipesLoaded(false);
+      // A stale map from a previous target (or a stale-cache recipe list)
+      // must never group fresh recipes — null degrades to the flat list.
+      setReadyByRecipe(null);
 
       // ?fresh=true bypasses localStorage cache (useful when backend changes invalidate cached data)
       const freshParam = new URLSearchParams(window.location.search).get('fresh');
@@ -128,6 +142,46 @@ export function TargetDetail() {
     return () => controller.abort();
   }, [displayName, radius, retryCount]);
 
+  // One batched availability pass for the whole page (the service chunks at
+  // the endpoint's 50-id cap). Cards render pill-less until this resolves —
+  // a single reflow from flat to grouped, no per-card churn.
+  useEffect(() => {
+    if (isAuthenticated) return;
+    if (!recipesLoaded || recipes.length === 0 || observations.length === 0) return;
+
+    const controller = new AbortController();
+    const idsPerRecipe = recipes.map((recipe) => ({
+      recipe,
+      obsIds: observationIdsForFilters(observations, recipe.filters),
+    }));
+    const unionIds = [...new Set(idsPerRecipe.flatMap((entry) => entry.obsIds))];
+    if (unionIds.length === 0) return;
+
+    checkDataAvailability(unionIds, controller.signal)
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        const availableFilters = new Set<string>();
+        for (const item of Object.values(result.results)) {
+          if (item?.available && item.filter) {
+            availableFilters.add(item.filter.toUpperCase());
+          }
+        }
+        const map = new Map<string, boolean>();
+        for (const { recipe } of idsPerRecipe) {
+          map.set(
+            recipe.name,
+            recipe.filters.every((f) => availableFilters.has(f.toUpperCase()))
+          );
+        }
+        setReadyByRecipe(map);
+      })
+      .catch(() => {
+        /* pending/failed both mean: keep the flat list, no pills */
+      });
+
+    return () => controller.abort();
+  }, [recipes, recipesLoaded, observations, isAuthenticated]);
+
   return (
     <div className="target-detail">
       <div className="target-detail-back">
@@ -172,7 +226,7 @@ export function TargetDetail() {
               ` \u00b7 ${recipes.length} composite recipe${recipes.length !== 1 ? 's' : ''} suggested`}
           </p>
 
-          {recipes.length > 0 && (
+          {recipes.length > 0 && (isAuthenticated || readyByRecipe === null) && (
             <section className="target-detail-recipes">
               <h3 className="target-detail-section-header">Suggested Composites</h3>
               <div className="recipe-card-list">
@@ -184,10 +238,21 @@ export function TargetDetail() {
                     isRecommended={i === 0}
                     observations={observations}
                     radius={radius}
+                    availability={isAuthenticated ? undefined : 'pending'}
                   />
                 ))}
               </div>
             </section>
+          )}
+
+          {recipes.length > 0 && !isAuthenticated && readyByRecipe !== null && (
+            <RecipeGroups
+              recipes={recipes}
+              readyByRecipe={readyByRecipe}
+              displayName={displayName}
+              observations={observations}
+              radius={radius}
+            />
           )}
 
           {recipes.length === 0 && !recipesLoaded && (
@@ -210,5 +275,56 @@ export function TargetDetail() {
         </>
       )}
     </div>
+  );
+}
+
+interface RecipeGroupsProps {
+  recipes: CompositeRecipe[];
+  readyByRecipe: Map<string, boolean>;
+  displayName: string;
+  observations: MastObservationResult[];
+  radius?: number;
+}
+
+/** Ready recipes first, then the ones whose data isn't in the library.
+ *  Empty groups render no header at all. */
+function RecipeGroups({
+  recipes,
+  readyByRecipe,
+  displayName,
+  observations,
+  radius,
+}: RecipeGroupsProps) {
+  const ready = recipes.filter((r) => readyByRecipe.get(r.name));
+  const missing = recipes.filter((r) => !readyByRecipe.get(r.name));
+
+  const renderCards = (group: CompositeRecipe[], availability: 'ready' | 'missing') =>
+    group.map((recipe, i) => (
+      <RecipeCard
+        key={`${recipe.rank}-${recipe.name}`}
+        recipe={recipe}
+        targetName={displayName}
+        isRecommended={availability === 'ready' && i === 0}
+        observations={observations}
+        radius={radius}
+        availability={availability}
+      />
+    ));
+
+  return (
+    <>
+      {ready.length > 0 && (
+        <section className="target-detail-recipes">
+          <h3 className="target-detail-section-header">Ready to render</h3>
+          <div className="recipe-card-list">{renderCards(ready, 'ready')}</div>
+        </section>
+      )}
+      {missing.length > 0 && (
+        <section className="target-detail-recipes target-detail-recipes-unavailable">
+          <h3 className="target-detail-section-header">Not in library</h3>
+          <div className="recipe-card-list">{renderCards(missing, 'missing')}</div>
+        </section>
+      )}
+    </>
   );
 }

--- a/frontend/jwst-frontend/src/services/jwstDataService.test.ts
+++ b/frontend/jwst-frontend/src/services/jwstDataService.test.ts
@@ -20,6 +20,7 @@ vi.mock('../utils/validationUtils', () => ({
 
 import { apiClient } from './apiClient';
 import {
+  checkDataAvailability,
   getAll,
   upload,
   archive,
@@ -291,5 +292,42 @@ describe('jwstDataService', () => {
       await expect(getCubeInfo(INVALID_ID)).rejects.toThrow(`Invalid data ID: ${INVALID_ID}`);
       expect(apiClient.get).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('checkDataAvailability chunking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The check-availability facade caps observationIds at 50 per request;
+  // targets like Carina exceed that across their recipes, so the service
+  // must chunk client-side and merge the results maps.
+  it('sends a single request for 50 or fewer ids', async () => {
+    vi.mocked(apiClient.post).mockResolvedValueOnce({ results: { a: { available: true } } });
+    const ids = Array.from({ length: 50 }, (_, i) => `obs-${i}`);
+    const result = await checkDataAvailability(ids);
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/jwstdata/check-availability',
+      { observationIds: ids },
+      undefined
+    );
+    expect(result.results.a.available).toBe(true);
+  });
+
+  it('chunks above 50 ids and merges the results maps', async () => {
+    vi.mocked(apiClient.post)
+      .mockResolvedValueOnce({ results: { 'obs-0': { available: true, filter: 'F090W' } } })
+      .mockResolvedValueOnce({ results: { 'obs-60': { available: true, filter: 'F187N' } } });
+    const ids = Array.from({ length: 70 }, (_, i) => `obs-${i}`);
+    const result = await checkDataAvailability(ids);
+    expect(apiClient.post).toHaveBeenCalledTimes(2);
+    const firstBatch = vi.mocked(apiClient.post).mock.calls[0][1] as { observationIds: string[] };
+    const secondBatch = vi.mocked(apiClient.post).mock.calls[1][1] as { observationIds: string[] };
+    expect(firstBatch.observationIds).toHaveLength(50);
+    expect(secondBatch.observationIds).toHaveLength(20);
+    expect(result.results['obs-0'].filter).toBe('F090W');
+    expect(result.results['obs-60'].filter).toBe('F187N');
   });
 });

--- a/frontend/jwst-frontend/src/services/jwstDataService.ts
+++ b/frontend/jwst-frontend/src/services/jwstDataService.ts
@@ -187,20 +187,31 @@ export async function getCubeInfo(dataId: string): Promise<CubeInfoResponse> {
   return apiClient.get<CubeInfoResponse>(`/api/jwstdata/${dataId}/cubeinfo`);
 }
 
+/** The check-availability endpoint rejects more than 50 ids per request. */
+const AVAILABILITY_BATCH_SIZE = 50;
+
 /**
  * Check which MAST observations have existing public data in the library.
- * Uses the anonymous check-availability endpoint.
+ * Uses the anonymous check-availability endpoint. Requests are chunked at
+ * the endpoint's 50-id cap and the results maps merged, so callers can pass
+ * a whole target's worth of observation ids.
  * @param observationIds - List of MAST obs_id strings to check
  */
 export async function checkDataAvailability(
   observationIds: string[],
   signal?: AbortSignal
 ): Promise<DataAvailabilityResponse> {
-  return apiClient.post<DataAvailabilityResponse>(
-    '/api/jwstdata/check-availability',
-    { observationIds },
-    signal ? { signal } : undefined
-  );
+  const merged: DataAvailabilityResponse = { results: {} };
+  for (let i = 0; i < observationIds.length; i += AVAILABILITY_BATCH_SIZE) {
+    const batch = observationIds.slice(i, i + AVAILABILITY_BATCH_SIZE);
+    const response = await apiClient.post<DataAvailabilityResponse>(
+      '/api/jwstdata/check-availability',
+      { observationIds: batch },
+      signal ? { signal } : undefined
+    );
+    Object.assign(merged.results, response.results);
+  }
+  return merged;
 }
 
 // Export as named object for convenience

--- a/frontend/jwst-frontend/src/utils/observationUtils.test.ts
+++ b/frontend/jwst-frontend/src/utils/observationUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { observationIdsForFilters } from './observationUtils';
+import type { MastObservationResult } from '../types/MastTypes';
+
+// TargetDetail's grouped availability map and RecipeCard's standalone
+// self-check both key off this selection — these tests lock the "both
+// consumers agree" invariant the helper exists to enforce.
+describe('observationIdsForFilters', () => {
+  const obs = (obs_id: string | undefined, filters: string) =>
+    ({
+      obs_id,
+      filters,
+      instrument_name: 'MIRI',
+      dataproduct_type: 'image',
+    }) as MastObservationResult;
+
+  it('picks the first observation per filter (dedup)', () => {
+    const result = observationIdsForFilters(
+      [obs('first-f770w', 'F770W'), obs('second-f770w', 'F770W')],
+      ['F770W']
+    );
+    expect(result).toEqual(['first-f770w']);
+  });
+
+  it('skips observations without an obs_id and takes the next matching one', () => {
+    const result = observationIdsForFilters(
+      [obs(undefined, 'F770W'), obs('with-id', 'F770W')],
+      ['F770W']
+    );
+    expect(result).toEqual(['with-id']);
+  });
+
+  it('matches filters case-insensitively', () => {
+    const result = observationIdsForFilters([obs('o1', 'f770w')], ['F770W']);
+    expect(result).toEqual(['o1']);
+  });
+
+  it('ignores observations whose filter is not in the recipe', () => {
+    const result = observationIdsForFilters([obs('o1', 'F770W'), obs('o2', 'F090W')], ['F770W']);
+    expect(result).toEqual(['o1']);
+  });
+
+  it('returns empty for empty inputs', () => {
+    expect(observationIdsForFilters([], ['F770W'])).toEqual([]);
+    expect(observationIdsForFilters([obs('o1', 'F770W')], [])).toEqual([]);
+  });
+});

--- a/frontend/jwst-frontend/src/utils/observationUtils.ts
+++ b/frontend/jwst-frontend/src/utils/observationUtils.ts
@@ -21,3 +21,26 @@ export function toObservationInputs(observations: MastObservationResult[]): Obse
   }
   return inputs;
 }
+
+/**
+ * The obs_ids backing a set of recipe filters: first observation per filter.
+ * TargetDetail's grouped availability map and RecipeCard's standalone
+ * self-check both use this — they MUST agree on what "this recipe" means,
+ * so the selection lives in one place.
+ */
+export function observationIdsForFilters(
+  observations: MastObservationResult[],
+  filters: string[]
+): string[] {
+  const filterSet = new Set(filters.map((f) => f.toUpperCase()));
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const obs of observations) {
+    const filterKey = obs.filters?.toUpperCase();
+    if (filterKey && filterSet.has(filterKey) && !seen.has(filterKey) && obs.obs_id) {
+      seen.add(filterKey);
+      ids.push(obs.obs_id);
+    }
+  }
+  return ids;
+}


### PR DESCRIPTION
## Summary

Closes #1674.

Target pages now group suggested recipes for anonymous visitors: **Ready to render** first, then a de-emphasized **Not in library** section. With the CE seed bundle shipping 71/93 featured recipes, "not in library" is a permanent state — this makes it structure the page instead of interleaving dead-looking cards with working ones.

### Design decisions (from CEO/eng review, all test-pinned)

- **One batched availability pass per page** replaces N per-card `check-availability` calls; `checkDataAvailability` now chunks at the facade's 50-id cap (a latent 400 for large targets, fixed here).
- **Graceful degradation**: flat pill-less list while the check is pending or if it fails — a renderable page is never presented as dead because one call hiccuped. Exactly one reflow (flat → grouped).
- **Navigation safety** (reviewer catch): the readiness map resets on every target load, so browsing target A → target B can never group B's recipes — or falsely mark them "Ready" — with A's results, even when recipe names collide.
- **Auth users unchanged**: their pill is always "Ready" (they can download), so grouping is meaningless — they keep today's flat layout, per-card behavior byte-identical (regression-tested).
- **Shared selection helper** (reviewer catch): the recipe→obs_id logic is extracted to `observationIdsForFilters` used by both `TargetDetail` and `RecipeCard`, so the group placement and the card's own pill can never disagree; helper semantics locked by 5 unit tests.

## Changes Made

- `src/services/jwstDataService.ts` (+ tests): chunked `checkDataAvailability`
- `src/pages/TargetDetail.tsx/.css` (+ 7 tests): availability effect, `RecipeGroups`, degradation states, navigation reset
- `src/components/discovery/RecipeCard.tsx` (+ 4 tests): optional `availability` prop ('ready' | 'missing' | 'pending'); absent → standalone self-check unchanged
- `src/utils/observationUtils.ts` (+ 5 tests): shared `observationIdsForFilters`
- `e2e/target-detail.spec.ts`: anonymous grouping spec (partial-availability mock)
- `docs/plans/features/quick/recipe-grouping-and-fetch-cli.md`: plan of record (covers this + #1675)

## Test Plan

- [x] Red-green: all tests written first (18 new)
- [x] Full frontend unit suite: **1151 passed** (102 files)
- [x] E2E `target-detail.spec.ts`: **14/14 chromium** incl. new anonymous grouping test (run against the worktree dev server; note: Playwright's `reuseExistingServer` silently reuses the main-checkout dev container if it's running — stop `jwst-frontend` first)
- [x] `tsc --noEmit` + eslint clean for changed files
- [x] Self-review rounds: R1 (2 SHOULD: navigation staleness, helper duplication — fixed), R2 (1 SHOULD: helper tests — fixed), R3 clean
- [ ] Reviewer walkthrough: open a CE build (`VITE_CE_MODE=true`) → any featured target → verify Ready section first, Not in library de-emphasized below; kill the network before the availability call resolves → flat list, no pills

## Documentation Checklist

- [x] Plan doc included; no architecture docs affected

## Tech Debt Impact

- [x] None new. Pre-existing (noted by reviewer, out of scope): authenticated cards still fire self-checks whose result is ignored.

## Risk & Rollback

- **Risk:** Low. Anonymous-only rendering change; auth path regression-tested unchanged; availability failure degrades to today's layout.
- **Rollback:** revert the commit.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
