### PR TITLE
feat: Mongo job store + /api/jobs endpoints + engine CORS (#1709 PR 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,18 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.python == 'true'
 
+    # The job-store tests (tests/test_jobs_*.py) exercise real Mongo update
+    # operators against throwaway collections — a fake would not test them.
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+
+    env:
+      MONGODB_URI: mongodb://localhost:27017
+      MONGODB_DATABASE: jwst_ci_tests
+
     steps:
     - uses: actions/checkout@v7
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -114,6 +114,9 @@ services:
       # Shared with the .NET backend (Jwt__SecretKey) so the engine can
       # validate .NET-issued access tokens (ADR-0001 Phase 1 slice).
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-CHANGE_THIS_IN_PRODUCTION_MIN_32_CHARS_SECURE_KEY_HERE}
+      # Frontend origins allowed to call the engine directly (/api/jobs,
+      # /api/calibration) — same list the .NET backend uses.
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173}
     volumes:
       - ../data:/app/data
     depends_on:

--- a/processing-engine/app/jobs/models.py
+++ b/processing-engine/app/jobs/models.py
@@ -1,0 +1,89 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""Job record models for the Mongo-persisted job store (ADR-0001 Phase 3).
+
+The ``jobs`` collection is Python-native and uses snake_case field names — a
+deliberate divergence from the PascalCase .NET-era collections (``jwst_data``,
+``users``). The wire shape is camelCase via ``app.db.casing`` in the routes.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# Statuses a job can be observed in while the engine still owes work on it.
+ACTIVE_STATUSES = ("queued", "downloading", "running")
+
+# Upper bound on the in-document log tail; full logs belong in storage.
+LOG_TAIL_MAX_LINES = 200
+
+
+class JobStatus(StrEnum):
+    QUEUED = "queued"
+    DOWNLOADING = "downloading"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class StageState(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class JobStageProgress(BaseModel):
+    name: str
+    status: StageState = StageState.PENDING
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
+
+class JobProgress(BaseModel):
+    stages: list[JobStageProgress] = Field(default_factory=list)
+    current_stage: str | None = None
+    message: str | None = None
+    download_pct: float | None = None
+
+
+class JobOutput(BaseModel):
+    storage_key: str
+    suffix: str
+    size_bytes: int
+
+
+class JobResult(BaseModel):
+    outputs: list[JobOutput] = Field(default_factory=list)
+    log_key: str | None = None
+    jwst_version: str | None = None
+    crds_context: str | None = None
+
+
+class JobRecord(BaseModel):
+    """A persisted job. ``request`` is job-type-specific (calibration embeds a
+    recipe snapshot there) and is treated as opaque data by the store."""
+
+    job_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    type: str
+    user_id: str
+    status: JobStatus = JobStatus.QUEUED
+    cancel_requested: bool = False
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    request: dict[str, Any] = Field(default_factory=dict)
+    progress: JobProgress = Field(default_factory=JobProgress)
+    log_tail: list[str] = Field(default_factory=list)
+    result: JobResult | None = None
+    error: str | None = None
+
+    def to_document(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -1,15 +1,77 @@
-"""Jobs routes (scaffold).
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
 
-Endpoints land in Phase 3 of the single-backend migration
-(docs/architecture/adr/0001-collapse-to-python-single-backend.md):
-``/api/jobs`` status queries plus the ``/ws/jobs`` WebSocket that replaces the
-``.NET`` SignalR ``/hubs/job-progress`` hub.
+"""Job status/cancel endpoints (ADR-0001 Phase 3, first slice).
 
-The router is intentionally empty for now so the import graph and OpenAPI tag
-are established without changing runtime behavior.
+Divergence from the ADR sketch: progress is delivered by HTTP polling of
+``GET /api/jobs/{id}`` rather than a ``/ws/jobs`` WebSocket — the frontend's
+job-progress hooks already support polling, and calibration jobs (the first
+consumer) change state on the order of seconds, not milliseconds.
+
+Wire shape is camelCase (``app.db.casing``); documents are snake_case.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.auth.deps import AuthenticatedUser, require_user
+from app.db.casing import snake_to_camel_keys
+from app.db.client import get_database
+from app.jobs.store import COLLECTION_NAME, JobStore
 
 
 router = APIRouter(prefix="/api/jobs", tags=["Jobs"])
+
+
+def get_job_store() -> JobStore:
+    return JobStore(get_database()[COLLECTION_NAME])
+
+
+def to_wire(job: dict) -> dict:
+    """camelCase the job envelope but keep ``request`` verbatim — it is
+    opaque, job-type-owned data (e.g. a calibration recipe snapshot whose
+    parameter names are meaningful snake_case identifiers, not field names)."""
+    request = job.get("request")
+    wire = snake_to_camel_keys({k: v for k, v in job.items() if k != "request"})
+    wire["request"] = request
+    return wire
+
+
+@router.get("")
+async def list_jobs(
+    user: AuthenticatedUser = Depends(require_user),
+    store: JobStore = Depends(get_job_store),
+    limit: int = 50,
+):
+    jobs = await store.list_for_user(user.user_id, limit=min(max(limit, 1), 200))
+    return {"jobs": [to_wire(j) for j in jobs]}
+
+
+@router.get("/{job_id}")
+async def get_job(
+    job_id: str,
+    user: AuthenticatedUser = Depends(require_user),
+    store: JobStore = Depends(get_job_store),
+):
+    job = await store.get(job_id)
+    # 404 for both "unknown" and "not yours" — don't leak job existence.
+    if job is None or (job.get("user_id") != user.user_id and user.role != "Admin"):
+        raise HTTPException(status_code=404, detail="Job not found")
+    return to_wire(job)
+
+
+@router.post("/{job_id}/cancel")
+async def cancel_job(
+    job_id: str,
+    user: AuthenticatedUser = Depends(require_user),
+    store: JobStore = Depends(get_job_store),
+):
+    # Deliberately no Admin bypass here (unlike get_job): admins observe any
+    # job but don't interfere with other users' runs.
+    accepted = await store.request_cancel(job_id, user.user_id)
+    if not accepted:
+        job = await store.get(job_id)
+        if job is None or job.get("user_id") != user.user_id:
+            raise HTTPException(status_code=404, detail="Job not found")
+        # Owned but already terminal — cancellation is a no-op, not an error.
+        return {"cancelRequested": False, "status": job.get("status")}
+    return {"cancelRequested": True}

--- a/processing-engine/app/jobs/runner.py
+++ b/processing-engine/app/jobs/runner.py
@@ -1,0 +1,86 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""Background job execution wrapper.
+
+Fire-and-forget ``asyncio`` task in the style of the MAST download worker
+(``app/mast/routes.py``), but with all state persisted through the
+:class:`~app.jobs.store.JobStore` so status survives request boundaries.
+
+SINGLE-WORKER REQUIREMENT: jobs execute as in-process asyncio tasks and
+startup reconciliation fails ALL active jobs, so the engine must run with
+exactly one uvicorn worker (the Dockerfile's ``--workers 1``). A multi-worker
+deployment needs an external queue first.
+"""
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+from app.jobs.models import JobRecord, JobResult, JobStatus
+from app.jobs.store import JobStore
+
+
+logger = logging.getLogger(__name__)
+
+
+class JobCancelled(Exception):
+    """Raised by job work when it observes a cancel request."""
+
+
+class JobContext:
+    """Handle passed to job work for progress/cancellation interaction."""
+
+    def __init__(self, store: JobStore, job_id: str):
+        self.store = store
+        self.job_id = job_id
+
+    async def log(self, *lines: str) -> None:
+        await self.store.append_log(self.job_id, *lines)
+
+    async def set_progress(self, **kwargs) -> None:
+        await self.store.set_progress(self.job_id, **kwargs)
+
+    async def set_status(self, status: JobStatus) -> None:
+        await self.store.set_status(self.job_id, status)
+
+    async def raise_if_cancelled(self) -> None:
+        """Call at safe boundaries (stage transitions, download chunks)."""
+        if await self.store.is_cancel_requested(self.job_id):
+            raise JobCancelled()
+
+
+JobWork = Callable[[JobContext], Awaitable[JobResult]]
+
+# Strong references so fire-and-forget tasks aren't garbage-collected mid-run.
+_running_tasks: set[asyncio.Task] = set()
+
+
+async def _run(store: JobStore, job_id: str, work: JobWork) -> None:
+    ctx = JobContext(store, job_id)
+    try:
+        await store.set_status(job_id, JobStatus.RUNNING)
+        result = await work(ctx)
+        await store.mark_succeeded(job_id, result)
+    except JobCancelled:
+        logger.info("Job %s cancelled", job_id)
+        await store.mark_cancelled(job_id)
+    except asyncio.CancelledError:
+        # Loop shutdown: record the state, then let cancellation propagate.
+        await store.mark_cancelled(job_id)
+        raise
+    except Exception as exc:
+        logger.exception("Job %s failed", job_id)
+        await store.mark_failed(job_id, str(exc))
+
+
+async def launch(store: JobStore, job: JobRecord, work: JobWork) -> str:
+    """Persist ``job`` and start executing ``work`` in the background.
+
+    Returns the job id immediately; callers poll ``GET /api/jobs/{id}``.
+    """
+    job_id = await store.create(job)
+    task = asyncio.create_task(_run(store, job_id, work), name=f"job-{job_id}")
+    _running_tasks.add(task)
+    task.add_done_callback(_running_tasks.discard)
+    return job_id

--- a/processing-engine/app/jobs/store.py
+++ b/processing-engine/app/jobs/store.py
@@ -1,0 +1,164 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""Mongo-backed job store — the engine's first write-capable repository.
+
+Every mutation is a single atomic ``$set``/``$push`` update; no
+read-modify-write cycles, so the executor thread and cancel requests can race
+safely. Long-running work must poll :meth:`is_cancel_requested` at safe
+boundaries.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from app.jobs.models import (
+    ACTIVE_STATUSES,
+    LOG_TAIL_MAX_LINES,
+    JobRecord,
+    JobResult,
+    JobStatus,
+)
+
+
+COLLECTION_NAME = "jobs"
+
+
+def _now_iso() -> str:
+    # Match pydantic's JSON serialization (trailing Z, not +00:00) so every
+    # timestamp in a job document carries the same format and sorts lexically.
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+class JobStore:
+    def __init__(self, collection: AsyncIOMotorCollection):
+        self._col = collection
+
+    async def ensure_indexes(self) -> None:
+        await self._col.create_index("job_id", unique=True)
+        await self._col.create_index([("user_id", 1), ("created_at", -1)])
+
+    async def create(self, job: JobRecord) -> str:
+        await self._col.insert_one(job.to_document())
+        return job.job_id
+
+    async def get(self, job_id: str) -> dict[str, Any] | None:
+        return await self._col.find_one({"job_id": job_id}, {"_id": 0})
+
+    async def list_for_user(self, user_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        cursor = (
+            self._col.find({"user_id": user_id}, {"_id": 0}).sort("created_at", -1).limit(limit)
+        )
+        return await cursor.to_list(length=limit)
+
+    async def request_cancel(self, job_id: str, user_id: str) -> bool:
+        """Flag an active, owned job for cancellation. Returns False when the
+        job doesn't exist, isn't owned by ``user_id``, or already finished."""
+        result = await self._col.update_one(
+            {
+                "job_id": job_id,
+                "user_id": user_id,
+                "status": {"$in": list(ACTIVE_STATUSES)},
+            },
+            {"$set": {"cancel_requested": True}},
+        )
+        return result.matched_count == 1
+
+    async def is_cancel_requested(self, job_id: str) -> bool:
+        doc = await self._col.find_one({"job_id": job_id}, {"cancel_requested": 1})
+        return bool(doc and doc.get("cancel_requested"))
+
+    async def set_status(self, job_id: str, status: JobStatus) -> None:
+        update: dict[str, Any] = {"status": status.value}
+        if status is JobStatus.RUNNING:
+            update["started_at"] = _now_iso()
+        await self._col.update_one({"job_id": job_id}, {"$set": update})
+
+    async def set_progress(
+        self,
+        job_id: str,
+        *,
+        current_stage: str | None = None,
+        message: str | None = None,
+        download_pct: float | None = None,
+        stages: list[dict[str, Any]] | None = None,
+    ) -> None:
+        fields: dict[str, Any] = {}
+        if current_stage is not None:
+            fields["progress.current_stage"] = current_stage
+        if message is not None:
+            fields["progress.message"] = message
+        if download_pct is not None:
+            fields["progress.download_pct"] = download_pct
+        if stages is not None:
+            fields["progress.stages"] = stages
+        if fields:
+            await self._col.update_one({"job_id": job_id}, {"$set": fields})
+
+    async def append_log(self, job_id: str, *lines: str) -> None:
+        if not lines:
+            return
+        await self._col.update_one(
+            {"job_id": job_id},
+            {
+                "$push": {
+                    "log_tail": {
+                        "$each": list(lines),
+                        # Keep only the newest lines; full logs go to storage.
+                        "$slice": -LOG_TAIL_MAX_LINES,
+                    }
+                }
+            },
+        )
+
+    async def mark_succeeded(self, job_id: str, result: JobResult) -> None:
+        await self._col.update_one(
+            {"job_id": job_id},
+            {
+                "$set": {
+                    "status": JobStatus.SUCCEEDED.value,
+                    "finished_at": _now_iso(),
+                    "result": result.model_dump(mode="json"),
+                }
+            },
+        )
+
+    async def mark_failed(self, job_id: str, error: str) -> None:
+        await self._col.update_one(
+            {"job_id": job_id},
+            {
+                "$set": {
+                    "status": JobStatus.FAILED.value,
+                    "finished_at": _now_iso(),
+                    "error": error,
+                }
+            },
+        )
+
+    async def mark_cancelled(self, job_id: str) -> None:
+        await self._col.update_one(
+            {"job_id": job_id},
+            {
+                "$set": {
+                    "status": JobStatus.CANCELLED.value,
+                    "finished_at": _now_iso(),
+                }
+            },
+        )
+
+    async def reconcile_interrupted(self) -> int:
+        """Mark jobs left active by a previous process as failed (v1 jobs do
+        not survive restarts — resume-on-restart is a tracked follow-up)."""
+        result = await self._col.update_many(
+            {"status": {"$in": list(ACTIVE_STATUSES)}},
+            {
+                "$set": {
+                    "status": JobStatus.FAILED.value,
+                    "finished_at": _now_iso(),
+                    "error": "interrupted by service restart",
+                }
+            },
+        )
+        return result.modified_count

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
@@ -29,7 +30,28 @@ from app.semantic.routes import router as semantic_router
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="JWST Data Processing Engine", version="1.0.0")
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    # v1 jobs don't survive restarts; anything still "active" from a previous
+    # process is dead. Resume-on-restart is a tracked follow-up. Jobs are
+    # full-mode-only, so CE skips reconciliation entirely.
+    if os.environ.get("CE_MODE", "").strip().lower() not in {"1", "true", "yes"}:
+        from app.jobs.store import COLLECTION_NAME, JobStore
+
+        try:
+            store = JobStore(get_database()[COLLECTION_NAME])
+            count = await store.reconcile_interrupted()
+            if count:
+                logger.warning("Marked %d interrupted job(s) as failed after restart", count)
+        except MongoNotConfiguredError:
+            logger.info("Job reconciliation skipped: MongoDB not configured")
+        except Exception:
+            logger.exception("Job reconciliation failed (continuing startup)")
+    yield
+
+
+app = FastAPI(title="JWST Data Processing Engine", version="1.0.0", lifespan=_lifespan)
 
 # Exception handlers — domain exceptions become structured JSON responses
 app.add_exception_handler(ProcessingEngineError, processing_engine_error_handler)
@@ -69,6 +91,29 @@ if CE_MODE:
         return await call_next(request)
 
 else:
+    # Frontend calls the engine directly for /api/jobs (+ upcoming
+    # /api/calibration) — cross-origin from the Vite dev server / app host,
+    # so CORS is required here. CE is same-origin behind nginx and the .NET
+    # gateway proxies everything else, hence full-mode-only.
+    from fastapi.middleware.cors import CORSMiddleware as _CORSMiddleware
+
+    _cors_origins = [
+        origin.strip()
+        for origin in os.environ.get(
+            "CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173"
+        ).split(",")
+        if origin.strip()
+    ]
+    # Never set CORS_ALLOWED_ORIGINS to "*": with allow_credentials=True,
+    # Starlette would echo any origin back — credentialed wildcard CORS.
+    app.add_middleware(
+        _CORSMiddleware,
+        allow_origins=_cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
     # Full engine surface (the .NET gateway depends on these routes)
     app.include_router(composite_router)
     app.include_router(mosaic_router)

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -1,0 +1,216 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Tests for /api/jobs routes: auth, ownership, camelCase wire shape, cancel
+semantics, and the full-mode CORS middleware.
+
+Uses httpx.AsyncClient over ASGITransport (not the sync TestClient) so the
+app, the motor client, and the test all share one event loop — and so app
+startup hooks (job reconciliation) don't fire against the real collection.
+Backing store is the real MongoDB with a throwaway collection per test.
+"""
+
+import time
+import uuid
+
+import httpx
+import jwt as pyjwt
+import pytest
+
+from app.db.client import get_database, reset_client
+from app.jobs.models import JobRecord, JobResult
+from app.jobs.routes import get_job_store
+from app.jobs.store import JobStore
+
+
+SECRET = "unit-test-secret-key-at-least-32-chars!!"
+ISSUER = "JwstDataAnalysis"
+AUDIENCE = "JwstDataAnalysisClient"
+ROLE_URI = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+
+USER = "user-a"
+OTHER = "user-b"
+
+
+@pytest.fixture(autouse=True)
+def _jwt_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JWT_SECRET_KEY", SECRET)
+
+
+def token_for(user_id: str, role: str = "User") -> str:
+    now = int(time.time())
+    return pyjwt.encode(
+        {
+            "sub": user_id,
+            ROLE_URI: role,
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "iat": now,
+            "exp": now + 900,
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+def bearer(user_id: str, role: str = "User") -> dict[str, str]:
+    return {"Authorization": f"Bearer {token_for(user_id, role)}"}
+
+
+@pytest.fixture()
+async def store():
+    # Fresh motor client per test: the cached global binds to the first
+    # event loop it touches, and pytest-asyncio makes a new loop per test.
+    reset_client()
+    collection = get_database()[f"jobs_test_{uuid.uuid4().hex}"]
+    yield JobStore(collection)
+    await collection.drop()
+    reset_client()
+
+
+@pytest.fixture()
+async def client(store: JobStore):
+    from main import app
+
+    app.dependency_overrides[get_job_store] = lambda: store
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as async_client:
+            yield async_client
+    finally:
+        app.dependency_overrides.pop(get_job_store, None)
+
+
+async def seed_job(store: JobStore, user_id: str = USER) -> str:
+    job = JobRecord(type="calibration", user_id=user_id, request={"recipe_id": "r1"})
+    await store.create(job)
+    return job.job_id
+
+
+class TestAuth:
+    async def test_list_requires_token(self, client: httpx.AsyncClient) -> None:
+        assert (await client.get("/api/jobs")).status_code == 401
+
+    async def test_get_requires_token(self, client: httpx.AsyncClient) -> None:
+        assert (await client.get("/api/jobs/some-id")).status_code == 401
+
+    async def test_cancel_requires_token(self, client: httpx.AsyncClient) -> None:
+        assert (await client.post("/api/jobs/some-id/cancel")).status_code == 401
+
+
+class TestOwnership:
+    async def test_get_own_job_camel_case(self, client: httpx.AsyncClient, store: JobStore) -> None:
+        job_id = await seed_job(store)
+        response = await client.get(f"/api/jobs/{job_id}", headers=bearer(USER))
+        assert response.status_code == 200
+        body = response.json()
+        assert body["jobId"] == job_id
+        assert body["userId"] == USER
+        assert body["cancelRequested"] is False
+        assert "logTail" in body
+        # No snake_case leakage on the wire.
+        assert "job_id" not in body and "user_id" not in body
+
+    async def test_request_blob_stays_verbatim_on_wire(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        # `request` is opaque job-type data: snake_case keys inside it (step
+        # names, parameter names) must NOT be camelCased by the facade.
+        job = JobRecord(
+            type="calibration",
+            user_id=USER,
+            request={
+                "recipe_id": "r1",
+                "run_overrides": {"tweakreg": {"abs_refcat": "GAIADR3"}},
+            },
+        )
+        await store.create(job)
+        response = await client.get(f"/api/jobs/{job.job_id}", headers=bearer(USER))
+        assert response.status_code == 200
+        assert response.json()["request"] == {
+            "recipe_id": "r1",
+            "run_overrides": {"tweakreg": {"abs_refcat": "GAIADR3"}},
+        }
+
+    async def test_get_foreign_job_is_404(self, client: httpx.AsyncClient, store: JobStore) -> None:
+        job_id = await seed_job(store, user_id=OTHER)
+        response = await client.get(f"/api/jobs/{job_id}", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_admin_can_read_any_job(self, client: httpx.AsyncClient, store: JobStore) -> None:
+        job_id = await seed_job(store, user_id=OTHER)
+        response = await client.get(f"/api/jobs/{job_id}", headers=bearer(USER, role="Admin"))
+        assert response.status_code == 200
+
+    async def test_get_unknown_job_is_404(self, client: httpx.AsyncClient) -> None:
+        response = await client.get("/api/jobs/does-not-exist", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_list_returns_only_own_jobs(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        mine = await seed_job(store)
+        await seed_job(store, user_id=OTHER)
+        response = await client.get("/api/jobs", headers=bearer(USER))
+        assert response.status_code == 200
+        jobs = response.json()["jobs"]
+        assert [j["jobId"] for j in jobs] == [mine]
+
+
+class TestCancel:
+    async def test_cancel_own_active_job(self, client: httpx.AsyncClient, store: JobStore) -> None:
+        job_id = await seed_job(store)
+        response = await client.post(f"/api/jobs/{job_id}/cancel", headers=bearer(USER))
+        assert response.status_code == 200
+        assert response.json() == {"cancelRequested": True}
+        assert await store.is_cancel_requested(job_id) is True
+
+    async def test_cancel_foreign_job_is_404(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        job_id = await seed_job(store, user_id=OTHER)
+        response = await client.post(f"/api/jobs/{job_id}/cancel", headers=bearer(USER))
+        assert response.status_code == 404
+        assert await store.is_cancel_requested(job_id) is False
+
+    async def test_cancel_unknown_job_is_404(self, client: httpx.AsyncClient) -> None:
+        response = await client.post("/api/jobs/does-not-exist/cancel", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_cancel_terminal_job_is_noop(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        job_id = await seed_job(store)
+        await store.mark_succeeded(job_id, JobResult())
+        response = await client.post(f"/api/jobs/{job_id}/cancel", headers=bearer(USER))
+        assert response.status_code == 200
+        assert response.json() == {"cancelRequested": False, "status": "succeeded"}
+
+
+class TestCors:
+    async def test_preflight_from_allowed_origin(self, client: httpx.AsyncClient) -> None:
+        response = await client.options(
+            "/api/jobs",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "authorization",
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+
+    async def test_preflight_from_unknown_origin_not_allowed(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        response = await client.options(
+            "/api/jobs",
+            headers={
+                "Origin": "http://evil.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert "access-control-allow-origin" not in response.headers

--- a/processing-engine/tests/test_jobs_store.py
+++ b/processing-engine/tests/test_jobs_store.py
@@ -1,0 +1,184 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Tests for the Mongo-backed job store and runner (app/jobs/).
+
+Runs against the real MongoDB in the dev container (MONGODB_URI) using a
+throwaway collection per test — the store's whole value is its atomic update
+operators, which an in-memory fake would not exercise honestly.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from app.db.client import get_database, reset_client
+from app.jobs.models import (
+    LOG_TAIL_MAX_LINES,
+    JobRecord,
+    JobResult,
+    JobStatus,
+)
+from app.jobs.runner import JobCancelled, JobContext, launch
+from app.jobs.store import JobStore
+
+
+USER = "user-a"
+OTHER = "user-b"
+
+
+@pytest.fixture()
+async def store():
+    # Fresh motor client per test: the cached global binds to the first
+    # event loop it touches, and pytest-asyncio makes a new loop per test.
+    reset_client()
+    collection = get_database()[f"jobs_test_{uuid.uuid4().hex}"]
+    yield JobStore(collection)
+    await collection.drop()
+    reset_client()
+
+
+def make_job(user_id: str = USER) -> JobRecord:
+    return JobRecord(type="calibration", user_id=user_id, request={"recipe_id": "x"})
+
+
+class TestJobStore:
+    async def test_create_and_get_roundtrip(self, store: JobStore) -> None:
+        job = make_job()
+        await store.create(job)
+        doc = await store.get(job.job_id)
+        assert doc is not None
+        assert doc["status"] == "queued"
+        assert doc["user_id"] == USER
+        assert doc["request"] == {"recipe_id": "x"}
+        assert "_id" not in doc
+
+    async def test_get_unknown_returns_none(self, store: JobStore) -> None:
+        assert await store.get("nope") is None
+
+    async def test_list_for_user_isolates_owners(self, store: JobStore) -> None:
+        mine = make_job()
+        theirs = make_job(user_id=OTHER)
+        await store.create(mine)
+        await store.create(theirs)
+        jobs = await store.list_for_user(USER)
+        assert [j["job_id"] for j in jobs] == [mine.job_id]
+
+    async def test_status_transitions_stamp_timestamps(self, store: JobStore) -> None:
+        job = make_job()
+        await store.create(job)
+        await store.set_status(job.job_id, JobStatus.RUNNING)
+        doc = await store.get(job.job_id)
+        assert doc["status"] == "running"
+        assert doc["started_at"] is not None
+
+        await store.mark_succeeded(job.job_id, JobResult())
+        doc = await store.get(job.job_id)
+        assert doc["status"] == "succeeded"
+        assert doc["finished_at"] is not None
+
+    async def test_cancel_only_active_owned_jobs(self, store: JobStore) -> None:
+        job = make_job()
+        await store.create(job)
+
+        assert await store.request_cancel(job.job_id, OTHER) is False
+        assert await store.request_cancel(job.job_id, USER) is True
+        assert await store.is_cancel_requested(job.job_id) is True
+
+        await store.mark_cancelled(job.job_id)
+        # Terminal job: further cancels are refused.
+        assert await store.request_cancel(job.job_id, USER) is False
+
+    async def test_append_log_caps_tail(self, store: JobStore) -> None:
+        job = make_job()
+        await store.create(job)
+        lines = [f"line {i}" for i in range(LOG_TAIL_MAX_LINES + 25)]
+        await store.append_log(job.job_id, *lines)
+        doc = await store.get(job.job_id)
+        assert len(doc["log_tail"]) == LOG_TAIL_MAX_LINES
+        assert doc["log_tail"][-1] == lines[-1]
+        assert doc["log_tail"][0] == lines[25]
+
+    async def test_set_progress_partial_updates(self, store: JobStore) -> None:
+        job = make_job()
+        await store.create(job)
+        await store.set_progress(job.job_id, current_stage="image3", message="resampling")
+        await store.set_progress(job.job_id, download_pct=42.5)
+        doc = await store.get(job.job_id)
+        assert doc["progress"]["current_stage"] == "image3"
+        assert doc["progress"]["message"] == "resampling"
+        assert doc["progress"]["download_pct"] == 42.5
+
+    async def test_reconcile_interrupted_fails_active_only(self, store: JobStore) -> None:
+        active = make_job()
+        done = make_job()
+        await store.create(active)
+        await store.create(done)
+        await store.set_status(active.job_id, JobStatus.RUNNING)
+        await store.mark_succeeded(done.job_id, JobResult())
+
+        assert await store.reconcile_interrupted() == 1
+        doc = await store.get(active.job_id)
+        assert doc["status"] == "failed"
+        assert doc["error"] == "interrupted by service restart"
+        assert (await store.get(done.job_id))["status"] == "succeeded"
+
+
+class TestRunner:
+    async def test_successful_work_marks_succeeded(self, store: JobStore) -> None:
+        async def work(ctx: JobContext) -> JobResult:
+            await ctx.log("starting", "working")
+            return JobResult(jwst_version="0.0-test")
+
+        job_id = await launch(store, make_job(), work)
+        await _wait_terminal(store, job_id)
+        doc = await store.get(job_id)
+        assert doc["status"] == "succeeded"
+        assert doc["result"]["jwst_version"] == "0.0-test"
+        assert doc["log_tail"] == ["starting", "working"]
+
+    async def test_raising_work_marks_failed(self, store: JobStore) -> None:
+        async def work(ctx: JobContext) -> JobResult:
+            raise RuntimeError("boom")
+
+        job_id = await launch(store, make_job(), work)
+        await _wait_terminal(store, job_id)
+        doc = await store.get(job_id)
+        assert doc["status"] == "failed"
+        assert doc["error"] == "boom"
+
+    async def test_cancel_observed_at_boundary(self, store: JobStore) -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def work(ctx: JobContext) -> JobResult:
+            started.set()
+            await release.wait()
+            await ctx.raise_if_cancelled()
+            return JobResult()
+
+        job_id = await launch(store, make_job(), work)
+        await started.wait()
+        assert await store.request_cancel(job_id, USER) is True
+        release.set()
+        await _wait_terminal(store, job_id)
+        assert (await store.get(job_id))["status"] == "cancelled"
+
+    async def test_job_cancelled_exception_maps_to_cancelled(self, store: JobStore) -> None:
+        async def work(ctx: JobContext) -> JobResult:
+            raise JobCancelled()
+
+        job_id = await launch(store, make_job(), work)
+        await _wait_terminal(store, job_id)
+        assert (await store.get(job_id))["status"] == "cancelled"
+
+
+async def _wait_terminal(store: JobStore, job_id: str, timeout: float = 5.0) -> None:
+    async with asyncio.timeout(timeout):
+        while True:
+            doc = await store.get(job_id)
+            if doc and doc["status"] in ("succeeded", "failed", "cancelled"):
+                return
+            await asyncio.sleep(0.02)


### PR DESCRIPTION
## Summary

PR 2 of the Calibration Recipes feature (plan: `docs/plans/features/1709-calibration-recipes.md`). Builds the ADR-0001 Phase 3 first slice: a Mongo-persisted job store with polling endpoints — the substrate the calibration executor (PR 5) launches into. Also adds CORS to the engine so the frontend can call it directly.

## Changes Made

- **`app/jobs/models.py`** (new): `JobRecord`/`JobProgress`/`JobResult` pydantic models. New `jobs` collection is snake_case (documented divergence from the PascalCase .NET-era collections); `request` is opaque job-type data (holds the calibration recipe snapshot from PR 5 on).
- **`app/jobs/store.py`** (new): first write-capable motor repository. Every mutation is a single atomic `$set`/`$push` — no read-modify-write, so executor/cancel races are safe. Log tail capped at 200 lines via `$push $slice`. `reconcile_interrupted()` fails jobs left active by a dead process.
- **`app/jobs/runner.py`** (new): fire-and-forget asyncio execution with cooperative cancellation (`JobContext.raise_if_cancelled()` at safe boundaries). Single-worker requirement documented (matches the Dockerfile's `--workers 1`).
- **`app/jobs/routes.py`** (scaffold → real): `GET /api/jobs`, `GET /api/jobs/{id}`, `POST /api/jobs/{id}/cancel`. All require a valid JWT (PR 1 deps). Ownership enforced; foreign/unknown jobs are indistinguishable 404s. Admins can read any job but deliberately cannot cancel others' jobs. camelCase wire via `to_wire()`, which keeps `request` verbatim.
- **`main.py`**: startup → lifespan handler with job reconciliation (non-CE only); `CORSMiddleware` in full mode reading `CORS_ALLOWED_ORIGINS` (engine had none — direct frontend→engine calls would fail preflight). CE surface unchanged.
- **`docker/docker-compose.yml`**: `CORS_ALLOWED_ORIGINS` on `jwst-processing` (same default list as the .NET backend).
- **`.github/workflows/ci.yml`**: MongoDB service container + `MONGODB_URI` for the Python Tests job — the new store tests exercise real Mongo update operators, and the job previously had no database.
- **Tests** (27 new): store atomicity/ownership/log-cap/reconciliation against real Mongo (throwaway collection per test), runner success/failure/cancel paths, route auth/ownership/cancel/CORS matrix via `httpx.ASGITransport` (single event loop — avoids motor cross-loop pitfalls).

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_jobs_store.py tests/test_jobs_routes.py` — 27/27 pass
- [x] Full engine suite — 1608 passed, no regressions (includes the CE mounting guard: no jobs surface in CE)
- [x] Live startup verified: engine boots healthy with the new lifespan; reconciliation runs clean
- [ ] Reviewer: `docker compose up -d --build`, mint a token via `POST /api/auth/register`, then `GET http://localhost:8000/api/jobs` with the Bearer token (expect `{"jobs":[]}`), without it (expect 401)

## Documentation Checklist

- [x] Plan file present (PR 1)
- [x] ADR divergence (HTTP polling instead of `/ws/jobs`) documented in the routes module docstring; ADR note itself lands in the PR 10 docs sweep
- [ ] `docs/quick-reference.md` endpoint/env tables — PR 10 docs sweep

## Tech Debt Impact

- [x] Follow-up filed: #1715 (resume interrupted jobs on restart — v1 fails them with a clear error)
- Single-worker constraint is inherent to the in-process job design; documented in `runner.py` and enforced by the existing Dockerfile `--workers 1`.

## Risk & Rollback

- **Risk: LOW-MED.** New collection + new endpoints; no existing behavior changes. The two watch-items are the lifespan handler (verified live) and CORS (explicit origin list, wildcard warned against in-code; no secrets involved).
- **Auth-adjacent** (flagging per policy): first consumer of the PR 1 JWT deps; ownership semantics (404-not-403, no admin cancel) are load-bearing choices, both tested.
- **Rollback:** revert the commit. The `jobs` collection is additive; documents are harmless if orphaned.

Part of #1709 (umbrella stays open). No linked issue to close.

https://claude.ai/code/session_01W5ZRaEbzFmit1DQs1nfP66
