### PR TITLE
feat: jwst dependency + calibration feature flag + CRDS wiring (#1709 PR 4)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -194,3 +194,13 @@ DOMAIN_NAME=
 
 # Host path holding the CE seed bundle (FITS files), mounted read-only.
 # CE_DATA_DIR=../data
+
+# --- Calibration Recipes (#1709) ---
+# Runtime gate for jwst pipeline runs (recipes stay browsable when false).
+CALIBRATION_ENABLED=true
+# CRDS reference-file server; the cache lives at /app/data/crds on the data
+# volume and grows to several GB per instrument — do not delete casually.
+CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+# Concurrent calibration runs (each is multi-core and RAM-heavy; keep at 1
+# unless the host has headroom).
+MAX_CONCURRENT_CALIBRATIONS=1

--- a/docker/docker-compose.ce.yml
+++ b/docker/docker-compose.ce.yml
@@ -52,6 +52,9 @@ services:
     build:
       context: ../processing-engine
       dockerfile: Dockerfile
+      args:
+        # CE never runs calibration — skip the ~2GB jwst layer (#1709).
+        INSTALL_CALIBRATION: "false"
     container_name: jwst-ce-engine
     restart: unless-stopped
     mem_limit: 4g

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -117,6 +117,13 @@ services:
       # Frontend origins allowed to call the engine directly (/api/jobs,
       # /api/calibration) — same list the .NET backend uses.
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173}
+      # Calibration Recipes (#1709): runtime gate for pipeline runs; CRDS
+      # reference-file cache (grows to GBs, lives on the data volume — never
+      # delete it casually) and the STScI CRDS server for lazy downloads.
+      - CALIBRATION_ENABLED=${CALIBRATION_ENABLED:-true}
+      - CRDS_PATH=/app/data/crds
+      - CRDS_SERVER_URL=${CRDS_SERVER_URL:-https://jwst-crds.stsci.edu}
+      - MAX_CONCURRENT_CALIBRATIONS=${MAX_CONCURRENT_CALIBRATIONS:-1}
     volumes:
       - ../data:/app/data
     depends_on:

--- a/processing-engine/Dockerfile
+++ b/processing-engine/Dockerfile
@@ -21,12 +21,25 @@ RUN if [ "$INSTALL_DEV" = "true" ]; then \
         pip install --no-cache-dir -r requirements.txt; \
     fi
 
+# STScI jwst calibration pipeline (#1709), in its own layer AFTER the base
+# requirements so jwst resolves against the already-pinned base deps (numpy/
+# astropy) instead of the base install overwriting jwst's resolution. Note:
+# base-requirement changes therefore DO rebuild this ~2GB layer (linear Docker
+# cache) — accepted cost; editing requirements-calibration.txt alone is cheap.
+# CE builds pass INSTALL_CALIBRATION=false to stay slim; runtime is
+# additionally gated by the CALIBRATION_ENABLED env var.
+ARG INSTALL_CALIBRATION=true
+COPY requirements-calibration.txt ./
+RUN if [ "$INSTALL_CALIBRATION" = "true" ]; then \
+        pip install --no-cache-dir -r requirements-calibration.txt; \
+    fi
+
 COPY . .
 
 # Create non-root user and writable data directories for MAST downloads/processing
 RUN groupadd --system --gid 1001 appgroup && \
     useradd --system --uid 1001 --gid appgroup --no-create-home appuser && \
-    mkdir -p /app/data/mast /app/data/semantic /app/data/model-cache /tmp/matplotlib /tmp/jwst-cache && \
+    mkdir -p /app/data/mast /app/data/semantic /app/data/model-cache /app/data/crds /tmp/matplotlib /tmp/jwst-cache && \
     chown -R appuser:appgroup /app/data && \
     chown -R appuser:appgroup /app /tmp/matplotlib /tmp/jwst-cache
 

--- a/processing-engine/app/calibration/flags.py
+++ b/processing-engine/app/calibration/flags.py
@@ -1,0 +1,45 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""Runtime feature gate for calibration runs.
+
+Two independent gates (#1709 PR 4):
+- build-time: the Docker ``INSTALL_CALIBRATION`` arg controls whether the
+  ``jwst`` package layer exists in the image at all;
+- runtime: the ``CALIBRATION_ENABLED`` env var lets an operator turn runs
+  off without rebuilding.
+
+Recipe browsing/CRUD works regardless — only *executing* runs is gated.
+"""
+
+import importlib.util
+import os
+from functools import lru_cache
+
+
+def calibration_env_enabled() -> bool:
+    return os.environ.get("CALIBRATION_ENABLED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+@lru_cache(maxsize=1)
+def jwst_available() -> bool:
+    """Whether the jwst package is installed (build-time gate). Cached — the
+    image contents cannot change at runtime."""
+    return importlib.util.find_spec("jwst") is not None
+
+
+@lru_cache(maxsize=1)
+def jwst_version() -> str | None:
+    if not jwst_available():
+        return None
+    from importlib.metadata import version
+
+    return version("jwst")
+
+
+def calibration_enabled() -> bool:
+    return calibration_env_enabled() and jwst_available()

--- a/processing-engine/app/calibration/routes.py
+++ b/processing-engine/app/calibration/routes.py
@@ -28,6 +28,18 @@ from app.db.client import get_database
 router = APIRouter(prefix="/api/calibration", tags=["Calibration"])
 
 
+@router.get("/capabilities")
+async def capabilities():
+    """Feature discovery for the frontend nav/gallery gating (camelCase wire
+    like every non-data payload)."""
+    from app.calibration.flags import calibration_enabled, jwst_version
+
+    return {
+        "calibrationEnabled": calibration_enabled(),
+        "jwstVersion": jwst_version(),
+    }
+
+
 def get_recipe_store() -> RecipeStore:
     return RecipeStore(get_database()[COLLECTION_NAME])
 

--- a/processing-engine/requirements-calibration.txt
+++ b/processing-engine/requirements-calibration.txt
@@ -1,0 +1,6 @@
+# STScI jwst calibration pipeline (Calibration Recipes, #1709).
+# Installed on top of requirements.txt when the Docker build arg
+# INSTALL_CALIBRATION=true (default for the full stack; CE builds pass false
+# to keep the image slim). Pin matches the JWPipeNB notebook vintage
+# (Build 12.3 line); bump deliberately alongside seed-recipe review.
+jwst==2.0.1

--- a/processing-engine/tests/test_calibration_flags.py
+++ b/processing-engine/tests/test_calibration_flags.py
@@ -1,0 +1,77 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Tests for the calibration feature gates and the capabilities endpoint.
+"""
+
+import httpx
+import pytest
+
+from app.calibration import flags
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    flags.jwst_available.cache_clear()
+    flags.jwst_version.cache_clear()
+    yield
+    flags.jwst_available.cache_clear()
+    flags.jwst_version.cache_clear()
+
+
+@pytest.fixture()
+async def client():
+    from main import app
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+class TestFlags:
+    def test_env_gate_off_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CALIBRATION_ENABLED", raising=False)
+        assert flags.calibration_env_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes"])
+    def test_env_gate_truthy_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("CALIBRATION_ENABLED", value)
+        assert flags.calibration_env_enabled() is True
+
+    def test_enabled_requires_both_gates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CALIBRATION_ENABLED", "true")
+        monkeypatch.setattr(flags, "jwst_available", lambda: False)
+        assert flags.calibration_enabled() is False
+
+        monkeypatch.setattr(flags, "jwst_available", lambda: True)
+        assert flags.calibration_enabled() is True
+
+        monkeypatch.setenv("CALIBRATION_ENABLED", "false")
+        assert flags.calibration_enabled() is False
+
+    def test_jwst_available_matches_reality(self) -> None:
+        # The dev image builds with INSTALL_CALIBRATION=true, so jwst must be
+        # importable here — this also guards the pin resolving on py3.12.
+        assert flags.jwst_available() is True
+        assert flags.jwst_version() is not None
+
+
+class TestCapabilitiesEndpoint:
+    async def test_capabilities_enabled(
+        self, client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CALIBRATION_ENABLED", "true")
+        response = await client.get("/api/calibration/capabilities")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["calibrationEnabled"] is True
+        assert isinstance(body["jwstVersion"], str)
+
+    async def test_capabilities_disabled_via_env(
+        self, client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CALIBRATION_ENABLED", "false")
+        response = await client.get("/api/calibration/capabilities")
+        assert response.status_code == 200
+        assert response.json()["calibrationEnabled"] is False

--- a/processing-engine/tests/test_calibration_flags.py
+++ b/processing-engine/tests/test_calibration_flags.py
@@ -5,6 +5,8 @@
 Tests for the calibration feature gates and the capabilities endpoint.
 """
 
+import importlib.util
+
 import httpx
 import pytest
 
@@ -50,9 +52,13 @@ class TestFlags:
         monkeypatch.setenv("CALIBRATION_ENABLED", "false")
         assert flags.calibration_enabled() is False
 
+    @pytest.mark.skipif(
+        importlib.util.find_spec("jwst") is None,
+        reason="jwst layer not installed (CI pip env); Docker dev image runs this",
+    )
     def test_jwst_available_matches_reality(self) -> None:
         # The dev image builds with INSTALL_CALIBRATION=true, so jwst must be
-        # importable here — this also guards the pin resolving on py3.12.
+        # importable there — this also guards the pin resolving on py3.12.
         assert flags.jwst_available() is True
         assert flags.jwst_version() is not None
 
@@ -61,12 +67,26 @@ class TestCapabilitiesEndpoint:
     async def test_capabilities_enabled(
         self, client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # Endpoint logic is tested independent of whether the jwst layer is
+        # installed in this environment (CI pip env lacks it; Docker has it).
         monkeypatch.setenv("CALIBRATION_ENABLED", "true")
+        monkeypatch.setattr(flags, "jwst_available", lambda: True)
+        monkeypatch.setattr(flags, "jwst_version", lambda: "2.0.1")
         response = await client.get("/api/calibration/capabilities")
         assert response.status_code == 200
         body = response.json()
         assert body["calibrationEnabled"] is True
-        assert isinstance(body["jwstVersion"], str)
+        assert body["jwstVersion"] == "2.0.1"
+
+    async def test_capabilities_disabled_when_jwst_missing(
+        self, client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CALIBRATION_ENABLED", "true")
+        monkeypatch.setattr(flags, "jwst_available", lambda: False)
+        monkeypatch.setattr(flags, "jwst_version", lambda: None)
+        response = await client.get("/api/calibration/capabilities")
+        assert response.status_code == 200
+        assert response.json() == {"calibrationEnabled": False, "jwstVersion": None}
 
     async def test_capabilities_disabled_via_env(
         self, client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

PR 4 of the Calibration Recipes feature (plan: `docs/plans/features/1709-calibration-recipes.md`). Lands the STScI `jwst` pipeline dependency behind a build arg, the runtime feature gate, and CRDS wiring — the infrastructure PR 5's executor runs on.

## Changes Made

- **`requirements-calibration.txt`** (new): `jwst==2.0.1` — the JWPipeNB Build 12.3 notebook vintage that the seed recipes were derived from. Bumps happen deliberately alongside seed review.
- **`Dockerfile`**: `ARG INSTALL_CALIBRATION=true` gates a separate pip layer AFTER base requirements (jwst resolves against the pinned numpy/astropy; comment documents that base-dep changes rebuild this layer — accepted cost). `/app/data/crds` created. **Image size: 8.1GB → 10.3GB with the layer; CE builds pass `false` and are unaffected.**
- **`docker-compose.ce.yml`**: `INSTALL_CALIBRATION: "false"` — CE is triple-gated (no jwst in image, no env flag, router never mounted).
- **`docker-compose.yml`**: `CALIBRATION_ENABLED` (default true for dev), `CRDS_PATH=/app/data/crds` (lives on the data volume; grows GBs per instrument — never delete casually), `CRDS_SERVER_URL`, `MAX_CONCURRENT_CALIBRATIONS=1`.
- **`app/calibration/flags.py`** (new): `calibration_enabled()` = env gate × jwst importability. Env read is uncached (operator/test flippable); jwst availability is `lru_cache`d (image contents are fixed).
- **`app/calibration/routes.py`**: `GET /api/calibration/capabilities` → `{calibrationEnabled, jwstVersion}` (anonymous — frontend feature discovery; camelCase wire).
- **Tests** (9 new): env-gate matrix, both-gates-required, jwst-importability guard (doubles as a pin-resolution check), capabilities enabled/disabled.

## Test Plan

- [x] Docker build with the jwst layer succeeds on `python:3.12-slim` (wheels only, no compile failures); `import jwst` verified in-container
- [x] `docker exec jwst-processing python -m pytest tests/test_calibration_flags.py tests/test_calibration_recipes.py` — 36/36
- [x] Full engine suite — 1644 passed
- [ ] Reviewer: `docker compose up -d --build` (expect a long first build), then `curl localhost:8000/api/calibration/capabilities` → `{"calibrationEnabled":true,"jwstVersion":"2.0.1"}`; set `CALIBRATION_ENABLED=false` in `.env`, recreate, expect `false`

## Documentation Checklist

- [x] `.env.example` documents the three new vars with operational warnings
- [ ] `docs/setup-guide.md` CRDS/first-run expectations — PR 10 docs sweep

## Tech Debt Impact

- [x] No new tech debt. The 10.3GB dev image is the accepted cost of same-container v1 (worker extraction path documented in the plan); CE image unchanged.

## Risk & Rollback

- **Risk: LOW-MED.** No behavioral change to existing routes; the run endpoints that consume the flag land in PR 5. Watch-items: image size (build-arg escape hatch exists) and CRDS being a live external dependency at run time (lazy, first-run-only downloads).
- **Rollback:** revert; optionally rebuild without the layer via `INSTALL_CALIBRATION=false`.

Part of #1709 (umbrella stays open). No linked issue to close.

https://claude.ai/code/session_01W5ZRaEbzFmit1DQs1nfP66
