### PR TITLE
feat: calibration recipe gallery UI + engine-bound service (#1709 PR 7)

### DIFF
--- a/frontend/jwst-frontend/src/App.tsx
+++ b/frontend/jwst-frontend/src/App.tsx
@@ -40,6 +40,7 @@ const MosaicPage = lazy(() =>
 const SearchPage = lazy(() =>
   import('./pages/SearchPage').then((m) => ({ default: m.SearchPage }))
 );
+const CalibrationGallery = lazy(() => import('./pages/CalibrationGallery'));
 const ArchivePage = lazy(() =>
   import('./pages/ArchivePage').then((m) => ({ default: m.ArchivePage }))
 );
@@ -87,6 +88,7 @@ function App() {
               <Route path="create" element={<GuidedCreate />} />
               {/* semantic search is out of CE v1 (its API never mounts) */}
               {!CE_MODE && <Route path="search" element={<SearchPage />} />}
+              {!CE_MODE && <Route path="calibrate" element={<CalibrationGallery />} />}
               <Route path="archive" element={<ArchivePage />} />
               {/* CE review decision 2026-07-06: /library is a public
                   read-only view — mutations are gated inside the dashboard */}

--- a/frontend/jwst-frontend/src/components/layout/SharedLayout.tsx
+++ b/frontend/jwst-frontend/src/components/layout/SharedLayout.tsx
@@ -49,6 +49,11 @@ export function SharedLayout() {
               <NavLink to="/library" className="nav-link">
                 {CE_MODE ? 'Library' : 'My Library'}
               </NavLink>
+              {!CE_MODE && (
+                <NavLink to="/calibrate" className="nav-link">
+                  Calibrate
+                </NavLink>
+              )}
             </nav>
           </div>
           <div className="header-right">

--- a/frontend/jwst-frontend/src/config/engine.ts
+++ b/frontend/jwst-frontend/src/config/engine.ts
@@ -1,0 +1,11 @@
+/**
+ * Processing-engine base URL (direct frontend → Python engine calls).
+ *
+ * Calibration (and the generic jobs API) are served by the Python engine,
+ * not the .NET gateway — the frontend calls the engine directly per
+ * ADR-0001. Override via VITE_ENGINE_URL; defaults to the local engine.
+ */
+// !== undefined (not ||): an explicit empty string is a deliberate
+// same-origin/proxy opt-in and must not fall back to localhost.
+const envEngineUrl = import.meta.env.VITE_ENGINE_URL;
+export const ENGINE_BASE_URL = envEngineUrl !== undefined ? envEngineUrl : 'http://localhost:8000';

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.css
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.css
@@ -1,0 +1,104 @@
+.calibration-gallery {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.calibration-gallery-header h1 {
+  margin: 0 0 0.5rem;
+}
+
+.calibration-gallery-subtitle {
+  color: var(--text-muted);
+  max-width: 60ch;
+}
+
+.calibration-version {
+  white-space: nowrap;
+}
+
+.calibration-disabled-banner {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color, rgba(255, 200, 87, 0.4));
+  border-radius: 8px;
+  color: var(--text-muted);
+  background: rgba(255, 200, 87, 0.08);
+}
+
+.calibration-loading {
+  color: var(--text-muted);
+}
+
+.calibration-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.calibration-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+  border-radius: 10px;
+  background: var(--surface-raised, rgba(255, 255, 255, 0.03));
+}
+
+.calibration-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.calibration-instrument {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.calibration-badge {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.2));
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.calibration-card-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.calibration-card-description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  flex: 1;
+}
+
+.calibration-card-stages {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.calibration-stage-chip {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 6px;
+  background: rgba(120, 160, 255, 0.12);
+}
+
+.calibration-card-meta {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import CalibrationGallery, { CalibrationRecipeCard } from './CalibrationGallery';
+import type { CalibrationRecipe } from '../types/CalibrationTypes';
+
+vi.mock('../services/calibrationService', () => ({
+  listRecipes: vi.fn(),
+  getCapabilities: vi.fn(),
+}));
+
+import { getCapabilities, listRecipes } from '../services/calibrationService';
+
+const seedRecipe: CalibrationRecipe = {
+  id: 'seed-miri-imaging',
+  schema_version: 1,
+  name: 'MIRI Imaging (uncal → i2d mosaic)',
+  description: 'MIRI broadband imaging reduction.',
+  instrument: 'miri',
+  mode: 'imaging',
+  source: 'seed',
+  is_public: true,
+  provenance: { notebook_name: 'JWPipeNB-MIRI-imaging.ipynb', jwst_version_authored: '2.0.0' },
+  input_source: {
+    type: 'mast_query',
+    proposal_id: '1040',
+    observation: '001',
+    filters: ['F770W'],
+    calib_level: 1,
+    product_suffixes: ['_uncal'],
+  },
+  stages: [
+    { name: 'detector1', enabled: true, step_overrides: { jump: { maximum_cores: 'half' } } },
+    { name: 'image2', enabled: true, step_overrides: { bkg_subtract: { sigma: 2 } } },
+    { name: 'image3', enabled: false, step_overrides: {} },
+  ],
+  association: { rule: 'DMS_Level3_Base', product_name: 'miri-imaging' },
+  output_suffixes: ['_i2d'],
+  created_by: null,
+  created_at: '2026-07-23T00:00:00Z',
+  updated_at: '2026-07-23T00:00:00Z',
+};
+
+describe('CalibrationRecipeCard', () => {
+  it('renders instrument, curated badge, enabled stages, and meta', () => {
+    render(<CalibrationRecipeCard recipe={seedRecipe} />);
+    expect(screen.getByText('MIRI')).toBeInTheDocument();
+    expect(screen.getByText('Curated')).toBeInTheDocument();
+    // Only enabled stages render as chips.
+    expect(screen.getByText('detector1')).toBeInTheDocument();
+    expect(screen.getByText('image2')).toBeInTheDocument();
+    expect(screen.queryByText('image3')).not.toBeInTheDocument();
+    expect(screen.getByText('MAST PID 1040')).toBeInTheDocument();
+    expect(screen.getByText('2 tuned parameters')).toBeInTheDocument();
+    expect(screen.getByText('STScI notebook')).toBeInTheDocument();
+  });
+});
+
+describe('CalibrationGallery', () => {
+  it('renders recipes and the pipeline version', async () => {
+    vi.mocked(listRecipes).mockResolvedValue([seedRecipe]);
+    vi.mocked(getCapabilities).mockResolvedValue({
+      calibrationEnabled: true,
+      jwstVersion: '2.0.1',
+    });
+    render(<CalibrationGallery />);
+    await waitFor(() => expect(screen.getByTestId('calibration-recipe-card')).toBeInTheDocument());
+    expect(screen.getByText(/Pipeline v2\.0\.1/)).toBeInTheDocument();
+    expect(screen.queryByText(/runs are disabled on this deployment/)).not.toBeInTheDocument();
+  });
+
+  it('shows the disabled banner when calibration is off', async () => {
+    vi.mocked(listRecipes).mockResolvedValue([seedRecipe]);
+    vi.mocked(getCapabilities).mockResolvedValue({
+      calibrationEnabled: false,
+      jwstVersion: null,
+    });
+    render(<CalibrationGallery />);
+    await waitFor(() =>
+      expect(screen.getByText(/runs are disabled on this deployment/)).toBeInTheDocument()
+    );
+  });
+
+  it('shows an error state when loading fails', async () => {
+    vi.mocked(listRecipes).mockRejectedValue(new Error('engine unreachable'));
+    vi.mocked(getCapabilities).mockResolvedValue({
+      calibrationEnabled: true,
+      jwstVersion: null,
+    });
+    render(<CalibrationGallery />);
+    await waitFor(() =>
+      expect(screen.getByText("Couldn't load calibration recipes")).toBeInTheDocument()
+    );
+    expect(screen.getByText('engine unreachable')).toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
@@ -1,0 +1,133 @@
+/**
+ * Calibration recipe gallery (#1709 PR 7): browse curated + own recipes.
+ * The run-configuration flow (/calibrate/:recipeId) lands in PR 8.
+ */
+
+import { useEffect, useState } from 'react';
+import { EmptyState } from '../components/ui/EmptyState';
+import { getCapabilities, listRecipes } from '../services/calibrationService';
+import type { CalibrationCapabilities, CalibrationRecipe } from '../types/CalibrationTypes';
+import './CalibrationGallery.css';
+
+const INSTRUMENT_LABELS: Record<CalibrationRecipe['instrument'], string> = {
+  nircam: 'NIRCam',
+  niriss: 'NIRISS',
+  miri: 'MIRI',
+};
+
+function overrideCount(recipe: CalibrationRecipe): number {
+  return recipe.stages.reduce(
+    (total, stage) =>
+      total +
+      Object.values(stage.step_overrides).reduce((n, params) => n + Object.keys(params).length, 0),
+    0
+  );
+}
+
+export function CalibrationRecipeCard({ recipe }: { recipe: CalibrationRecipe }) {
+  const enabledStages = recipe.stages.filter((stage) => stage.enabled);
+  const inputLabel =
+    recipe.input_source.type === 'mast_query'
+      ? `MAST PID ${recipe.input_source.proposal_id}`
+      : 'Library files';
+  const overrides = overrideCount(recipe);
+
+  return (
+    <article className="calibration-card" data-testid="calibration-recipe-card">
+      <header className="calibration-card-header">
+        <span className={`calibration-instrument calibration-instrument-${recipe.instrument}`}>
+          {INSTRUMENT_LABELS[recipe.instrument]}
+        </span>
+        {recipe.source === 'seed' && <span className="calibration-badge">Curated</span>}
+      </header>
+      <h2 className="calibration-card-title">{recipe.name}</h2>
+      <p className="calibration-card-description">{recipe.description}</p>
+      <div className="calibration-card-stages" aria-label="Pipeline stages">
+        {enabledStages.map((stage) => (
+          <span key={stage.name} className="calibration-stage-chip">
+            {stage.name}
+          </span>
+        ))}
+      </div>
+      <footer className="calibration-card-meta">
+        <span>{inputLabel}</span>
+        <span>
+          {overrides === 0
+            ? 'Pipeline defaults'
+            : `${overrides} tuned parameter${overrides === 1 ? '' : 's'}`}
+        </span>
+        {recipe.provenance.notebook_name && (
+          <span title={`Derived from ${recipe.provenance.notebook_name}`}>STScI notebook</span>
+        )}
+      </footer>
+    </article>
+  );
+}
+
+export default function CalibrationGallery() {
+  const [recipes, setRecipes] = useState<CalibrationRecipe[] | null>(null);
+  const [capabilities, setCapabilities] = useState<CalibrationCapabilities | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([listRecipes(), getCapabilities()])
+      .then(([recipeList, caps]) => {
+        if (cancelled) return;
+        setRecipes(recipeList);
+        setCapabilities(caps);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load recipes');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="calibration-gallery">
+        <EmptyState title="Couldn't load calibration recipes" description={error} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="calibration-gallery">
+      <header className="calibration-gallery-header">
+        <h1>Calibration Recipes</h1>
+        <p className="calibration-gallery-subtitle">
+          Run the official JWST calibration pipeline with curated, editable settings — from quick
+          Stage&nbsp;3 re-mosaics of library data to full raw-data reductions.
+          {capabilities?.jwstVersion && (
+            <span className="calibration-version"> Pipeline v{capabilities.jwstVersion}</span>
+          )}
+        </p>
+        {capabilities && !capabilities.calibrationEnabled && (
+          <div className="calibration-disabled-banner" role="status">
+            Calibration runs are disabled on this deployment — recipes are browsable, but the run
+            flow is unavailable.
+          </div>
+        )}
+      </header>
+      {recipes === null ? (
+        <p className="calibration-loading" role="status">
+          Loading recipes…
+        </p>
+      ) : recipes.length === 0 ? (
+        <EmptyState
+          title="No recipes yet"
+          description="Curated recipes are seeded at engine startup; user recipes appear here once created."
+        />
+      ) : (
+        <div className="calibration-card-grid">
+          {recipes.map((recipe) => (
+            <CalibrationRecipeCard key={recipe.id} recipe={recipe} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/jwst-frontend/src/services/apiClient.ts
+++ b/frontend/jwst-frontend/src/services/apiClient.ts
@@ -242,7 +242,7 @@ export async function ensureTokenFresh(): Promise<void> {
   }
 }
 
-class ApiClient {
+export class ApiClient {
   private baseUrl: string;
 
   constructor(baseUrl: string = API_BASE_URL) {
@@ -576,4 +576,3 @@ class ApiClient {
 export const apiClient = new ApiClient();
 
 // Export class for testing or custom instances
-export { ApiClient };

--- a/frontend/jwst-frontend/src/services/calibrationService.ts
+++ b/frontend/jwst-frontend/src/services/calibrationService.ts
@@ -1,0 +1,49 @@
+/**
+ * Calibration API client (#1709) — talks DIRECTLY to the Python engine
+ * (ENGINE_BASE_URL), not the .NET gateway, per ADR-0001. JWT injection and
+ * refresh come from the shared ApiClient plumbing.
+ */
+
+import { ENGINE_BASE_URL } from '../config/engine';
+import { ApiClient } from './apiClient';
+import type {
+  CalibrationCapabilities,
+  CalibrationRecipe,
+  StartRunRequest,
+  StartRunResponse,
+} from '../types/CalibrationTypes';
+
+const engineClient = new ApiClient(ENGINE_BASE_URL);
+
+export async function getCapabilities(): Promise<CalibrationCapabilities> {
+  return engineClient.get<CalibrationCapabilities>('/api/calibration/capabilities');
+}
+
+export async function listRecipes(): Promise<CalibrationRecipe[]> {
+  const response = await engineClient.get<{ recipes: CalibrationRecipe[] }>(
+    '/api/calibration/recipes'
+  );
+  return response.recipes;
+}
+
+export async function getRecipe(recipeId: string): Promise<CalibrationRecipe> {
+  return engineClient.get<CalibrationRecipe>(
+    `/api/calibration/recipes/${encodeURIComponent(recipeId)}`
+  );
+}
+
+export async function startRun(request: StartRunRequest): Promise<StartRunResponse> {
+  return engineClient.post<StartRunResponse>('/api/calibration/runs', request);
+}
+
+/** Generic jobs API lives on the engine too (poll from the run UI, PR 8). */
+export async function getJob<T = Record<string, unknown>>(jobId: string): Promise<T> {
+  return engineClient.get<T>(`/api/jobs/${encodeURIComponent(jobId)}`);
+}
+
+export async function cancelJob(jobId: string): Promise<{ cancelRequested: boolean }> {
+  return engineClient.post<{ cancelRequested: boolean }>(
+    `/api/jobs/${encodeURIComponent(jobId)}/cancel`,
+    {}
+  );
+}

--- a/frontend/jwst-frontend/src/types/CalibrationTypes.ts
+++ b/frontend/jwst-frontend/src/types/CalibrationTypes.ts
@@ -1,0 +1,71 @@
+/**
+ * Calibration Recipes types (#1709).
+ *
+ * IMPORTANT wire contract: recipe payloads travel VERBATIM snake_case — the
+ * field names inside `stages`/`step_overrides` are meaningful jwst pipeline
+ * identifiers (e.g. `bkg_subtract`, `maximum_cores`), not DTO field names.
+ * Do NOT run camelCase conversion over these objects. Only the small
+ * non-recipe payloads (capabilities, run start) are camelCase.
+ */
+
+export type ScalarOverride = string | number | boolean | null;
+
+export interface StepOverrides {
+  [step: string]: { [param: string]: ScalarOverride | ScalarOverride[] };
+}
+
+export interface RecipeStage {
+  name: 'detector1' | 'image2' | 'image3' | 'coron3';
+  enabled: boolean;
+  step_overrides: StepOverrides;
+}
+
+export interface MastQueryInput {
+  type: 'mast_query';
+  proposal_id: string;
+  observation: string | null;
+  filters: string[];
+  calib_level: 1 | 2;
+  product_suffixes: string[];
+}
+
+export interface LibraryProductsInput {
+  type: 'library_products';
+  product_suffixes: string[];
+}
+
+export interface CalibrationRecipe {
+  id: string;
+  schema_version: number;
+  name: string;
+  description: string;
+  instrument: 'nircam' | 'niriss' | 'miri';
+  mode: 'imaging' | 'coronagraphy';
+  source: 'seed' | 'imported' | 'user';
+  is_public: boolean;
+  provenance: { notebook_name: string | null; jwst_version_authored: string | null };
+  input_source: MastQueryInput | LibraryProductsInput;
+  stages: RecipeStage[];
+  association: { rule: string; product_name: string };
+  output_suffixes: string[];
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** camelCase payloads (non-recipe wire). */
+export interface CalibrationCapabilities {
+  calibrationEnabled: boolean;
+  jwstVersion: string | null;
+}
+
+export interface StartRunRequest {
+  recipeId: string;
+  /** Storage keys of library `_cal` files; empty for MAST-driven recipes. */
+  inputs: string[];
+  runOverrides: StepOverrides;
+}
+
+export interface StartRunResponse {
+  jobId: string;
+}


### PR DESCRIPTION
## Summary

PR 7 of the Calibration Recipes feature (plan: `docs/plans/features/1709-calibration-recipes.md`) — the first frontend slice: the `/calibrate` recipe gallery and the engine-bound API service. The run-configuration + live-progress flow lands in PR 8.

## Changes Made

- **`src/config/engine.ts`** (new): `ENGINE_BASE_URL` from `VITE_ENGINE_URL` (default `http://localhost:8000`); explicit-empty-string same-origin opt-in documented.
- **`src/services/calibrationService.ts`** (new): second `ApiClient` instance bound to the engine (frontend → Python engine directly, per ADR-0001; JWT injection/refresh reuse the shared plumbing) — capabilities, recipes, `startRun`, `getJob`, `cancelJob`. `ApiClient` class export added.
- **`src/types/CalibrationTypes.ts`** (new): documented wire split — recipe payloads are **verbatim snake_case** (jwst identifiers; no casing conversion), capabilities/run payloads camelCase.
- **`src/pages/CalibrationGallery.tsx/.css`** (new): gallery with instrument-tagged cards (enabled-stage chips, tuned-parameter count, STScI-notebook provenance, curated badge), loading/empty/error states (`role="status"` throughout), and a disabled banner when `calibrationEnabled=false`.
- **`App.tsx` / `SharedLayout.tsx`**: lazy `/calibrate` route + Calibrate nav link, both `!CE_MODE` (CE never loads the module, so the engine URL is never called there).
- **Tests**: 4 new vitest cases (card rendering incl. enabled-stage filtering, version render, disabled banner, error state).

## Test Plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 1174/1174 (4 new)
- [x] Self-review round: all-clear (CE gating, cross-origin JWT confined to the first-party engine URL, snake_case contract, a11y nits fixed)
- [ ] Reviewer: `docker compose up -d --build`, open http://localhost:3000/calibrate → 3 seeded recipe cards + "Pipeline v2.0.1"; set `CALIBRATION_ENABLED=false` and recreate the engine → disabled banner

## Documentation Checklist

- [x] Wire contract documented in `CalibrationTypes.ts`
- [ ] `docs/quick-reference.md` (`VITE_ENGINE_URL`) — PR 10 docs sweep

## Tech Debt Impact

- [x] No new tech debt. `/calibrate` is public-browse like `/search`; write/run authorization is engine-enforced.

## Risk & Rollback

- **Risk: LOW.** Pure additive UI; no existing components changed beyond a nav link and route. The only cross-cutting touch is exporting the `ApiClient` class (no behavior change).
- **Rollback:** revert.

Part of #1709 (umbrella stays open). No linked issue to close.

https://claude.ai/code/session_01W5ZRaEbzFmit1DQs1nfP66
