### PR TITLE
feat: calibration run-config + live progress UI (#1709 PR 8)

### DIFF
--- a/frontend/jwst-frontend/e2e/calibrate.spec.ts
+++ b/frontend/jwst-frontend/e2e/calibrate.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Calibration recipes (#1709 PRs 7-8).
+ *
+ * The gallery reads the engine's seeded recipes (loaded at engine startup),
+ * so no auth or mocking is needed for browse/config. The run itself is
+ * exercised by the engine's own test suite — starting real pipeline jobs is
+ * out of scope for E2E.
+ */
+
+test.describe('Calibration recipes', () => {
+  test('gallery lists the seeded recipes', async ({ page }) => {
+    await page.goto('/calibrate');
+    await expect(page.getByRole('heading', { name: 'Calibration Recipes' })).toBeVisible();
+    const cards = page.getByTestId('calibration-recipe-card');
+    await expect(cards).toHaveCount(3);
+    await expect(page.getByText('NIRCam Imaging (uncal → i2d mosaic)')).toBeVisible();
+    await expect(page.getByText('Pipeline v', { exact: false })).toBeVisible();
+  });
+
+  test('recipe card opens the run configuration page', async ({ page }) => {
+    await page.goto('/calibrate');
+    await page
+      .getByTestId('calibration-recipe-card')
+      .filter({ hasText: 'MIRI Imaging' })
+      .getByRole('link', { name: 'Configure & run' })
+      .click();
+    await expect(page).toHaveURL(/\/calibrate\/seed-miri-imaging$/);
+    await expect(page.getByRole('heading', { name: 'Stages' })).toBeVisible();
+    // Seeded parameters are editable rows.
+    await expect(page.getByLabel('Step for parameter 1')).toHaveValue('jump');
+    await expect(page.getByRole('button', { name: 'Run calibration' })).toBeEnabled();
+  });
+
+  test('mocked run start shows the progress view', async ({ page }) => {
+    // Intercept engine calls so no real pipeline job starts.
+    await page.route('**/api/calibration/runs', (route) =>
+      route.fulfill({ json: { jobId: 'e2e-job-1' }, status: 202 })
+    );
+    await page.route('**/api/jobs/e2e-job-1', (route) =>
+      route.fulfill({
+        json: {
+          jobId: 'e2e-job-1',
+          type: 'calibration',
+          status: 'running',
+          cancelRequested: false,
+          createdAt: new Date().toISOString(),
+          startedAt: new Date().toISOString(),
+          finishedAt: null,
+          progress: {
+            stages: [
+              { name: 'detector1', status: 'done' },
+              { name: 'image2', status: 'running' },
+              { name: 'image3', status: 'pending' },
+            ],
+            currentStage: 'image2',
+            message: 'running image2',
+            downloadPct: null,
+          },
+          logTail: ['Step flat_field running with args'],
+          result: null,
+          error: null,
+          request: {},
+        },
+      })
+    );
+    await page.goto('/calibrate/seed-nircam-imaging');
+    await expect(page.getByRole('button', { name: 'Run calibration' })).toBeEnabled();
+    await page.getByRole('button', { name: 'Run calibration' }).click();
+    await expect(page.getByRole('heading', { name: 'Run progress' })).toBeVisible();
+    await expect(page.getByText('running image2')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Cancel run' })).toBeVisible();
+  });
+});

--- a/frontend/jwst-frontend/src/App.tsx
+++ b/frontend/jwst-frontend/src/App.tsx
@@ -41,6 +41,7 @@ const SearchPage = lazy(() =>
   import('./pages/SearchPage').then((m) => ({ default: m.SearchPage }))
 );
 const CalibrationGallery = lazy(() => import('./pages/CalibrationGallery'));
+const CalibrateRun = lazy(() => import('./pages/CalibrateRun'));
 const ArchivePage = lazy(() =>
   import('./pages/ArchivePage').then((m) => ({ default: m.ArchivePage }))
 );
@@ -89,6 +90,7 @@ function App() {
               {/* semantic search is out of CE v1 (its API never mounts) */}
               {!CE_MODE && <Route path="search" element={<SearchPage />} />}
               {!CE_MODE && <Route path="calibrate" element={<CalibrationGallery />} />}
+              {!CE_MODE && <Route path="calibrate/:recipeId" element={<CalibrateRun />} />}
               <Route path="archive" element={<ArchivePage />} />
               {/* CE review decision 2026-07-06: /library is a public
                   read-only view — mutations are gated inside the dashboard */}

--- a/frontend/jwst-frontend/src/hooks/useCalibrationJob.test.ts
+++ b/frontend/jwst-frontend/src/hooks/useCalibrationJob.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCalibrationJob } from './useCalibrationJob';
+import type { CalibrationJob } from '../types/CalibrationTypes';
+
+vi.mock('../services/calibrationService', () => ({
+  getJob: vi.fn(),
+}));
+
+import { getJob } from '../services/calibrationService';
+
+function makeJob(status: CalibrationJob['status']): CalibrationJob {
+  return {
+    jobId: 'j1',
+    type: 'calibration',
+    status,
+    cancelRequested: false,
+    createdAt: '2026-07-24T00:00:00Z',
+    startedAt: null,
+    finishedAt: null,
+    progress: { stages: [], currentStage: null, message: null, downloadPct: null },
+    logTail: [],
+    result: null,
+    error: null,
+    request: {},
+  };
+}
+
+describe('useCalibrationJob', () => {
+  beforeEach(() => {
+    vi.mocked(getJob).mockReset();
+  });
+
+  it('does nothing without a job id', () => {
+    const { result } = renderHook(() => useCalibrationJob(null));
+    expect(result.current.job).toBeNull();
+    expect(getJob).not.toHaveBeenCalled();
+  });
+
+  it('polls until the job is terminal, then stops', async () => {
+    vi.mocked(getJob)
+      .mockResolvedValueOnce(makeJob('running'))
+      .mockResolvedValueOnce(makeJob('succeeded'));
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useCalibrationJob('j1'));
+      // First poll resolves with running.
+      await vi.waitFor(() => expect(result.current.job?.status).toBe('running'));
+      // Advance to the second poll → terminal.
+      await vi.advanceTimersByTimeAsync(1600);
+      await vi.waitFor(() => expect(result.current.job?.status).toBe('succeeded'));
+      expect(result.current.isTerminal).toBe(true);
+      const callsAtTerminal = vi.mocked(getJob).mock.calls.length;
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(vi.mocked(getJob).mock.calls.length).toBe(callsAtTerminal);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps polling through transient errors and surfaces the message', async () => {
+    vi.mocked(getJob)
+      .mockRejectedValueOnce(new Error('blip'))
+      .mockResolvedValueOnce(makeJob('succeeded'));
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useCalibrationJob('j1'));
+      await vi.waitFor(() => expect(result.current.error).toBe('blip'));
+      await vi.advanceTimersByTimeAsync(1600);
+      await vi.waitFor(() => expect(result.current.job?.status).toBe('succeeded'));
+      expect(result.current.error).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/jwst-frontend/src/hooks/useCalibrationJob.ts
+++ b/frontend/jwst-frontend/src/hooks/useCalibrationJob.ts
@@ -1,0 +1,83 @@
+/**
+ * Lean polling hook for calibration jobs (#1709 PR 8).
+ *
+ * Deliberately NOT a retrofit of useJobProgress — that hook is coupled to
+ * SignalR + the .NET import-job shape. Calibration jobs live on the Python
+ * engine and change state on the order of seconds, so plain polling of
+ * GET /api/jobs/{id} is the right tool (ADR-0001 divergence, documented).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { getJob } from '../services/calibrationService';
+import type { CalibrationJob } from '../types/CalibrationTypes';
+import { TERMINAL_JOB_STATUSES } from '../types/CalibrationTypes';
+
+const POLL_INTERVAL_MS = 1500;
+const MAX_CONSECUTIVE_FAILURES = 5;
+
+export interface UseCalibrationJobResult {
+  job: CalibrationJob | null;
+  isTerminal: boolean;
+  error: string | null;
+}
+
+interface Snapshot {
+  key: string | null;
+  job: CalibrationJob | null;
+  error: string | null;
+}
+
+export function useCalibrationJob(jobId: string | null): UseCalibrationJobResult {
+  const [snapshot, setSnapshot] = useState<Snapshot>({
+    key: jobId,
+    job: null,
+    error: null,
+  });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset during render when the job id changes (React's documented
+  // derived-state pattern) — avoids a synchronous setState inside the effect.
+  if (snapshot.key !== jobId) {
+    setSnapshot({ key: jobId, job: null, error: null });
+  }
+
+  useEffect(() => {
+    if (!jobId) return undefined;
+
+    let cancelled = false;
+    let consecutiveFailures = 0;
+
+    const poll = async () => {
+      try {
+        const next = await getJob<CalibrationJob>(jobId);
+        if (cancelled) return;
+        consecutiveFailures = 0;
+        setSnapshot({ key: jobId, job: next, error: null });
+        if ((TERMINAL_JOB_STATUSES as readonly string[]).includes(next.status)) {
+          return; // done — stop polling
+        }
+      } catch (err: unknown) {
+        if (cancelled) return;
+        // Tolerate transient failures, but stop on a persistently missing
+        // job (e.g. an evicted/invalid id) instead of polling forever.
+        consecutiveFailures += 1;
+        const message = err instanceof Error ? err.message : 'Failed to fetch job';
+        setSnapshot((prev) => (prev.key === jobId ? { ...prev, error: message } : prev));
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) return;
+      }
+      timerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
+    };
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [jobId]);
+
+  const job = snapshot.key === jobId ? snapshot.job : null;
+  const error = snapshot.key === jobId ? snapshot.error : null;
+  const isTerminal =
+    job !== null && (TERMINAL_JOB_STATUSES as readonly string[]).includes(job.status);
+  return { job, isTerminal, error };
+}

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.css
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.css
@@ -1,0 +1,121 @@
+.calibrate-run {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.calibrate-run-breadcrumb {
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.calibrate-run-description {
+  color: var(--text-muted);
+  max-width: 65ch;
+}
+
+.calibrate-section {
+  margin-top: 1.75rem;
+}
+
+.calibrate-section h2 {
+  font-size: 1.05rem;
+  margin-bottom: 0.5rem;
+}
+
+.calibrate-hint {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.calibrate-stage-toggles {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.calibrate-stage-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.9rem;
+}
+
+.calibrate-param-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr auto;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.calibrate-param-row input {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85rem;
+  padding: 0.35rem 0.5rem;
+}
+
+.calibrate-input-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.calibrate-input-file {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.8rem;
+  margin-left: 0.4rem;
+  word-break: break-all;
+}
+
+.calibrate-run-button {
+  margin-top: 1.5rem;
+}
+
+.calibrate-error {
+  color: var(--danger, #ff6b6b);
+}
+
+.calibrate-status {
+  margin: 0.5rem 0;
+}
+
+.calibrate-stage-checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.9rem;
+}
+
+.calibrate-stage-checklist li[data-status='done'] {
+  color: var(--success, #7bd88f);
+}
+
+.calibrate-stage-checklist li[data-status='running'] {
+  font-weight: 600;
+}
+
+.calibrate-stage-status {
+  display: inline-block;
+  width: 1.4rem;
+}
+
+.calibrate-result {
+  margin-top: 1rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--border-color, rgba(123, 216, 143, 0.35));
+  border-radius: 8px;
+}
+
+.calibrate-result code {
+  word-break: break-all;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import CalibrateRun from './CalibrateRun';
+import type { CalibrationJob, CalibrationRecipe } from '../types/CalibrationTypes';
+
+vi.mock('../services/calibrationService', () => ({
+  getRecipe: vi.fn(),
+  startRun: vi.fn(),
+  cancelJob: vi.fn(),
+  getJob: vi.fn(),
+}));
+vi.mock('../services/jwstDataService', () => ({
+  getAll: vi.fn().mockResolvedValue([]),
+}));
+
+import { getJob, getRecipe, startRun } from '../services/calibrationService';
+
+const recipe: CalibrationRecipe = {
+  id: 'seed-nircam-imaging',
+  schema_version: 1,
+  name: 'NIRCam Imaging',
+  description: 'Full reduction.',
+  instrument: 'nircam',
+  mode: 'imaging',
+  source: 'seed',
+  is_public: true,
+  provenance: { notebook_name: null, jwst_version_authored: null },
+  input_source: {
+    type: 'mast_query',
+    proposal_id: '2739',
+    observation: '001',
+    filters: ['F200W'],
+    calib_level: 1,
+    product_suffixes: ['_uncal'],
+  },
+  stages: [
+    { name: 'detector1', enabled: true, step_overrides: { jump: { maximum_cores: 'half' } } },
+    { name: 'image2', enabled: true, step_overrides: {} },
+    { name: 'image3', enabled: true, step_overrides: {} },
+  ],
+  association: { rule: 'DMS_Level3_Base', product_name: 'nircam-imaging' },
+  output_suffixes: ['_i2d'],
+  created_by: null,
+  created_at: '2026-07-23T00:00:00Z',
+  updated_at: '2026-07-23T00:00:00Z',
+};
+
+function runningJob(): CalibrationJob {
+  return {
+    jobId: 'job-1',
+    type: 'calibration',
+    status: 'running',
+    cancelRequested: false,
+    createdAt: '2026-07-24T00:00:00Z',
+    startedAt: '2026-07-24T00:00:01Z',
+    finishedAt: null,
+    progress: {
+      stages: [
+        { name: 'detector1', status: 'done' },
+        { name: 'image2', status: 'running' },
+        { name: 'image3', status: 'pending' },
+      ],
+      currentStage: 'image2',
+      message: 'running image2',
+      downloadPct: null,
+    },
+    logTail: ['Step flat_field running'],
+    result: null,
+    error: null,
+    request: {},
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/calibrate/seed-nircam-imaging']}>
+      <Routes>
+        <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('CalibrateRun', () => {
+  beforeEach(() => {
+    vi.mocked(getRecipe).mockResolvedValue(recipe);
+  });
+
+  it('renders stage toggles and seeded parameters', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
+    expect(screen.getByLabelText('Step for parameter 1')).toHaveValue('jump');
+    expect(screen.getByLabelText('Name for parameter 1')).toHaveValue('maximum_cores');
+    expect(screen.getByText(/Data is fetched from MAST/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run calibration' })).toBeEnabled();
+  });
+
+  it('starts a run and shows live progress', async () => {
+    vi.mocked(startRun).mockResolvedValue({ jobId: 'job-1' });
+    vi.mocked(getJob).mockResolvedValue(runningJob());
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+    await waitFor(() => expect(screen.getByText('Run progress')).toBeInTheDocument());
+    expect(vi.mocked(startRun)).toHaveBeenCalledWith({
+      recipeId: 'seed-nircam-imaging',
+      inputs: [],
+      runOverrides: { jump: { maximum_cores: 'half' } },
+      enabledStages: { detector1: true, image2: true, image3: true },
+    });
+    await waitFor(() => expect(screen.getByText('image2')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Cancel run' })).toBeInTheDocument();
+  });
+
+  it('shows the failure state', async () => {
+    vi.mocked(startRun).mockResolvedValue({ jobId: 'job-1' });
+    const failed = { ...runningJob(), status: 'failed' as const, error: 'boom' };
+    vi.mocked(getJob).mockResolvedValue(failed);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+    await waitFor(() => expect(screen.getByText(/Run failed: boom/)).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -1,0 +1,384 @@
+/**
+ * Calibration run configuration + live progress (#1709 PR 8).
+ *
+ * /calibrate/:recipeId — stage toggles, per-step parameter editor (seeded
+ * from the recipe's own overrides), input selection (recipe MAST query or
+ * library _cal files), then a live progress view: per-stage checklist,
+ * download %, log tail, cancel.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { LogPanel } from '../components/wizard/LogPanel';
+import { EmptyState } from '../components/ui/EmptyState';
+import { useCalibrationJob } from '../hooks/useCalibrationJob';
+import { cancelJob, getRecipe, startRun } from '../services/calibrationService';
+import * as jwstDataService from '../services/jwstDataService';
+import type { CalibrationRecipe, ScalarOverride, StepOverrides } from '../types/CalibrationTypes';
+import './CalibrateRun.css';
+
+interface ParamRow {
+  step: string;
+  param: string;
+  value: string;
+}
+
+function rowsFromRecipe(recipe: CalibrationRecipe): ParamRow[] {
+  const rows: ParamRow[] = [];
+  for (const stage of recipe.stages) {
+    for (const [step, params] of Object.entries(stage.step_overrides)) {
+      for (const [param, value] of Object.entries(params)) {
+        rows.push({ step, param, value: JSON.stringify(value) });
+      }
+    }
+  }
+  return rows;
+}
+
+function parseValue(raw: string): ScalarOverride | ScalarOverride[] {
+  const trimmed = raw.trim();
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (trimmed === 'null' || trimmed === '') return null;
+  if (trimmed.startsWith('[')) {
+    // List-valued params round-trip as JSON (e.g. [1.0, 2.0]).
+    try {
+      return JSON.parse(trimmed) as ScalarOverride[];
+    } catch {
+      return trimmed;
+    }
+  }
+  if (trimmed.startsWith('"')) {
+    // Quoted = force string ("010" stays "010", never the number 10).
+    return trimmed.replace(/^"(.*)"$/, '$1');
+  }
+  const numeric = Number(trimmed);
+  if (!Number.isNaN(numeric)) return numeric;
+  return trimmed;
+}
+
+function overridesFromRows(rows: ParamRow[]): StepOverrides {
+  const overrides: StepOverrides = {};
+  for (const row of rows) {
+    if (!row.step.trim() || !row.param.trim()) continue;
+    overrides[row.step.trim()] ??= {};
+    overrides[row.step.trim()][row.param.trim()] = parseValue(row.value);
+  }
+  return overrides;
+}
+
+export default function CalibrateRun() {
+  const { recipeId } = useParams<{ recipeId: string }>();
+  const [recipe, setRecipe] = useState<CalibrationRecipe | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [enabledStages, setEnabledStages] = useState<Record<string, boolean>>({});
+  const [paramRows, setParamRows] = useState<ParamRow[]>([]);
+  const [libraryFiles, setLibraryFiles] = useState<string[]>([]);
+  const [selectedInputs, setSelectedInputs] = useState<string[]>([]);
+
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [cancelling, setCancelling] = useState(false);
+  const [startError, setStartError] = useState<string | null>(null);
+  const { job, isTerminal, error: pollError } = useCalibrationJob(jobId);
+
+  useEffect(() => {
+    if (!recipeId) return undefined;
+    let cancelled = false;
+    getRecipe(recipeId)
+      .then((loaded) => {
+        if (cancelled) return;
+        setRecipe(loaded);
+        setEnabledStages(Object.fromEntries(loaded.stages.map((s) => [s.name, s.enabled])));
+        setParamRows(rowsFromRecipe(loaded));
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err.message : 'Failed to load recipe');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [recipeId]);
+
+  const needsLibraryInputs = recipe?.input_source.type === 'library_products';
+
+  useEffect(() => {
+    if (!needsLibraryInputs) return undefined;
+    let cancelled = false;
+    jwstDataService
+      .getAll(false)
+      .then((items) => {
+        if (cancelled) return;
+        const suffixes = recipe?.input_source.product_suffixes ?? ['_cal'];
+        const files = items
+          .map((item) => item.filePath)
+          .filter((path): path is string =>
+            Boolean(path && suffixes.some((s) => path.includes(s)))
+          );
+        setLibraryFiles(files);
+      })
+      .catch(() => {
+        if (!cancelled) setLibraryFiles([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [needsLibraryInputs, recipe]);
+
+  const runDisabled = useMemo(() => {
+    if (!recipe || jobId) return true;
+    if (needsLibraryInputs && selectedInputs.length === 0) return true;
+    return !Object.values(enabledStages).some(Boolean);
+  }, [recipe, jobId, needsLibraryInputs, selectedInputs, enabledStages]);
+
+  const handleRun = async () => {
+    if (!recipe) return;
+    setStartError(null);
+    try {
+      const response = await startRun({
+        recipeId: recipe.id,
+        inputs: needsLibraryInputs ? selectedInputs : [],
+        runOverrides: overridesFromRows(paramRows),
+        enabledStages,
+      });
+      setJobId(response.jobId);
+    } catch (err: unknown) {
+      setStartError(err instanceof Error ? err.message : 'Failed to start run');
+    }
+  };
+
+  if (loadError) {
+    return (
+      <div className="calibrate-run">
+        <EmptyState title="Couldn't load recipe" description={loadError} />
+      </div>
+    );
+  }
+  if (!recipe) {
+    return (
+      <div className="calibrate-run">
+        <p role="status">Loading recipe…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="calibrate-run">
+      <nav className="calibrate-run-breadcrumb">
+        <Link to="/calibrate">← All recipes</Link>
+      </nav>
+      <h1>{recipe.name}</h1>
+      <p className="calibrate-run-description">{recipe.description}</p>
+
+      {!jobId && (
+        <>
+          <section className="calibrate-section" aria-labelledby="stages-heading">
+            <h2 id="stages-heading">Stages</h2>
+            <div className="calibrate-stage-toggles">
+              {recipe.stages.map((stage) => (
+                <label key={stage.name} className="calibrate-stage-toggle">
+                  <input
+                    type="checkbox"
+                    checked={enabledStages[stage.name] ?? false}
+                    onChange={(event) =>
+                      setEnabledStages((prev) => ({
+                        ...prev,
+                        [stage.name]: event.target.checked,
+                      }))
+                    }
+                  />
+                  <span>{stage.name}</span>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="calibrate-section" aria-labelledby="params-heading">
+            <h2 id="params-heading">Parameters</h2>
+            <p className="calibrate-hint">
+              Values are jwst step parameters; run values override the recipe. Numbers/booleans are
+              auto-detected — wrap a value in quotes (&quot;010&quot;) to force a string; lists use
+              JSON ([1.0, 2.0]).
+            </p>
+            {paramRows.map((row, index) => (
+              <div className="calibrate-param-row" key={`${row.step}-${row.param}-${index}`}>
+                <input
+                  aria-label={`Step for parameter ${index + 1}`}
+                  value={row.step}
+                  onChange={(e) =>
+                    setParamRows((rows) =>
+                      rows.map((r, i) => (i === index ? { ...r, step: e.target.value } : r))
+                    )
+                  }
+                />
+                <input
+                  aria-label={`Name for parameter ${index + 1}`}
+                  value={row.param}
+                  onChange={(e) =>
+                    setParamRows((rows) =>
+                      rows.map((r, i) => (i === index ? { ...r, param: e.target.value } : r))
+                    )
+                  }
+                />
+                <input
+                  aria-label={`Value for parameter ${index + 1}`}
+                  value={row.value}
+                  onChange={(e) =>
+                    setParamRows((rows) =>
+                      rows.map((r, i) => (i === index ? { ...r, value: e.target.value } : r))
+                    )
+                  }
+                />
+                <button
+                  type="button"
+                  className="btn-base btn-compact"
+                  onClick={() => setParamRows((rows) => rows.filter((_, i) => i !== index))}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              className="btn-base btn-compact"
+              onClick={() => setParamRows((rows) => [...rows, { step: '', param: '', value: '' }])}
+            >
+              Add parameter
+            </button>
+          </section>
+
+          <section className="calibrate-section" aria-labelledby="inputs-heading">
+            <h2 id="inputs-heading">Inputs</h2>
+            {needsLibraryInputs ? (
+              libraryFiles.length === 0 ? (
+                <p className="calibrate-hint">
+                  No matching library files found (looking for{' '}
+                  {recipe.input_source.product_suffixes.join(', ')}).
+                </p>
+              ) : (
+                <ul className="calibrate-input-list">
+                  {libraryFiles.map((file) => (
+                    <li key={file}>
+                      <label>
+                        <input
+                          type="checkbox"
+                          checked={selectedInputs.includes(file)}
+                          onChange={(event) =>
+                            setSelectedInputs((prev) =>
+                              event.target.checked
+                                ? [...prev, file]
+                                : prev.filter((f) => f !== file)
+                            )
+                          }
+                        />
+                        <span className="calibrate-input-file">{file}</span>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              )
+            ) : (
+              <p className="calibrate-hint">
+                Data is fetched from MAST (proposal{' '}
+                {recipe.input_source.type === 'mast_query' ? recipe.input_source.proposal_id : ''})
+                when the run starts.
+              </p>
+            )}
+          </section>
+
+          {startError && (
+            <p className="calibrate-error" role="alert">
+              {startError}
+            </p>
+          )}
+          <button
+            type="button"
+            className="btn-base btn-standard calibrate-run-button"
+            disabled={runDisabled}
+            onClick={() => void handleRun()}
+          >
+            Run calibration
+          </button>
+        </>
+      )}
+
+      {jobId && (
+        <section className="calibrate-section" aria-labelledby="progress-heading">
+          <h2 id="progress-heading">Run progress</h2>
+          {pollError && (
+            <p className="calibrate-hint" role="alert">
+              {pollError} (retrying…)
+            </p>
+          )}
+          {job && (
+            <>
+              <p className="calibrate-status" role="status">
+                Status: <strong>{job.status}</strong>
+                {job.progress.message ? ` — ${job.progress.message}` : ''}
+                {job.status === 'downloading' && job.progress.downloadPct !== null
+                  ? ` (${job.progress.downloadPct}%)`
+                  : ''}
+              </p>
+              {job.progress.stages.length > 0 && (
+                <ul className="calibrate-stage-checklist">
+                  {job.progress.stages.map((stage) => (
+                    <li key={stage.name} data-status={stage.status}>
+                      <span className="calibrate-stage-status">
+                        {stage.status === 'done' ? '✓' : stage.status === 'running' ? '…' : '○'}
+                      </span>
+                      {stage.name}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <LogPanel messages={job.logTail} defaultOpen={true} />
+              {!isTerminal && (
+                <button
+                  type="button"
+                  className="btn-base btn-compact"
+                  onClick={() => {
+                    setCancelling(true);
+                    cancelJob(job.jobId).catch(() => setCancelling(false));
+                  }}
+                  disabled={cancelling || job.cancelRequested}
+                >
+                  {cancelling || job.cancelRequested ? 'Cancelling…' : 'Cancel run'}
+                </button>
+              )}
+              {job.status === 'succeeded' && job.result && (
+                <div className="calibrate-result" role="status">
+                  <h3>Outputs</h3>
+                  <ul>
+                    {job.result.outputs.map((output) => (
+                      <li key={output.storageKey}>
+                        <code>{output.storageKey}</code> (
+                        {(output.sizeBytes / 1024 / 1024).toFixed(1)} MB)
+                      </li>
+                    ))}
+                  </ul>
+                  {job.result.jwstVersion && (
+                    <p className="calibrate-hint">
+                      jwst {job.result.jwstVersion}
+                      {job.result.crdsContext ? ` · CRDS ${job.result.crdsContext}` : ''}
+                    </p>
+                  )}
+                </div>
+              )}
+              {job.status === 'failed' && (
+                <p className="calibrate-error" role="alert">
+                  Run failed: {job.error ?? 'unknown error'}
+                </p>
+              )}
+              {job.status === 'cancelled' && (
+                <p className="calibrate-hint" role="status">
+                  Run cancelled.
+                </p>
+              )}
+            </>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.css
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.css
@@ -102,3 +102,7 @@
   color: var(--text-muted);
   font-size: 0.8rem;
 }
+
+.calibration-card-cta {
+  align-self: flex-start;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import CalibrationGallery, { CalibrationRecipeCard } from './CalibrationGallery';
 import type { CalibrationRecipe } from '../types/CalibrationTypes';
@@ -42,7 +43,11 @@ const seedRecipe: CalibrationRecipe = {
 
 describe('CalibrationRecipeCard', () => {
   it('renders instrument, curated badge, enabled stages, and meta', () => {
-    render(<CalibrationRecipeCard recipe={seedRecipe} />);
+    render(
+      <MemoryRouter>
+        <CalibrationRecipeCard recipe={seedRecipe} />
+      </MemoryRouter>
+    );
     expect(screen.getByText('MIRI')).toBeInTheDocument();
     expect(screen.getByText('Curated')).toBeInTheDocument();
     // Only enabled stages render as chips.
@@ -62,7 +67,11 @@ describe('CalibrationGallery', () => {
       calibrationEnabled: true,
       jwstVersion: '2.0.1',
     });
-    render(<CalibrationGallery />);
+    render(
+      <MemoryRouter>
+        <CalibrationGallery />
+      </MemoryRouter>
+    );
     await waitFor(() => expect(screen.getByTestId('calibration-recipe-card')).toBeInTheDocument());
     expect(screen.getByText(/Pipeline v2\.0\.1/)).toBeInTheDocument();
     expect(screen.queryByText(/runs are disabled on this deployment/)).not.toBeInTheDocument();
@@ -74,7 +83,11 @@ describe('CalibrationGallery', () => {
       calibrationEnabled: false,
       jwstVersion: null,
     });
-    render(<CalibrationGallery />);
+    render(
+      <MemoryRouter>
+        <CalibrationGallery />
+      </MemoryRouter>
+    );
     await waitFor(() =>
       expect(screen.getByText(/runs are disabled on this deployment/)).toBeInTheDocument()
     );
@@ -86,7 +99,11 @@ describe('CalibrationGallery', () => {
       calibrationEnabled: true,
       jwstVersion: null,
     });
-    render(<CalibrationGallery />);
+    render(
+      <MemoryRouter>
+        <CalibrationGallery />
+      </MemoryRouter>
+    );
     await waitFor(() =>
       expect(screen.getByText("Couldn't load calibration recipes")).toBeInTheDocument()
     );

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { EmptyState } from '../components/ui/EmptyState';
 import { getCapabilities, listRecipes } from '../services/calibrationService';
 import type { CalibrationCapabilities, CalibrationRecipe } from '../types/CalibrationTypes';
@@ -49,6 +50,9 @@ export function CalibrationRecipeCard({ recipe }: { recipe: CalibrationRecipe })
           </span>
         ))}
       </div>
+      <Link className="btn-base btn-compact calibration-card-cta" to={`/calibrate/${recipe.id}`}>
+        Configure &amp; run
+      </Link>
       <footer className="calibration-card-meta">
         <span>{inputLabel}</span>
         <span>

--- a/frontend/jwst-frontend/src/types/CalibrationTypes.ts
+++ b/frontend/jwst-frontend/src/types/CalibrationTypes.ts
@@ -64,8 +64,48 @@ export interface StartRunRequest {
   /** Storage keys of library `_cal` files; empty for MAST-driven recipes. */
   inputs: string[];
   runOverrides: StepOverrides;
+  /** Per-run stage toggles, applied to the recipe snapshot server-side. */
+  enabledStages: Record<string, boolean>;
 }
 
 export interface StartRunResponse {
   jobId: string;
 }
+
+/** Job envelope from GET /api/jobs/{id} (camelCase; `request` verbatim). */
+export interface CalibrationJobStage {
+  name: string;
+  status: 'pending' | 'running' | 'done' | 'failed' | 'skipped';
+}
+
+export interface CalibrationJobOutput {
+  storageKey: string;
+  suffix: string;
+  sizeBytes: number;
+}
+
+export interface CalibrationJob {
+  jobId: string;
+  type: string;
+  status: 'queued' | 'downloading' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+  cancelRequested: boolean;
+  createdAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  progress: {
+    stages: CalibrationJobStage[];
+    currentStage: string | null;
+    message: string | null;
+    downloadPct: number | null;
+  };
+  logTail: string[];
+  result: {
+    outputs: CalibrationJobOutput[];
+    jwstVersion: string | null;
+    crdsContext: string | null;
+  } | null;
+  error: string | null;
+  request: Record<string, unknown>;
+}
+
+export const TERMINAL_JOB_STATUSES = ['succeeded', 'failed', 'cancelled'] as const;

--- a/processing-engine/app/calibration/routes.py
+++ b/processing-engine/app/calibration/routes.py
@@ -138,6 +138,18 @@ async def start_run(
         raise HTTPException(status_code=404, detail="Recipe not found")
     recipe = CalibrationRecipe.model_validate(recipe_doc)
 
+    # Per-run stage toggles: applied to the recipe snapshot BEFORE validation
+    # and execution, so the job's embedded snapshot reflects what actually ran.
+    enabled_stages = payload.get("enabledStages") or {}
+    if not isinstance(enabled_stages, dict) or not all(
+        isinstance(v, bool) for v in enabled_stages.values()
+    ):
+        raise HTTPException(status_code=422, detail="enabledStages must map stage->bool")
+    if enabled_stages:
+        for stage in recipe.stages:
+            if stage.name in enabled_stages:
+                stage.enabled = enabled_stages[stage.name]
+
     try:
         # Scalar-only shape check (schema validator), then the executor's
         # allowlist/path checks per enabled stage — all BEFORE a job exists.

--- a/processing-engine/tests/test_calibration_executor.py
+++ b/processing-engine/tests/test_calibration_executor.py
@@ -676,6 +676,68 @@ class TestRunsEndpoint:
         assert body["status"] == "succeeded"
         assert body["request"]["recipe_snapshot"]["id"] == "test-stage3"
 
+    async def test_enabled_stages_toggle_applies_to_run(
+        self,
+        client,
+        recipe_store,
+        store,
+        fake_full_chain,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Per-run toggles must actually change what runs (dead-toggle
+        # regression, PR 8 review MUST FIX) and be reflected in the snapshot.
+        self._enable(monkeypatch)
+        calls, _ = fake_full_chain
+        recipe = make_full_recipe(created_by=USER)
+        await recipe_store.upsert(recipe)
+        response = await client.post(
+            "/api/calibration/runs",
+            json={
+                "recipeId": recipe.id,
+                "inputs": [],
+                "enabledStages": {"detector1": False, "image2": False},
+            },
+            headers=bearer(),
+        )
+        assert response.status_code == 202
+        job_id = response.json()["jobId"]
+        import asyncio
+
+        async with asyncio.timeout(10):
+            while (await store.get(job_id))["status"] not in (
+                "succeeded",
+                "failed",
+                "cancelled",
+            ):
+                await asyncio.sleep(0.02)
+        doc = await store.get(job_id)
+        # Only image3 ran (inputs came from the MAST download fake).
+        assert calls["stages"] == ["image3"]
+        snapshot_stages = {
+            s["name"]: s["enabled"] for s in doc["request"]["recipe_snapshot"]["stages"]
+        }
+        assert snapshot_stages == {"detector1": False, "image2": False, "image3": True}
+
+    async def test_all_stages_disabled_is_422(
+        self, client, recipe_store, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An all-false enabledStages map must not launch a no-op job:
+        # _enabled_stages raises inside the route's validation block.
+        self._enable(monkeypatch)
+        recipe = make_full_recipe(created_by=USER)
+        await recipe_store.upsert(recipe)
+        response = await client.post(
+            "/api/calibration/runs",
+            json={
+                "recipeId": recipe.id,
+                "inputs": [],
+                "enabledStages": {"detector1": False, "image2": False, "image3": False},
+            },
+            headers=bearer(),
+        )
+        assert response.status_code == 422
+        assert "no enabled runnable stages" in response.text
+
     @staticmethod
     def _enable(monkeypatch: pytest.MonkeyPatch) -> None:
         from app.calibration import flags


### PR DESCRIPTION
## Summary

PR 8 of the Calibration Recipes feature (plan: `docs/plans/features/1709-calibration-recipes.md`) — the run flow: `/calibrate/:recipeId` configuration (stage toggles, parameter editor, input selection) and live job progress (per-stage checklist, log tail, cancel). With this, the feature is fully usable end-to-end from the browser.

## Changes Made

- **`src/pages/CalibrateRun.tsx/.css`** (new): stage toggle checkboxes, per-step parameter editor seeded from the recipe's overrides (scalar/list parsing; quoted-string escape hatch documented in the UI), input selection (MAST info for query recipes, library `_cal` checkbox picker otherwise), Run → live progress: status/download %, stage checklist driven by real engine events, `LogPanel` tail, cancel with immediate feedback and failure reset, outputs/failed/cancelled terminal states.
- **Run contract fix (review round 1 MUST FIX)**: the stage toggles were initially display-only. The contract now carries `enabledStages`, and the **engine** applies it to the recipe snapshot before validation/execution — so the job record reflects what actually ran. Engine regression tests: toggles change execution + snapshot; all-disabled → 422 (no no-op jobs).
- **`src/hooks/useCalibrationJob.ts`** (new): lean polling hook (1.5s; stops on terminal; bails after 5 consecutive failures; render-time reset per React's derived-state pattern). Deliberately not a `useJobProgress` retrofit (that hook is SignalR/import-coupled).
- **`CalibrationGallery`**: cards gain the "Configure & run" CTA.
- **Tests**: 6 new vitest (hook lifecycle ×3, page config/run/failure ×3), 2 engine tests, `e2e/calibrate.spec.ts` (seeded gallery, config nav, mocked run start → progress; passes on chromium locally, all browsers in CI).

## Test Plan

- [x] `tsc --noEmit` clean; `vitest run` 1180/1180
- [x] Engine full suite — 1692 passed (enabledStages regression tests included)
- [x] `playwright test e2e/calibrate.spec.ts` — 3/3 on chromium locally (firefox/webkit binaries not installed locally; CI runs all)
- [ ] Reviewer: open a seeded recipe, uncheck detector1+image2, add a `tweakreg` override, Run against library `_cal` files, watch the checklist/log tail live, cancel mid-run

## Documentation Checklist

- [x] Wire-contract and hook rationale documented in-code
- [ ] docs sweep — PR 10

## Tech Debt Impact

- [x] No new tech debt.

## Risk & Rollback

- **Risk: MED-LOW.** Additive UI + one additive engine contract field (`enabledStages`, optional — absent means recipe defaults, so PR 5/6 behavior is unchanged).
- **Rollback:** revert.

Part of #1709 (umbrella stays open). No linked issue to close.

https://claude.ai/code/session_01W5ZRaEbzFmit1DQs1nfP66
