### PR TITLE
feat: fetch-recipe admin CLI — gap-fill missing data for one recipe

### DIFF
--- a/processing-engine/scripts/seed_ce.py
+++ b/processing-engine/scripts/seed_ce.py
@@ -21,6 +21,14 @@ Subcommands:
                 files.txt          relative FITS paths for rsync
                 manifest.json      targets/recipes/sizes/verdicts
 
+    fetch   — admin gap-fill for ONE recipe (#1675): download exactly its
+              missing filters, then re-check renderability at the CE posture.
+              Exit codes: 0 fetched (or nothing to fetch) and renders at the
+              CE posture; 1 hard error (no mosaics on MAST, download failed);
+              2 usage; 3 a needed file exceeds --max-file-size (nothing
+              downloaded — re-run with the printed value); 4 downloaded but
+              the recipe STILL fails the estimate.
+
 Runs inside the engine container (like prefetch_discovery.py):
     docker exec jwst-processing python scripts/seed_ce.py report
 
@@ -201,6 +209,48 @@ def apply_threshold(verdict: dict, fail_threshold: float | None) -> dict:
     else:
         status = "fail"
     return {**verdict, "status": status}
+
+
+@dataclass
+class FetchPlan:
+    """What a recipe still needs: downloads within the size cap, files over
+    it (require an explicit --max-file-size), and filters with no combined
+    mosaic on MAST at all."""
+
+    downloads: list = field(default_factory=list)
+    over_cap: list = field(default_factory=list)
+    unfindable: list[str] = field(default_factory=list)
+
+
+def plan_fetch(
+    recipe: dict,
+    availability: dict,
+    mosaics_by_filter: dict,
+    max_bytes: int,
+    obs_filters: dict | None = None,
+) -> FetchPlan:
+    plan = FetchPlan()
+    # Same fallback as cmd_fetch's own missing computation — the two MUST
+    # agree or the plan describes a different filter set than the one the
+    # mosaics were gathered for (null-filter entries would read as missing
+    # here and produce false "unfindable" aborts or re-downloads).
+    for flt in missing_filters(recipe, availability, obs_filters):
+        mosaic = mosaics_by_filter.get(str(flt).upper())
+        if mosaic is None:
+            plan.unfindable.append(flt)
+        elif mosaic.size_bytes > max_bytes:
+            plan.over_cap.append(mosaic)
+        else:
+            plan.downloads.append(mosaic)
+    return plan
+
+
+def find_recipe(recipes: list[dict], name: str) -> dict:
+    for recipe in recipes:
+        if recipe.get("name") == name:
+            return recipe
+    names = "\n  ".join(r.get("name", "?") for r in recipes)
+    raise SystemExit(f"no recipe named {name!r} for this target. Available:\n  {names}")
 
 
 def transform_doc(doc: dict) -> dict:
@@ -478,17 +528,158 @@ def _unique_bytes(reports: list[RecipeReport]) -> int:
     return total
 
 
+def cmd_fetch(args, client: EngineClient, target: dict) -> int:
+    """Gap-fill one recipe: download exactly its missing filters, then
+    re-check renderability at the CE posture. Runs in the engine container
+    against the DEV stack (CE itself is read-only — updates reach it via
+    bundle rebuild + restore-seed.sh)."""
+    from scripts.prefetch_discovery import check_disk_ok, find_combined_mosaics
+
+    name = target["name"]
+    search_name = (target.get("mastSearchParams") or {}).get("target") or name
+    rows = [r for r in client.search_target(search_name) if r.get("dataproduct_type") == "image"]
+    if not rows:
+        logger.error("no MAST image observations for %s", search_name)
+        return 1
+    recipes = client.suggest_recipes(name, _to_observation_inputs(rows))
+    recipe = find_recipe(recipes, args.recipe)
+    availability = client.check_availability(recipe.get("observationIds") or [])
+    obs_filters = {
+        r.get("obs_id"): str(r.get("filters") or "").upper() for r in rows if r.get("obs_id")
+    }
+    missing = missing_filters(recipe, availability, obs_filters)
+    if not missing:
+        logger.info("recipe %r already has every filter locally — nothing to fetch", args.recipe)
+        return 0
+    logger.info("missing filters: %s", ", ".join(missing))
+
+    from app.mast.mast_service import MastService
+
+    mast = MastService()
+    missing_set = {str(f).upper() for f in missing}
+    mosaics_by_filter: dict = {}
+    for row in rows:
+        flt = str(row.get("filters") or "").upper()
+        if flt not in missing_set or not row.get("obs_id"):
+            continue
+        try:
+            products = mast.get_data_products(row["obs_id"])
+        except Exception as exc:
+            logger.warning("get_data_products(%s) failed: %s", row["obs_id"], exc)
+            continue
+        for mosaic in find_combined_mosaics(products, row["obs_id"]):
+            existing = mosaics_by_filter.get(mosaic.filter_name)
+            if existing is None or mosaic.size_bytes < existing.size_bytes:
+                mosaics_by_filter[mosaic.filter_name] = mosaic
+
+    max_bytes = int(args.max_file_size * 1e9)
+    plan = plan_fetch(recipe, availability, mosaics_by_filter, max_bytes, obs_filters)
+    if plan.unfindable:
+        logger.error(
+            "no combined L3 mosaic on MAST for: %s — this recipe cannot be gap-filled",
+            ", ".join(plan.unfindable),
+        )
+        return 1
+    if plan.over_cap:
+        biggest = max(m.size_bytes for m in plan.over_cap) / 1e9
+        for m in plan.over_cap:
+            logger.error("over cap: %s %s (%.2f GB)", m.filter_name, m.filename, m.size_bytes / 1e9)
+        logger.error(
+            "nothing downloaded. To fetch these deliberately, re-run with: --max-file-size %.0f",
+            biggest + 1,
+        )
+        return 3
+    total = sum(m.size_bytes for m in plan.downloads)
+    for m in plan.downloads:
+        logger.info("will download %s: %s (%.2f GB)", m.filter_name, m.filename, m.size_bytes / 1e9)
+    logger.info("total: %.2f GB", total / 1e9)
+    if args.dry_run:
+        return 0
+
+    downloaded_keys: list[str] = []
+    for m in plan.downloads:
+        # cumulative cap deliberately vacuous (1e9 GB): the live free-space
+        # floor (10GB) re-reads the disk before every download and is the
+        # guard that matters for a hand-run, few-file tool
+        ok, reason = check_disk_ok(
+            mast.download_dir, m.size_bytes, 10.0, 1e9, 0, args.max_file_size
+        )
+        if not ok:
+            logger.error("disk guard refused %s: %s", m.filename, reason)
+            return 1
+        result = mast.download_product(m.filename, m.obs_id)
+        if result.get("status") != "completed" or not result.get("files"):
+            logger.error(
+                "download failed for %s: %s", m.filter_name, result.get("error", "unknown")
+            )
+            return 1
+        data_root = os.path.dirname(mast.download_dir)
+        downloaded_keys.append(os.path.relpath(result["files"][0], data_root))
+        logger.info("downloaded %s", downloaded_keys[-1])
+
+    # Renderability check at the CE posture: newly fetched files + the
+    # filters that were already local. Downloading 20GB for a recipe CE
+    # still can't render is exactly the surprise this preflight prevents.
+    existing_ids = [
+        d
+        for e in availability.values()
+        if e.get("available") and e.get("dataIds")
+        for d in e["dataIds"]
+    ]
+    docs = _fetch_docs(_mongo_collection(), existing_ids) if existing_ids else []
+    paths_by_id = {str(d["_id"]): d.get("FilePath") for d in docs}
+    # One channel per FILTER, exactly like the real render and the gate —
+    # the memory verdict is channel-count-sensitive, so per-file channels
+    # would be pessimistic and could cry wolf on a recipe the gate passes.
+    channels = build_estimate_channels(recipe, availability, paths_by_id, obs_filters)
+    for i, _mosaic in enumerate(plan.downloads):
+        channels.append(
+            {
+                "file_paths": [downloaded_keys[i]],
+                "color": {"hue": ((len(channels) + i) * _HUE_STEP) % 360.0},
+            }
+        )
+    verdict = client.estimate(channels)
+    if args.fail_threshold is not None:
+        verdict = apply_threshold(verdict, args.fail_threshold)
+    logger.info(
+        "estimate verdict at CE posture: %s (%s)", verdict.get("status"), verdict.get("detail", "")
+    )
+
+    print(
+        "\nNext steps:\n"
+        "  1. Trigger the .NET scan so the new files get metadata:\n"
+        "     POST /api/DataManagement/import/scan (authenticated)\n"
+        "  2. Re-run the gate for this target:\n"
+        f"     ./scripts/seed-ce.sh gate --target {name!r} --fail-threshold 0.15\n"
+        "  3. Rebuild the bundle (seed-ce.sh build ...) and re-run\n"
+        "     restore-seed.sh on the CE host."
+    )
+    return 0 if verdict.get("status") in ("ok", "warn") else 4
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("command", choices=["report", "gate", "export"])
+    parser.add_argument("command", choices=["report", "gate", "export", "fetch"])
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
     parser.add_argument("--targets", default=str(DEFAULT_TARGETS))
     parser.add_argument("--target", help="limit to a single featured target name")
     parser.add_argument("--out", default="/tmp/ce-seed", help="export output directory")
     parser.add_argument("--budget-gb", type=float, default=100.0, help="disk budget for the report")
     parser.add_argument("--generated-at", help="ISO timestamp stamped into manifest.json (export)")
+    parser.add_argument("--recipe", help="fetch: exact recipe name to gap-fill")
+    parser.add_argument(
+        "--max-file-size",
+        type=float,
+        default=6.0,
+        help="fetch: per-file size cap in GB (default 6 — the prefetch default whose "
+        "skips created the known gaps; fetching bigger files must be deliberate)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="fetch: plan and print, download nothing"
+    )
     parser.add_argument(
         "--fail-threshold",
         type=float,
@@ -527,6 +718,11 @@ def main(argv: list[str] | None = None) -> int:
             return 2
 
     client = EngineClient(args.base_url)
+    if args.command == "fetch":
+        if not args.target or not args.recipe:
+            logger.error("fetch requires --target and --recipe")
+            return 2
+        return cmd_fetch(args, client, targets[0])
     if args.fail_threshold is not None:
         # visible, not silent: a gate that validated the wrong posture is
         # worse than no gate (green light for recipes strangers can't render)

--- a/processing-engine/tests/test_seed_ce.py
+++ b/processing-engine/tests/test_seed_ce.py
@@ -19,7 +19,9 @@ from scripts.seed_ce import (
     evaluate_all,
     evaluate_recipe,
     export_bundle,
+    find_recipe,
     missing_filters,
+    plan_fetch,
     transform_doc,
 )
 
@@ -607,3 +609,88 @@ class TestExcludePatterns:
         monkeypatch.setattr(mod, "EngineClient", lambda _url: None)
         monkeypatch.setattr(mod, "evaluate_all", lambda _c, _t, _m, **_kw: (reports, []))
         assert mod.main(["gate", "--targets", str(targets_file)]) == 0
+
+
+class TestFetchPlanning:
+    """Admin gap-fill (#1675): plan exactly what a recipe is missing, refuse
+    over-cap files BEFORE any download, and surface unfindable filters."""
+
+    def _mosaic(self, filt, size):
+        from scripts.prefetch_discovery import MosaicInfo
+
+        return MosaicInfo(
+            obs_id=f"jw0001-{filt.lower()}",
+            filename=f"jw0001_{filt.lower()}_i2d.fits",
+            filter_name=filt,
+            instrument="NIRCAM",
+            size_bytes=size,
+            data_uri="mast:JWST/x",
+        )
+
+    def test_complete_recipe_plans_nothing(self):
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": "F090W"},
+            ),
+            (
+                "jw02733-o001_t001_nircam_clear-f187n",
+                {"available": True, "dataIds": ["b" * 24], "filter": "F187N"},
+            ),
+        )
+        plan = plan_fetch(RECIPE, avail, {}, max_bytes=6_000_000_000)
+        assert plan.downloads == [] and plan.unfindable == [] and plan.over_cap == []
+
+    def test_missing_filters_become_downloads(self):
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": "F090W"},
+            ),
+        )
+        mosaics = {"F187N": self._mosaic("F187N", 1_000)}
+        plan = plan_fetch(RECIPE, avail, mosaics, max_bytes=6_000_000_000)
+        assert [m.filter_name for m in plan.downloads] == ["F187N"]
+        assert plan.unfindable == [] and plan.over_cap == []
+
+    def test_over_cap_files_are_separated_not_downloaded(self):
+        mosaics = {
+            "F090W": self._mosaic("F090W", 20_000_000_000),
+            "F187N": self._mosaic("F187N", 1_000),
+        }
+        plan = plan_fetch(RECIPE, _availability(), mosaics, max_bytes=6_000_000_000)
+        assert [m.filter_name for m in plan.over_cap] == ["F090W"]
+        assert [m.filter_name for m in plan.downloads] == ["F187N"]
+
+    def test_null_filter_entry_with_fallback_is_not_planned(self):
+        """MUST-fix regression: a null-filter availability entry covered via
+        the obs_filters fallback must not be re-planned as missing (false
+        'unfindable' abort or re-download of a local filter)."""
+        avail = _availability(
+            (
+                "jw02733-o001_t001_nircam_clear-f090w",
+                {"available": True, "dataIds": ["a" * 24], "filter": None},
+            ),
+        )
+        obs_filters = {"jw02733-o001_t001_nircam_clear-f090w": "F090W"}
+        mosaics = {"F187N": self._mosaic("F187N", 1_000)}
+        plan = plan_fetch(RECIPE, avail, mosaics, max_bytes=6_000_000_000, obs_filters=obs_filters)
+        assert [m.filter_name for m in plan.downloads] == ["F187N"]
+        assert plan.unfindable == []  # F090W covered via fallback, not unfindable
+
+    def test_unfindable_filters_reported(self):
+        plan = plan_fetch(RECIPE, _availability(), {}, max_bytes=6_000_000_000)
+        assert plan.unfindable == ["F090W", "F187N"]
+        assert plan.downloads == []
+
+
+class TestFindRecipe:
+    def test_exact_match(self):
+        recipes = [{"name": "A"}, {"name": "B"}]
+        assert find_recipe(recipes, "B") == {"name": "B"}
+
+    def test_miss_raises_with_available_names(self):
+        import pytest
+
+        with pytest.raises(SystemExit, match=r"Classic 3-color MIRI"):
+            find_recipe([{"name": "Classic 3-color MIRI"}], "Clasic MIRI")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -150,6 +150,39 @@ Captures:
 
 ---
 
+## Community Edition Seeding
+
+### `prefetch-discovery.sh`
+Download combined L3 mosaics for the featured discovery targets from MAST
+(runs inside the engine container). `--dry-run` surveys sizes only.
+
+```bash
+./scripts/prefetch-discovery.sh --dry-run --all-instruments --target "SMACS 0723"
+```
+
+### `seed-ce.sh`
+Build and gate the CE seed bundle (CE plan Phase 5). `report` surveys
+coverage/sizes, `gate` fails on any non-renderable featured recipe, `build`
+assembles the bundle (FITS tree + Mongo export + restore script).
+
+```bash
+SEED_HARDLINK=1 ./scripts/seed-ce.sh build --out /path/to/bundle   --fail-threshold 0.15 --allow-failures --exclude "Carina Nebula/*NIRCam*"
+```
+
+### `restore-seed.sh`
+Ships INSIDE the bundle; run it on the CE host to mongoimport the seed
+metadata (idempotent upsert) and ensure the read-only `ceReader` user.
+
+### `fetch-recipe.sh`
+Admin gap-fill (#1675): download the missing data for ONE featured recipe,
+then re-check it renders at the CE posture. Refuses files over
+`--max-file-size` (default 6GB) before downloading anything; `--dry-run`
+plans only. Exit codes documented in the script header.
+
+```bash
+./scripts/fetch-recipe.sh --target "SMACS 0723"   --recipe "NASA Deep Field (SMACS 0723)" --dry-run
+```
+
 ## Adding New Scripts
 
 When adding new scripts:

--- a/scripts/fetch-recipe.sh
+++ b/scripts/fetch-recipe.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Admin gap-fill: download the missing data for ONE featured recipe (#1675).
+#
+# Runs against the DEV stack — CE itself is anonymous/read-only by design,
+# so admin writes happen here and reach CE via bundle rebuild + reseed
+# (the tool prints that checklist when it finishes).
+#
+# Usage:
+#   ./scripts/fetch-recipe.sh --target "SMACS 0723" --recipe "NASA Deep Field (SMACS 0723)" --dry-run
+#   ./scripts/fetch-recipe.sh --target "SMACS 0723" --recipe "NASA Deep Field (SMACS 0723)" --max-file-size 20
+#
+# Flags pass through to seed_ce.py fetch (--max-file-size GB, --dry-run,
+# --fail-threshold; default cap 6GB — fetching bigger files must be typed out).
+#
+# Exit codes (propagated from seed_ce.py fetch):
+#   0  fetched (or nothing to fetch) and the recipe renders at the CE posture
+#   1  hard error (no mosaics on MAST, download failure)
+#   2  usage error
+#   3  a needed file exceeds --max-file-size — nothing downloaded
+#   4  downloaded, but the recipe STILL fails the render estimate
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+info()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
+err()   { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
+die()   { err "$@"; exit 1; }
+
+CONTAINER="jwst-processing"
+ENGINE_TARGETS="$PROJECT_ROOT/processing-engine/app/discovery/featured_targets.json"
+DOTNET_TARGETS="$PROJECT_ROOT/backend/JwstDataAnalysis.API/Configuration/featured-targets.json"
+
+docker inspect "$CONTAINER" &>/dev/null || die "Container '$CONTAINER' is not running. Start with: docker compose up -d"
+
+if ! diff -q "$ENGINE_TARGETS" "$DOTNET_TARGETS" >/dev/null; then
+    die "featured target lists have drifted — sync them first"
+fi
+
+info "Running seed_ce.py fetch in $CONTAINER..."
+docker exec "$CONTAINER" python scripts/seed_ce.py fetch --fail-threshold 0.15 "$@"


### PR DESCRIPTION
## Summary

Closes #1675.

**Admin gap-fill CLI** for the CE seed catalog: `./scripts/fetch-recipe.sh --target "SMACS 0723" --recipe "NASA Deep Field (SMACS 0723)"` downloads exactly the files a featured recipe is missing, then verifies the recipe actually renders at the CE posture.

Deliberately **not** an in-app admin endpoint: CE is anonymous, deny-by-default, read-only Mongo, `:ro` data mount — admin writes happen on the dev stack, and CE picks them up via the normal bundle rebuild + `restore-seed.sh` (the tool prints that checklist when it finishes).

### Behavior

- Resolves the recipe via the real stranger flow (search → suggest-recipes → check-availability with the GuidedCreate null-filter fallback) and diffs to the missing filters
- Picks the smallest combined L3 mosaic per missing filter (reuses `find_combined_mosaics` from the prefetch tool)
- **Refuses over-cap files before downloading anything** — prints sizes and the exact `--max-file-size N` re-run command (default cap 6GB; fetching bigger files must be typed out deliberately)
- Post-fetch estimate preflight at the CE threshold with **per-filter channels matching the real render** — exits 4 if the recipe still can't render (the "downloaded 20GB for nothing" guard)
- `--dry-run` plans only; exit codes 0/1/2/3/4 documented in both headers

### Review hardening (round 1: 1 MUST / 1 SHOULD — fixed, round 2 clean)

- MUST: `plan_fetch` recomputed missing filters *without* the null-filter fallback `cmd_fetch` used — a divergence that falsely rejected gap-fillable recipes as "unfindable" (regression-tested)
- SHOULD: preflight channels were per-file, inflating the channel-count-sensitive memory verdict vs the real render — now grouped per filter like the gate

### Live smokes

Dry-runs against the two real Phase 5 gaps: Tarantula Best-6 → found a cap-compliant 1.22GB F200W (the prefetch skip was a larger duplicate mosaic — this recipe is fillable!); SMACS NASA Deep Field → 2 files, 2.97GB, also under cap.

## Changes Made

- `processing-engine/scripts/seed_ce.py`: `FetchPlan` + `plan_fetch` + `find_recipe` + `fetch` subcommand (`--recipe`, `--max-file-size`, `--dry-run`)
- `processing-engine/tests/test_seed_ce.py`: 7 new tests (plan partitioning incl. over-cap and unfindable, null-filter fallback regression, recipe lookup)
- `scripts/fetch-recipe.sh`: wrapper (featured-list parity check, CE-posture default, exit-code docs)
- `scripts/README.md`: new "Community Edition Seeding" section (also documents the Phase 5 scripts that predated it)

## Test Plan

- [x] Red-green: planning tests written first; 41 seed tests / **1563 total** pass in Docker
- [x] Live dry-run smokes against real gaps (Tarantula, SMACS) — correct plans, exit 0
- [x] Self-review round 1 (1 MUST / 1 SHOULD — fixed + regression test) + round 2 clean
- [x] ruff clean; `bash -n` on the wrapper
- [ ] Reviewer walkthrough: `./scripts/fetch-recipe.sh --target "Tarantula Nebula" --recipe "Best 6 filters · NIRCam + MIRI" --dry-run` (plans 1.22GB, downloads nothing)

## Documentation Checklist

- [x] scripts/README.md updated in this PR; exit codes in both script headers

## Tech Debt Impact

- [x] None new. check_disk_ok's cumulative cap is deliberately vacuous for this hand-run tool (commented at the call site; the live 10GB free-space floor is the active guard).

## Risk & Rollback

- **Risk:** Low — build-time admin tooling; nothing ships in runtime images; CE unaffected until an admin rebuilds + reseeds a bundle.
- **Rollback:** revert the commit.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
