### PR TITLE
ci: include E2E mock engine in the app paths filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
               - 'processing-engine/**'
               - 'docker/**'
               - 'tests/fixtures/e2e/**'
+              - 'tests/mock-processing-engine/**'
               - '.github/workflows/ci.yml'
             code:
               - 'backend/**'

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -18,6 +18,11 @@ services:
 
   processing-engine:
     image: docker-mock-processing-engine
+    # The calibration UI calls the engine directly from the browser
+    # (VITE_ENGINE_URL defaults to localhost:8000); the base compose does not
+    # publish this port — only the dev override does — so E2E must.
+    ports:
+      - "127.0.0.1:8000:8000"
     build:
       context: ../tests/mock-processing-engine
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

Follow-up to #1725: the `app` paths filter didn't include `tests/mock-processing-engine/**`, so changes to the E2E mock skipped the E2E job — the exact coverage they alter. #1725 therefore merged without its proof. This PR closes the filter gap, and because `ci.yml` is in every filter, its own E2E run IS the proof that the calibration-aware mock fixes `calibrate.spec.ts`.

## Changes Made
- `.github/workflows/ci.yml`: add `tests/mock-processing-engine/**` to the `app` filter (E2E trigger).
- `docker/docker-compose.e2e.yml`: publish the mock engine on `127.0.0.1:8000` — the base compose never exposes the engine port (the dev override does, which is why local E2E passed); browser-direct calibration calls connection-refused in CI.

## Test Plan
- [x] E2E runs on this PR (ci.yml change triggers all jobs) — green E2E here validates #1725

## Documentation Checklist
- [x] N/A — CI config only

## Tech Debt Impact
- [x] Closes a CI blind spot.

## Risk & Rollback
- **Risk: LOW.** Filter addition only. **Rollback:** revert.

Part of #1709. No linked issue to close.

https://claude.ai/code/session_01W5ZRaEbzFmit1DQs1nfP66
