### PR TITLE
feat: full uncal pipeline + MAST input source (#1709 PR 6)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -204,3 +204,5 @@ CRDS_SERVER_URL=https://jwst-crds.stsci.edu
 # Concurrent calibration runs (each is multi-core and RAM-heavy; keep at 1
 # unless the host has headroom).
 MAX_CONCURRENT_CALIBRATIONS=1
+# Per-stage timeout for calibration pipeline runs (seconds).
+CALIBRATION_TIMEOUT_S=14400

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -124,6 +124,9 @@ services:
       - CRDS_PATH=/app/data/crds
       - CRDS_SERVER_URL=${CRDS_SERVER_URL:-https://jwst-crds.stsci.edu}
       - MAX_CONCURRENT_CALIBRATIONS=${MAX_CONCURRENT_CALIBRATIONS:-1}
+      # Per-stage ceiling for calibration pipeline runs (relaxed-threshold
+      # posture — Detector1 on deep exposures can legitimately take hours).
+      - CALIBRATION_TIMEOUT_S=${CALIBRATION_TIMEOUT_S:-14400}
     volumes:
       - ../data:/app/data
     depends_on:

--- a/processing-engine/app/calibration/executor.py
+++ b/processing-engine/app/calibration/executor.py
@@ -1,11 +1,14 @@
 # Copyright (c) JWST Data Analysis. All rights reserved.
 # Licensed under the MIT License.
 
-"""Stage-3 fast-path executor (#1709 PR 5).
+"""Calibration executor (#1709 PRs 5-6).
 
-Runs ``Image3Pipeline`` on already-calibrated Level-2 ``_cal`` files from the
-library, producing drizzled ``_i2d`` mosaics. Detector1/Image2 (full uncal
-path) land in PR 6.
+Runs a recipe's enabled stage chain: the stage-3 fast path (``Image3Pipeline``
+on library ``_cal`` files → drizzled ``_i2d`` mosaics) or the full
+``Detector1 → Image2 → Image3`` reduction from raw ``_uncal`` files fetched
+via the recipe's MAST query. Each stage runs under a per-stage timeout
+(``CALIBRATION_TIMEOUT_S``); file handoff between stages is by suffix
+(``_uncal`` → ``_rate`` → ``_cal`` → ``_i2d``) inside the per-job workdir.
 
 Security posture (requirement recorded in the plan, from the PR 3 review):
 recipes/run overrides are scalar-only by schema, but scalar strings can be
@@ -16,7 +19,10 @@ strings) are rejected before anything reaches ``Pipeline.call``.
 Cancellation is cooperative at stage boundaries: ``Pipeline.call`` is a
 monolithic C-accelerated run we do not kill mid-flight in v1. A cancel
 request is honored before the run starts and after it returns (outputs are
-then discarded).
+then discarded). A stage TIMEOUT likewise cannot kill the worker thread —
+the job fails but the orphaned thread keeps the concurrency permit (held,
+not released) so MAX_CONCURRENT_CALIBRATIONS still bounds memory; the slot
+frees on engine restart. Subprocess isolation is the tracked long-term fix.
 """
 
 import asyncio
@@ -39,12 +45,42 @@ from app.storage.helpers import resolve_fits_path, validate_fits_file_size
 logger = logging.getLogger(__name__)
 
 # Steps the executor will pass through to each pipeline stage. Anything not
-# listed is rejected — this is the executable-surface allowlist.
+# listed is rejected — this is the executable-surface allowlist. Flat run
+# overrides are applied to EVERY enabled stage that allows the step (only
+# "resample" exists in two stages; its params are stage-appropriate either way).
 ALLOWED_STEPS: dict[str, frozenset[str]] = {
+    "detector1": frozenset(
+        {
+            "group_scale",
+            "dq_init",
+            "emicorr",
+            "saturation",
+            "ipc",
+            "superbias",
+            "refpix",
+            "rscd",
+            "firstframe",
+            "lastframe",
+            "linearity",
+            "dark_current",
+            "reset",
+            "persistence",
+            "charge_migration",
+            "jump",
+            "clean_flicker_noise",
+            "ramp_fit",
+            "gain_scale",
+        }
+    ),
+    "image2": frozenset({"bkg_subtract", "assign_wcs", "flat_field", "photom", "resample"}),
     "image3": frozenset(
         {"assign_mtwcs", "tweakreg", "skymatch", "outlier_detection", "resample", "source_catalog"}
     ),
 }
+
+# Intermediate products each stage consumes/produces (file handoff).
+_STAGE_INPUT_SUFFIX = {"detector1": "_uncal", "image2": "_rate", "image3": "_cal"}
+_RUNNABLE_STAGES = ("detector1", "image2", "image3")
 
 # Run-control/behavior params the executor owns or that smuggle behavior:
 # output_* / suffix / input_dir break workdir confinement (a bare relative
@@ -175,6 +211,8 @@ class _JobLogHandler(logging.Handler):
         self._buffer: list[str] = []
         self._sent = 0
         self._last_submission = None
+        # Updated by the stage loop; prefixes parsed step boundaries.
+        self.current_stage = "run"
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
@@ -188,7 +226,7 @@ class _JobLogHandler(logging.Handler):
             step, event = match.group("step"), match.group("event")
             self._submit(
                 self._ctx.set_progress(
-                    current_stage=f"image3:{step}",
+                    current_stage=f"{self.current_stage}:{step}",
                     message=f"{step} {'running' if event == 'running' else 'complete'}",
                 )
             )
@@ -257,21 +295,128 @@ def _run_image3_sync(
     )
 
 
-async def run_stage3_job(
+def _run_per_file_stage_sync(
+    stage_name: str, input_paths: list[Path], steps: dict, workdir: Path
+) -> None:
+    """Blocking Detector1/Image2 invocation, one file at a time."""
+    from jwst.pipeline import Detector1Pipeline, Image2Pipeline
+
+    pipeline_cls = {"detector1": Detector1Pipeline, "image2": Image2Pipeline}[stage_name]
+    for path in input_paths:
+        pipeline_cls.call(
+            str(path),
+            steps=steps,
+            output_dir=str(workdir),
+            save_results=True,
+        )
+
+
+def _stage_timeout_seconds() -> float:
+    # Relaxed-threshold posture (like the CE render timeout): generous
+    # per-stage ceiling so slow-but-progressing runs aren't killed.
+    return float(os.environ.get("CALIBRATION_TIMEOUT_S", "14400"))
+
+
+def _download_mast_inputs_sync(query, dest: Path, progress_callback=None) -> list[Path]:
+    """Download the recipe's MAST inputs (JWPipeNB idiom): query by proposal
+    (+observation), filter products by suffix/calib level, download per file."""
+    from astroquery.mast import Observations
+
+    criteria: dict[str, Any] = {"proposal_id": query.proposal_id, "obs_collection": "JWST"}
+    if query.filters:
+        criteria["filters"] = list(query.filters)
+    obs_table = Observations.query_criteria(**criteria)
+    if query.observation:
+        # JWST obs_ids embed the observation as "-oNNN" (e.g. jw02739-o001_...).
+        token = f"-o{query.observation.zfill(3)}"
+        mask = [token in str(row) for row in obs_table["obs_id"]]
+        obs_table = obs_table[mask]
+    if len(obs_table) == 0:
+        raise RecipeValidationError("no MAST observations matched the recipe query")
+
+    products = Observations.get_product_list(obs_table)
+    sub_groups = [s.lstrip("_").upper() for s in query.product_suffixes]
+    filtered = Observations.filter_products(
+        products,
+        productSubGroupDescription=sub_groups,
+        calib_level=[query.calib_level],
+    )
+    if len(filtered) == 0:
+        raise RecipeValidationError("no MAST products matched the recipe query")
+    if len(filtered) > MAX_CALIBRATION_INPUTS:
+        raise RecipeValidationError(
+            f"MAST query matched too many products ({len(filtered)} > {MAX_CALIBRATION_INPUTS})"
+        )
+
+    from app.storage.helpers import MAX_FITS_FILE_SIZE_BYTES
+
+    oversized = [
+        str(p["productFilename"])
+        for p in filtered
+        if int(p["size"] or 0) > MAX_FITS_FILE_SIZE_BYTES
+    ]
+    if oversized:
+        raise RecipeValidationError(
+            f"products exceed MAX_FITS_FILE_SIZE_MB before download: {oversized[:3]}"
+        )
+
+    dest.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    total = len(filtered)
+    for index, product in enumerate(filtered):
+        if progress_callback:
+            progress_callback(str(product["productFilename"]), index, total)
+        manifest = Observations.download_products(
+            filtered[index : index + 1], download_dir=str(dest)
+        )
+        paths.extend(Path(p) for p in manifest["Local Path"])
+    if progress_callback:
+        progress_callback("done", total, total)
+    return paths
+
+
+def _enabled_stages(recipe: CalibrationRecipe) -> list:
+    stages = [s for s in recipe.stages if s.enabled and s.name in _RUNNABLE_STAGES]
+    if not stages:
+        raise RecipeValidationError("recipe has no enabled runnable stages")
+    return stages
+
+
+def _assign_run_overrides(stages: list, run_overrides: dict) -> dict[str, dict]:
+    """Assign flat run overrides to every enabled stage that allows the step;
+    reject steps no enabled stage accepts."""
+    per_stage: dict[str, dict] = {s.name: {} for s in stages}
+    for step, params in run_overrides.items():
+        matched = False
+        for stage in stages:
+            if step in ALLOWED_STEPS[stage.name]:
+                per_stage[stage.name][step] = params
+                matched = True
+        if not matched:
+            raise RecipeValidationError(f"step '{step}' is not allowed in any enabled stage")
+    return per_stage
+
+
+async def run_calibration_job(
     ctx: JobContext,
     recipe: CalibrationRecipe,
     input_keys: list[str],
     run_overrides: dict,
 ) -> JobResult:
-    """Job work function (see app/jobs/runner.py) for a stage-3-only run."""
-    stage = next((s for s in recipe.stages if s.name == "image3" and s.enabled), None)
-    if stage is None:
-        raise RecipeValidationError("recipe has no enabled image3 stage")
-
-    validate_step_overrides("image3", stage.step_overrides)
-    validate_step_overrides("image3", run_overrides)
-    steps = merge_overrides(stage.step_overrides, run_overrides)
-    step_names = sorted(ALLOWED_STEPS["image3"])
+    """Job work function (see app/jobs/runner.py): runs the recipe's enabled
+    stage chain. Inputs come from library storage keys when given, otherwise
+    from the recipe's MAST query (downloaded into the job workdir)."""
+    stages = _enabled_stages(recipe)
+    per_stage_run = _assign_run_overrides(stages, run_overrides)
+    merged_by_stage: dict[str, dict] = {}
+    all_step_names: set[str] = set()
+    for stage in stages:
+        validate_step_overrides(stage.name, stage.step_overrides)
+        validate_step_overrides(stage.name, per_stage_run[stage.name])
+        merged_by_stage[stage.name] = merge_overrides(
+            stage.step_overrides, per_stage_run[stage.name]
+        )
+        all_step_names.update(ALLOWED_STEPS[stage.name])
 
     work_root = _work_root()
     work_root.mkdir(parents=True, exist_ok=True)
@@ -282,56 +427,92 @@ async def run_stage3_job(
             f"too many inputs ({len(input_keys)} > {MAX_CALIBRATION_INPUTS})"
         )
 
-    # Resolve inputs BEFORE claiming a run slot (fails fast on bad keys).
-    # NOTE trust boundary: keys are only traversal-guarded — the library is
-    # shared/public today and the engine has no per-user file ownership.
-    # Per-user input authorization is tracked for when ownership lands.
-    input_paths = [resolve_fits_path(key) for key in input_keys]
-    for path in input_paths:
-        validate_fits_file_size(path)
-
     workdir = work_root / ctx.job_id
     workdir.mkdir(parents=True, exist_ok=True)
     loop = asyncio.get_running_loop()
-    handler = _JobLogHandler(loop, ctx, step_names)
+    handler = _JobLogHandler(loop, ctx, sorted(all_step_names))
     stpipe_logger = logging.getLogger("stpipe")
 
-    await ctx.raise_if_cancelled()
-    await ctx.set_progress(current_stage="image3", message="waiting for a run slot")
-
-    semaphore = _get_semaphore()
     try:
+        await ctx.raise_if_cancelled()
+        stage_list = [{"name": s.name, "status": "pending"} for s in stages]
+        await ctx.set_progress(stages=stage_list, message="preparing inputs")
+
+        if input_keys:
+            # Library inputs. NOTE trust boundary: keys are only
+            # traversal-guarded — the library is shared/public today and the
+            # engine has no per-user file ownership (#1719).
+            input_paths = [resolve_fits_path(key) for key in input_keys]
+        else:
+            input_paths = await _download_inputs(ctx, recipe, workdir)
+        for path in input_paths:
+            validate_fits_file_size(path)
+
+        await ctx.set_progress(message="waiting for a run slot")
+        semaphore = _get_semaphore()
         await asyncio.to_thread(semaphore.acquire)
+        release_permit = True
         # Everything after a successful acquire sits inside this try so the
         # permit can never leak (a cancel/Mongo error in the pre-run window
         # would otherwise burn the only slot permanently).
         try:
-            await ctx.raise_if_cancelled()
-            await ctx.set_progress(current_stage="image3", message="running Image3Pipeline")
             # stpipe's logger inherits the root level; make sure INFO step
             # boundaries reach our handler, restoring the level afterwards.
             previous_level = stpipe_logger.level
             stpipe_logger.setLevel(logging.INFO)
             stpipe_logger.addHandler(handler)
             try:
-                await asyncio.to_thread(
-                    _run_image3_sync,
-                    input_paths,
-                    steps,
-                    recipe.association.product_name,
-                    workdir,
+                current = input_paths
+                for index, stage in enumerate(stages):
+                    await ctx.raise_if_cancelled()
+                    handler.current_stage = stage.name
+                    stage_list[index]["status"] = "running"
+                    await ctx.set_progress(
+                        stages=stage_list,
+                        current_stage=stage.name,
+                        message=f"running {stage.name}",
+                    )
+                    current = await asyncio.wait_for(
+                        _run_stage(
+                            stage.name,
+                            current,
+                            merged_by_stage[stage.name],
+                            recipe,
+                            workdir,
+                        ),
+                        timeout=_stage_timeout_seconds(),
+                    )
+                    stage_list[index]["status"] = "done"
+                    await ctx.set_progress(stages=stage_list)
+            except TimeoutError:
+                # asyncio.wait_for cannot kill the worker thread: the jwst run
+                # is STILL consuming the slot's CPU/RAM. Keep the permit so
+                # MAX_CONCURRENT_CALIBRATIONS keeps bounding memory; the slot
+                # frees on engine restart. Subprocess isolation is the real
+                # fix (tracked follow-up).
+                release_permit = False
+                logger.error(
+                    "Job %s: stage timed out; permit retained (orphaned pipeline thread)",
+                    ctx.job_id,
                 )
+                raise
             finally:
                 stpipe_logger.removeHandler(handler)
                 stpipe_logger.setLevel(previous_level)
                 handler.flush_remaining()
         finally:
-            semaphore.release()
+            if release_permit:
+                semaphore.release()
 
         if await ctx.store.is_cancel_requested(ctx.job_id):
             raise JobCancelled()
 
-        outputs = _persist_outputs(ctx.job_id, workdir, recipe.output_suffixes)
+        # Scope persistence to the terminal stage's products: in the full
+        # chain Image2 also emits per-exposure _i2d files into the workdir,
+        # which are intermediates, not the recipe's declared output.
+        terminal = stages[-1].name
+        prefix = recipe.association.product_name if terminal == "image3" else None
+        outputs = _persist_outputs(ctx.job_id, workdir, recipe.output_suffixes, name_prefix=prefix)
         if not outputs:
             raise RuntimeError(
                 f"pipeline completed but produced no {recipe.output_suffixes} outputs"
@@ -347,12 +528,65 @@ async def run_stage3_job(
         shutil.rmtree(workdir, ignore_errors=True)
 
 
-def _persist_outputs(job_id: str, workdir: Path, suffixes: list[str]) -> list[JobOutput]:
+# Backward-compatible name used by the run route/tests since PR 5.
+run_stage3_job = run_calibration_job
+
+
+async def _run_stage(
+    stage_name: str,
+    input_paths: list[Path],
+    steps: dict,
+    recipe: CalibrationRecipe,
+    workdir: Path,
+) -> list[Path]:
+    """Run one stage in a worker thread; return the next stage's inputs."""
+    if stage_name == "image3":
+        await asyncio.to_thread(
+            _run_image3_sync, input_paths, steps, recipe.association.product_name, workdir
+        )
+        return input_paths  # terminal stage; outputs collected by suffix later
+    await asyncio.to_thread(_run_per_file_stage_sync, stage_name, input_paths, steps, workdir)
+    produced_suffix = {"detector1": "_rate", "image2": "_cal"}[stage_name]
+    produced = sorted(
+        p for p in workdir.iterdir() if p.is_file() and p.stem.endswith(produced_suffix)
+    )
+    if not produced:
+        raise RuntimeError(f"stage {stage_name} produced no {produced_suffix} files")
+    return produced
+
+
+async def _download_inputs(ctx: JobContext, recipe: CalibrationRecipe, workdir: Path) -> list[Path]:
+    if recipe.input_source.type != "mast_query":
+        raise RecipeValidationError("recipe expects library inputs but none were provided")
+    from app.jobs.models import JobStatus
+
+    await ctx.set_status(JobStatus.DOWNLOADING)
+    loop = asyncio.get_running_loop()
+
+    def _progress(filename: str, current: int, total: int) -> None:
+        pct = round(100.0 * current / max(total, 1), 1)
+        asyncio.run_coroutine_threadsafe(
+            ctx.set_progress(download_pct=pct, message=f"downloading {filename}"),
+            loop,
+        )
+
+    paths = await asyncio.to_thread(
+        _download_mast_inputs_sync, recipe.input_source, workdir / "inputs", _progress
+    )
+    await ctx.set_status(JobStatus.RUNNING)
+    return paths
+
+
+def _persist_outputs(
+    job_id: str, workdir: Path, suffixes: list[str], name_prefix: str | None = None
+) -> list[JobOutput]:
     storage = get_storage_provider()
     outputs: list[JobOutput] = []
     for path in sorted(workdir.iterdir()):
         suffix = next((s for s in suffixes if path.stem.endswith(s)), None)
         if suffix is None or not path.is_file():
+            continue
+        if name_prefix is not None and not path.name.startswith(name_prefix):
             continue
         key = f"{OUTPUT_PREFIX}/{job_id}/{path.name}"
         storage.write_from_path(key, path)

--- a/processing-engine/app/calibration/routes.py
+++ b/processing-engine/app/calibration/routes.py
@@ -99,10 +99,13 @@ async def start_run(
     store: RecipeStore = Depends(get_recipe_store),
     job_store: JobStore = Depends(get_job_store),
 ):
-    """Start a stage-3 calibration run. Returns {jobId}; poll /api/jobs/{id}."""
+    """Start a calibration run (stage-3 fast path on library inputs, or the
+    recipe's full MAST-driven chain). Returns {jobId}; poll /api/jobs/{id}."""
     from app.calibration.executor import (
         RecipeValidationError,
-        run_stage3_job,
+        _assign_run_overrides,
+        _enabled_stages,
+        run_calibration_job,
         validate_step_overrides,
     )
     from app.calibration.flags import calibration_enabled
@@ -120,12 +123,10 @@ async def start_run(
     from app.calibration.executor import MAX_CALIBRATION_INPUTS
 
     recipe_id = payload.get("recipeId")
-    input_keys = payload.get("inputs")
+    input_keys = payload.get("inputs") or []
     run_overrides = payload.get("runOverrides") or {}
-    if not recipe_id or not isinstance(input_keys, list) or not input_keys:
-        raise HTTPException(
-            status_code=422, detail="recipeId and a non-empty inputs list are required"
-        )
+    if not recipe_id or not isinstance(input_keys, list):
+        raise HTTPException(status_code=422, detail="recipeId is required; inputs must be a list")
     if len(input_keys) > MAX_CALIBRATION_INPUTS:
         raise HTTPException(
             status_code=422,
@@ -139,12 +140,19 @@ async def start_run(
 
     try:
         # Scalar-only shape check (schema validator), then the executor's
-        # allowlist/path checks — both BEFORE a job record exists.
-        StageConfig(name="image3", step_overrides=run_overrides)
-        validate_step_overrides("image3", run_overrides)
+        # allowlist/path checks per enabled stage — all BEFORE a job exists.
+        StageConfig(name="image3", step_overrides=run_overrides)  # shape only
+        stages = _enabled_stages(recipe)
+        per_stage = _assign_run_overrides(stages, run_overrides)
+        for stage in stages:
+            validate_step_overrides(stage.name, per_stage[stage.name])
         for key in input_keys:
             if not isinstance(key, str):
                 raise RecipeValidationError("inputs must be storage-key strings")
+        if not input_keys and recipe.input_source.type != "mast_query":
+            raise RecipeValidationError(
+                "this recipe takes library inputs — provide a non-empty inputs list"
+            )
     except (ValidationError, RecipeValidationError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -160,7 +168,7 @@ async def start_run(
     )
 
     async def work(ctx):
-        return await run_stage3_job(ctx, recipe, list(input_keys), run_overrides)
+        return await run_calibration_job(ctx, recipe, list(input_keys), run_overrides)
 
     job_id = await launch(job_store, job, work)
     return {"jobId": job_id}

--- a/processing-engine/app/jobs/store.py
+++ b/processing-engine/app/jobs/store.py
@@ -71,10 +71,14 @@ class JobStore:
         return bool(doc and doc.get("cancel_requested"))
 
     async def set_status(self, job_id: str, status: JobStatus) -> None:
-        update: dict[str, Any] = {"status": status.value}
+        await self._col.update_one({"job_id": job_id}, {"$set": {"status": status.value}})
         if status is JobStatus.RUNNING:
-            update["started_at"] = _now_iso()
-        await self._col.update_one({"job_id": job_id}, {"$set": update})
+            # Stamp started_at only on the FIRST running transition — a job
+            # returning from DOWNLOADING must not shift its start time.
+            await self._col.update_one(
+                {"job_id": job_id, "started_at": None},
+                {"$set": {"started_at": _now_iso()}},
+            )
 
     async def set_progress(
         self,

--- a/processing-engine/tests/test_calibration_executor.py
+++ b/processing-engine/tests/test_calibration_executor.py
@@ -2,9 +2,10 @@
 # Licensed under the MIT License.
 
 """
-Tests for the stage-3 executor: the security allowlist, override merging,
-the full job lifecycle against a FAKE Image3Pipeline (no jwst run in CI),
-log-line parsing, and the /api/calibration/runs endpoint.
+Tests for the calibration executor: the security allowlist, override merging,
+job lifecycles for the stage-3 fast path AND the full Detector1->Image2->Image3
+chain (all against FAKE pipeline invocations — no jwst run in CI), MAST input
+download, log-line parsing, and the /api/calibration/runs endpoint.
 """
 
 import time
@@ -95,8 +96,9 @@ class TestValidateStepOverrides:
         )
 
     def test_unknown_stage_rejected(self) -> None:
+        # coron3 is schema-reserved but not runnable until Phase 2.
         with pytest.raises(RecipeValidationError, match="not runnable"):
-            validate_step_overrides("detector1", {})
+            validate_step_overrides("coron3", {})
 
     def test_disallowed_step_rejected(self) -> None:
         with pytest.raises(RecipeValidationError, match="not allowed"):
@@ -257,7 +259,7 @@ class TestRunStage3Job:
         recipe = make_recipe(stages=[{"name": "image3", "enabled": False, "step_overrides": {}}])
         doc = await _run_to_terminal(store, recipe, ["k"], {})
         assert doc["status"] == "failed"
-        assert "no enabled image3" in doc["error"]
+        assert "no enabled runnable stages" in doc["error"]
 
     async def test_bad_run_override_fails_before_pipeline(
         self, store: JobStore, fake_pipeline
@@ -336,6 +338,237 @@ class TestRunStage3Job:
         doc = await _run_to_terminal(store, make_recipe(), ["k"], {})
         assert doc["status"] == "failed"
         assert "insufficient disk space" in doc["error"]
+
+
+def make_full_recipe(**overrides) -> CalibrationRecipe:
+    payload = {
+        "id": "test-full",
+        "name": "Full chain test",
+        "instrument": "nircam",
+        "input_source": {
+            "type": "mast_query",
+            "proposal_id": "2739",
+            "observation": "001",
+            "filters": ["F200W"],
+            "calib_level": 1,
+            "product_suffixes": ["_uncal"],
+        },
+        "stages": [
+            {
+                "name": "detector1",
+                "enabled": True,
+                "step_overrides": {"jump": {"maximum_cores": "half"}},
+            },
+            {"name": "image2", "enabled": True, "step_overrides": {}},
+            {"name": "image3", "enabled": True, "step_overrides": {}},
+        ],
+        "association": {"rule": "DMS_Level3_Base", "product_name": "full-product"},
+    }
+    payload.update(overrides)
+    return CalibrationRecipe.model_validate(payload)
+
+
+@pytest.fixture()
+def fake_full_chain(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Fake per-file stages + image3 + MAST download for full-chain tests."""
+    calls: dict = {"stages": []}
+
+    def _fake_per_file(stage_name, input_paths, steps, workdir):
+        calls["stages"].append(stage_name)
+        calls[f"{stage_name}_steps"] = steps
+        suffix = {"detector1": "_rate", "image2": "_cal"}[stage_name]
+        for i, _ in enumerate(input_paths):
+            (Path(workdir) / f"f{i}{suffix}.fits").write_bytes(b"X")
+
+    def _fake_image3(input_paths, steps, product_name, workdir):
+        calls["stages"].append("image3")
+        calls["image3_inputs"] = [p.name for p in input_paths]
+        (Path(workdir) / f"{product_name}_i2d.fits").write_bytes(b"FAKE_I2D")
+
+    def _fake_download(query, dest, progress_callback=None):
+        calls["query"] = query
+        dest.mkdir(parents=True, exist_ok=True)
+        if progress_callback:
+            progress_callback("a_uncal.fits", 0, 2)
+            progress_callback("b_uncal.fits", 1, 2)
+            progress_callback("done", 2, 2)
+        paths = [dest / "a_uncal.fits", dest / "b_uncal.fits"]
+        for p in paths:
+            p.write_bytes(b"RAW")
+        return paths
+
+    monkeypatch.setattr(executor, "_run_per_file_stage_sync", _fake_per_file)
+    monkeypatch.setattr(executor, "_run_image3_sync", _fake_image3)
+    monkeypatch.setattr(executor, "_download_mast_inputs_sync", _fake_download)
+    monkeypatch.setattr(executor, "_jwst_version", lambda: "2.0.1-fake")
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(executor, "get_storage_provider", lambda: fake_storage)
+    return calls, fake_storage
+
+
+class TestFullChain:
+    async def test_full_chain_downloads_and_runs_all_stages(
+        self, store: JobStore, fake_full_chain
+    ) -> None:
+        calls, fake_storage = fake_full_chain
+        doc = await _run_to_terminal(store, make_full_recipe(), [], {})
+        assert doc["status"] == "succeeded"
+        assert calls["stages"] == ["detector1", "image2", "image3"]
+        # Detector1 consumed the two downloaded uncal files → image3 got cals.
+        assert sorted(calls["image3_inputs"]) == ["f0_cal.fits", "f1_cal.fits"]
+        assert calls["detector1_steps"] == {"jump": {"maximum_cores": "half"}}
+        # Download progress was reported before the run.
+        assert doc["progress"]["download_pct"] == 100.0
+        # Stage checklist fully done.
+        assert [s["status"] for s in doc["progress"]["stages"]] == ["done"] * 3
+        [output] = doc["result"]["outputs"]
+        assert output["suffix"] == "_i2d"
+        assert fake_storage.written[output["storage_key"]] == b"FAKE_I2D"
+
+    async def test_stage_toggles_skip_disabled(
+        self, store: JobStore, fake_full_chain, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls, _ = fake_full_chain
+        # detector1+image2 disabled → stage3-only over provided library inputs.
+        recipe = make_full_recipe(
+            stages=[
+                {"name": "detector1", "enabled": False, "step_overrides": {}},
+                {"name": "image2", "enabled": False, "step_overrides": {}},
+                {"name": "image3", "enabled": True, "step_overrides": {}},
+            ]
+        )
+        fits = Path(executor._work_root()).parent / "lib_cal.fits"
+        fits.parent.mkdir(parents=True, exist_ok=True)
+        fits.write_bytes(b"CAL")
+        monkeypatch.setattr(executor, "resolve_fits_path", lambda _key: fits)
+        doc = await _run_to_terminal(store, recipe, ["lib_cal.fits"], {})
+        assert doc["status"] == "succeeded"
+        assert calls["stages"] == ["image3"]
+
+    @pytest.mark.usefixtures("fake_full_chain")
+    async def test_download_failure_fails_job(
+        self, store: JobStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(query, dest, progress_callback=None):
+            raise RuntimeError("MAST is down")
+
+        monkeypatch.setattr(executor, "_download_mast_inputs_sync", _boom)
+        doc = await _run_to_terminal(store, make_full_recipe(), [], {})
+        assert doc["status"] == "failed"
+        assert "MAST is down" in doc["error"]
+
+    async def test_cancel_between_stages(
+        self, store: JobStore, fake_full_chain, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls, fake_storage = fake_full_chain
+
+        def _cancel_during_det1(stage_name, input_paths, steps, workdir):
+            calls["stages"].append(stage_name)
+            for i, _ in enumerate(input_paths):
+                (Path(workdir) / f"f{i}_rate.fits").write_bytes(b"X")
+            # Cancel lands while detector1 runs; observed at the next boundary.
+            import asyncio as _a
+
+            _a.run_coroutine_threadsafe(
+                store.request_cancel(calls["job_id"], USER), calls["loop"]
+            ).result()
+
+        monkeypatch.setattr(executor, "_run_per_file_stage_sync", _cancel_during_det1)
+
+        import asyncio
+
+        job = JobRecord(type="calibration", user_id=USER, request={})
+
+        async def work(ctx):
+            calls["job_id"] = ctx.job_id
+            calls["loop"] = asyncio.get_running_loop()
+            return await run_stage3_job(ctx, make_full_recipe(), [], {})
+
+        job_id = await launch(store, job, work)
+        async with asyncio.timeout(10):
+            while (await store.get(job_id))["status"] not in (
+                "succeeded",
+                "failed",
+                "cancelled",
+            ):
+                await asyncio.sleep(0.02)
+        doc = await store.get(job_id)
+        assert doc["status"] == "cancelled"
+        # image3 never ran; nothing persisted.
+        assert "image3" not in calls["stages"][1:] or calls["stages"] == ["detector1"]
+        assert fake_storage.written == {}
+
+    @pytest.mark.usefixtures("fake_full_chain")
+    async def test_stage_timeout_fails_job(
+        self, store: JobStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CALIBRATION_TIMEOUT_S", "0.05")
+
+        def _slow(stage_name, input_paths, steps, workdir):
+            import time as _t
+
+            _t.sleep(0.5)
+
+        monkeypatch.setattr(executor, "_run_per_file_stage_sync", _slow)
+        doc = await _run_to_terminal(store, make_full_recipe(), [], {})
+        assert doc["status"] == "failed"
+
+    async def test_intermediate_i2d_products_not_persisted(
+        self, store: JobStore, fake_full_chain, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls, fake_storage = fake_full_chain
+
+        def _fake_image2_with_i2d(stage_name, input_paths, steps, workdir):
+            calls["stages"].append(stage_name)
+            suffix = {"detector1": "_rate", "image2": "_cal"}[stage_name]
+            for i, _ in enumerate(input_paths):
+                (Path(workdir) / f"f{i}{suffix}.fits").write_bytes(b"X")
+            if stage_name == "image2":
+                # Image2's resample emits per-exposure _i2d intermediates.
+                (Path(workdir) / "f0_i2d.fits").write_bytes(b"INTERMEDIATE")
+
+        monkeypatch.setattr(executor, "_run_per_file_stage_sync", _fake_image2_with_i2d)
+        doc = await _run_to_terminal(store, make_full_recipe(), [], {})
+        assert doc["status"] == "succeeded"
+        keys = [o["storage_key"] for o in doc["result"]["outputs"]]
+        assert len(keys) == 1
+        assert keys[0].endswith("full-product_i2d.fits")
+
+    @pytest.mark.usefixtures("fake_full_chain")
+    async def test_started_at_not_restamped_after_download(self, store: JobStore) -> None:
+        import asyncio
+
+        job = JobRecord(type="calibration", user_id=USER, request={})
+        first_started = {}
+
+        async def work(ctx):
+            doc = await store.get(ctx.job_id)
+            first_started["value"] = doc["started_at"]
+            await asyncio.sleep(0.05)  # make a re-stamp observable
+            return await run_stage3_job(ctx, make_full_recipe(), [], {})
+
+        job_id = await launch(store, job, work)
+        async with asyncio.timeout(10):
+            while (await store.get(job_id))["status"] not in (
+                "succeeded",
+                "failed",
+                "cancelled",
+            ):
+                await asyncio.sleep(0.02)
+        doc = await store.get(job_id)
+        assert doc["status"] == "succeeded"
+        # DOWNLOADING -> RUNNING must not shift the original start time.
+        assert doc["started_at"] == first_started["value"]
+
+    @pytest.mark.usefixtures("fake_full_chain")
+    async def test_override_step_not_in_any_enabled_stage_fails(self, store: JobStore) -> None:
+        recipe = make_full_recipe(
+            stages=[{"name": "image3", "enabled": True, "step_overrides": {}}]
+        )
+        doc = await _run_to_terminal(store, recipe, [], {"jump": {"maximum_cores": "half"}})
+        assert doc["status"] == "failed"
+        assert "not allowed in any enabled stage" in doc["error"]
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

PR 6 of the Calibration Recipes feature (plan: `docs/plans/features/1709-calibration-recipes.md`). The executor now runs the recipe's **full enabled stage chain** — Detector1 → Image2 → Image3 from raw `_uncal` files fetched via the recipe's MAST query — completing the server-side pipeline story. The stage-3 fast path from PR 5 is unchanged (it's the same runner with only image3 enabled).

## Changes Made

- **`app/calibration/executor.py`**: `run_calibration_job` (alias `run_stage3_job` kept) — enabled-stage chain with per-stage `asyncio.wait_for(CALIBRATION_TIMEOUT_S)` (default 4h, relaxed posture), stage checklist progress, cancel checks at stage boundaries, file handoff by suffix (`_uncal`→`_rate`→`_cal`); `ALLOWED_STEPS` gains the detector1/image2 step sets; `_download_mast_inputs_sync` implements the JWPipeNB idiom (proposal/observation/filter query → suffix+calib-level product filter → per-file download with progress + `DOWNLOADING` status) with **pre-download size checks** against the product table and the input-count cap.
- **Review fixes (round 1 → all-clear round 2)**: terminal-stage output scoping (Image2's per-exposure `_i2d` intermediates are not persisted — only the `product_name` mosaic); **timeout keeps the concurrency permit** (an orphaned pipeline thread still owns the slot's CPU/RAM, so `MAX_CONCURRENT_CALIBRATIONS` keeps bounding memory; documented; #1721 tracks killable-subprocess isolation); `started_at` stamped only on the first RUNNING transition; observation matching tightened to the JWST `-oNNN` token; log-parsed step boundaries carry the correct stage prefix.
- **`app/calibration/routes.py`**: `inputs` now optional for `mast_query` recipes (422 for library recipes without inputs); run overrides validated per enabled stage before job creation.
- **`app/jobs/store.py`**: `set_status` stamps `started_at` once (guarded update).
- **Compose/.env.example**: `CALIBRATION_TIMEOUT_S`.
- **Tests** (+9): full-chain download→3-stage run with checklist/progress assertions, toggle matrix, download failure, cancel-between-stages, per-stage timeout, override-not-in-any-enabled-stage, intermediate-`_i2d` pollution regression, `started_at` regression.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_calibration_executor.py` — 45/45
- [x] Full engine suite — 1690 passed
- [ ] Reviewer (optional, long): run the seeded NIRISS recipe end-to-end via `POST /api/calibration/runs {"recipeId":"seed-niriss-imaging"}` (no inputs → MAST download) and watch the DOWNLOADING → detector1 → image2 → image3 checklist

## Documentation Checklist

- [x] Module docstring covers the full chain + timeout accounting
- [ ] `docs/quick-reference.md` / setup guide — PR 10 docs sweep

## Tech Debt Impact

- [x] Follow-up filed: #1721 (killable subprocess stages — fixes orphan-thread timeout accounting and enables mid-run cancel)

## Risk & Rollback

- **Risk: MED.** Extends the run surface to hour-scale multi-stage jobs with live MAST+CRDS dependencies. Bounded by the same guards as PR 5 plus per-stage timeouts and pre-download size checks. Kill switch unchanged (`CALIBRATION_ENABLED=false`).
- **Rollback:** revert; stage-3 fast path unaffected conceptually (same runner).

Part of #1709 (umbrella stays open). No linked issue to close.

https://claude.ai/code/session_01W5ZRaEbzFmit1DQs1nfP66
