### PR TITLE
feat: Python JWT validation dependency for engine routes (#1709 PR 1)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -111,6 +111,9 @@ services:
       - S3_FORCE_PATH_STYLE=${S3_FORCE_PATH_STYLE:-true}
       - S3_PUBLIC_ENDPOINT=${S3_PUBLIC_ENDPOINT:-http://localhost:8333}
       - SEMANTIC_DATA_DIR=/app/data/semantic
+      # Shared with the .NET backend (Jwt__SecretKey) so the engine can
+      # validate .NET-issued access tokens (ADR-0001 Phase 1 slice).
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-CHANGE_THIS_IN_PRODUCTION_MIN_32_CHARS_SECURE_KEY_HERE}
     volumes:
       - ../data:/app/data
     depends_on:

--- a/docs/plans/features/1709-calibration-recipes.md
+++ b/docs/plans/features/1709-calibration-recipes.md
@@ -1,0 +1,83 @@
+# Calibration Recipes (#1709) — Implementation Plan
+
+## Context
+
+Deep review of all 17 STScI [jwst-pipeline-notebooks](https://github.com/spacetelescope/jwst-pipeline-notebooks) showed they are template-generated: stage execution is a serializable dict-of-dicts passed to `XxxPipeline.call(input, steps=...)`, with boolean stage gates and a structured MAST query. The user wants these importable/usable in-app **without ever executing user Python**. Approach (CEO review, mode A, decisions logged in #1709): recipes as **pure declarative data**, executed by our trusted engine, plus a curated gallery. Approved expansions: Stage-3-only fast path, library "Reprocess with latest pipeline", per-stage progress + log tail, coronagraphy as phase 2. Deferred: sharing (#1710), cubes (#1711), spectroscopy (#1712), full disk quotas (#1713).
+
+**Architecture decision (user-approved):** Python-native. Build the ADR-0001 Phase-3 jobs slice in the engine (Mongo-persisted job store, HTTP polling — a deliberate divergence from ADR-0001's sketched `/ws/jobs` WebSocket; document it in the ADR note), plus a minimal Python JWT-validation dependency for .NET-issued tokens (verified: HS256, `JWT_SECRET_KEY` from `docker/.env`, issuer `JwstDataAnalysis`, audience `JwstDataAnalysisClient` — `backend/JwstDataAnalysis.API/Services/JwtTokenService.cs:41-63`). No .NET changes; frontend calls the engine directly for calibration.
+
+Naming: **Calibration** everywhere (`/api/calibration`, `app/calibration/`) — the word "Recipe" alone is taken by discovery composite suggestions (`app/discovery/models.py:50`).
+
+## Schemas (engine `app/calibration/models.py`; Mongo snake_case — new-collection divergence from PascalCase .NET docs, documented)
+
+**CalibrationRecipe** (collection `calibration_recipes`):
+`id` (slug for seeds / ObjectId-str), `schema_version=1`, `name`, `description`, `instrument` (nircam|niriss|miri), `mode` (imaging | coronagraphy [phase 2]), `source` (seed|imported|user), `provenance` {notebook_name?, jwst_version_authored?}, `input_source` (discriminated union: `mast_query` {proposal_id, observation?, filters, calib_level 1|2, product_suffixes} | `library_products` {product_suffixes}), `input_roles` [{role: science|psf_ref|background, required, min_count}] (v1: science only; future-proofs Coron3), `stages` ordered [{name: detector1|image2|image3 (+coron3 reserved), enabled, step_overrides: {step: {param: Scalar|list[Scalar]}}}] — validator **rejects non-scalar values** (the "pure data, never code" guarantee), `association` {rule: allowlist ["DMS_Level3_Base"], product_name (sanitized)}, `output_suffixes` (e.g. ["_i2d"]), `created_by?`, timestamps.
+
+**Job** (collection `jobs` — the generic ADR-0001 jobs slice; calibration is first consumer; no separate runs collection):
+`job_id` (uuid4), `type="calibration"`, `user_id`, `status` (queued|downloading|running|succeeded|failed|cancelled), `cancel_requested`, timestamps, `request` {recipe_id, **recipe_snapshot** (embedded full copy — runs stay reproducible), inputs [{path/product_id, role}], run_overrides}, `progress` {stages [{name, status, started_at, finished_at}], current_stage, message, download_pct}, `log_tail` (capped ~200), `result` {outputs [{storage_key, suffix, size_bytes}], log_key, jwst_version, crds_context} | null, `error?`.
+
+Wire = camelCase via facade mapping (pattern: `app/discovery/api_routes.py`); internal = snake_case.
+
+## PR sequence (1 task = 1 PR, branch prefix `feature/calibration-*`, Red-Green TDD, self-review rounds until clean)
+
+Master plan file `docs/plans/features/1709-calibration-recipes.md` (issue-number naming convention) created in PR 1 (satisfies require-plan-file hook for all subsequent branches).
+
+Cloud-refinement corrections folded in: PRs 1–2 fill the **existing mounted scaffolds** (`app/auth/routes.py`, `app/jobs/routes.py` — already mounted full-mode-only, excluded from CE); the engine reuses the **existing `CORS_ALLOWED_ORIGINS`** compose var (defaults already include :3000/:5173); casing via `app/db/casing.py` helpers, never hand-rolled.
+
+**PR 1 — feat: Python JWT validation dependency (S, ~250 LOC)**
+`app/auth/deps.py`: `require_user`/`optional_user` FastAPI deps (PyJWT, HS256, `JWT_SECRET_KEY`, iss/aud above; extract `sub`, `role`). Add `pyjwt` to requirements; add `JWT_SECRET_KEY` to `jwst-processing` env in `docker/docker-compose.yml`. **Empirically decode a live token from the running backend before asserting claim names** (.NET outbound claim mapping). Tests: mint tokens in-test; 401 matrix (expired/wrong iss/aud/key/malformed).
+
+**PR 2 — feat: Mongo job store + generic `/api/jobs` + engine CORS (M, ~550 LOC)**
+`app/jobs/store.py` (first write-capable motor repo), `models.py`, `runner.py` (`asyncio.create_task` wrapper; modeled on `app/mast/download_tracker.py` but Mongo-backed; atomic `$set`/`$push` only). Routes: `GET /api/jobs/{id}`, `GET /api/jobs`, `POST /api/jobs/{id}/cancel` — auth from PR 1, ownership enforced, camelCase facade. Startup reconciliation: interrupted jobs → failed ("interrupted by service restart"); **file follow-up issue for resume-on-restart**. **[eng review P1] Add `CORSMiddleware` to `main.py`** with env-configured origins (`CORS_ALLOWED_ORIGINS`, default `http://localhost:3000`) — engine has none today; direct frontend→engine calls would fail preflight. Tests: store/runner unit (pattern `tests/test_download_tracker.py`), ownership, CORS headers, reconciliation.
+
+**PR 3 — feat: CalibrationRecipe schema, seeds, CRUD (M, ~700 LOC)**
+`app/calibration/models.py` + `validation.py` (scalar-only enforcement, allowlists, sanitization); `seeds/*.json` — 3 recipes hand-derived from the NIRCam/NIRISS/MIRI imaging notebooks; idempotent startup seeder. Routes: `GET /api/calibration/recipes`(+one) anonymous; `POST/PUT/DELETE` auth'd; seeds immutable. **Full-mode-only: not in CE allowlist; extend `tests/test_ce_mode_mounting.py`.** Tests: validation matrix (non-scalar rejected, unknown stages/rules), seed round-trip, casing contract test (`tests/contract/`).
+
+**PR 4 — feat: calibration deps, feature flag, CRDS wiring (M effort, small diff)**
+`requirements-calibration.txt` (exact `jwst` pin; pulls stpipe/stcal/crds). Dockerfile `ARG INSTALL_CALIBRATION=true` gating the pip layer (CE builds false; mirrors `Dockerfile.mast` split); wheels expected on py3.12-slim — if any sdist compiles, builder stage with build-essential. Runtime `CALIBRATION_ENABLED` env (via `app/config.py` helpers): off → run endpoints 501, recipes still browsable; expose `calibrationEnabled` via `GET /api/calibration/capabilities`. Compose: `CRDS_PATH=/app/data/crds` named volume, `CRDS_SERVER_URL=https://jwst-crds.stsci.edu`, `MAX_CONCURRENT_CALIBRATIONS=1`. Same-container (not separate worker) for v1 — executor touches only job store + storage provider, so extracting a worker later is mechanical. Tests: flag on/off mounting, 501.
+
+**PR 5 — feat: Stage-3 fast-path executor (L, ~900 LOC — core PR)**
+`app/calibration/executor.py`: resolve library `_cal` inputs via `app/storage/helpers.py:resolve_fits_path`; `asn_from_list` with allowlisted rule; `Image3Pipeline.call(asn, steps=merged, output_dir=workdir)` in `asyncio.to_thread` under a dedicated plain `threading.BoundedSemaphore(MAX_CONCURRENT_CALIBRATIONS)` — no 429 admission stage (jobs queue in Mongo by design, unlike composite's synchronous request-scoped renders; leave composite's `_render_slots` untouched); outputs → StorageProvider under `calibration/<job_id>/`; full log → storage. **Real per-stage progress**: scoped `logging.Handler` on stpipe/jwst loggers; parse step boundaries → job stage checklist + log_tail (best-effort; job completes even if parsing misses). `POST /api/calibration/runs` {recipeId, inputs, runOverrides} → {jobId}. Disk-floor guard (basic; full quotas = #1713). GAIADR3 tweakreg needs network — surface in docs/UI copy. Tests: monkeypatched `Image3Pipeline.call` fake (emits real-looking log lines, writes dummy `_i2d`) covering sequencing/override merge/cancel/semaphore/log-parse/output registration; log-parser units against captured real stpipe log fixtures. **Opt-in real smoke**: `pytest -m calibration_smoke`, small NIRCam subarray `_cal` pair (minutes) — also live-verifies PR 4 CRDS wiring.
+
+**PR 6 — feat: full uncal pipeline + MAST input source (M/L, ~600 LOC)**
+Detector1 → Image2 → Image3 with `enabled` toggles + file handoff; `mast_query` input via `app/mast/mast_service.py` (calib_level filter, progress callback → "downloading" phase). `CALIBRATION_TIMEOUT_S` (generous, relaxed-threshold posture). Workdir cleanup, keep declared `output_suffixes` only. Tests: mocked multi-stage toggle matrix, download-failure, mid-run cancel; smoke: one small subarray `_uncal` full-through.
+
+**PR 7 — feat: gallery UI + calibration service (M, ~600 LOC)**
+`src/config/engine.ts` (`VITE_ENGINE_URL`, style of `config/api.ts`); `services/calibrationService.ts` (second `ApiClient` instance bound to the engine base URL **[eng review P2]**; camelCase DTOs), `types/CalibrationTypes.ts`, lazy `/calibrate` route in `App.tsx` under `SharedLayout`, gallery cloning `RecipeCard` + `RecipeGroups` (`pages/TargetDetail.tsx:291`). Nav gated `!CE_MODE` + `calibrationEnabled`. Vitest: service mapping, gallery render.
+
+**PR 8 — feat: run-config + live progress UI (L, ~900 LOC — main net-new UI)**
+`/calibrate/:recipeId`: stage toggles + curated per-step param editor (from seed params; advanced free-form section; analog: GuidedCreate adjustment panels), input picker (library `_cal` files | recipe's MAST query), Run. Progress: new lean `useCalibrationJob` polling hook against engine `/api/jobs/{id}` (do NOT retrofit `useJobProgress` — it's SignalR/MAST-coupled; reuse its `appendBufferedMessage` buffer helper), real-stage checklist (à la `ProcessStep`), `LogPanel` tail, cancel. `ui/Steps`/`Modal`/`toast`; per-component CSS; no inline styles. Vitest: override-editor state, progress render from fixtures. E2E: `e2e/calibrate.spec.ts` (mocked engine API, modeled on `guided-create.spec.ts`).
+
+**PR 9 — feat: notebook importer (M/L, ~700 LOC)**
+`app/calibration/importer.py`: `ast`-based static parse of JWPipeNB cells (config assignments, `do<stage>` booleans, `dict[step][param] = scalar`, MAST params). **Fail closed**: allowlist exact template AST shapes; any funcdef/non-allowlisted call/import/non-literal RHS → reject naming cell+line and supported template vintage. Never executes anything. `POST /api/calibration/recipes/import` (auth, size cap). Frontend import button + error display. Tests: 3 cloned notebooks as golden fixtures (parse ≈ hand-written seeds — cross-check); adversarial fixtures (exec/eval/os/loops/f-strings) all rejected; corrupt ipynb.
+
+**PR 10 — feat: library Reprocess action + docs sweep (S, ~300 LOC)**
+`DataCard.tsx` `onReprocess` prop (gated `!CE_MODE` + capability) → navigate `/calibrate/:defaultRecipeId` pre-filled with that observation's `_cal` products (stage-3 path). Final docs/diagram pass.
+
+## Parallelization
+
+Sequential through PR 5 (each depends on the previous). After PR 5: **Lane A** PR 6 (engine) ∥ **Lane B** PR 7→8 (frontend). PR 9 after PR 3 technically, but schedule after PR 8 (needs UI surface). PR 10 last. Solo-dev default remains sequential; lanes are an option, not a requirement.
+
+## Test plan summary
+
+- Engine: everything below PR 5's pipeline boundary runs on mocked `Pipeline.call` fakes — no long runs in CI. Real `jwst` exercised only by opt-in `-m calibration_smoke` (small subarrays). CE-mode route guard extended. Casing contract tests for new wire shapes.
+- Frontend: vitest co-located; one new Playwright spec (`calibrate.spec.ts`) with mocked engine.
+- CRITICAL regression guards: `tests/test_ce_mode_mounting.py` (no calibration surface in CE), composite semaphore untouched (calibration gets its own), auth 401 matrix.
+- Manual: Docker rebuild (`docker compose up -d --build`), run seeded MIRI-imaging recipe stage-3 path on library data, watch per-stage progress + log tail, verify i2d lands in library storage and renders in compositor.
+
+## Docs to update (across the PRs, final sweep PR 10)
+
+- `docs/architecture/`: new "Calibration pipeline flow" page + index entry; ADR-0001 note (jobs slice landed, calibration first consumer)
+- `docs/key-files.md`: `app/calibration/`, `app/jobs/`, `app/auth/deps.py`, `calibrationService.ts`, calibrate pages
+- `docs/quick-reference.md`: `/api/calibration/*`, `/api/jobs/*`, new env vars (`CALIBRATION_ENABLED`, `MAX_CONCURRENT_CALIBRATIONS`, `CRDS_*`, `JWT_SECRET_KEY` on engine, `CORS_ALLOWED_ORIGINS`, `VITE_ENGINE_URL`)
+- `docs/setup-guide.md`: CRDS volume + first-run reference-file download expectations; build arg
+- `docs/development-plan.md` status entry; `docker/.env.example` new vars
+- Follow-up issues to file during implementation: job resume-on-restart (PR 2); anything else discovered
+
+## Risks (top)
+
+1. `jwst`+CRDS environment (PR 4/5) — highest uncertainty; smoke test lands same week as deps PR. Exact version pin; snapshot `jwst_version`+`crds_context` per run.
+2. Auth claim mapping (PR 1) — de-risked by decoding a live token first.
+3. Restart-lost jobs — v1 accepts (reconciliation → failed); follow-up issue.
+4. Importer template drift — parser allowlist is data-driven; rejection message names supported vintage.
+5. Image size — build-arg keeps CE slim; layer ordering for cache; never `--no-cache`.

--- a/processing-engine/app/auth/deps.py
+++ b/processing-engine/app/auth/deps.py
@@ -1,0 +1,123 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""JWT validation dependencies for engine routes.
+
+Validates access tokens issued by the .NET backend
+(``backend/JwstDataAnalysis.API/Services/JwtTokenService.cs``): HS256 with the
+shared ``JWT_SECRET_KEY``, issuer ``JwstDataAnalysis``, audience
+``JwstDataAnalysisClient``. Live tokens carry ``sub``, ``unique_name``, ``email``, and the role under the
+full ``schemas.microsoft.com`` claim URI (the handler's outbound map does not
+shorten ``ClaimTypes.Role``).
+
+This is the first slice of ADR-0001 Phase 1 (Python absorbs auth); token
+*issuance* stays in .NET for now — the engine only validates.
+"""
+
+import os
+from dataclasses import dataclass
+
+import jwt
+from fastapi import Depends, HTTPException, Request
+
+
+_ALGORITHM = "HS256"
+_DEFAULT_ISSUER = "JwstDataAnalysis"
+_DEFAULT_AUDIENCE = "JwstDataAnalysisClient"
+
+# .NET's JwtSecurityTokenHandler outbound map does NOT shorten ClaimTypes.Role
+# — live tokens carry the full URI (verified empirically against the running
+# backend, 2026-07-23). Accept the short name too for forward compatibility.
+_ROLE_CLAIMS = (
+    "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
+    "role",
+)
+
+
+@dataclass(frozen=True)
+class AuthenticatedUser:
+    """Identity extracted from a validated access token."""
+
+    user_id: str
+    username: str | None
+    email: str | None
+    role: str
+
+
+def _unauthorized(detail: str) -> HTTPException:
+    return HTTPException(
+        status_code=401,
+        detail=detail,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def _decode(token: str) -> AuthenticatedUser:
+    secret = os.environ.get("JWT_SECRET_KEY")
+    if not secret:
+        # Fail closed server-side: without the shared secret the engine can
+        # neither accept nor meaningfully reject tokens.
+        raise HTTPException(
+            status_code=503, detail="Authentication is not configured on the engine"
+        )
+
+    try:
+        claims = jwt.decode(
+            token,
+            secret,
+            algorithms=[_ALGORITHM],
+            issuer=os.environ.get("JWT_ISSUER", _DEFAULT_ISSUER),
+            audience=os.environ.get("JWT_AUDIENCE", _DEFAULT_AUDIENCE),
+            options={"require": ["exp", "iss", "aud", "sub"]},
+            # Match the .NET validator's ClockSkewSeconds (JwtSettings.cs) so
+            # both services agree on token expiry at the boundary.
+            leeway=int(os.environ.get("JWT_CLOCK_SKEW_SECONDS", "30")),
+        )
+    except jwt.InvalidTokenError as exc:
+        raise _unauthorized("Invalid or expired token") from exc
+
+    role = next((claims[name] for name in _ROLE_CLAIMS if claims.get(name)), "User")
+    return AuthenticatedUser(
+        user_id=str(claims["sub"]),
+        username=claims.get("unique_name"),
+        email=claims.get("email"),
+        role=str(role),
+    )
+
+
+def _bearer_token(request: Request) -> str | None:
+    header = request.headers.get("Authorization")
+    if not header:
+        return None
+    scheme, _, token = header.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return None
+    return token.strip()
+
+
+def require_user(request: Request) -> AuthenticatedUser:
+    """FastAPI dependency: reject the request unless a valid token is present."""
+    token = _bearer_token(request)
+    if token is None:
+        raise _unauthorized("Not authenticated")
+    return _decode(token)
+
+
+def optional_user(request: Request) -> AuthenticatedUser | None:
+    """FastAPI dependency: anonymous is allowed, but a present token must be
+    valid — a bad token is a 401, never a silent downgrade to anonymous."""
+    token = _bearer_token(request)
+    if token is None:
+        return None
+    return _decode(token)
+
+
+def require_role(role: str):
+    """Dependency factory: require a valid token carrying the given role."""
+
+    def _check(user: AuthenticatedUser = Depends(require_user)) -> AuthenticatedUser:
+        if user.role != role:
+            raise HTTPException(status_code=403, detail="Insufficient role")
+        return user
+
+    return _check

--- a/processing-engine/tests/test_auth_deps.py
+++ b/processing-engine/tests/test_auth_deps.py
@@ -1,0 +1,210 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Tests for the JWT validation dependencies (app/auth/deps.py).
+
+Tokens are minted in-test with the same HS256 secret/issuer/audience the
+.NET backend uses (backend/JwstDataAnalysis.API/Services/JwtTokenService.cs)
+so the validation path mirrors production exactly. Claim names verified
+against a live backend token (2026-07-23): ``sub``, ``unique_name``,
+``email``, ``jti``, ``iat``, and the role under the full
+``schemas.microsoft.com`` URI (outbound mapping does NOT shorten it).
+"""
+
+import time
+
+import jwt
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from app.auth.deps import AuthenticatedUser, optional_user, require_user
+
+
+SECRET = "unit-test-secret-key-at-least-32-chars!!"
+ISSUER = "JwstDataAnalysis"
+AUDIENCE = "JwstDataAnalysisClient"
+
+USER_ID = "6862f1a2b3c4d5e6f7a8b9c0"
+
+ROLE_URI = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+
+
+@pytest.fixture(autouse=True)
+def _jwt_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JWT_SECRET_KEY", SECRET)
+    monkeypatch.setenv("JWT_ISSUER", ISSUER)
+    monkeypatch.setenv("JWT_AUDIENCE", AUDIENCE)
+
+
+def mint_token(
+    *,
+    secret: str = SECRET,
+    issuer: str = ISSUER,
+    audience: str = AUDIENCE,
+    role: str = "User",
+    expires_in: int = 900,
+    **extra: object,
+) -> str:
+    now = int(time.time())
+    claims: dict[str, object] = {
+        "sub": USER_ID,
+        "unique_name": "testuser",
+        "email": "test@example.com",
+        ROLE_URI: role,
+        "jti": "00000000-0000-0000-0000-000000000001",
+        "iat": now,
+        "exp": now + expires_in,
+        "iss": issuer,
+        "aud": audience,
+    }
+    claims.update(extra)
+    return jwt.encode(claims, secret, algorithm="HS256")
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    app = FastAPI()
+
+    @app.get("/protected")
+    def protected(user: AuthenticatedUser = Depends(require_user)) -> dict[str, str]:
+        return {"user_id": user.user_id, "role": user.role}
+
+    @app.get("/optional")
+    def optional(
+        user: AuthenticatedUser | None = Depends(optional_user),
+    ) -> dict[str, str | None]:
+        return {"user_id": user.user_id if user else None}
+
+    return TestClient(app)
+
+
+def auth_header(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestRequireUser:
+    def test_valid_token_returns_user(self, client: TestClient) -> None:
+        response = client.get("/protected", headers=auth_header(mint_token()))
+        assert response.status_code == 200
+        assert response.json() == {"user_id": USER_ID, "role": "User"}
+
+    def test_admin_role_extracted(self, client: TestClient) -> None:
+        response = client.get("/protected", headers=auth_header(mint_token(role="Admin")))
+        assert response.status_code == 200
+        assert response.json()["role"] == "Admin"
+
+    def test_short_role_claim_also_accepted(self, client: TestClient) -> None:
+        # Forward-compat: accept the short "role" name alongside the .NET URI.
+        now = int(time.time())
+        token = jwt.encode(
+            {
+                "sub": USER_ID,
+                "role": "Admin",
+                "iss": ISSUER,
+                "aud": AUDIENCE,
+                "exp": now + 900,
+            },
+            SECRET,
+            algorithm="HS256",
+        )
+        response = client.get("/protected", headers=auth_header(token))
+        assert response.status_code == 200
+        assert response.json()["role"] == "Admin"
+
+    def test_missing_header_is_401(self, client: TestClient) -> None:
+        response = client.get("/protected")
+        assert response.status_code == 401
+        assert response.headers.get("WWW-Authenticate") == "Bearer"
+
+    def test_expired_token_is_401(self, client: TestClient) -> None:
+        response = client.get("/protected", headers=auth_header(mint_token(expires_in=-60)))
+        assert response.status_code == 401
+
+    def test_just_expired_token_within_clock_skew_is_accepted(self, client: TestClient) -> None:
+        # .NET validates with ClockSkewSeconds=30; the engine must agree at
+        # the boundary or the two services intermittently disagree on expiry.
+        response = client.get("/protected", headers=auth_header(mint_token(expires_in=-10)))
+        assert response.status_code == 200
+
+    def test_expired_beyond_clock_skew_is_401(self, client: TestClient) -> None:
+        response = client.get("/protected", headers=auth_header(mint_token(expires_in=-31)))
+        assert response.status_code == 401
+
+    def test_wrong_issuer_is_401(self, client: TestClient) -> None:
+        response = client.get("/protected", headers=auth_header(mint_token(issuer="Evil")))
+        assert response.status_code == 401
+
+    def test_wrong_audience_is_401(self, client: TestClient) -> None:
+        response = client.get("/protected", headers=auth_header(mint_token(audience="OtherClient")))
+        assert response.status_code == 401
+
+    def test_wrong_key_is_401(self, client: TestClient) -> None:
+        response = client.get(
+            "/protected",
+            headers=auth_header(mint_token(secret="a-completely-different-32char-key!!")),
+        )
+        assert response.status_code == 401
+
+    def test_malformed_token_is_401(self, client: TestClient) -> None:
+        response = client.get("/protected", headers=auth_header("not.a.jwt"))
+        assert response.status_code == 401
+
+    def test_non_bearer_scheme_is_401(self, client: TestClient) -> None:
+        response = client.get("/protected", headers={"Authorization": f"Basic {mint_token()}"})
+        assert response.status_code == 401
+
+    def test_unsigned_alg_none_is_401(self, client: TestClient) -> None:
+        # alg=none tokens must never validate, even with matching claims.
+        now = int(time.time())
+        token = jwt.encode(
+            {
+                "sub": USER_ID,
+                "role": "Admin",
+                "iss": ISSUER,
+                "aud": AUDIENCE,
+                "exp": now + 900,
+            },
+            key="",
+            algorithm="none",
+        )
+        response = client.get("/protected", headers=auth_header(token))
+        assert response.status_code == 401
+
+    def test_missing_sub_claim_is_401(self, client: TestClient) -> None:
+        now = int(time.time())
+        token = jwt.encode(
+            {"iss": ISSUER, "aud": AUDIENCE, "exp": now + 900, "role": "User"},
+            SECRET,
+            algorithm="HS256",
+        )
+        response = client.get("/protected", headers=auth_header(token))
+        assert response.status_code == 401
+
+    def test_missing_secret_env_is_503(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An engine deployed without JWT_SECRET_KEY must fail closed with a
+        # server-side error, not accept or mis-reject tokens.
+        monkeypatch.delenv("JWT_SECRET_KEY")
+        response = client.get("/protected", headers=auth_header(mint_token()))
+        assert response.status_code == 503
+
+
+class TestOptionalUser:
+    def test_no_header_returns_none(self, client: TestClient) -> None:
+        response = client.get("/optional")
+        assert response.status_code == 200
+        assert response.json() == {"user_id": None}
+
+    def test_valid_token_returns_user(self, client: TestClient) -> None:
+        response = client.get("/optional", headers=auth_header(mint_token()))
+        assert response.status_code == 200
+        assert response.json() == {"user_id": USER_ID}
+
+    def test_invalid_token_is_401(self, client: TestClient) -> None:
+        # A present-but-bad token is an error, not anonymous access —
+        # silently downgrading would mask expired sessions.
+        response = client.get("/optional", headers=auth_header(mint_token(expires_in=-60)))
+        assert response.status_code == 401


### PR DESCRIPTION
## Summary

PR 1 of the Calibration Recipes feature (part of #1709; plan: `docs/plans/features/1709-calibration-recipes.md`). Adds JWT validation to the Python processing engine so upcoming job/recipe write endpoints can authenticate users — the first slice of ADR-0001 Phase 1 (Python absorbs auth). Token *issuance* stays in .NET; the engine only validates.

## Changes Made

- **`processing-engine/app/auth/deps.py`** (new): `require_user` / `optional_user` / `require_role` FastAPI dependencies. HS256 only (alg pinned), requires `exp`/`iss`/`aud`/`sub`, fails closed with 503 when `JWT_SECRET_KEY` is unset, 401 with `WWW-Authenticate: Bearer` on any invalid token. `optional_user` returns `None` only when no header is present — a present-but-bad token is 401, never a silent anonymous downgrade.
- **Claim mapping verified empirically**: registered a throwaway user against the running backend and decoded the live token. The role claim arrives under the full `http://schemas.microsoft.com/ws/2008/06/identity/claims/role` URI (the .NET outbound map does *not* shorten `ClaimTypes.Role`); the deps accept both the URI and short `role`.
- **Clock skew aligned**: `leeway` defaults to 30s (`JWT_CLOCK_SKEW_SECONDS`) matching the .NET validator's `ClockSkewSeconds` so both services agree on expiry at the boundary (self-review round 1 finding).
- **`docker/docker-compose.yml`**: `JWT_SECRET_KEY` added to the `jwst-processing` service env (same var the backend maps to `Jwt__SecretKey`).
- **`docs/plans/features/1709-calibration-recipes.md`** (new): the approved 10-PR implementation plan.
- **`processing-engine/tests/test_auth_deps.py`** (new): 18 tests.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_auth_deps.py` — 18/18 pass: valid token, role extraction (URI + short name), 401 matrix (missing header, expired, wrong iss/aud/key, malformed, non-Bearer scheme, alg=none, missing `sub`), clock-skew boundary (−10s accepted, −31s rejected), 503 when secret unset, optional_user matrix
- [x] Full engine suite — 1579 passed, no regressions
- [x] Live-token verification: real backend-issued JWT decoded; claim names asserted from reality, not docs
- [ ] Reviewer: `docker compose up -d --build`, then mint a token via `POST /api/auth/register` (any scratch user) and call any engine route with/without `Authorization: Bearer <token>` once PR 2 wires the first protected endpoint — this PR adds no protected routes yet

## Documentation Checklist

- [x] Plan file added (`docs/plans/features/1709-calibration-recipes.md`)
- [ ] `docs/quick-reference.md` env-var table — deferred to the PR 10 docs sweep (vars: `JWT_SECRET_KEY` on engine, `JWT_ISSUER`, `JWT_AUDIENCE`, `JWT_CLOCK_SKEW_SECONDS`)
- [x] Module docstrings document the .NET claim-mapping contract inline

## Tech Debt Impact

- [x] No new tech debt introduced
- Notes for the endpoint-wiring PR (deliberate, from self-review): `require_role` has no Admin bypass yet (no consumers exist); absent role claim defaults to `"User"` (matches .NET, which always emits the role claim).

## Risk & Rollback

- **Risk: LOW.** Pure additive — no routes consume the dependencies yet, so runtime behavior is unchanged. The only live-config change is one new env var on the engine container.
- **Auth-adjacent** (flagging per policy): this establishes the engine-side token validation contract that PRs 2–10 build on. The 401/403/503 semantics and claim mapping are the load-bearing choices; both are tested and were verified against a live token.
- **Rollback:** revert the commit; no data or schema involved.

Part of #1709 (umbrella issue stays open across the 10-PR sequence). No linked issue to close.

https://claude.ai/code/session_01W5ZRaEbzFmit1DQs1nfP66
