### PR TITLE
feat: redesign Result-step rotation control as a stable segmented pill

### DIFF
--- a/frontend/jwst-frontend/e2e/guided-create.spec.ts
+++ b/frontend/jwst-frontend/e2e/guided-create.spec.ts
@@ -523,8 +523,9 @@ test.describe('Guided create — result step (step 3)', () => {
     const rotateBtns = rotation.locator('.result-rotate-btn');
     await expect(rotateBtns).toHaveCount(2);
 
-    // Reset button should NOT be visible at 0°
-    await expect(rotation.locator('.result-rotate-reset')).not.toBeVisible();
+    // Reset is always present but disabled at 0° (segmented pill — no reflow on rotate)
+    await expect(rotation.locator('.result-rotate-reset')).toBeVisible();
+    await expect(rotation.locator('.result-rotate-reset')).toBeDisabled();
   });
 
   test('rotation buttons update the displayed angle', async ({ page }) => {
@@ -544,8 +545,8 @@ test.describe('Guided create — result step (step 3)', () => {
     await rotateBtns.nth(1).click();
     await expect(input).toHaveValue('15');
 
-    // Reset button should now be visible
-    await expect(rotation.locator('.result-rotate-reset')).toBeVisible();
+    // Reset becomes enabled once rotated away from 0°
+    await expect(rotation.locator('.result-rotate-reset')).toBeEnabled();
 
     // Click CW again — should go to 30°
     await rotateBtns.nth(1).click();
@@ -555,9 +556,10 @@ test.describe('Guided create — result step (step 3)', () => {
     await rotateBtns.nth(0).click();
     await expect(input).toHaveValue('15');
 
-    // Click Reset — should go back to 0°
+    // Click Reset — should go back to 0° and Reset should disable again
     await rotation.locator('.result-rotate-reset').click();
     await expect(input).toHaveValue('0');
+    await expect(rotation.locator('.result-rotate-reset')).toBeDisabled();
   });
 
   test('shows quick adjustment sliders', async ({ page }) => {

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.css
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.css
@@ -531,34 +531,76 @@
   justify-content: center;
 }
 
-/* Layout handled by .btn-icon.btn-icon-sm; overrides for visual style */
-.result-rotate-btn {
+/* Segmented pill: [ ↺ | −000° | ↻ ] — a single grouped control so nothing
+   reflows when the value or the reset button state changes. */
+.result-rotation-group {
+  display: inline-flex;
+  align-items: stretch;
   border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
   background: var(--bg-surface);
+  overflow: hidden;
+}
+
+.result-rotate-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  min-height: 30px;
+  border: none;
+  background: transparent;
   color: var(--text-primary);
   font-size: var(--text-lg);
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .result-rotate-btn:hover {
   background: var(--bg-elevated);
-  border-color: var(--accent-primary);
+  color: var(--accent-primary);
 }
 
 .result-rotate-btn:focus-visible {
   outline: 2px solid var(--accent-primary);
-  outline-offset: 2px;
+  outline-offset: -2px;
+}
+
+.result-rotate-btn-left {
+  border-right: 1px solid var(--border-default);
+}
+
+.result-rotate-btn-right {
+  border-left: 1px solid var(--border-default);
+}
+
+/* Fixed width so −150 and 5 never shift the pill. */
+.result-rotation-field {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  width: 60px;
+  padding: 0 var(--space-1);
+  transition: background var(--transition-fast);
+}
+
+.result-rotation-field:focus-within {
+  background: var(--bg-elevated);
 }
 
 .result-rotation-input {
-  width: 48px;
-  text-align: center;
+  width: 36px;
+  text-align: right;
   font-size: var(--text-sm);
   font-family: var(--font-mono, monospace);
   color: var(--text-primary);
-  background: var(--bg-surface);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-sm);
-  padding: 2px 4px;
+  background: transparent;
+  border: none;
+  padding: 0;
   -moz-appearance: textfield;
 }
 
@@ -569,8 +611,7 @@
 }
 
 .result-rotation-input:focus {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 1px;
+  outline: none;
 }
 
 .result-rotation-unit {
@@ -579,19 +620,34 @@
   color: var(--text-secondary);
 }
 
+/* Always present so the row never reflows; dim + disabled at 0°. */
 .result-rotate-reset {
-  padding: 2px var(--space-2);
-  border: none;
-  border-radius: var(--radius-sm);
-  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  min-height: 30px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
   color: var(--text-secondary);
-  font-size: var(--text-sm);
+  font-size: var(--text-lg);
+  line-height: 1;
   cursor: pointer;
-  transition: color var(--transition-fast);
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    opacity var(--transition-fast);
 }
 
-.result-rotate-reset:hover {
+.result-rotate-reset:hover:not(:disabled) {
   color: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+
+.result-rotate-reset:disabled {
+  opacity: 0.35;
+  cursor: default;
 }
 
 .result-rotate-reset:focus-visible {

--- a/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ResultStep.tsx
@@ -533,45 +533,52 @@ export function ResultStep({
 
           <div className="result-actions result-rotation">
             <div className="result-rotation-controls">
-              <button
-                type="button"
-                className="btn-icon btn-icon-sm result-rotate-btn"
-                onClick={(e) => handleRotate(-1, e.shiftKey ? 90 : 15)}
-                title="Rotate counter-clockwise (15°, Shift+click for 90°)"
-              >
-                &#x21ba;
-              </button>
-              <input
-                type="number"
-                className="result-rotation-input"
-                value={rotation}
-                min={-180}
-                max={180}
-                onChange={(e) => {
-                  const val = parseInt(e.target.value, 10);
-                  if (!isNaN(val)) setRotation(Math.max(-180, Math.min(180, val)));
-                }}
-                title="Enter rotation angle"
-                aria-label="Rotation angle in degrees"
-              />
-              <span className="result-rotation-unit">°</span>
-              <button
-                type="button"
-                className="btn-icon btn-icon-sm result-rotate-btn"
-                onClick={(e) => handleRotate(1, e.shiftKey ? 90 : 15)}
-                title="Rotate clockwise (15°, Shift+click for 90°)"
-              >
-                &#x21bb;
-              </button>
-              {rotation !== 0 && (
+              <div className="result-rotation-group" role="group" aria-label="Rotate image">
                 <button
                   type="button"
-                  className="btn-base result-rotate-reset"
-                  onClick={() => setRotation(0)}
+                  className="result-rotate-btn result-rotate-btn-left"
+                  onClick={(e) => handleRotate(-1, e.shiftKey ? 90 : 15)}
+                  title="Rotate counter-clockwise (15°, Shift+click for 90°)"
+                  aria-label="Rotate counter-clockwise"
                 >
-                  Reset
+                  &#x21ba;
                 </button>
-              )}
+                <div className="result-rotation-field">
+                  <input
+                    type="number"
+                    className="result-rotation-input"
+                    value={rotation}
+                    min={-180}
+                    max={180}
+                    onChange={(e) => {
+                      const val = parseInt(e.target.value, 10);
+                      if (!isNaN(val)) setRotation(Math.max(-180, Math.min(180, val)));
+                    }}
+                    title="Enter rotation angle"
+                    aria-label="Rotation angle in degrees"
+                  />
+                  <span className="result-rotation-unit">°</span>
+                </div>
+                <button
+                  type="button"
+                  className="result-rotate-btn result-rotate-btn-right"
+                  onClick={(e) => handleRotate(1, e.shiftKey ? 90 : 15)}
+                  title="Rotate clockwise (15°, Shift+click for 90°)"
+                  aria-label="Rotate clockwise"
+                >
+                  &#x21bb;
+                </button>
+              </div>
+              <button
+                type="button"
+                className="result-rotate-reset"
+                onClick={() => setRotation(0)}
+                disabled={rotation === 0}
+                title="Reset rotation to 0°"
+                aria-label="Reset rotation"
+              >
+                &#x27f2;
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
No linked issue

## Summary

Redesigns the rotation control on the guided Result step. The old version was a placeholder — bare icon buttons, a naked number field, and a text "Reset" that only rendered when `rotation !== 0`, so the whole centered row **reflowed the instant you clicked a rotate button**.

It's now a single **segmented pill** — `[ ↺ | −000° | ↻ ]` — with a fixed-width readout and an **always-present Reset** icon that dims + disables at 0° instead of appearing/disappearing. Nothing shifts on click.

## Why

The reflow-on-click was jarring and the control looked unfinished. Stable layout + a grouped pill reads as intentional and is easier to use.

## Changes Made

- **`guided/ResultStep.tsx`** — wrapped the CCW / readout / CW controls in a single `result-rotation-group` pill; moved the `°` unit inside a fixed-width field; made Reset always-rendered with `disabled={rotation === 0}` (removed the `rotation !== 0 &&` conditional that caused the reflow). Interaction unchanged: click = 15°, Shift+click = 90°, typed angle clamped to ±180°.
- **`guided/ResultStep.css`** — segmented-pill styling (joined borders, fixed-width readout so `−150` and `5` don't shift it, hover/focus states) and a dim+disabled state for the always-present Reset.
- **`e2e/guided-create.spec.ts`** — updated the rotation E2E to the new behavior: Reset is visible+disabled at 0°, enabled after rotating, and disabled again after reset (previously asserted Reset was hidden at 0°).

## Test Plan

- [x] Full pre-commit suite green locally: `tsc --noEmit` clean, ESLint 0 errors, Prettier clean, existing `ResultStep.test.tsx` (6/6) still pass. Rebuilt the CE stack and verified in the browser (http://localhost:3055): clicking rotate no longer reflows the row; Reset is dim/disabled at 0° and active otherwise.
- [ ] Manual reviewer spot-check: on the Result step, click ↺/↻ repeatedly and confirm the control does not shift; type an angle; confirm Reset disables at 0°.

## Documentation Checklist

- [x] No documentation updates needed

## Tech Debt Impact

- [x] No new tech debt introduced

## Risk & Rollback

- **Risk:** Low. Presentational-only change to one control on the guided Result step; no logic, API, or state-shape changes (the `rotation` state and `handleRotate` are untouched).
- **Rollback:** Revert this PR; no migrations or persisted-state involved.
