### PR TITLE
fix: wizard availability now matches the target card (any obs per filter)

### DIFF
--- a/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
+++ b/frontend/jwst-frontend/src/pages/GuidedCreate.tsx
@@ -39,7 +39,11 @@ import {
   rgbToHue,
   filterToInstrument,
 } from '../utils/wavelengthUtils';
-import { toObservationInputs, buildFilterCoverage } from '../utils/observationUtils';
+import {
+  toObservationInputs,
+  buildFilterCoverage,
+  selectRecipeObservations,
+} from '../utils/observationUtils';
 import './GuidedCreate.css';
 
 /** Router state passed from RecipeCard to skip redundant MAST + recipe API calls */
@@ -302,13 +306,9 @@ export function GuidedCreate() {
 
         // Use the recipe's deduplicated observation_ids when available.
         // The recipe engine deduplicates c-prefix (pipeline mosaic) vs o-prefix
-        // observations, always preferring o-prefix (reliably downloadable).
-        // Without this, the frontend would pick arbitrary obs_ids from MAST
-        // results by filter name alone, often selecting c-prefix obs_ids that
-        // fail to download.
-        const recipeObsIdSet = matched.observationIds?.length
-          ? new Set(matched.observationIds)
-          : null;
+        // observations, always preferring o-prefix (reliably downloadable) —
+        // which is why DOWNLOADS stay restricted to matched.observationIds
+        // (inside selectRecipeObservations) while availability is filter-wide.
 
         // eslint-disable-next-line no-console -- Observability: trace recipe→download obs_id flow
         console.log(
@@ -320,17 +320,11 @@ export function GuidedCreate() {
           matched.observationIds ?? 'none (filter-match mode)'
         );
 
-        const recipeFilterSet = new Set(matched.filters.map((f) => f.toUpperCase()));
-        // ALL observations matching the recipe filters — availability must
-        // consider every one (the library may hold a filter from an obs set
-        // that doesn't sort first; Cas A regression). Dedup happens later,
-        // only for choosing which obs to DOWNLOAD.
-        const matchingObs = observations.filter((o) => {
-          if (!o.filters || !recipeFilterSet.has(o.filters.toUpperCase())) return false;
-          // If recipe specifies exact obs_ids, only include those
-          if (recipeObsIdSet && o.obs_id) return recipeObsIdSet.has(o.obs_id);
-          return true;
-        });
+        // availabilityObs: every filter-matching obs (library data may live
+        // under any of them); downloadObs: restricted to the engine's own
+        // observationIds. See selectRecipeObservations for the rationale.
+        const { availabilityObs: filterMatchingObs, downloadObs: matchingObs } =
+          selectRecipeObservations(observations, matched.filters, matched.observationIds);
         const relevantObs = deduplicateByFilter(matchingObs);
 
         // eslint-disable-next-line no-console -- Observability: trace which obs_ids will be downloaded
@@ -346,14 +340,14 @@ export function GuidedCreate() {
         }
 
         // Check if data already exists in the library (anonymous — no auth
-        // needed). Query ALL matching observations, not just the deduped
-        // download candidates — any obs may hold the library copy.
-        const obsIds = matchingObs.map((o) => o.obs_id).filter(Boolean) as string[];
-        const availability = await checkDataAvailability(obsIds);
+        // needed). Query ALL filter-matching observations, not just the
+        // recipe's chosen ones — any obs may hold the library copy.
+        const obsIds = filterMatchingObs.map((o) => o.obs_id).filter(Boolean) as string[];
+        const availability = await checkDataAvailability(obsIds, controller.signal);
         if (controller.signal.aborted) return;
 
         // Map filter → dataIds from existing data (any covering obs wins)
-        const existingFilterData = buildFilterCoverage(availability.results, matchingObs);
+        const existingFilterData = buildFilterCoverage(availability.results, filterMatchingObs);
 
         // Check which filters still need downloading
         const needsDownload = relevantObs.filter((obs) => {

--- a/frontend/jwst-frontend/src/utils/observationUtils.test.ts
+++ b/frontend/jwst-frontend/src/utils/observationUtils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { observationIdsForFilters, buildFilterCoverage } from './observationUtils';
+import {
+  observationIdsForFilters,
+  buildFilterCoverage,
+  selectRecipeObservations,
+} from './observationUtils';
 import type { MastObservationResult } from '../types/MastTypes';
 
 // TargetDetail's grouped availability map and RecipeCard's standalone
@@ -105,5 +109,48 @@ describe('observationIdsForFilters multi-filter union', () => {
     expect(
       observationIdsForFilters([obs('a', 'F770W'), obs('b', 'F1800W')], ['F770W', 'F1800W'])
     ).toEqual(['a', 'b']);
+  });
+});
+
+describe('selectRecipeObservations', () => {
+  const obs = (obs_id: string, filters: string) =>
+    ({
+      obs_id,
+      filters,
+      instrument_name: 'MIRI',
+      dataproduct_type: 'image',
+    }) as MastObservationResult;
+
+  it('availability spans all filter-matching obs while downloads honor recipe obs_ids (Cas A regression)', () => {
+    // recipe chose obs A; the library holds the filter under obs B
+    const observations = [obs('obs-a', 'F1800W'), obs('obs-b', 'F1800W')];
+    const { availabilityObs, downloadObs } = selectRecipeObservations(
+      observations,
+      ['F1800W'],
+      ['obs-a']
+    );
+    expect(availabilityObs.map((o) => o.obs_id)).toEqual(['obs-a', 'obs-b']);
+    expect(downloadObs.map((o) => o.obs_id)).toEqual(['obs-a']);
+  });
+
+  it('filter-match mode (no recipe obs_ids) keeps both sets identical', () => {
+    const observations = [obs('obs-a', 'F770W'), obs('obs-b', 'F770W')];
+    const { availabilityObs, downloadObs } = selectRecipeObservations(
+      observations,
+      ['F770W'],
+      null
+    );
+    expect(downloadObs).toEqual(availabilityObs);
+  });
+
+  it('non-recipe filters are excluded from both sets', () => {
+    const observations = [obs('obs-a', 'F770W'), obs('obs-c', 'F090W')];
+    const { availabilityObs, downloadObs } = selectRecipeObservations(
+      observations,
+      ['F770W'],
+      null
+    );
+    expect(availabilityObs.map((o) => o.obs_id)).toEqual(['obs-a']);
+    expect(downloadObs.map((o) => o.obs_id)).toEqual(['obs-a']);
   });
 });

--- a/frontend/jwst-frontend/src/utils/observationUtils.ts
+++ b/frontend/jwst-frontend/src/utils/observationUtils.ts
@@ -74,3 +74,30 @@ export function buildFilterCoverage(
   }
   return coverage;
 }
+
+/**
+ * The two observation sets GuidedCreate needs for a recipe:
+ * - availabilityObs: EVERY observation matching the recipe's filters — the
+ *   library may hold a filter under any of them (Cas A regression), so
+ *   availability/coverage must query them all.
+ * - downloadObs: restricted to the recipe's own observationIds when the
+ *   engine specified them — downloads honor the engine's vetted selection.
+ * Splitting these is the fix for "card says Ready, create says Not in
+ * library": readiness and coverage are filter-wise, downloads are not.
+ */
+export function selectRecipeObservations(
+  observations: MastObservationResult[],
+  recipeFilters: string[],
+  recipeObservationIds: string[] | null | undefined
+): { availabilityObs: MastObservationResult[]; downloadObs: MastObservationResult[] } {
+  const filterSet = new Set(recipeFilters.map((f) => f.toUpperCase()));
+  const availabilityObs = observations.filter(
+    (o) => o.filters && filterSet.has(o.filters.toUpperCase())
+  );
+  const idSet =
+    recipeObservationIds && recipeObservationIds.length > 0 ? new Set(recipeObservationIds) : null;
+  const downloadObs = idSet
+    ? availabilityObs.filter((o) => (o.obs_id ? idSet.has(o.obs_id) : true))
+    : availabilityObs;
+  return { availabilityObs, downloadObs };
+}


### PR DESCRIPTION
## Summary

No linked issue (live CE follow-up to #1679, user-reported).

**Bug**: `/create?target=Cassiopeia A&recipe=Best 7 filters · NIRCam + MIRI` — the target card said **Ready**, but the wizard showed **Not in library**. The recipe carries the engine's chosen `observationIds` (the `jw01947-o002_t003` set, not in the seed bundle); GuidedCreate restricted its availability check to those observations, while the card (post-#1679) correctly checks any filter-matching observation.

**Fix**: new shared `selectRecipeObservations` splits the two concerns explicitly —
- **availability/coverage** query *every* filter-matching observation (library data may live under any of them)
- **downloads** still honor the engine's vetted `observationIds` (the o-prefix vs c-prefix download-reliability rationale is unchanged)

Reviewer confirmed semantics: nothing downstream derives render inputs from `recipe.observationIds` (payloads come from the coverage map), mixed-pointing risk degrades to partial overlap exactly as before (reproject + overlapWarning), and the zero-match guard and needsDownload derivation are behavior-identical. Coverage is a strict superset of the old value.

**Live-verified** on the exact reported URL against the CE stack: renders 7 channels from library data, no explainer.

## Changes Made

- `src/utils/observationUtils.ts`: `selectRecipeObservations` (availabilityObs vs downloadObs) with rationale doc
- `src/pages/GuidedCreate.tsx`: uses the helper; availability request now passes the abort signal (reviewer NIT)
- `src/utils/observationUtils.test.ts`: 3 tests locking the split (Cas A shape: recipe chose obs A, library holds obs B → availability spans both, downloads restricted to A)

## Test Plan

- [x] Full frontend unit suite: **1159 passed**
- [x] E2E chromium: **36/36** (guided-create + target-detail)
- [x] Live CE verification on the exact reported URL (before: explainer; after: 7-channel render)
- [x] Self-review: round 1 clean except 1 SHOULD (extract + test the selection seam) — done; tsc/eslint clean (remaining GuidedCreate warnings are the pre-existing #1417 set)

## Documentation Checklist

- [x] Helper doc comment carries the rationale; no external docs affected

## Tech Debt Impact

- [x] None new. Noted by reviewer (pre-existing, unblocked): overlapWarning/feather strength are computed against the engine's obs set while renders may use library data from another set — soft params, flagged for awareness.

## Risk & Rollback

- **Risk:** Low. Availability widening only adds coverage; download selection byte-identical; auth flows untouched.
- **Rollback:** revert the commit.

https://claude.ai/code/session_01XMkL328R1NyEXucXsVBLpC
