### PR TITLE
fix: confirm before applying channel color in guided ResultStep

### DIFF
--- a/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.tsx
@@ -237,14 +237,27 @@ export function ExportFramingPanel({
     img.src = previewUrl;
   }, [previewUrl, drawCanvas]);
 
-  // Auto-fit when preset or rotation changes
+  // Auto-fit the framing. Changing the target frame (preset/dimensions) does a
+  // full reset. Changing only the rotation preserves the user's zoom and pan —
+  // it just raises the zoom to the minimum needed to keep the rotated content
+  // filling the frame (no black corners), so zoom-then-rotate no longer wipes
+  // the user's zoom.
+  const prevFrameRef = useRef({ targetW, targetH });
   useEffect(() => {
     const bounds = boundsRef.current;
     if (!bounds) return;
     const fit = computeAutoFit(bounds.width, bounds.height, targetW, targetH, rotation);
-    setCropZoom(fit.zoom);
-    setCropCenterX(fit.centerX);
-    setCropCenterY(fit.centerY);
+    const frameChanged =
+      prevFrameRef.current.targetW !== targetW || prevFrameRef.current.targetH !== targetH;
+    prevFrameRef.current = { targetW, targetH };
+    if (frameChanged) {
+      setCropZoom(fit.zoom);
+      setCropCenterX(fit.centerX);
+      setCropCenterY(fit.centerY);
+    } else {
+      // Rotation-only change: keep zoom/pan, only bump up to the fill minimum.
+      setCropZoom((z) => Math.max(z, fit.zoom));
+    }
   }, [targetW, targetH, rotation]);
 
   // Redraw on state changes

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -355,6 +355,47 @@
   outline-offset: 2px;
 }
 
+.result-channel-rgb-row {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.result-channel-rgb-field {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex: 1;
+  min-width: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.result-channel-rgb-label {
+  flex-shrink: 0;
+  width: 12px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.result-channel-rgb-input {
+  width: 100%;
+  min-width: 0;
+  min-height: 28px;
+  padding: var(--space-1);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  text-align: center;
+}
+
+.result-channel-rgb-input:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 1px;
+}
+
 .result-channel-picker-actions {
   display: flex;
   justify-content: flex-end;

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -286,8 +286,6 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  position: relative;
-  cursor: pointer;
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -302,15 +300,59 @@
   height: 18px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-default);
+  flex-shrink: 0;
 }
 
-.result-channel-color-input {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
+/* Inline hue slider — spectrum track matches the hue-only channel color model,
+   so no native OS color popup is needed. */
+.result-channel-hue-slider {
+  flex: 1;
+  min-width: 0;
+  height: 12px;
+  margin: 0;
+  padding: 0;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-default);
+  background: linear-gradient(
+    to right,
+    hsl(0, 100%, 50%),
+    hsl(60, 100%, 50%),
+    hsl(120, 100%, 50%),
+    hsl(180, 100%, 50%),
+    hsl(240, 100%, 50%),
+    hsl(300, 100%, 50%),
+    hsl(360, 100%, 50%)
+  );
+  -webkit-appearance: none;
+  appearance: none;
   cursor: pointer;
+}
+
+.result-channel-hue-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bg-base);
+  border: 2px solid var(--text-primary);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+}
+
+.result-channel-hue-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bg-base);
+  border: 2px solid var(--text-primary);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+}
+
+.result-channel-hue-slider:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }
 
 .result-channel-picker-actions {

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -313,6 +313,42 @@
   cursor: pointer;
 }
 
+.result-channel-picker-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.result-channel-picker-actions .btn-base {
+  min-height: 30px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.result-channel-picker-cancel {
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+}
+
+.result-channel-picker-cancel:hover {
+  background: var(--border-subtle);
+  color: var(--text-primary);
+}
+
+.result-channel-picker-apply {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary) !important;
+  color: var(--bg-base);
+}
+
+.result-channel-picker-apply:hover {
+  filter: brightness(1.1);
+}
+
 .result-channel-name {
   flex-shrink: 0;
   width: 70px;

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.test.tsx
@@ -1,0 +1,130 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ResultStep } from './ResultStep';
+import type { NChannelConfigPayload } from '../../types/CompositeTypes';
+
+vi.mock('./ExportFramingPanel', () => ({
+  ExportFramingPanel: () => <div />,
+}));
+
+const channels: NChannelConfigPayload[] = [
+  {
+    dataIds: ['f356w-data'],
+    color: { hue: 210 },
+    label: 'F356W',
+    stretch: 'asinh',
+    blackPoint: 0,
+    whitePoint: 1,
+    gamma: 1,
+    asinhA: 0.1,
+    curve: 'linear',
+    weight: 1,
+  },
+];
+
+function renderResultStep(onChannelsChange = vi.fn()) {
+  render(
+    <MemoryRouter>
+      <ResultStep
+        targetName="Cassiopeia A"
+        recipeName="2 filters - NIRCam"
+        filters={['F356W']}
+        previewUrl={null}
+        isExporting={false}
+        exportError={null}
+        compositeWarning={null}
+        onAdjust={vi.fn()}
+        channels={channels}
+        onChannelsChange={onChannelsChange}
+        activePresetId="auto"
+        onPresetChange={vi.fn()}
+        onExport={vi.fn()}
+      />
+    </MemoryRouter>
+  );
+  return onChannelsChange;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ResultStep channel colors', () => {
+  it('keeps a custom color open until it is applied', () => {
+    vi.useFakeTimers();
+    const onChannelsChange = renderResultStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
+    fireEvent.change(screen.getByLabelText('Custom'), { target: { value: '#ff00ff' } });
+
+    expect(screen.getByLabelText('Custom')).toHaveValue('#ff00ff');
+    expect(screen.getByRole('button', { name: 'Apply color' })).toBeInTheDocument();
+    expect(onChannelsChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply color' }));
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(onChannelsChange).toHaveBeenCalledWith([
+      expect.objectContaining({ color: { hue: 300 } }),
+    ]);
+    expect(screen.queryByRole('button', { name: 'Apply color' })).not.toBeInTheDocument();
+  });
+
+  it('stages a preset selection until it is applied', () => {
+    vi.useFakeTimers();
+    const onChannelsChange = renderResultStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Green' }));
+
+    expect(onChannelsChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply color' }));
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(onChannelsChange).toHaveBeenCalledWith([
+      expect.objectContaining({ color: { hue: 120 } }),
+    ]);
+    expect(screen.queryByRole('button', { name: 'Apply color' })).not.toBeInTheDocument();
+  });
+
+  it('discards a staged color when cancelled', () => {
+    vi.useFakeTimers();
+    const onChannelsChange = renderResultStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
+    fireEvent.change(screen.getByLabelText('Custom'), { target: { value: '#ff00ff' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(onChannelsChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Apply color' })).not.toBeInTheDocument();
+  });
+
+  it('discards a staged color when Escape is pressed', () => {
+    vi.useFakeTimers();
+    const onChannelsChange = renderResultStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
+    fireEvent.change(screen.getByLabelText('Custom'), { target: { value: '#ff00ff' } });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(onChannelsChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Apply color' })).not.toBeInTheDocument();
+  });
+
+  it('discards a staged color when clicking outside the popover', () => {
+    vi.useFakeTimers();
+    const onChannelsChange = renderResultStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
+    fireEvent.change(screen.getByLabelText('Custom'), { target: { value: '#ff00ff' } });
+    fireEvent.mouseDown(document.body);
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(onChannelsChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Apply color' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.test.tsx
@@ -56,9 +56,9 @@ describe('ResultStep channel colors', () => {
     const onChannelsChange = renderResultStep();
 
     fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
-    fireEvent.change(screen.getByLabelText('Custom'), { target: { value: '#ff00ff' } });
+    fireEvent.change(screen.getByLabelText('Custom hue'), { target: { value: '300' } });
 
-    expect(screen.getByLabelText('Custom')).toHaveValue('#ff00ff');
+    expect(screen.getByLabelText('Custom hue')).toHaveValue('300');
     expect(screen.getByRole('button', { name: 'Apply color' })).toBeInTheDocument();
     expect(onChannelsChange).not.toHaveBeenCalled();
 
@@ -94,7 +94,7 @@ describe('ResultStep channel colors', () => {
     const onChannelsChange = renderResultStep();
 
     fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
-    fireEvent.change(screen.getByLabelText('Custom'), { target: { value: '#ff00ff' } });
+    fireEvent.change(screen.getByLabelText('Custom hue'), { target: { value: '300' } });
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     act(() => vi.advanceTimersByTime(1000));
 
@@ -107,7 +107,7 @@ describe('ResultStep channel colors', () => {
     const onChannelsChange = renderResultStep();
 
     fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
-    fireEvent.change(screen.getByLabelText('Custom'), { target: { value: '#ff00ff' } });
+    fireEvent.change(screen.getByLabelText('Custom hue'), { target: { value: '300' } });
     fireEvent.keyDown(document, { key: 'Escape' });
     act(() => vi.advanceTimersByTime(1000));
 
@@ -120,7 +120,7 @@ describe('ResultStep channel colors', () => {
     const onChannelsChange = renderResultStep();
 
     fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
-    fireEvent.change(screen.getByLabelText('Custom'), { target: { value: '#ff00ff' } });
+    fireEvent.change(screen.getByLabelText('Custom hue'), { target: { value: '300' } });
     fireEvent.mouseDown(document.body);
     act(() => vi.advanceTimersByTime(1000));
 

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.test.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.test.tsx
@@ -66,9 +66,28 @@ describe('ResultStep channel colors', () => {
     act(() => vi.advanceTimersByTime(1000));
 
     expect(onChannelsChange).toHaveBeenCalledWith([
-      expect.objectContaining({ color: { hue: 300 } }),
+      expect.objectContaining({ color: { rgb: [1, 0, 1] } }),
     ]);
     expect(screen.queryByRole('button', { name: 'Apply color' })).not.toBeInTheDocument();
+  });
+
+  it('preserves a muted RGB color instead of coercing it to a pure hue', () => {
+    vi.useFakeTimers();
+    const onChannelsChange = renderResultStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change color' }));
+    fireEvent.change(screen.getByLabelText('R value'), { target: { value: '131' } });
+    fireEvent.change(screen.getByLabelText('G value'), { target: { value: '84' } });
+    fireEvent.change(screen.getByLabelText('B value'), { target: { value: '127' } });
+
+    expect(onChannelsChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply color' }));
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(onChannelsChange).toHaveBeenCalledWith([
+      expect.objectContaining({ color: { rgb: [131 / 255, 84 / 255, 127 / 255] } }),
+    ]);
   });
 
   it('stages a preset selection until it is applied', () => {
@@ -84,7 +103,7 @@ describe('ResultStep channel colors', () => {
     act(() => vi.advanceTimersByTime(1000));
 
     expect(onChannelsChange).toHaveBeenCalledWith([
-      expect.objectContaining({ color: { hue: 120 } }),
+      expect.objectContaining({ color: { rgb: [0, 1, 0] } }),
     ]);
     expect(screen.queryByRole('button', { name: 'Apply color' })).not.toBeInTheDocument();
   });

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import {
   channelColorToHex,
   hexToRgb,
+  rgbToHex,
   rgbToHue,
   hueToHex,
   NASA_PALETTE,
@@ -226,9 +227,11 @@ export function ResultStep({
   }
 
   function handleChannelColorChange(index: number, hex: string) {
-    const [r, g, b] = hexToRgb(hex);
-    const hue = rgbToHue(r, g, b);
-    const updated = displayChannels.map((ch, i) => (i === index ? { ...ch, color: { hue } } : ch));
+    // Store the full RGB triple (0–1) so muted/desaturated colors survive — the
+    // render pipeline honors `rgb` verbatim, whereas `{ hue }` is forced to full
+    // saturation. hexToRgb already returns normalized 0–1 components.
+    const rgb = hexToRgb(hex);
+    const updated = displayChannels.map((ch, i) => (i === index ? { ...ch, color: { rgb } } : ch));
     setLocalChannels(updated);
     debouncedApply(updated);
   }
@@ -431,6 +434,28 @@ export function ResultStep({
                       className="result-channel-hue-slider"
                       aria-label="Custom hue"
                     />
+                  </div>
+                  <div className="result-channel-rgb-row">
+                    {(['R', 'G', 'B'] as const).map((label, idx) => (
+                      <label key={label} className="result-channel-rgb-field">
+                        <span className="result-channel-rgb-label">{label}</span>
+                        <input
+                          type="number"
+                          min={0}
+                          max={255}
+                          value={Math.round([r, g, b][idx] * 255)}
+                          onChange={(e) => {
+                            const component =
+                              Math.max(0, Math.min(255, Number(e.target.value) || 0)) / 255;
+                            const next: [number, number, number] = [r, g, b];
+                            next[idx] = component;
+                            setPickerColor(rgbToHex(next[0], next[1], next[2]));
+                          }}
+                          className="result-channel-rgb-input"
+                          aria-label={`${label} value`}
+                        />
+                      </label>
+                    ))}
                   </div>
                   <div className="result-channel-picker-actions">
                     <button

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -157,6 +157,7 @@ export function ResultStep({
 
   // Color picker popover state — rendered via portal to escape overflow containers
   const [openPickerIndex, setOpenPickerIndex] = useState<number | null>(null);
+  const [pickerColor, setPickerColor] = useState<string | null>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
   const swatchBtnRef = useRef<Map<number, globalThis.HTMLButtonElement>>(new Map());
   const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null);
@@ -186,6 +187,7 @@ export function ResultStep({
         const target = event.target as HTMLElement;
         if (target.closest('.result-channel-swatch-btn')) return;
         setOpenPickerIndex(null);
+        setPickerColor(null);
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
@@ -196,17 +198,31 @@ export function ResultStep({
     function handleEscape(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         setOpenPickerIndex(null);
+        setPickerColor(null);
       }
     }
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
   }, []);
 
-  function handlePresetSelect(index: number, hue: number) {
-    const updated = displayChannels.map((ch, i) => (i === index ? { ...ch, color: { hue } } : ch));
-    setLocalChannels(updated);
+  function handlePickerToggle(index: number, color: string) {
+    if (openPickerIndex === index) {
+      setOpenPickerIndex(null);
+      setPickerColor(null);
+      return;
+    }
+    setPickerColor(color);
+    setOpenPickerIndex(index);
+  }
+
+  function handlePickerApply(index: number, hex: string) {
+    handleChannelColorChange(index, hex);
     setOpenPickerIndex(null);
-    debouncedApply(updated);
+    setPickerColor(null);
+  }
+
+  function handlePresetSelect(hue: number) {
+    setPickerColor(hueToHex(hue));
   }
 
   function handleChannelColorChange(index: number, hex: string) {
@@ -342,7 +358,7 @@ export function ResultStep({
                             if (el) swatchBtnRef.current.set(i, el);
                             else swatchBtnRef.current.delete(i);
                           }}
-                          onClick={() => setOpenPickerIndex(openPickerIndex === i ? null : i)}
+                          onClick={() => handlePickerToggle(i, hex)}
                         >
                           <span
                             className="result-channel-swatch"
@@ -374,8 +390,9 @@ export function ResultStep({
             (() => {
               const ch = displayChannels[openPickerIndex];
               if (!ch) return null;
-              const hex = channelColorToHex(ch.color);
-              const currentHue = ch.color.hue ?? (ch.color.rgb ? rgbToHue(...ch.color.rgb) : 0);
+              const selectedHex = pickerColor ?? channelColorToHex(ch.color);
+              const [r, g, b] = hexToRgb(selectedHex);
+              const currentHue = rgbToHue(r, g, b);
               return createPortal(
                 <div
                   ref={pickerRef}
@@ -393,7 +410,7 @@ export function ResultStep({
                           className={`btn-base result-channel-preset${isActive ? ' active' : ''}`}
                           style={{ backgroundColor: presetHex }}
                           title={preset.name}
-                          onClick={() => handlePresetSelect(openPickerIndex, preset.hue)}
+                          onClick={() => handlePresetSelect(preset.hue)}
                         />
                       );
                     })}
@@ -403,18 +420,34 @@ export function ResultStep({
                     <span className="result-channel-custom-label">Custom</span>
                     <span
                       className="result-channel-custom-swatch"
-                      style={{ backgroundColor: hex }}
+                      style={{ backgroundColor: selectedHex }}
                     />
                     <input
                       type="color"
-                      value={hex}
-                      onChange={(e) => {
-                        handleChannelColorChange(openPickerIndex, e.target.value);
-                        setOpenPickerIndex(null);
-                      }}
+                      value={selectedHex}
+                      onChange={(e) => setPickerColor(e.target.value)}
                       className="result-channel-color-input"
                     />
                   </label>
+                  <div className="result-channel-picker-actions">
+                    <button
+                      type="button"
+                      className="btn-base result-channel-picker-cancel"
+                      onClick={() => {
+                        setOpenPickerIndex(null);
+                        setPickerColor(null);
+                      }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-base result-channel-picker-apply"
+                      onClick={() => handlePickerApply(openPickerIndex, selectedHex)}
+                    >
+                      Apply color
+                    </button>
+                  </div>
                 </div>,
                 document.body
               );

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -416,19 +416,22 @@ export function ResultStep({
                     })}
                   </div>
                   <div className="result-channel-picker-divider" />
-                  <label className="result-channel-custom-row">
-                    <span className="result-channel-custom-label">Custom</span>
+                  <div className="result-channel-custom-row">
+                    <span className="result-channel-custom-label">Hue</span>
                     <span
                       className="result-channel-custom-swatch"
                       style={{ backgroundColor: selectedHex }}
                     />
                     <input
-                      type="color"
-                      value={selectedHex}
-                      onChange={(e) => setPickerColor(e.target.value)}
-                      className="result-channel-color-input"
+                      type="range"
+                      min={0}
+                      max={359}
+                      value={Math.round(currentHue)}
+                      onChange={(e) => setPickerColor(hueToHex(Number(e.target.value)))}
+                      className="result-channel-hue-slider"
+                      aria-label="Custom hue"
                     />
-                  </label>
+                  </div>
                   <div className="result-channel-picker-actions">
                     <button
                       type="button"

--- a/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/CompositePreviewStep.tsx
@@ -821,7 +821,6 @@ export const CompositePreviewStep: React.FC<CompositePreviewStepProps> = ({
 
         const completeCb = onExportCompleteRef.current;
         if (completeCb) {
-          // eslint-disable-next-line @eslint-react/web-api-no-leaked-timeout -- cleared via timerRef in effect cleanup and unmount
           const timer = setTimeout(() => completeCb(), 500);
           timerRef.current = timer;
         }


### PR DESCRIPTION
No linked issue

## Summary

Reworks the guided-flow channel **color picker** and fixes a framing bug on the Result step.

- **Confirm before apply**: selecting a preset, dragging the hue slider, or editing the R/G/B fields now only *stages* a color; it commits (via `onChannelsChange`) when you click **Apply color**. **Cancel**, **Escape**, and **click-outside** discard. Previously any touch applied instantly and auto-closed the popover.
- **No more native OS popup**: the old `<input type="color">` opened the browser's color popup on top of the popover, hiding Apply/Cancel. Replaced with an **inline hue slider** + **inline R/G/B number inputs (0–255)**.
- **Muted colors now render**: the apply path stored `{ hue }`, which the engine locks to full saturation, so muted/desaturated colors could never render. It now stores `{ rgb }` (0–1), which the engine honors verbatim as color-mixing weights — RGB(131,84,127) renders exactly.
- **Export framing bug**: zooming in and then rotating reset the zoom/pan. The auto-fit effect fired on every rotation change and clobbered zoom/center. Rotation-only changes now preserve the user's zoom/pan.

## Why

Accidental one-click color changes were easy and irreversible; the native color popup was clunky and hid the confirm buttons; muted colors silently snapped to full-saturation hues; and the framing zoom was wiped whenever the user rotated. All are user-visible papercuts on the guided composite flow.

## Changes Made

- **`guided/ResultStep.tsx`** — `pickerColor` staging state; `handlePickerToggle`/`handlePickerApply`; hue slider + R/G/B inputs both drive the staged hex; `handleChannelColorChange` stores `{ rgb }` (normalized 0–1 via `hexToRgb`) instead of coercing to `{ hue }`; Escape / click-outside / Cancel reset staged state.
- **`guided/ResultStep.css`** — styles for the Apply/Cancel action row, the rainbow hue slider, and the R/G/B number inputs.
- **`guided/ExportFramingPanel.tsx`** — split the auto-fit effect: frame/preset changes do a full reset; rotation-only changes preserve zoom/pan and only raise zoom to the fill minimum (detected via `prevFrameRef`, no exhaustive-deps suppression).
- **`guided/ResultStep.test.tsx`** (new) — 6 tests: custom-hue apply, muted-RGB-survives-apply, preset apply, and discard via Cancel / Escape / click-outside.
- **`wizard/CompositePreviewStep.tsx`** — incidental pre-existing fix: removed a stale `eslint-disable` for `@eslint-react/web-api-no-leaked-timeout` (rule no longer defined), which was erroring the project-wide pre-commit lint and blocking all commits. Comment-only, zero behavior change.

## Test Plan

- [x] Full pre-commit suite green locally: 103 files / **1169 unit tests pass**, `tsc --noEmit` clean, ESLint 0 errors, Prettier clean. New `ResultStep.test.tsx` (6/6) covers stage-then-apply and all discard paths, including a muted-RGB-survives-apply assertion.
- [x] Rebuilt and ran the CE stack; verified in the browser (http://localhost:3055): confirm-before-apply works, no native color popup appears, RGB fields set muted colors, and zoom persists through rotation.
- [ ] Manual reviewer spot-check: on the Result step, open a channel swatch → set RGB(131,84,127) → Apply → confirm the composite renders that muted color; zoom in → rotate → confirm zoom holds.

## Documentation Checklist

- [x] No documentation updates needed

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

- **Risk:** Low. Pure frontend UI-state change confined to the guided color picker and framing panel; the apply/export paths reuse existing debounced `onChannelsChange` and the server render. No API, data-model, or auth surface touched. Note (pre-existing, out of scope): the picker is hue/RGB only — opening it on an achromatic/luminance channel highlights Red and Apply would set an rgb; can be a follow-up to disable the picker for luminance channels.
- **Rollback:** Revert this PR; no migrations, config, or persisted-state changes involved.
