### PR TITLE
fix: recipe availability must not depend on MAST row order

### DIFF
--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -39,7 +39,7 @@ import {
   rgbToHue,
   filterToInstrument,
 } from '../utils/wavelengthUtils';
-import { toObservationInputs } from '../utils/observationUtils';
+import { toObservationInputs, buildFilterCoverage } from '../utils/observationUtils';
 import './GuidedCreate.css';
 
 /** Router state passed from RecipeCard to skip redundant MAST + recipe API calls */
@@ -321,14 +321,17 @@ export function GuidedCreate() {
         );
 
         const recipeFilterSet = new Set(matched.filters.map((f) => f.toUpperCase()));
-        const relevantObs = deduplicateByFilter(
-          observations.filter((o) => {
-            if (!o.filters || !recipeFilterSet.has(o.filters.toUpperCase())) return false;
-            // If recipe specifies exact obs_ids, only include those
-            if (recipeObsIdSet && o.obs_id) return recipeObsIdSet.has(o.obs_id);
-            return true;
-          })
-        );
+        // ALL observations matching the recipe filters — availability must
+        // consider every one (the library may hold a filter from an obs set
+        // that doesn't sort first; Cas A regression). Dedup happens later,
+        // only for choosing which obs to DOWNLOAD.
+        const matchingObs = observations.filter((o) => {
+          if (!o.filters || !recipeFilterSet.has(o.filters.toUpperCase())) return false;
+          // If recipe specifies exact obs_ids, only include those
+          if (recipeObsIdSet && o.obs_id) return recipeObsIdSet.has(o.obs_id);
+          return true;
+        });
+        const relevantObs = deduplicateByFilter(matchingObs);
 
         // eslint-disable-next-line no-console -- Observability: trace which obs_ids will be downloaded
         console.log(
@@ -342,23 +345,15 @@ export function GuidedCreate() {
           return;
         }
 
-        // Check if data already exists in the library (anonymous — no auth needed)
-        const obsIds = relevantObs.map((o) => o.obs_id).filter(Boolean) as string[];
+        // Check if data already exists in the library (anonymous — no auth
+        // needed). Query ALL matching observations, not just the deduped
+        // download candidates — any obs may hold the library copy.
+        const obsIds = matchingObs.map((o) => o.obs_id).filter(Boolean) as string[];
         const availability = await checkDataAvailability(obsIds);
         if (controller.signal.aborted) return;
 
-        // Map filter → dataIds from existing data
-        const existingFilterData = new Map<string, string[]>();
-        for (const obsId of obsIds) {
-          const item = availability.results[obsId];
-          if (item?.available && item.dataIds.length > 0) {
-            const obs = relevantObs.find((o) => o.obs_id === obsId);
-            const filterName = item.filter ?? obs?.filters?.toUpperCase();
-            if (filterName) {
-              existingFilterData.set(filterName.toUpperCase(), item.dataIds);
-            }
-          }
-        }
+        // Map filter → dataIds from existing data (any covering obs wins)
+        const existingFilterData = buildFilterCoverage(availability.results, matchingObs);
 
         // Check which filters still need downloading
         const needsDownload = relevantObs.filter((obs) => {

--- a/frontend/jwst-frontend/src/utils/observationUtils.test.ts
+++ b/frontend/jwst-frontend/src/utils/observationUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { observationIdsForFilters } from './observationUtils';
+import { observationIdsForFilters, buildFilterCoverage } from './observationUtils';
 import type { MastObservationResult } from '../types/MastTypes';
 
 // TargetDetail's grouped availability map and RecipeCard's standalone
@@ -14,20 +14,28 @@ describe('observationIdsForFilters', () => {
       dataproduct_type: 'image',
     }) as MastObservationResult;
 
-  it('picks the first observation per filter (dedup)', () => {
+  it('collects EVERY observation per filter — coverage must not depend on MAST row order', () => {
+    // Cas A regression: the library held F1800W from obs set B while obs
+    // set A sorted first; first-per-filter selection read the filter as
+    // missing even though renderable data existed. Any obs may cover it.
     const result = observationIdsForFilters(
       [obs('first-f770w', 'F770W'), obs('second-f770w', 'F770W')],
       ['F770W']
     );
-    expect(result).toEqual(['first-f770w']);
+    expect(result).toEqual(['first-f770w', 'second-f770w']);
   });
 
-  it('skips observations without an obs_id and takes the next matching one', () => {
+  it('skips observations without an obs_id', () => {
     const result = observationIdsForFilters(
       [obs(undefined, 'F770W'), obs('with-id', 'F770W')],
       ['F770W']
     );
     expect(result).toEqual(['with-id']);
+  });
+
+  it('does not duplicate an obs_id listed twice', () => {
+    const result = observationIdsForFilters([obs('o1', 'F770W'), obs('o1', 'F770W')], ['F770W']);
+    expect(result).toEqual(['o1']);
   });
 
   it('matches filters case-insensitively', () => {
@@ -43,5 +51,59 @@ describe('observationIdsForFilters', () => {
   it('returns empty for empty inputs', () => {
     expect(observationIdsForFilters([], ['F770W'])).toEqual([]);
     expect(observationIdsForFilters([obs('o1', 'F770W')], [])).toEqual([]);
+  });
+});
+
+describe('buildFilterCoverage', () => {
+  const obs = (obs_id: string, filters: string) =>
+    ({
+      obs_id,
+      filters,
+      instrument_name: 'MIRI',
+      dataproduct_type: 'image',
+    }) as MastObservationResult;
+
+  it('covers a filter when ANY observation provides data (Cas A regression)', () => {
+    // first-in-row-order obs has no data; a later obs of the same filter does
+    const coverage = buildFilterCoverage(
+      { 'obs-b': { available: true, dataIds: ['d1'], filter: 'F1800W' } },
+      [obs('obs-a', 'F1800W'), obs('obs-b', 'F1800W')]
+    );
+    expect(coverage.get('F1800W')).toEqual(['d1']);
+  });
+
+  it('falls back to the observation filter only when the entry filter is null', () => {
+    const coverage = buildFilterCoverage(
+      { 'obs-a': { available: true, dataIds: ['d1'], filter: null as unknown as string } },
+      [obs('obs-a', 'f770w')]
+    );
+    expect(coverage.get('F770W')).toEqual(['d1']);
+  });
+
+  it('ignores unavailable and empty-dataIds entries', () => {
+    const coverage = buildFilterCoverage(
+      {
+        'obs-a': { available: false, dataIds: ['d1'], filter: 'F770W' },
+        'obs-b': { available: true, dataIds: [], filter: 'F1800W' },
+      },
+      [obs('obs-a', 'F770W'), obs('obs-b', 'F1800W')]
+    );
+    expect(coverage.size).toBe(0);
+  });
+});
+
+describe('observationIdsForFilters multi-filter union', () => {
+  const obs = (obs_id: string, filters: string) =>
+    ({
+      obs_id,
+      filters,
+      instrument_name: 'MIRI',
+      dataproduct_type: 'image',
+    }) as MastObservationResult;
+
+  it('collects observations across several filters', () => {
+    expect(
+      observationIdsForFilters([obs('a', 'F770W'), obs('b', 'F1800W')], ['F770W', 'F1800W'])
+    ).toEqual(['a', 'b']);
   });
 });

--- a/frontend/jwst-frontend/src/utils/observationUtils.ts
+++ b/frontend/jwst-frontend/src/utils/observationUtils.ts
@@ -1,4 +1,5 @@
 import type { MastObservationResult } from '../types/MastTypes';
+import type { DataAvailabilityResponse } from '../types/JwstDataTypes';
 import type { ObservationInput } from '../types/DiscoveryTypes';
 
 /**
@@ -23,10 +24,14 @@ export function toObservationInputs(observations: MastObservationResult[]): Obse
 }
 
 /**
- * The obs_ids backing a set of recipe filters: first observation per filter.
- * TargetDetail's grouped availability map and RecipeCard's standalone
- * self-check both use this — they MUST agree on what "this recipe" means,
- * so the selection lives in one place.
+ * The obs_ids backing a set of recipe filters: EVERY observation matching a
+ * recipe filter. A filter counts as covered when ANY of its observations has
+ * library data — coverage must not depend on MAST row order (the library
+ * may hold a filter from obs set B while obs set A happens to sort first).
+ * This matches GuidedCreate's needsDownload semantics, which also considers
+ * all matching observations. TargetDetail's grouped availability map and
+ * RecipeCard's standalone self-check both use this — they MUST agree on
+ * what "this recipe" means, so the selection lives in one place.
  */
 export function observationIdsForFilters(
   observations: MastObservationResult[],
@@ -37,10 +42,35 @@ export function observationIdsForFilters(
   const ids: string[] = [];
   for (const obs of observations) {
     const filterKey = obs.filters?.toUpperCase();
-    if (filterKey && filterSet.has(filterKey) && !seen.has(filterKey) && obs.obs_id) {
-      seen.add(filterKey);
+    if (filterKey && filterSet.has(filterKey) && obs.obs_id && !seen.has(obs.obs_id)) {
+      seen.add(obs.obs_id);
       ids.push(obs.obs_id);
     }
   }
   return ids;
+}
+
+/**
+ * Build filter → dataIds coverage from a check-availability response over
+ * ANY matching observation (entry filter first, observation filter as the
+ * nullish fallback — GuidedCreate semantics). A filter is covered when any
+ * observation provides data for it, regardless of MAST row order.
+ */
+export function buildFilterCoverage(
+  results: DataAvailabilityResponse['results'],
+  observations: MastObservationResult[]
+): Map<string, string[]> {
+  const coverage = new Map<string, string[]>();
+  for (const [obsId, item] of Object.entries(results)) {
+    if (!item?.available || !item.dataIds || item.dataIds.length === 0) continue;
+    const obs = observations.find((o) => o.obs_id === obsId);
+    const filterName = item.filter ?? obs?.filters;
+    if (!filterName) continue;
+    const key = filterName.toUpperCase();
+    // first covering observation wins; any one of them renders the filter
+    if (!coverage.has(key)) {
+      coverage.set(key, item.dataIds);
+    }
+  }
+  return coverage;
 }


### PR DESCRIPTION
## Summary

No linked issue (live-testing follow-up to #1674; found on the CE stack).

**Bug**: Cassiopeia A's target page showed 1/6 recipes "Ready" although the library held every filter. Coverage was checked against the *first* observation per filter in MAST row order — Cas A's library files come from observation set `jw01947-o001_t010`, but `jw01947-o015_t012` sorts first, so every MIRI recipe read as "Not in library" despite being fully renderable.

**Fix**: `observationIdsForFilters` now collects **every** matching observation; a filter counts as covered when *any* observation provides library data. Reviewer round 1 caught that stopping there would relocate the bug: GuidedCreate's own `deduplicateByFilter` is also first-per-filter, so a now-"Ready" card would route into a wizard that stalls waiting for auth in CE. GuidedCreate therefore now queries availability across all matching observations and builds its filter coverage via the new shared `buildFilterCoverage` (entry-filter `??` obs-filter fallback preserved; download candidates still dedup to one obs per filter).

**Live-verified** on the CE stack: Cas A renders **6/6 recipes under "Ready to render"** (screenshot in session), and the bundle really does hold those filters — the display heuristic just couldn't see them.

## Changes Made

- `src/utils/observationUtils.ts`: `observationIdsForFilters` → all-obs-per-filter (dedup by obs_id); new `buildFilterCoverage` shared helper
- `src/pages/GuidedCreate.tsx`: availability over all matching observations + `buildFilterCoverage`; `relevantObs`/download flow unchanged
- `src/utils/observationUtils.test.ts`: Cas A regression + null-filter fallback + unavailable/empty entries + multi-filter union (10 tests)

## Test Plan

- [x] Full frontend unit suite: **1156 passed**
- [x] E2E chromium: **36/36** (target-detail + guided-create) against the worktree dev server
- [x] Live CE verification: Cas A 6/6 Ready, 0 not-in-library (was 1/5)
- [x] Self-review round 1 (1 MUST: GuidedCreate parity — fixed) + round 2 clean
- [x] tsc + eslint clean

## Documentation Checklist

- [x] Helper doc comments explain the any-obs invariant; no external docs affected

## Tech Debt Impact

- [x] None new. Noted (reviewer, pre-existing, live-working): TargetDetail/RecipeCard coverage loops lack the null-filter `??` fallback that buildFilterCoverage carries — defensive-only, left alone.

## Risk & Rollback

- **Risk:** Low. Widening availability queries only adds coverage; download selection and auth-user behavior unchanged; chunking already handles the larger id sets.
- **Rollback:** revert the commit.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
