### PR TITLE
feat: JWPipeNB notebook importer (#1709 PR 9)

### DIFF
--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.css
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.css
@@ -106,3 +106,33 @@
 .calibration-card-cta {
   align-self: flex-start;
 }
+
+.calibration-import {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.calibration-import-input {
+  display: none;
+}
+
+.calibration-import-hint,
+.calibrate-hint {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.calibration-import-error {
+  color: var(--danger, #ff6b6b);
+  margin-top: 0.5rem;
+}
+
+.calibration-import-warnings {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.test.tsx
@@ -7,9 +7,11 @@ import type { CalibrationRecipe } from '../types/CalibrationTypes';
 vi.mock('../services/calibrationService', () => ({
   listRecipes: vi.fn(),
   getCapabilities: vi.fn(),
+  importNotebook: vi.fn(),
 }));
 
-import { getCapabilities, listRecipes } from '../services/calibrationService';
+import userEvent from '@testing-library/user-event';
+import { getCapabilities, importNotebook, listRecipes } from '../services/calibrationService';
 
 const seedRecipe: CalibrationRecipe = {
   id: 'seed-miri-imaging',
@@ -108,5 +110,53 @@ describe('CalibrationGallery', () => {
       expect(screen.getByText("Couldn't load calibration recipes")).toBeInTheDocument()
     );
     expect(screen.getByText('engine unreachable')).toBeInTheDocument();
+  });
+});
+
+describe('CalibrationGallery import', () => {
+  it('imports a notebook and prepends the recipe with warnings', async () => {
+    vi.mocked(listRecipes).mockResolvedValue([seedRecipe]);
+    vi.mocked(getCapabilities).mockResolvedValue({
+      calibrationEnabled: true,
+      jwstVersion: '2.0.1',
+    });
+    vi.mocked(importNotebook).mockResolvedValue({
+      recipe: { ...seedRecipe, id: 'user-imported', name: 'Imported: x.ipynb', source: 'imported' },
+      warnings: ['cell 7: custom code is not carried into the recipe'],
+    });
+    render(
+      <MemoryRouter>
+        <CalibrationGallery />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByTestId('calibration-recipe-card')).toBeInTheDocument());
+    const file = new File(['{"cells":[]}'], 'x.ipynb', { type: 'application/json' });
+    const input = screen.getByLabelText('Import a JWPipeNB notebook') as HTMLInputElement;
+    await userEvent.upload(input, file);
+    await waitFor(() => expect(screen.getByText('Imported: x.ipynb')).toBeInTheDocument());
+    expect(screen.getByText(/custom code is not carried/)).toBeInTheDocument();
+  });
+
+  it('shows an import error', async () => {
+    vi.mocked(listRecipes).mockResolvedValue([seedRecipe]);
+    vi.mocked(getCapabilities).mockResolvedValue({
+      calibrationEnabled: true,
+      jwstVersion: '2.0.1',
+    });
+    vi.mocked(importNotebook).mockRejectedValue(new Error('not a recognizable JWPipeNB notebook'));
+    render(
+      <MemoryRouter>
+        <CalibrationGallery />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByTestId('calibration-recipe-card')).toBeInTheDocument());
+    const file = new File(['garbage'], 'bad.ipynb', { type: 'application/json' });
+    await userEvent.upload(
+      screen.getByLabelText('Import a JWPipeNB notebook') as HTMLInputElement,
+      file
+    );
+    await waitFor(() =>
+      expect(screen.getByText('not a recognizable JWPipeNB notebook')).toBeInTheDocument()
+    );
   });
 });

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
@@ -3,10 +3,10 @@
  * The run-configuration flow (/calibrate/:recipeId) lands in PR 8.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { EmptyState } from '../components/ui/EmptyState';
-import { getCapabilities, listRecipes } from '../services/calibrationService';
+import { getCapabilities, importNotebook, listRecipes } from '../services/calibrationService';
 import type { CalibrationCapabilities, CalibrationRecipe } from '../types/CalibrationTypes';
 import './CalibrationGallery.css';
 
@@ -72,6 +72,26 @@ export default function CalibrationGallery() {
   const [recipes, setRecipes] = useState<CalibrationRecipe[] | null>(null);
   const [capabilities, setCapabilities] = useState<CalibrationCapabilities | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importWarnings, setImportWarnings] = useState<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleImportFile = async (file: File) => {
+    setImportError(null);
+    setImportWarnings([]);
+    if (file.size > 5 * 1024 * 1024) {
+      setImportError('Notebook exceeds the 5MB import limit.');
+      return;
+    }
+    try {
+      const text = await file.text();
+      const result = await importNotebook(file.name, text);
+      setImportWarnings(result.warnings);
+      setRecipes((prev) => (prev ? [result.recipe, ...prev] : [result.recipe]));
+    } catch (err: unknown) {
+      setImportError(err instanceof Error ? err.message : 'Import failed');
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -109,6 +129,42 @@ export default function CalibrationGallery() {
             <span className="calibration-version"> Pipeline v{capabilities.jwstVersion}</span>
           )}
         </p>
+        <div className="calibration-import">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".ipynb"
+            className="calibration-import-input"
+            aria-label="Import a JWPipeNB notebook"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) void handleImportFile(file);
+              event.target.value = '';
+            }}
+          />
+          <button
+            type="button"
+            className="btn-base btn-compact"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            Import notebook…
+          </button>
+          <span className="calibrate-hint calibration-import-hint">
+            STScI JWPipeNB imaging notebooks are parsed into recipes — code is never executed.
+          </span>
+        </div>
+        {importError && (
+          <p className="calibration-import-error" role="alert">
+            {importError}
+          </p>
+        )}
+        {importWarnings.length > 0 && (
+          <ul className="calibration-import-warnings" role="status">
+            {importWarnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        )}
         {capabilities && !capabilities.calibrationEnabled && (
           <div className="calibration-disabled-banner" role="status">
             Calibration runs are disabled on this deployment — recipes are browsable, but the run

--- a/frontend/jwst-frontend/src/services/calibrationService.ts
+++ b/frontend/jwst-frontend/src/services/calibrationService.ts
@@ -47,3 +47,18 @@ export async function cancelJob(jobId: string): Promise<{ cancelRequested: boole
     {}
   );
 }
+
+export interface ImportRecipeResponse {
+  recipe: CalibrationRecipe;
+  warnings: string[];
+}
+
+export async function importNotebook(
+  filename: string,
+  notebookText: string
+): Promise<ImportRecipeResponse> {
+  return engineClient.post<ImportRecipeResponse>('/api/calibration/recipes/import', {
+    filename,
+    notebook: notebookText,
+  });
+}

--- a/processing-engine/app/calibration/importer.py
+++ b/processing-engine/app/calibration/importer.py
@@ -1,0 +1,289 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""JWPipeNB notebook importer (#1709 PR 9).
+
+Statically parses an STScI jwst-pipeline-notebook (.ipynb) into a
+CalibrationRecipe. The notebook is treated as DATA: cells are parsed with
+``ast`` and **never executed**. Extraction is fail-closed:
+
+- only recognized template patterns are extracted (config assignments,
+  ``do<stage>`` toggles, ``<stage>dict['step']['param'] = <literal>``
+  overrides, ``Observations.query_criteria`` literal kwargs);
+- a non-literal value on a recognized target rejects the import (we would
+  otherwise silently guess);
+- notebooks that don't carry the template's essential markers are rejected
+  with the supported vintage named;
+- everything else (association helpers, visualization, custom analysis) is
+  ignored for extraction and reported as warnings so the user knows what the
+  recipe does NOT carry over.
+
+Extracted overrides still pass the executor's security allowlist
+(``validate_step_overrides``) before a recipe is created.
+"""
+
+import ast
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.calibration.executor import RecipeValidationError, validate_step_overrides
+from app.calibration.models import CalibrationRecipe
+
+
+SUPPORTED_VINTAGE = "JWPipeNB Build 12.3 / jwst 2.0.x"
+MAX_NOTEBOOK_BYTES = 5 * 1024 * 1024
+
+_STAGE_DICTS = {"det1dict": "detector1", "image2dict": "image2", "image3dict": "image3"}
+_TOGGLES = {"dodet1": "detector1", "doimage2": "image2", "doimage3": "image3"}
+_IMAGING_INSTRUMENTS = {
+    "NIRCAM/IMAGE": "nircam",
+    "NIRISS/IMAGE": "niriss",
+    "MIRI/IMAGE": "miri",
+}
+
+
+class NotebookImportError(ValueError):
+    """The notebook cannot be imported; message names the reason/location."""
+
+
+@dataclass
+class _Extraction:
+    program: str | None = None
+    observation: str | None = None
+    filters: list[str] = field(default_factory=list)
+    instrument: str | None = None
+    toggles: dict[str, bool] = field(default_factory=dict)
+    overrides: dict[str, dict[str, dict[str, Any]]] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+
+def _literal(node: ast.expr) -> Any:
+    """Literal scalar / flat list, or raise ValueError."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        inner = _literal(node.operand)
+        if isinstance(inner, int | float):
+            return -inner
+        raise ValueError("non-numeric negation")
+    if isinstance(node, ast.List | ast.Tuple):
+        return [_literal(item) for item in node.elts]
+    raise ValueError("not a literal")
+
+
+def _subscript_chain(target: ast.expr) -> tuple[str, str, str] | None:
+    """Match ``name['step']['param']`` → (name, step, param)."""
+    if not (isinstance(target, ast.Subscript) and isinstance(target.value, ast.Subscript)):
+        return None
+    outer, inner = target, target.value
+    if not isinstance(inner.value, ast.Name):
+        return None
+    step = inner.slice
+    param = outer.slice
+    if not (isinstance(step, ast.Constant) and isinstance(param, ast.Constant)):
+        return None
+    if not (isinstance(step.value, str) and isinstance(param.value, str)):
+        return None
+    return inner.value.id, step.value, param.value
+
+
+def _handle_assign(node: ast.Assign, cell_no: int, out: _Extraction) -> None:
+    if len(node.targets) != 1:
+        return  # tuple inits like `d['a'], d['b'] = {}, {}` — ignore
+    target = node.targets[0]
+
+    if isinstance(target, ast.Name):
+        name = target.id
+        if name in _TOGGLES:
+            try:
+                value = _literal(node.value)
+            except ValueError:
+                raise NotebookImportError(
+                    f"cell {cell_no}, line {node.lineno}: '{name}' must be a literal True/False"
+                ) from None
+            if not isinstance(value, bool):
+                raise NotebookImportError(
+                    f"cell {cell_no}, line {node.lineno}: '{name}' must be a boolean"
+                )
+            out.toggles[_TOGGLES[name]] = value
+        elif name in ("program", "proposal_id"):
+            # First literal wins; the template later reuses `program` with
+            # computed values (association cells) — those are ignored. Only
+            # stage overrides are hard-fail on non-literals (they feed
+            # Pipeline.call); identity fields are user-reviewable in the UI.
+            try:
+                value = str(_literal(node.value))
+            except ValueError:
+                if out.program is None:
+                    out.warnings.append(
+                        f"cell {cell_no}, line {node.lineno}: non-literal '{name}' ignored"
+                    )
+                return
+            if out.program is None:
+                out.program = value
+        elif name in ("sci_observtn", "observtn", "obs_num"):
+            try:
+                value = str(_literal(node.value))
+            except ValueError:
+                return
+            if out.observation is None:
+                out.observation = value
+        return
+
+    chain = _subscript_chain(target)
+    if chain is None:
+        return
+    dict_name, step, param = chain
+    stage = _STAGE_DICTS.get(dict_name)
+    if stage is None:
+        return
+    if isinstance(node.value, ast.Dict) and not node.value.keys:
+        return  # `det1dict['jump'] = {}`-style init (single-subscript won't match here)
+    try:
+        value = _literal(node.value)
+    except ValueError:
+        raise NotebookImportError(
+            f"cell {cell_no}, line {node.lineno}: override "
+            f"{dict_name}['{step}']['{param}'] has a non-literal value — "
+            "cannot import safely"
+        ) from None
+    out.overrides.setdefault(stage, {}).setdefault(step, {})[param] = value
+
+
+def _handle_call(node: ast.Call, out: _Extraction) -> None:
+    func = node.func
+    if not (isinstance(func, ast.Attribute) and func.attr == "query_criteria"):
+        return
+    for keyword in node.keywords:
+        if keyword.arg == "instrument_name":
+            try:
+                names = _literal(keyword.value)
+            except ValueError:
+                continue
+            for raw in names if isinstance(names, list) else [names]:
+                if isinstance(raw, str) and raw.upper() in _IMAGING_INSTRUMENTS:
+                    out.instrument = _IMAGING_INSTRUMENTS[raw.upper()]
+                elif isinstance(raw, str):
+                    raise NotebookImportError(
+                        f"instrument mode '{raw}' is not importable — only "
+                        f"imaging modes are supported ({SUPPORTED_VINTAGE})"
+                    )
+        elif keyword.arg == "filters":
+            try:
+                values = _literal(keyword.value)
+            except ValueError:
+                continue
+            for item in values if isinstance(values, list) else [values]:
+                if isinstance(item, str) and item not in out.filters:
+                    out.filters.append(item)
+
+
+def parse_notebook(raw: bytes, filename: str) -> tuple[dict, list[str]]:
+    """Parse a JWPipeNB .ipynb into recipe fields + warnings. Never executes."""
+    if len(raw) > MAX_NOTEBOOK_BYTES:
+        raise NotebookImportError("notebook exceeds the 5MB import limit")
+    try:
+        notebook = json.loads(raw.decode("utf-8"))
+        cells = notebook["cells"]
+        assert isinstance(cells, list)
+    except Exception:
+        raise NotebookImportError("not a valid .ipynb (JSON with a cells list)") from None
+
+    out = _Extraction()
+    for cell_no, cell in enumerate(cells, start=1):
+        if not isinstance(cell, dict) or cell.get("cell_type") != "code":
+            continue
+        source = cell.get("source") or []
+        text = "".join(source) if isinstance(source, list) else str(source)
+        try:
+            tree = ast.parse(text)
+        except (SyntaxError, ValueError, RecursionError):
+            # ValueError: null bytes in source; RecursionError: pathological
+            # nesting within the size cap. Fail-open per cell — extraction is
+            # already fail-closed on the essentials check.
+            out.warnings.append(f"cell {cell_no}: unparseable — skipped")
+            continue
+        has_custom = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                _handle_assign(node, cell_no, out)
+            elif isinstance(node, ast.Call):
+                _handle_call(node, out)
+            elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                has_custom = True
+        if has_custom:
+            out.warnings.append(
+                f"cell {cell_no}: custom code (function/class definitions) is not "
+                "carried into the recipe"
+            )
+
+    missing = []
+    if out.instrument is None:
+        missing.append("an imaging instrument_name query")
+    if out.program is None:
+        missing.append("a 'program' assignment")
+    if not out.toggles and not out.overrides:
+        missing.append("stage toggles or stage parameter dicts")
+    if missing:
+        raise NotebookImportError(
+            "not a recognizable JWPipeNB imaging notebook — missing "
+            + ", ".join(missing)
+            + f" (supported vintage: {SUPPORTED_VINTAGE})"
+        )
+
+    stages = []
+    for stage_name in ("detector1", "image2", "image3"):
+        step_overrides = out.overrides.get(stage_name, {})
+        try:
+            validate_step_overrides(stage_name, step_overrides)
+        except RecipeValidationError as exc:
+            raise NotebookImportError(f"unsafe override rejected: {exc}") from exc
+        stages.append(
+            {
+                "name": stage_name,
+                "enabled": out.toggles.get(stage_name, True),
+                "step_overrides": step_overrides,
+            }
+        )
+
+    base_name = filename.rsplit("/", 1)[-1][:80]
+    recipe_fields = {
+        "schema_version": 1,
+        "name": f"Imported: {base_name}",
+        "description": f"Imported from {base_name} (static parse — custom code, "
+        "associations, and visualization are not carried over).",
+        "instrument": out.instrument,
+        "mode": "imaging",
+        "source": "imported",
+        "provenance": {"notebook_name": base_name, "jwst_version_authored": None},
+        "input_source": {
+            "type": "mast_query",
+            "proposal_id": out.program.lstrip("0") or "0" if out.program else None,
+            "observation": out.observation,
+            "filters": out.filters,
+            "calib_level": 1,
+            "product_suffixes": ["_uncal"],
+        },
+        "stages": stages,
+        "association": {
+            "rule": "DMS_Level3_Base",
+            "product_name": f"{out.instrument}-imported",
+        },
+        "output_suffixes": ["_i2d"],
+    }
+    return recipe_fields, out.warnings
+
+
+def import_notebook(
+    raw: bytes, filename: str, user_id: str, recipe_id: str
+) -> tuple[CalibrationRecipe, list[str]]:
+    """Full import: parse, then validate through the recipe schema."""
+    fields, warnings = parse_notebook(raw, filename)
+    fields["id"] = recipe_id
+    fields["created_by"] = user_id
+    try:
+        recipe = CalibrationRecipe.model_validate(fields)
+    except Exception as exc:
+        raise NotebookImportError(f"extracted config failed validation: {exc}") from exc
+    return recipe, warnings

--- a/processing-engine/app/calibration/routes.py
+++ b/processing-engine/app/calibration/routes.py
@@ -186,6 +186,39 @@ async def start_run(
     return {"jobId": job_id}
 
 
+@router.post("/recipes/import", status_code=201)
+async def import_recipe(
+    payload: dict,
+    user: AuthenticatedUser = Depends(require_user),
+    store: RecipeStore = Depends(get_recipe_store),
+):
+    """Import a JWPipeNB notebook as a recipe (static parse — the notebook is
+    never executed). Body: {"filename": str, "notebook": str (raw ipynb JSON)}."""
+    from app.calibration.importer import (
+        MAX_NOTEBOOK_BYTES,
+        NotebookImportError,
+        import_notebook,
+    )
+
+    filename = payload.get("filename") or "notebook.ipynb"
+    notebook_text = payload.get("notebook")
+    if not isinstance(notebook_text, str) or not notebook_text:
+        raise HTTPException(status_code=422, detail="notebook (raw ipynb text) is required")
+    raw = notebook_text.encode("utf-8")
+    if len(raw) > MAX_NOTEBOOK_BYTES:
+        raise HTTPException(status_code=413, detail="notebook exceeds the 5MB import limit")
+
+    try:
+        recipe, warnings = import_notebook(
+            raw, str(filename), user.user_id, f"user-{uuid.uuid4().hex[:12]}"
+        )
+    except NotebookImportError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    await store.upsert(recipe)
+    return {"recipe": await store.get(recipe.id), "warnings": warnings}
+
+
 @router.post("/recipes", status_code=201)
 async def create_recipe(
     payload: dict,

--- a/processing-engine/pyproject.toml
+++ b/processing-engine/pyproject.toml
@@ -20,6 +20,9 @@ exclude = [
     "dist",
     ".eggs",
     "*.egg-info",
+    # Verbatim STScI notebooks used as importer golden fixtures (#1709) —
+    # must not be reformatted; they are test data, not project source.
+    "tests/fixtures/jwpipenb",
 ]
 
 [tool.ruff.lint]

--- a/processing-engine/tests/fixtures/jwpipenb/JWPipeNB-MIRI-imaging.ipynb
+++ b/processing-engine/tests/fixtures/jwpipenb/JWPipeNB-MIRI-imaging.ipynb
@@ -1,0 +1,1470 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "095a295c",
+   "metadata": {},
+   "source": [
+    "<img style=\"float: center;\" src='https://github.com/spacetelescope/jwst-pipeline-notebooks/raw/main/_static/stsci_header.png' alt=\"stsci_logo\" width=\"900px\"/> "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0393e357-9d9d-4516-b28d-4d335fad33a0",
+   "metadata": {},
+   "source": [
+    "# MIRI Imaging Pipeline Notebook\n",
+    "\n",
+    "**Authors**: M. Cracraft<br>\n",
+    "**Last Updated**: April 17, 2026<br>\n",
+    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a74b566-3d8c-4985-a4f3-d654a6d39371",
+   "metadata": {},
+   "source": [
+    "**Purpose**:<br>\n",
+    "This notebook provides a framework for processing generic Mid-Infrared Instrument \n",
+    "(MIRI) Imaging data through all\n",
+    "three James Webb Space Telescope (JWST) pipeline stages.  Data is assumed\n",
+    "to be located in one observation folder according to paths set up below.\n",
+    "It should not be necessary to edit any cells other than in the\n",
+    "[Configuration](#1.-Configuration) section unless modifying the standard\n",
+    "pipeline processing options.\n",
+    "\n",
+    "**Data**:<br>\n",
+    "This example is set up to use an example dataset is from\n",
+    "[Program ID](https://www.stsci.edu/jwst/science-execution/program-information)\n",
+    "1040 (PI: O. Detre, Co-I: A. Noriega-Crespo) which is an external flat commissioning program.\n",
+    "The MIRI imaging dataset uses a 5-step dither pattern. Example input data to use will be\n",
+    "downloaded automatically unless disabled (i.e., to use local files instead).\n",
+    "\n",
+    "**JWST pipeline version and CRDS context**:<br>\n",
+    "This notebook was written for the calibration pipeline version given above and uses the context associated with this version of the JWST Calibration Pipeline. Information about this an other contexts can be found in the JWST Calibration Reference Data System (CRDS) [server]((https://jwst-crds.stsci.edu/)). If you use different pipeline\n",
+    "versions, please refer to the table [here](https://jwst-crds.stsci.edu/display_build_contexts/) to determine what context to use. To learn more about the differences for the pipeline, read the relevant [documentation](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/jwst-operations-pipeline-build-information)<br>\n",
+    "\n",
+    "**Updates**:<br>\n",
+    "This notebook is regularly updated as improvements are made to the\n",
+    "pipeline. Find the most up to date version of this notebook at:\n",
+    "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
+    "\n",
+    "**Recent Changes**:<br>\n",
+    "September 25, 2024: original notebook released<br>\n",
+    "November 22, 2024: Updates to workflow when skipping pipeline modules<br>\n",
+    "January 16, 2025: Add handling for dedicated backgrounds, update to jwst 1.17.1<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)<br>\n",
+    "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
+    "December 10, 2025: Updated to jwst 1.20.2 (no significant changes)<br>\n",
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fecaabc8",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "231ccda6",
+   "metadata": {},
+   "source": [
+    "## Table of Contents\n",
+    "1. [Configuration](#1.-Configuration)\n",
+    "2. [Package Imports](#2.-Package-Imports)\n",
+    "3. [Demo Mode Setup (ignore if not using demo data)](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
+    "4. [Directory Setup](#4.-Directory-Setup)\n",
+    "3. [Detector 1 Pipeline](#5.-Detector1-Pipeline)\n",
+    "4. [Image2 Pipeline](#6.-Image2-Pipeline)\n",
+    "5. [Image3 Pipeline](#7.-Image3-Pipeline)\n",
+    "6. [Visualize the data](#8.-Visualize-the-drizzle-combined-image)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d5f7ab9",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43bd07d7",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration\n",
+    "------------------\n",
+    "Set basic configuration for running notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026a649d-a0d2-4e3f-ab6d-cf8c26e6ce1d",
+   "metadata": {},
+   "source": [
+    "### Install dependencies and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84b6c02c-a7cd-4999-96a0-87ce398d7e9a",
+   "metadata": {},
+   "source": [
+    "To make sure that the pipeline version is compatabile with the steps\n",
+    "discussed below and the required dependencies and packages are installed,\n",
+    "you can create a fresh conda environment and install the provided\n",
+    "`requirements.txt` file before starting this notebook: <br>\n",
+    "```\n",
+    "conda create -n miri_imaging_pipeline python=3.13\n",
+    "conda activate miri_imaging_pipeline\n",
+    "pip install -r requirements.txt\n",
+    "```\n",
+    "\n",
+    "Set the basic parameters to use with this notebook. These will affect\n",
+    "what data is used, where data is located (if already in disk), and\n",
+    "pipeline modules run in this data. The list of parameters are:\n",
+    "\n",
+    "* demo_mode\n",
+    "* directories with data\n",
+    "* pipeline modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06ea414c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic import necessary for configuration\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61bb14e6",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Note that <code>demo_mode</code> must be set appropriately below.\n",
+    "</div>\n",
+    "\n",
+    "Set <code>demo_mode = True </code> to run in demonstration mode. In this\n",
+    "mode this notebook will download example data from the Barbara A.\n",
+    "Mikulski Archive for Space Telescopes\n",
+    "([MAST](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html))\n",
+    "and process it through the pipeline. This will all happen in a local\n",
+    "directory unless modified in\n",
+    "[Section 3](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data)) below.<br>\n",
+    "\n",
+    "Set <code>demo_mode = False</code> if you want to process your own data\n",
+    "that has already been downloaded and provide the location of the data.<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "323f87d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set parameters for demo_mode and processing steps.\n",
+    "\n",
+    "# -----------------------------Demo Mode---------------------------------\n",
+    "demo_mode = True\n",
+    "\n",
+    "if demo_mode:\n",
+    "    print('Running in demonstration mode using online example data!')\n",
+    "\n",
+    "# --------------------------User Mode Directories------------------------\n",
+    "# If demo_mode = False, look for user data in these paths\n",
+    "if not demo_mode:\n",
+    "    # Set directory paths for processing specific data; these will need\n",
+    "    # to be changed to your local directory setup (below are given as\n",
+    "    # examples)\n",
+    "    user_home_dir = os.path.expanduser('~')\n",
+    "\n",
+    "    # Point to where science observation data are\n",
+    "    # Assumes uncalibrated data in sci_dir/uncal/ and results in stage1,\n",
+    "    # stage2, stage3 directories\n",
+    "    sci_dir = os.path.join(user_home_dir, 'FlightData/APT1040/data/Obs001/')\n",
+    "    \n",
+    "    # Point to where background observation data are\n",
+    "    # Assumes uncalibrated data in bg_dir/uncal/ and results in stage1 directory\n",
+    "    #bg_dir = os.path.join(user_home_dir, 'FlightData/APT1714/data/Obs02/')\n",
+    "    bg_dir = '' # If no background observation, use an empty string\n",
+    "\n",
+    "# --------------------------Set Processing Steps--------------------------\n",
+    "# Individual pipeline stages can be turned on/off here.  Note that a later\n",
+    "# stage won't be able to run unless data products have already been\n",
+    "# produced from the prior stage.\n",
+    "\n",
+    "# Science processing\n",
+    "dodet1 = True  # calwebb_detector1\n",
+    "doimage2 = True  # calwebb_image2\n",
+    "doimage3 = True  # calwebb_image3\n",
+    "doviz = True # Visualize calwebb_image3 results\n",
+    "\n",
+    "# Background processing (if present)\n",
+    "dodet1bg = True  # calwebb_detector1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1070079a",
+   "metadata": {},
+   "source": [
+    "### Set CRDS context and server\n",
+    "Before importing <code>CRDS</code> and <code>JWST</code> modules, we need\n",
+    "to configure our environment. This includes defining a CRDS cache\n",
+    "directory in which to keep the reference files that will be used by the\n",
+    "calibration pipeline.<br>\n",
+    "\n",
+    "If the root directory for the local CRDS cache directory has not been set\n",
+    "already, it will be set to create one in the home directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baf7070d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ------------------------Set CRDS context and paths----------------------\n",
+    "# Each version of the calibration pipeline is associated with a specific CRDS\n",
+    "# context file. The pipeline will select the appropriate context file behind\n",
+    "# the scenes while running. However, if you wish to override the default context\n",
+    "# file and run the pipeline with a different context, you can set that using\n",
+    "# the CRDS_CONTEXT environment variable. Here we show how this is done,\n",
+    "# although we leave the line commented out in order to use the default context.\n",
+    "# If you wish to specify a different context, uncomment the line below.\n",
+    "#%env CRDS_CONTEXT jwst_1293.pmap\n",
+    "\n",
+    "# Check whether the local CRDS cache directory has been set.\n",
+    "# If not, set it to the user home directory\n",
+    "if (os.getenv('CRDS_PATH') is None):\n",
+    "    os.environ['CRDS_PATH'] = os.path.join(os.path.expanduser('~'), 'crds')\n",
+    "\n",
+    "# Check whether the CRDS server URL has been set.  If not, set it.\n",
+    "if (os.getenv('CRDS_SERVER_URL') is None):\n",
+    "    os.environ['CRDS_SERVER_URL'] = 'https://jwst-crds.stsci.edu'\n",
+    "\n",
+    "# Echo CRDS path in use\n",
+    "print(f\"CRDS local filepath: {os.environ['CRDS_PATH']}\")\n",
+    "print(f\"CRDS file server: {os.environ['CRDS_SERVER_URL']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be716575",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "575588c8",
+   "metadata": {},
+   "source": [
+    "## 2. Package Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4415f6d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the entire available screen width for this notebook\n",
+    "from IPython.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:95% !important; }</style>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb9f7f54-ff98-428b-9fa9-b39c50210c3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic system utilities for interacting with files\n",
+    "# ----------------------General Imports------------------------------------\n",
+    "import glob\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "from collections import defaultdict\n",
+    "#import urllib.request\n",
+    "\n",
+    "# Numpy for doing calculations\n",
+    "import numpy as np\n",
+    "\n",
+    "# To display full output of cell, not just the last result\n",
+    "from IPython.core.interactiveshell import InteractiveShell\n",
+    "InteractiveShell.ast_node_interactivity = \"all\"\n",
+    "\n",
+    "# --------------------Astroquery Imports------------------------------\n",
+    "# ASCII files, and downloading demo files\n",
+    "from astroquery.mast import Observations\n",
+    "\n",
+    "# ----------------Matplotlib for visualizing images-------------------\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# -------------------Astropy routines for visualizing detected sources----------\n",
+    "from astropy.table import Table\n",
+    "from astropy.io import fits\n",
+    "\n",
+    "# ----------------------JWST calibration pipeline------------------------\n",
+    "import jwst\n",
+    "import crds\n",
+    "\n",
+    "from jwst.pipeline import Detector1Pipeline\n",
+    "from jwst.pipeline import Image2Pipeline\n",
+    "from jwst.pipeline import Image3Pipeline\n",
+    "\n",
+    "# JWST pipeline utilities\n",
+    "from jwst import datamodels\n",
+    "from jwst.datamodels import ImageModel\n",
+    "from jwst.associations import asn_from_list as afl  # Tools for creating association files\n",
+    "from jwst.associations.lib.rules_level2_base import DMSLevel2bBase  # Definition of a Lvl2 association file\n",
+    "from jwst.associations.lib.rules_level3_base import DMS_Level3_Base  # Definition of a Lvl3 association file\n",
+    "\n",
+    "# Echo pipeline version and CRDS context in use\n",
+    "print(f\"JWST Calibration Pipeline Version: {jwst.__version__}\")\n",
+    "print(f\"Using CRDS Context: {crds.get_context_name('jwst')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5844d476-f8b3-4c24-9c79-091d6016314d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start a timer to keep track of runtime\n",
+    "time0 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ae973c7",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ef8050f",
+   "metadata": {},
+   "source": [
+    "## 3. Demo Mode Setup (ignore if not using demo data)\n",
+    "------------------\n",
+    "If running in demonstration mode, set up the program information to\n",
+    "retrieve the uncalibrated data automatically from MAST using\n",
+    "[astroquery](https://astroquery.readthedocs.io/en/latest/mast/mast.html).\n",
+    "MAST allows for flexibility of searching by the proposal ID and the\n",
+    "observation ID instead of just filenames.<br>\n",
+    "\n",
+    "For illustrative purposes, we focus on data taken through the MIRI\n",
+    "[F770W filter](https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument/miri-observing-modes/miri-imaging#MIRIImaging-MIRIFiltersImagingfilters)\n",
+    "and start with uncalibrated data products. The files are named\n",
+    "`jw01040001005_03103_0000n_miri_uncal.fits`, where *n* refers to the\n",
+    "dither step number which ranges from 1 - 5.\n",
+    "\n",
+    "More information about the JWST file naming conventions can be found at:\n",
+    "https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/file_naming.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d595f1e-2590-4f01-bb92-13bb43a22b3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up the program information and paths for demo program\n",
+    "if demo_mode:\n",
+    "    print('Running in demonstration mode and will download example data from MAST!')\n",
+    "    program = '01040'\n",
+    "    sci_observtn = \"001\"\n",
+    "    visit = \"005\"\n",
+    "    data_dir = os.path.join('.', 'mir_im_demo_data')\n",
+    "    download_dir = data_dir\n",
+    "    sci_dir = os.path.join(data_dir, 'Obs' + sci_observtn)\n",
+    "    uncal_dir = os.path.join(sci_dir, 'uncal')\n",
+    "    bg_dir = ''\n",
+    "\n",
+    "    # Ensure filepaths for input data exist\n",
+    "    if not os.path.exists(uncal_dir):\n",
+    "        os.makedirs(uncal_dir)\n",
+    "\n",
+    "    # Create directory if it does not exist\n",
+    "    if not os.path.isdir(data_dir):\n",
+    "        os.mkdir(data_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6674a8b8",
+   "metadata": {},
+   "source": [
+    "Identify list of science (SCI) uncalibrated files associated with visits.\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Selects only filter <i>f770w</i> data\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4b22375",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Obtain a list of observation IDs for the specified demo program\n",
+    "if demo_mode:\n",
+    "    # Science data\n",
+    "    sci_obs_id_table = Observations.query_criteria(instrument_name=[\"MIRI/IMAGE\"],\n",
+    "                                                   provenance_name=[\"CALJWST\"],  # Executed observations\n",
+    "                                                   filters=['F770W'],  # Data for Specific Filter\n",
+    "                                                   obs_id=['jw' + program + '-o' + sci_observtn + '*']\n",
+    "                                                   )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a666350e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Turn the list of visits into a list of uncalibrated data files\n",
+    "if demo_mode:\n",
+    "    # Define types of files to select\n",
+    "    file_dict = {'uncal': {'product_type': 'SCIENCE',\n",
+    "                           'productSubGroupDescription': 'UNCAL',\n",
+    "                           'calib_level': [1]}}\n",
+    "\n",
+    "    # Science files\n",
+    "    sci_files_to_download = []\n",
+    "\n",
+    "    # Loop over visits identifying uncalibrated files that are associated\n",
+    "    # with them\n",
+    "    for exposure in (sci_obs_id_table):\n",
+    "        products = Observations.get_product_list(exposure)\n",
+    "        for filetype, query_dict in file_dict.items():\n",
+    "            filtered_products = Observations.filter_products(products, productType=query_dict['product_type'],\n",
+    "                                                             productSubGroupDescription=query_dict['productSubGroupDescription'],\n",
+    "                                                             calib_level=query_dict['calib_level'])\n",
+    "            sci_files_to_download.extend(filtered_products['dataURI'])\n",
+    "\n",
+    "    # Download only the files in a single visit\n",
+    "    sci_files_to_download = [match for match in sci_files_to_download if ('jw' + program + sci_observtn + visit) in match]\n",
+    "    sci_files_to_download = sorted(sci_files_to_download)\n",
+    "    print(f\"Science files selected for downloading: {len(sci_files_to_download)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c36a54be",
+   "metadata": {},
+   "source": [
+    "Download all the uncal files and place them into the appropriate\n",
+    "directories.<br>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Warning: If this notebook is halted during this step the downloaded file\n",
+    "may be incomplete, and cause crashes later on!\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "764fa682",
+   "metadata": {
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "if demo_mode:\n",
+    "    for filename in sci_files_to_download:\n",
+    "        sci_manifest = Observations.download_file(filename,\n",
+    "                                                  local_path=os.path.join(uncal_dir, Path(filename).name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f46eeea8",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6c51254-6295-4f98-bc25-d07300e0d8f4",
+   "metadata": {},
+   "source": [
+    "## 4. Directory Setup\n",
+    "---------------------\n",
+    "Set up detailed paths to input/output stages here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bffbedc3-fbe3-4c56-ad18-85b5d0c7d880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define output subdirectories to keep science data products organized\n",
+    "uncal_dir = os.path.join(sci_dir, 'uncal')  # Uncalibrated pipeline inputs should be here\n",
+    "det1_dir = os.path.join(sci_dir, 'stage1')  # calwebb_detector1 pipeline outputs will go here\n",
+    "image2_dir = os.path.join(sci_dir, 'stage2')  # calwebb_spec2 pipeline outputs will go here\n",
+    "image3_dir = os.path.join(sci_dir, 'stage3')  # calwebb_spec3 pipeline outputs will go here\n",
+    "\n",
+    "# Output subdirectories to keep background data products organized\n",
+    "uncal_bgdir = os.path.join(bg_dir, 'uncal')  # Uncalibrated pipeline inputs should be here\n",
+    "det1_bgdir = os.path.join(bg_dir, 'stage1')  # calwebb_detector1 pipeline outputs will go here\n",
+    "\n",
+    "# We need to check that the desired output directories exist, and if not\n",
+    "# create them\n",
+    "if not os.path.exists(det1_dir):\n",
+    "    os.makedirs(det1_dir)\n",
+    "if not os.path.exists(image2_dir):\n",
+    "    os.makedirs(image2_dir)\n",
+    "if not os.path.exists(image3_dir):\n",
+    "    os.makedirs(image3_dir)\n",
+    "    \n",
+    "if ((bg_dir != '') & (not os.path.exists(det1_bgdir))):\n",
+    "    os.makedirs(det1_bgdir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f843ff7f-58b6-4294-bfaa-606c29abc524",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55c14d80",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "267e28e0-a63f-4790-b8a0-3ad4bff5a167",
+   "metadata": {},
+   "source": [
+    "## 5. Detector1 Pipeline\n",
+    "Run the datasets through the\n",
+    "[Detector1](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline-overview/stages-of-jwst-data-processing/calwebb_detector1)\n",
+    "stage of the pipeline to apply detector level calibrations and create a\n",
+    "countrate data product where slopes are fitted to the integration ramps.\n",
+    "These `*_rate.fits` products are 2D (nrows x ncols), averaged over all\n",
+    "integrations. 3D countrate data products (`*_rateints.fits`) are also\n",
+    "created (nintegrations x nrows x ncols) which have the fitted ramp slopes\n",
+    "for each integration.<br>\n",
+    "\n",
+    "By default, all steps in the `Detector1` stage of the pipeline are run for\n",
+    "MIRI except: the `group_scale`, `ipc` and the `gain_scale` steps.<br>\n",
+    "\n",
+    "MIRI performs a few pipeline steps in calwebb_detector1 that are not performed for other instruments.\n",
+    "The [emicorr](https://jwst-pipeline.readthedocs.io/en/latest/jwst/emicorr/index.html#emicorr-step) step corrects\n",
+    "for known noise patterns in MIRI data. For certain subarrays, these noise patterns are clearly imprinted on\n",
+    "the data in the `rate.fits` files.<br>\n",
+    "\n",
+    "The [firstframe](https://jwst-pipeline.readthedocs.io/en/latest/jwst/firstframe/index.html#firstframe-step) step flags the first frame in each integration as bad, if the number of groups per integration is greater than 3.<br>\n",
+    "\n",
+    "The [lastframe](https://jwst-pipeline.readthedocs.io/en/latest/jwst/lastframe/index.html#lastframe-step) step\n",
+    "flags the last frame in each integration as bad, if the number of groups per integration is greater than 2.<br>\n",
+    "\n",
+    "The [reset](https://jwst-pipeline.readthedocs.io/en/latest/jwst/reset/index.html#reset-step) correction step\n",
+    "corrects for the reset anomaly effect. This effect is caused by the non-ideal behavior of the field effect\n",
+    "transistor (FET) upon resetting in the dark causing the initial frames in an integration to be offset\n",
+    "from their expected values.<br>\n",
+    "\n",
+    "The [rscd](https://jwst-pipeline.readthedocs.io/en/latest/jwst/rscd/index.html#rscd-step) step reads a reference\n",
+    "file for each data file and determines how many frames at the start of a ramp should be flagged as bad. There are a\n",
+    "number of nonlinearities at the start of MIRI ramps, and the flagging allows the more linear portion of the ramp to\n",
+    "be used for jump detection and ramp fitting, without using the initial, non-linear portion of the ramp. The number\n",
+    "of groups flagged depend on filter and subarray.<br>\n",
+    "\n",
+    "As of CRDS context `jwst_1201.pmap` and later, the\n",
+    "[jump](https://jwst-pipeline.readthedocs.io/en/latest/api/jwst.jump.JumpStep.html) step\n",
+    "of the `DETECTOR1` stage of the pipeline will remove residuals associated\n",
+    "with [showers](https://jwst-docs.stsci.edu/known-issues-with-jwst-data/shower-and-snowball-artifacts)\n",
+    "for the MIRI imaging mode, but only for data with filter F1500W and shorter. The default parameters for this correction,\n",
+    "where `find_showers` set to `True` turns on the shower\n",
+    "removal algorithm, are specified in the `pars-jumpstep` parameter\n",
+    "reference files. Users may wish to alter parameters to optimize removal of\n",
+    "shower residuals. Available parameters are discussed in the\n",
+    "[Detection and Flagging of Showers and Snowballs in JWST Technical Report (Regan 2023)](https://www.stsci.edu/files/live/sites/www/files/home/jwst/documentation/technical-documents/_documents/JWST-STScI-008545.pdf)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3592ee58-b424-4bd6-973b-88fd081b81d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Detector1 pipeline should be configured\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "det1dict = defaultdict(dict)\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped\n",
+    "# skipping the refpix step\n",
+    "#det1dict['refpix']['skip'] = True\n",
+    "#det1dict['jump']['find_showers'] = False # Turn off detection of cosmic ray showers\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#det1dict['dq_init']['override_mask'] = 'myfile.fits'  # Bad pixel mask\n",
+    "#det1dict['saturation']['override_saturation'] = 'myfile.fits'  # Saturation\n",
+    "#det1dict['reset']['override_reset'] = 'myfile.fits'  # Reset\n",
+    "#det1dict['linearity']['override_linearity'] = 'myfile.fits'  # Linearity\n",
+    "#det1dict['rscd']['override_rscd'] = 'myfile.fits'  # RSCD\n",
+    "#det1dict['dark_current']['override_dark'] = 'myfile.fits'  # Dark current subtraction\n",
+    "#det1dict['jump']['override_gain'] = 'myfile.fits'  # Gain used by jump step\n",
+    "#det1dict['ramp_fit']['override_gain'] = 'myfile.fits'  # Gain used by ramp fitting step\n",
+    "#det1dict['jump']['override_readnoise'] = 'myfile.fits'  # Read noise used by jump step\n",
+    "#det1dict['ramp_fit']['override_readnoise'] = 'myfile.fits'  # Read noise used by ramp fitting step\n",
+    "\n",
+    "# Turn on multi-core processing (off by default).  Choose what fraction of cores to use (quarter, half, or all)\n",
+    "det1dict['jump']['maximum_cores'] = 'half'\n",
+    "\n",
+    "# Alter parameters to optimize removal of shower residuals (example)\n",
+    "#det1dict['jump']['after_jump_flag_dn1'] = X  # A floating point value in units of DN\n",
+    "#det1dict['jump']['after_jump_flag_time1'] = x.x # A floating point value in units of seconds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fc8001b",
+   "metadata": {},
+   "source": [
+    "### Calibrating Science Files\n",
+    "Look for input science files and run calwebb_detector1 pipeline using the call method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "453bba1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uncal_files = sorted(glob.glob(os.path.join(uncal_dir, '*_uncal.fits')))\n",
+    "uncal_bgfiles = sorted(glob.glob(os.path.join(uncal_bgdir, '*_uncal.fits')))\n",
+    "\n",
+    "print('Found ' + str(len(uncal_files)) + ' science input files')\n",
+    "print('Found ' + str(len(uncal_bgfiles)) + ' background input files')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "024a9df0",
+   "metadata": {},
+   "source": [
+    "Look at the first file to determine exposure parameters and practice using\n",
+    "JWST datamodels¶"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4a7f724",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if dodet1:\n",
+    "    # print file name\n",
+    "    print(uncal_files[0])\n",
+    "\n",
+    "    # Open file as JWST datamodel\n",
+    "    examine = datamodels.open(uncal_files[0])\n",
+    "\n",
+    "    # Print out exposure info\n",
+    "    print(f\"Instrument: {examine.meta.instrument.name}\")\n",
+    "    print(f\"Filter: {examine.meta.instrument.filter}\")\n",
+    "    print(f\"Number of integrations: {examine.meta.exposure.nints}\")\n",
+    "    print(f\"Number of groups: {examine.meta.exposure.ngroups}\")\n",
+    "    print(f\"Readout pattern: {examine.meta.exposure.readpatt}\")\n",
+    "    print(f\"Dither position number: {examine.meta.dither.position_number}\")\n",
+    "    print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ee917a7",
+   "metadata": {},
+   "source": [
+    "From the above, we confirm that the demo data file is for the MIRI instrument\n",
+    "using the `F770W` filter in the [Filter Wheel](https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument/miri-instrumentation/miri-filters-and-dispersers#gsc.tab=0). This observation uses\n",
+    "the MIRI [readout pattern](https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument/miri-instrumentation/miri-detector-overview/miri-detector-readout-overview#gsc.tab=0) FASTR1,\n",
+    "6 groups per integration, and 1 integration per exposure. This data file\n",
+    "is the 1st dither position in this exposure sequence. For more information\n",
+    "about how JWST exposures are defined by up-the-ramp sampling, see the\n",
+    "[Understanding Exposure Times JDox article](https://jwst-docs.stsci.edu/understanding-exposure-times).<br>\n",
+    "\n",
+    "This metadata will be the same for all exposures in this observation other\n",
+    "than the dither position number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f8f107b-5f80-4674-bc34-2d88791e4409",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Run Detector1 stage of pipeline, specifying:\n",
+    "# output directory to save *_rate.fits files\n",
+    "# save_results flag set to True so the rate files are saved\n",
+    "\n",
+    "if dodet1:\n",
+    "    for uncal in uncal_files:\n",
+    "        rate_result = Detector1Pipeline.call(uncal, output_dir=det1_dir, steps=det1dict, save_results=True,)\n",
+    "else:\n",
+    "    print('Skipping Detector1 processing')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae69bfe2",
+   "metadata": {},
+   "source": [
+    "### Calibrating Background Files\n",
+    "Look for input background files and run calwebb_detector1\n",
+    "pipeline using the call method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c536f68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run Detector1 stage of pipeline on any background files\n",
+    "\n",
+    "if dodet1bg:\n",
+    "    for uncal in uncal_bgfiles:\n",
+    "        rate_result = Detector1Pipeline.call(uncal, output_dir=det1_bgdir, steps=det1dict, save_results=True,)\n",
+    "else:\n",
+    "    print('Skipping Detector1 BG processing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4cc2b48-7ec7-4b59-b3ee-2dfdf0782c01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime for Detector1: {time1 - time0:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fc5520a-6097-482b-b3e0-a6bf94cf7af3",
+   "metadata": {},
+   "source": [
+    "### Exploring the data\n",
+    "\n",
+    "Identify `*_rate.fits` files and verify which pipeline steps were run and\n",
+    "which calibration reference files were applied.<br>\n",
+    "\n",
+    "The header contains information about which calibration steps were\n",
+    "completed and skipped and which reference files were used to process the\n",
+    "data.<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c122766-a545-4042-93e8-f68c18f62fdf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if dodet1:\n",
+    "    # find rate files\n",
+    "    rate_files = sorted(glob.glob(os.path.join(det1_dir, '*_rate.fits')))\n",
+    "\n",
+    "    # Read in file as datamodel\n",
+    "    rate_f = datamodels.open(rate_files[0])\n",
+    "\n",
+    "    # Check which steps were run\n",
+    "    rate_f.meta.cal_step.instance\n",
+    "\n",
+    "    # Check which reference files were used to calibrate the dataset:\n",
+    "    rate_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30e4ff98",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "350808ee-9579-4cb5-8f02-a74904c91449",
+   "metadata": {},
+   "source": [
+    "## 6. Image2 Pipeline \n",
+    "\n",
+    "In the [Image2](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image2.html) stage of the pipeline,\n",
+    "calibrated unrectified data products are created (`*_cal.fits` or\n",
+    "`*_calints.fits` files, depending on whether the input files are\n",
+    "`*_rate.fits` or `*_rateints.fits`). \n",
+    "\n",
+    "In this pipeline processing stage, the\n",
+    "[background subtraction](https://jwst-pipeline.readthedocs.io/en/latest/jwst/background_step/index.html#background-step)\n",
+    "step is performed if the data have a dedicated background defined,\n",
+    "the [world coordinate system (WCS)](https://jwst-pipeline.readthedocs.io/en/latest/jwst/assign_wcs/index.html#assign-wcs-step)\n",
+    "is assigned, the data are [flat fielded](https://jwst-pipeline.readthedocs.io/en/latest/jwst/flatfield/index.html#flatfield-step),\n",
+    "and a [photometric calibration](https://jwst-pipeline.readthedocs.io/en/latest/jwst/photom/index.html#photom-step)\n",
+    "is applied to convert from units of countrate (ADU/s) to surface brightness (MJy/sr).\n",
+    "\n",
+    "The [resampling](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step)\n",
+    "step is performed, to create resampled images of each dither position, but this is\n",
+    "only a quick-look product. The resampling step occurs during the `Image3` stage by\n",
+    "default. While the resampling step is done in the `Image2` stage, the data quality\n",
+    "from the `Image3` stage will be better since the bad pixels, which adversely affect\n",
+    "both the centroids and photometry in individual images, will be mostly\n",
+    "removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a091817-7a3c-4a60-a914-f9ac54d36e56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_image2 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b00fda2-a7c0-445a-bf23-0d9b4f050419",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Image2 pipeline should be configured.\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "image2dict = defaultdict(dict)\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped (example)\n",
+    "#image2dict['resample']['skip'] = False\n",
+    "\n",
+    "# Change the nsigma used for clipping the input background data\n",
+    "image2dict['bkg_subtract']['sigma'] = 2\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#image2dict['assign_wcs']['override_distortion'] = 'myfile.asdf'  # Spatial distortion (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_filteroffset'] = 'myfile.asdf'  # Imager filter offsets (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_specwcs'] = 'myfile.asdf'  # Spectral distortion (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_wavelengthrange'] = 'myfile.asdf'  # Wavelength channel mapping (ASDF file)\n",
+    "#image2dict['flat_field']['override_flat'] = 'myfile.fits'  # Pixel flatfield\n",
+    "#image2dict['photom']['override_photom'] = 'myfile.fits'  # Photometric calibration array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bd5c61a",
+   "metadata": {},
+   "source": [
+    "Define a function to create association files for Stage 2. This will enable use of the pixel-based background subtraction, if chosen above. This requires *one* input SCI file, but can have multiple input background files.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Note that the background will not be applied properly to all files if more than *one* SCI file is included in the association.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5aeae956",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def writel2asn(onescifile, bgfiles, asnfile, prodname):\n",
+    "    # Define the basic association of science files\n",
+    "    asn = afl.asn_from_list([onescifile], rule=DMSLevel2bBase, product_name=prodname)  # Wrap in array since input was single exposure\n",
+    "\n",
+    "    # Filter configuration for this sci file\n",
+    "    with fits.open(onescifile) as hdu:\n",
+    "        hdu.verify()\n",
+    "        hdr = hdu[0].header\n",
+    "        this_filter = hdr['FILTER']\n",
+    "\n",
+    "    # If backgrounds were provided, find which are appropriate to this\n",
+    "    # filter and add to association\n",
+    "    for file in bgfiles:\n",
+    "        with fits.open(file) as hdu:\n",
+    "            hdu.verify()\n",
+    "            if (hdu[0].header['FILTER'] == this_filter):\n",
+    "                asn['products'][0]['members'].append({'expname': file, 'exptype': 'background'})              \n",
+    "\n",
+    "    # Write the association to a json file\n",
+    "    _, serialized = asn.dump()\n",
+    "    with open(asnfile, 'w') as outfile:\n",
+    "        outfile.write(serialized)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247170cd-a3ee-4d9d-b8b3-f930727f8abc",
+   "metadata": {},
+   "source": [
+    "Find and sort all of the input files, ensuring use of absolute paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d19cd4e6-cc38-4e26-8e8b-7fb143856940",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find all Science rate.fits files\n",
+    "sstring = os.path.join(det1_dir, 'jw*rate.fits')  # Use files from the detector1 output folder\n",
+    "rate_files = sorted(glob.glob(sstring))\n",
+    "for ii in range(0, len(rate_files)):\n",
+    "    rate_files[ii] = os.path.abspath(rate_files[ii])\n",
+    "rate_files = np.array(rate_files)\n",
+    "\n",
+    "# Background Files\n",
+    "sstring = os.path.join(det1_bgdir, 'jw*rate.fits')\n",
+    "bgfiles = sorted(glob.glob(sstring))\n",
+    "for ii in range(0, len(bgfiles)):\n",
+    "    bgfiles[ii] = os.path.abspath(bgfiles[ii])\n",
+    "bgfiles = np.array(bgfiles)\n",
+    "\n",
+    "print(f\"Found  {str(len(rate_files))} science files\")\n",
+    "print(f\"Found  {str(len(bgfiles))} background files\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81d916e5-dd5d-472d-9aff-b2b4c86decf8",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Run Image2 stage of pipeline, specifying the output directory to save *_cal.fits files\n",
+    "# and save_results flag set to True so the rate files are saved\n",
+    "if doimage2:\n",
+    "    for rate in rate_files:\n",
+    "        asnfile = os.path.join(sci_dir, 'l2asn.json')\n",
+    "        writel2asn(rate, bgfiles, asnfile, 'Level2')\n",
+    "        cal_result = Image2Pipeline.call(asnfile, output_dir=image2_dir, steps=image2dict, save_results=True)\n",
+    "else:\n",
+    "    print(\"Skipping Image2 processing.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d58b94d-e1d7-4b73-b598-756c99d81174",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.0f} seconds\")\n",
+    "print(f\"Runtime for Image2: {time1 - time_image2:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da57b7d0-95ef-4227-b730-6f54a3eaaa16",
+   "metadata": {},
+   "source": [
+    "### Verify which pipeline steps were run and reference files used"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27390bbd-ae2d-49e7-977a-59d3765c0946",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage2:\n",
+    "    # Identify *_cal.fits files\n",
+    "    cal_files = sorted(glob.glob(os.path.join(image2_dir, '*_cal.fits')))\n",
+    "\n",
+    "    cal_f = datamodels.open(cal_files[0])\n",
+    "\n",
+    "    # Check which steps were run:\n",
+    "    cal_f.meta.cal_step.instance\n",
+    "\n",
+    "    # Check which reference files were used to calibrate the dataset:\n",
+    "    cal_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe5b9a4d",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cfbb244-7af9-4cbf-90d9-08598378c16a",
+   "metadata": {},
+   "source": [
+    "## 7. Image3 Pipeline\n",
+    "\n",
+    "In the [Image3](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image3.html)\n",
+    "stage of the pipeline, the individual `*_cal.fits` files for each of the dither positions are\n",
+    "combined to one single distortion corrected image. First, an \n",
+    "[Association](https://jwst-pipeline.readthedocs.io/en/latest/jwst/associations/overview.html)\n",
+    "needs to be created to inform the pipeline that these individual exposures are linked together.\n",
+    "\n",
+    "By default, the `Image3` stage of the pipeline performs the following steps on MIRI data:\n",
+    "* [tweakreg](https://jwst-pipeline.readthedocs.io/en/latest/jwst/tweakreg/index.html#tweakreg-step) -\n",
+    "  creates source catalogs of pointlike sources for each input image. The source catalog for each input\n",
+    "  image is compared to each other to derive coordinate transforms to align the images relative to each other.\n",
+    "    * As of pipeline version 1.14.0, the default source finding algorithm is `IRAFStarFinder`.\n",
+    "* [skymatch](https://jwst-pipeline.readthedocs.io/en/latest/jwst/skymatch/index.html#skymatch-step) -\n",
+    "  measures the background level from the sky to use as input into the subsequent `outlier detection` and `resample` steps.\n",
+    "* [outlier detection](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/index.html#outlier-detection-step) -\n",
+    "  flags any remaining cosmic rays, bad pixels, or other artifacts not already flagged during the `DETECTOR1` stage\n",
+    "  of the pipeline, using all input images to create a median image so that outliers in individual images can be identified.\n",
+    "* [resample](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step) -\n",
+    "  resamples each input image based on its WCS and distortion information and creates a single undistorted image.\n",
+    "* [source catalog](https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/index.html#source-catalog-step) -\n",
+    "  creates a catalog of detected sources along with measured photometries and morphologies (i.e., point-like vs extended).\n",
+    "  Useful for quicklooks, but optimization is likely needed for specific science cases. Users may wish to experiment with\n",
+    "  changing the `snr_threshold` and `deblend` options. Modifications to the following parameters will not significantly\n",
+    "  improve data quality and it is advised to keep them at their default values: `aperture_ee1`, `aperture_ee2`,\n",
+    "  `aperture_ee3`, `ci1_star_threshold`, `ci2_star_threshold`.\n",
+    "\n",
+    "Some values that have been shown to give good results for MIRI data are to set the outlier_detection's parameter `scale`\n",
+    "to '1.0 0.8' and to set the resample parameter `weight_type` to 'exptime', both currently set in the \n",
+    "[parameter reference file](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/parameter_files.html#parameter-files)\n",
+    "<I>pars-outlierdetectionstep</I>, but can be overridden as indicated below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8e81dc9-78dd-4bba-879c-9dfa2a4da69c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_image3 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8159e63d-3c89-44ef-9a43-caaccd1abb4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Image3 pipeline should be configured\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "image3dict = defaultdict(dict)\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped (example)\n",
+    "#image3dict['outlier_detection']['skip'] = True\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#image3dict['source_catalog']['override_apcorr'] = 'myfile.fits'  # Aperture correction parameters\n",
+    "#image3dict['source_catalog']['override_abvegaoffset'] = 'myfile.asdf'  # Data to convert from AB to Vega magnitudes (ASDF file)\n",
+    "\n",
+    "# Overrides for specific parameters in the step (examples)\n",
+    "#image3dict['resample']['weight_type'] = ['exptime']\n",
+    "#image3dict['outlier_detection']['scale'] = ['1.0 0.8']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e10da872-21ae-46c2-a3b1-f9cdefae3b36",
+   "metadata": {},
+   "source": [
+    "Find and sort all of the input files, ensuring use of absolute paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f0b5b47-62e9-4593-abc4-7ec630492e96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Science Files need are the cal.fits files\n",
+    "sstring = os.path.join(image2_dir, 'jw*cal.fits')\n",
+    "cal_files = sorted(glob.glob(sstring))\n",
+    "for ii in range(0, len(cal_files)):\n",
+    "    cal_files[ii] = os.path.abspath(cal_files[ii])\n",
+    "calfiles = np.array(cal_files)\n",
+    "\n",
+    "print(f'Found {str(len(cal_files))} science files to process')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db5cb6f5-44a1-4f28-95dc-b23a97451465",
+   "metadata": {},
+   "source": [
+    "### Create Association File\n",
+    "\n",
+    "An association file lists the exposures to calibrated together in `Stage3`\n",
+    "of the pipeline. Note that an association file is available for download\n",
+    "from MAST, with a filename of `*_asn.json`. Here we show how to create an\n",
+    "association file to point to the data products created when processing data\n",
+    "through the pipeline. Note that the output products will have a rootname\n",
+    "that is specified by the `product_name` in the association file. For\n",
+    "this tutorial, the rootname of the output products will be\n",
+    "`image3_association`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b31f80f-8d7b-45ae-8537-15d0208637df",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create a Level 3 Association\n",
+    "if doimage3:\n",
+    "    associations = afl.asn_from_list(cal_files, rule=DMS_Level3_Base, product_name='image3_association')\n",
+    "\n",
+    "    associations.data['asn_type'] = 'image3'\n",
+    "    program = datamodels.open(cal_files[0]).meta.observation.program_number\n",
+    "    associations.data['program'] = program\n",
+    "\n",
+    "    # Format association as .json file\n",
+    "    asn_filename, serialized = associations.dump(format=\"json\")\n",
+    "\n",
+    "    # Write out association file\n",
+    "    association_im3 = os.path.join(sci_dir, asn_filename)\n",
+    "    with open(association_im3, \"w\") as fd:\n",
+    "        fd.write(serialized)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "629cad5b-e5a7-473e-8583-ad12cda55fa4",
+   "metadata": {},
+   "source": [
+    "### Run Image3 stage of the pipeline\n",
+    "\n",
+    "Given the grouped exposures in the association file, the products if the\n",
+    "`Image3` stage of the pipeline are:\n",
+    "* a `*_crf.fits` file produced by the `outlier_detection` step, where the `DQ` array marks the pixels flagged as outliers.\n",
+    "* a final combined, rectified image with name `*_i2d.fits`,\n",
+    "* a source catalog with name `*_cat.ecsv`,\n",
+    "* a segmentation map file (`*_segm.fits`) which has integer values at the pixel locations where a source is detected where the pixel values match the source ID number in the catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0cebfd8-a650-41a3-8ff0-a8fd43e079d6",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Run Stage 3\n",
+    "if doimage3:\n",
+    "    i2d_result = Image3Pipeline.call(association_im3, output_dir=image3_dir, steps=image3dict, save_results=True)\n",
+    "else:\n",
+    "    print('Skipping Spec3 processing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f67d2c65-4614-4592-aa67-daa2de985013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.0f} seconds\")\n",
+    "print(f\"Runtime for Image3: {time1 - time_image3:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bcb6c40-fbb8-4226-b620-64b0c02c8ceb",
+   "metadata": {},
+   "source": [
+    "### Verify which pipeline steps were run and reference files used"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c754530a-d4e2-493b-bf8b-bf8d1ad08770",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3:\n",
+    "    # Identify *_i2d file and open as datamodel\n",
+    "    i2d = glob.glob(os.path.join(image3_dir, \"*_i2d.fits\"))[0]\n",
+    "    i2d_f = datamodels.open(i2d)\n",
+    "\n",
+    "    # Check which steps were run\n",
+    "    i2d_f.meta.cal_step.instance\n",
+    "\n",
+    "    # Check which reference files were used to calibrate the dataset\n",
+    "    i2d_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "947f990e",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46be5421-7fc8-4d96-b2cd-2484f294e082",
+   "metadata": {},
+   "source": [
+    "## 8. Visualize the drizzle-combined image\n",
+    "\n",
+    "We will use matplotlib routines for visualizing the data. Display the combined i2d image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4994ba3a-1022-4061-85b6-b2bd08477852",
+   "metadata": {
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "if doviz:\n",
+    "    # Look at the final i2d image (combined mosaic)\n",
+    "    sstring = os.path.join(image3_dir, '*i2d.fits')\n",
+    "    miri_mosaic_file = glob.glob(sstring)\n",
+    "    print(miri_mosaic_file)\n",
+    "\n",
+    "    # Read your mosaic image into an ImageModel datamodel\n",
+    "    miri_mosaic = ImageModel(miri_mosaic_file[0])\n",
+    "    \n",
+    "    # Autoscale the stretch\n",
+    "    display_vals = [np.nanpercentile(miri_mosaic.data, 1), np.nanpercentile(miri_mosaic.data, 99)]\n",
+    "\n",
+    "    plt.figure(figsize=(8, 8))\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(8, 8))\n",
+    "\n",
+    "    # Set up image\n",
+    "    cax = ax.imshow(miri_mosaic.data, cmap='Greys', origin='lower', vmin=display_vals[0], vmax=display_vals[1])\n",
+    "\n",
+    "    # Set up colorbar\n",
+    "    cb = fig.colorbar(cax, fraction=0.046)\n",
+    "    cb.ax.set_ylabel('MJy/str', fontsize=14)\n",
+    "\n",
+    "    # Set labels \n",
+    "    ax.set_xlabel('X', fontsize=16)\n",
+    "    ax.set_ylabel('Y', fontsize=16)\n",
+    "    ax.set_title('Final MIRI mosaic', fontsize=16)\n",
+    "    plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "170bb10f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display_vals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "018733eb-07ec-44a4-a5a7-d6d2f27d193a",
+   "metadata": {},
+   "source": [
+    "## <a id='detections'>Visualize Detected Sources</a>\n",
+    "Using the source catalog created by the `IMAGE3` stage of the pipeline,\n",
+    "mark the detected sources, using different markers for point sources\n",
+    "and extended sources. The source catalog is saved in\n",
+    "`image3/image3_association_cat.ecsv` file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ad6ee55-f940-4be3-96c9-114bc83eb784",
+   "metadata": {},
+   "source": [
+    "### Read in catalog file and identify point/extended sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32235fdc-4ec2-42e6-89e7-b9f62824e179",
+   "metadata": {
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "if doviz:\n",
+    "    catalog_file = glob.glob(os.path.join(image3_dir, \"*_cat.ecsv\"))[0]\n",
+    "    catalog = Table.read(catalog_file)\n",
+    "\n",
+    "    # find where sources are considered extended or point sources\n",
+    "    pt_src, = np.where(~catalog['is_extended'])\n",
+    "    ext_src, = np.where(catalog['is_extended'])\n",
+    "\n",
+    "    # Get x and y coordinates of the objects found \n",
+    "    miri_x = catalog['xcentroid'][pt_src]\n",
+    "    miri_y = catalog['ycentroid'][pt_src]\n",
+    "\n",
+    "    ext_x = catalog['xcentroid'][ext_src]\n",
+    "    ext_y = catalog['ycentroid'][ext_src]\n",
+    "\n",
+    "    # Show catalog\n",
+    "    catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be9e9069-375d-431b-bbfb-e84e6cefc2d4",
+   "metadata": {},
+   "source": [
+    "### Mark the extended and point sources on the image\n",
+    "\n",
+    "Display combined image with point sources marked with red dots and extended sources marked with blue triangles. You will see that there are a grouping of sources near the top edge of the MIRI image, several of which may be spurious sources, which tend to be found near image edges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eafd7ef5-f2c1-4698-8a66-1b8009871c02",
+   "metadata": {
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "if doviz:\n",
+    "    # Look at mosaic data and sources found with source_catalog\n",
+    "    fig, ax = plt.subplots(figsize=(8, 8))\n",
+    "\n",
+    "    # Set up image\n",
+    "    cax = ax.imshow(miri_mosaic.data, cmap='Greys', origin='lower', vmin=display_vals[0], vmax=display_vals[1])\n",
+    "    ax.scatter(miri_x, miri_y, lw=1, s=10, color='red')  # overplot point source positions\n",
+    "    ax.scatter(ext_x, ext_y, lw=1, s=20, color='blue', marker='v')  # overplot extended source positions\n",
+    "\n",
+    "    # Set up colorbar\n",
+    "    cb = fig.colorbar(cax, fraction=0.046)\n",
+    "    cb.ax.set_ylabel('MJy/str', fontsize=14)\n",
+    "\n",
+    "    # Set labels\n",
+    "    ax.set_xlabel('X', fontsize=16)\n",
+    "    ax.set_ylabel('Y', fontsize=16)\n",
+    "    ax.set_title('Final MIRI mosaic', fontsize=16)\n",
+    "    plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f59557af",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6303c0e7-13af-4e4c-bed7-8b85cc8e3645",
+   "metadata": {},
+   "source": [
+    "<img style=\"float: center;\" src=\"https://github.com/spacetelescope/jwst-pipeline-notebooks/raw/main/_static/stsci_footer.png\" alt=\"stsci_logo\" width=\"200px\"/> "
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/processing-engine/tests/fixtures/jwpipenb/JWPipeNB-nircam-imaging.ipynb
+++ b/processing-engine/tests/fixtures/jwpipenb/JWPipeNB-nircam-imaging.ipynb
@@ -1,0 +1,1993 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "095a295c",
+   "metadata": {},
+   "source": [
+    "<img style=\"float: center;\" src='https://github.com/spacetelescope/jwst-pipeline-notebooks/raw/main/_static/stsci_header.png' alt=\"stsci_logo\" width=\"900px\"/> "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0393e357-9d9d-4516-b28d-4d335fad33a0",
+   "metadata": {},
+   "source": [
+    "#  NIRCam Imaging Pipeline Notebook\n",
+    "\n",
+    "**Authors**: B. Hilbert, based on the NIRISS imaging notebook by R. Diaz<br>\n",
+    "**Last Updated**: April 17, 2026<br>\n",
+    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7da2029f",
+   "metadata": {},
+   "source": [
+    "**Purpose**:<BR>\n",
+    "This notebook provides a framework for processing generic Near-Infrared\n",
+    "Camera (NIRCam) Imaging data through all three James Webb Space Telescope\n",
+    "(JWST) pipeline stages.  Data is assumed to be located in a folder structure\n",
+    "following the paths set up below. It should not be necessary to edit\n",
+    "any cells other than in the [Configuration](#1.-Configuration) section unless\n",
+    "modifying the standard pipeline processing options.\n",
+    "\n",
+    "**Data**:<BR>\n",
+    "This example is set up to use an example dataset is from\n",
+    "[Program ID](https://www.stsci.edu/jwst/science-execution/program-information)\n",
+    "2739 (PI: Pontoppidan) which is a Cycle 1 Outreach program. \n",
+    "We focus on the data from Observation 001 Visit 002, in which M-16, or the\n",
+    "\"Pillars of Creation\" were observed.\n",
+    "Example input data to use will be downloaded automatically unless\n",
+    "disabled (i.e., to use local files instead).\n",
+    "\n",
+    "**JWST pipeline version and CRDS context**:<BR>\n",
+    "This notebook was written for the calibration pipeline version given \n",
+    "above. It sets the CRDS context to the latest context in the JWST \n",
+    "Calibration Reference Data System (CRDS) associated with that\n",
+    "pipeline version. If you use different pipeline versions or\n",
+    "CRDS context, please read the relevant release notes\n",
+    "([here for pipeline](https://github.com/spacetelescope/jwst),\n",
+    "[here for CRDS](https://jwst-crds.stsci.edu/)) for possibly relevant\n",
+    "changes.<BR>\n",
+    "\n",
+    "**Updates**:<BR>\n",
+    "This notebook is regularly updated as improvements are made to the\n",
+    "pipeline. Find the most up to date version of this notebook at:\n",
+    "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
+    "\n",
+    "**Recent Changes**:<br>\n",
+    "Sept 5, 2024: original notebook created<br>\n",
+    "Nov 11, 2024: Comment out line to set the context<br>\n",
+    "Nov 18, 2024: Do not require both SW and LW user-provided data<br>\n",
+    "November 22, 2024: Updates to workflow when skipping pipeline modules<br>\n",
+    "January 31, 2025: Update to build 11.2, update JDAViz Links Control to Orientation call<br>\n",
+    "February 25, 2025: Add optional call to clean_flicker_noise<br>\n",
+    "April 02, 2025: Update JDAviz call to work with JDAviz 4.2.1<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)<br>\n",
+    "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
+    "Sept 30, 2025: Updated to jwst 1.20.0, update to work with JDAViz 4.4.1<br>\n",
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13e92341",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5291c2f1",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Table of Contents\n",
+    "1. [Configuration](#1.-Configuration) \n",
+    "2. [Package Imports](#2.-Package-Imports)\n",
+    "3. [Demo Mode Setup (ignore if not using demo data)](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
+    "4. [Directory Setup](#4.-Directory-Setup)\n",
+    "5. [Detector1 Pipeline](#5.-Detector1-Pipeline)\n",
+    "6. [Image2 Pipeline](#6.-Image2-Pipeline)\n",
+    "7. [Image3 Pipeline](#7.-Image3-Pipeline)\n",
+    "8. [Visualize the resampled images](#8.-Visualize-the-resampled-images)\n",
+    "9. [Visualize Detected Sources](#9.-Visualize-Detected-Sources)\n",
+    "10. [Notes](#10.-Notes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "139a63d0",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43bd07d7",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d5fe58d-f3c5-4aec-8e14-5323eaf786bd",
+   "metadata": {},
+   "source": [
+    "------------------\n",
+    "Set basic configuration for runing notebook. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026a649d-a0d2-4e3f-ab6d-cf8c26e6ce1d",
+   "metadata": {},
+   "source": [
+    "#### Install dependencies and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe5c4ca9",
+   "metadata": {},
+   "source": [
+    "To make sure that the pipeline version is compatabile with the steps\n",
+    "discussed below and the required dependencies and packages are installed,\n",
+    " you can create a fresh conda environment and install the provided\n",
+    "`requirements.txt` file:\n",
+    "```\n",
+    "conda create -n nircam_imaging_pipeline python=3.13\n",
+    "conda activate nircam_imaging_pipeline\n",
+    "pip install -r requirements.txt\n",
+    "```\n",
+    "\n",
+    "Set the basic parameters to use with this notebook. These will affect\n",
+    "what data is used, where data is located (if already in disk), and\n",
+    "pipeline modules run in this data. The list of parameters are:\n",
+    "\n",
+    "* demo_mode\n",
+    "* directories with data\n",
+    "* pipeline modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06ea414c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic import necessary for configuration\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61bb14e6",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Note that <code>demo_mode</code> must be set appropriately below.\n",
+    "</div>\n",
+    "\n",
+    "Set <code>demo_mode = True </code> to run in demonstration mode. In this\n",
+    "mode this notebook will download example data from the Barbara A.\n",
+    "Mikulski Archive for Space Telescopes \n",
+    "([MAST](https://mast.stsci.edu/search/ui/#/jwst)) and process it through \n",
+    "the pipeline. This will all happen in a local directory unless modified in \n",
+    "[Section 3](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data)) below. \n",
+    "\n",
+    "Set <code>demo_mode = False</code> if you want to process your own data\n",
+    "that has already been downloaded and provide the location of the data.<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "323f87d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set parameters for demo_mode, channel, band, data mode directories, and \n",
+    "# processing steps.\n",
+    "\n",
+    "# -----------------------------Demo Mode---------------------------------\n",
+    "demo_mode = True\n",
+    "\n",
+    "if demo_mode:\n",
+    "    print('Running in demonstration mode using online example data!')\n",
+    "\n",
+    "# --------------------------User Mode Directories------------------------\n",
+    "# If demo_mode = False, look for user data in these paths\n",
+    "if not demo_mode:\n",
+    "    # Set directory paths for processing specific data; these will need\n",
+    "    # to be changed to your local directory setup (below are given as\n",
+    "    # examples)\n",
+    "    user_home_dir = os.path.expanduser('~')\n",
+    "\n",
+    "    # Point to where science observation data are\n",
+    "    # Assumes uncalibrated data in <sci_dir>/uncal/ and results in stage1,\n",
+    "    # stage2, stage3 directories\n",
+    "    sci_dir = os.path.join(user_home_dir, 'PID2739/Obs001/')\n",
+    "\n",
+    "# --------------------------Set Processing Steps--------------------------\n",
+    "# Individual pipeline stages can be turned on/off here.  Note that a later\n",
+    "# stage won't be able to run unless data products have already been\n",
+    "# produced from the prior stage.\n",
+    "\n",
+    "# Science processing\n",
+    "dodet1 = True  # calwebb_detector1\n",
+    "doimage2 = True  # calwebb_image2\n",
+    "doimage3 = True  # calwebb_image3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1070079a",
+   "metadata": {},
+   "source": [
+    "### Set CRDS context and server\n",
+    "Before importing <code>CRDS</code> and <code>JWST</code> modules, we need\n",
+    "to configure our environment. This includes defining a CRDS cache\n",
+    "directory in which to keep the reference files that will be used by the\n",
+    "calibration pipeline.\n",
+    "\n",
+    "If the root directory for the local CRDS cache directory has not been set\n",
+    "already, it will be set to create one in the home directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baf7070d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ------------------------Set CRDS context and paths----------------------\n",
+    "\n",
+    "# Each version of the calibration pipeline is associated with a specific CRDS\n",
+    "# context file. The pipeline will select the appropriate context file behind\n",
+    "# the scenes while running. However, if you wish to override the default context\n",
+    "# file and run the pipeline with a different context, you can set that using\n",
+    "# the CRDS_CONTEXT environment variable. Here we show how this is done,\n",
+    "# although we leave the line commented out in order to use the default context.\n",
+    "# If you wish to specify a different context, uncomment the line below.\n",
+    "#%env CRDS_CONTEXT jwst_1293.pmap\n",
+    "\n",
+    "# Check whether the local CRDS cache directory has been set.\n",
+    "# If not, set it to the user home directory\n",
+    "if (os.getenv('CRDS_PATH') is None):\n",
+    "    os.environ['CRDS_PATH'] = os.path.join(os.path.expanduser('~'), 'crds')\n",
+    "# Check whether the CRDS server URL has been set.  If not, set it.\n",
+    "if (os.getenv('CRDS_SERVER_URL') is None):\n",
+    "    os.environ['CRDS_SERVER_URL'] = 'https://jwst-crds.stsci.edu'\n",
+    "\n",
+    "# Echo CRDS path in use\n",
+    "print(f\"CRDS local filepath: {os.environ['CRDS_PATH']}\")\n",
+    "print(f\"CRDS file server: {os.environ['CRDS_SERVER_URL']}\")\n",
+    "if os.getenv('CRDS_CONTEXT'):\n",
+    "    print(f\"CRDS CONTEXT: {os.environ['CRDS_CONTEXT']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdd10c54",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "575588c8",
+   "metadata": {},
+   "source": [
+    "## 2. Package Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4415f6d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the entire available screen width for this notebook\n",
+    "from IPython.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:95% !important; }</style>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb9f7f54-ff98-428b-9fa9-b39c50210c3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic system utilities for interacting with files\n",
+    "# ----------------------General Imports------------------------------------\n",
+    "import glob\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Numpy for doing calculations\n",
+    "import numpy as np\n",
+    "\n",
+    "# To display full ouptut of cell, not just the last result\n",
+    "from IPython.core.interactiveshell import InteractiveShell\n",
+    "InteractiveShell.ast_node_interactivity = \"all\"\n",
+    "\n",
+    "# -----------------------Astroquery Imports--------------------------------\n",
+    "# ASCII files, and downloading demo files\n",
+    "from astroquery.mast import Observations\n",
+    "\n",
+    "# Astropy routines for visualizing detected sources:\n",
+    "from astropy.table import Table\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "# ------------ Pipeline and  Visualization Imports -----------------------\n",
+    "\n",
+    "# for JWST calibration pipeline\n",
+    "import jwst\n",
+    "import crds\n",
+    "\n",
+    "from jwst.pipeline import Detector1Pipeline\n",
+    "from jwst.pipeline import Image2Pipeline\n",
+    "from jwst.pipeline import Image3Pipeline\n",
+    "\n",
+    "# JWST pipeline utilities\n",
+    "from asdf import AsdfFile\n",
+    "from jwst import datamodels\n",
+    "from jwst.associations import asn_from_list  # Tools for creating association files\n",
+    "from jwst.associations.lib.rules_level3_base import DMS_Level3_Base  # Definition of a Lvl3 association file\n",
+    "\n",
+    "# For visualizing images\n",
+    "from jdaviz import Imviz\n",
+    "\n",
+    "# Echo pipeline version and CRDS context in use\n",
+    "print(f\"JWST Calibration Pipeline Version: {jwst.__version__}\")\n",
+    "print(f\"Using CRDS Context: {crds.get_context_name('jwst')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5844d476-f8b3-4c24-9c79-091d6016314d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start a timer to keep track of runtime\n",
+    "time0 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea709b51",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ef8050f",
+   "metadata": {},
+   "source": [
+    "## 3. Demo Mode Setup (ignore if not using demo data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e96f182c-cf63-4f82-b5a7-0285be9c21e3",
+   "metadata": {},
+   "source": [
+    "------------------\n",
+    "If running in demonstration mode, set up the program information to\n",
+    "retrieve the uncalibrated data automatically from MAST using\n",
+    "[astroquery](https://astroquery.readthedocs.io/en/latest/mast/mast.html).\n",
+    "MAST allows for flexibility of searching by the proposal ID and the\n",
+    "observation ID instead of just filenames.<br>\n",
+    "\n",
+    "For illustrative purposes, we focus on data taken using the NIRCam\n",
+    "[F200W and F444W filters](https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-instrumentation/nircam-filters)\n",
+    "and start with uncalibrated data products. The files are named\n",
+    "`jw02739001002_02105_0000<dither>_nrc<det>_uncal.fits`, where *dither* refers to the\n",
+    "dither step number, and *det* is the detector name. Through this notebook we will refer to data\n",
+    "with filter `F200W` as SW data and `F444W` as LW data.\n",
+    " \n",
+    "More information about the JWST file naming conventions can be found at:\n",
+    "https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/file_naming.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d595f1e-2590-4f01-bb92-13bb43a22b3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up the program information and paths for demo program\n",
+    "if demo_mode:\n",
+    "    print('Running in demonstration mode and will download example data from MAST!')\n",
+    "    program = \"02739\"\n",
+    "    sci_observtn = \"001\"\n",
+    "    \n",
+    "    data_dir = os.path.join('.', 'nrc_im_demo_data')\n",
+    "    download_dir = data_dir\n",
+    "    sci_dir = os.path.join(data_dir, 'Obs' + sci_observtn)\n",
+    "    uncal_dir = os.path.join(sci_dir, 'uncal')\n",
+    "\n",
+    "    # Ensure filepaths for input data exist\n",
+    "    if not os.path.exists(uncal_dir):\n",
+    "        os.makedirs(uncal_dir)\n",
+    "        \n",
+    "    # Create directory if it does not exist\n",
+    "    if not os.path.isdir(data_dir):\n",
+    "        os.mkdir(data_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6674a8b8",
+   "metadata": {},
+   "source": [
+    "Identify list of science (SCI) uncalibrated files associated with visits.\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Work one filter at a time, so that we can more easily filter by detector and keep only the module A files.\n",
+    "</div>\n",
+    "\n",
+    "First download the F200W data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4b22375",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Obtain a list of observation IDs for the specified demo program\n",
+    "if demo_mode:\n",
+    "    # Science data\n",
+    "    sci_obs_id_table = Observations.query_criteria(instrument_name=[\"NIRCAM/IMAGE\"],\n",
+    "                                                   provenance_name=[\"CALJWST\"],  # Executed observations\n",
+    "                                                   filters=['F200W'],  # Data for Specific Filter\n",
+    "                                                   obs_id=['jw' + program + '-o' + sci_observtn + '*']\n",
+    "                                                   )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3aa123f1-be6a-4be8-8e6d-daffc6514098",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if demo_mode:\n",
+    "    sci_obs_id_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a666350e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Turn the list of visits into a list of uncalibrated data files\n",
+    "if demo_mode:\n",
+    "    # Define types of files to select\n",
+    "    file_dict = {'uncal': {'product_type': 'SCIENCE',\n",
+    "                           'productSubGroupDescription': 'UNCAL',\n",
+    "                           'calib_level': [1]}}\n",
+    "\n",
+    "    # Science files\n",
+    "    sci_files_to_download = []\n",
+    "    # Loop over visits identifying uncalibrated files that are associated\n",
+    "    # with them\n",
+    "    for exposure in (sci_obs_id_table):\n",
+    "        products = Observations.get_product_list(exposure)\n",
+    "        for filetype, query_dict in file_dict.items():\n",
+    "            filtered_products = Observations.filter_products(products, productType=query_dict['product_type'],\n",
+    "                                                             productSubGroupDescription=query_dict['productSubGroupDescription'],\n",
+    "                                                             calib_level=query_dict['calib_level'])\n",
+    "            sci_files_to_download.extend(filtered_products['dataURI'])\n",
+    "\n",
+    "    # To limit data volume, keep only files from visit 002, dithers 1 and 2, and only A-module\n",
+    "    sw_sci_files_to_download = [fname for fname in sci_files_to_download if 'jw02739001002_02105' in fname and \n",
+    "                                ('nrca2' in fname or 'nrca4' in fname) and ('00001' in fname or '00002' in fname)]\n",
+    "    sw_sci_files_to_download = sorted(sw_sci_files_to_download)\n",
+    "    print(f\"Science files selected for downloading: {len(sw_sci_files_to_download)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ed1e7d5-4f12-47f0-b43e-764c37943644",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List the SW files to download\n",
+    "if demo_mode:\n",
+    "    sw_sci_files_to_download"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4add251e-56ed-44ba-85a6-db0a4d55588c",
+   "metadata": {},
+   "source": [
+    "Now repeat the process for the F444W data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5809aad0-a5f2-47ce-b813-3adb5888d646",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Obtain a list of observation IDs for the specified demo program\n",
+    "if demo_mode:\n",
+    "    # Science data\n",
+    "    sci_obs_id_table = Observations.query_criteria(instrument_name=[\"NIRCAM/IMAGE\"],\n",
+    "                                                   provenance_name=[\"CALJWST\"],  # Executed observations\n",
+    "                                                   filters=['F444W'],  # Data for Specific Filter\n",
+    "                                                   obs_id=['jw' + program + '-o' + sci_observtn + '*']\n",
+    "                                                   )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d2ef61a-4b6c-4aa9-b5c6-4051b56a4274",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if demo_mode:\n",
+    "    sci_obs_id_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25b8b8a4-c271-49ac-be28-228fc25891ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Turn the list of visits into a list of uncalibrated data files\n",
+    "if demo_mode:\n",
+    "    # Define types of files to select\n",
+    "    file_dict = {'uncal': {'product_type': 'SCIENCE',\n",
+    "                           'productSubGroupDescription': 'UNCAL',\n",
+    "                           'calib_level': [1]}}\n",
+    "\n",
+    "    # Science files\n",
+    "    sci_files_to_download = []\n",
+    "    # Loop over visits identifying uncalibrated files that are associated\n",
+    "    # with them\n",
+    "    for exposure in (sci_obs_id_table):\n",
+    "        products = Observations.get_product_list(exposure)\n",
+    "        for filetype, query_dict in file_dict.items():\n",
+    "            filtered_products = Observations.filter_products(products, productType=query_dict['product_type'],\n",
+    "                                                             productSubGroupDescription=query_dict['productSubGroupDescription'],\n",
+    "                                                             calib_level=query_dict['calib_level'])\n",
+    "            sci_files_to_download.extend(filtered_products['dataURI'])\n",
+    "\n",
+    "    # To limit data volume, keep only files from visit 002, dithers 1 and 2, and only A-module\n",
+    "    lw_sci_files_to_download = [fname for fname in sci_files_to_download if 'jw02739001002_02105' in fname and \n",
+    "                                'nrca' in fname and ('00001' in fname or '00002' in fname)]\n",
+    "    lw_sci_files_to_download = sorted(lw_sci_files_to_download)\n",
+    "    print(f\"Science files selected for downloading: {len(lw_sci_files_to_download)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfad7360-0456-430e-9f85-8e46e49e689c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List the LW files to download\n",
+    "if demo_mode:\n",
+    "    lw_sci_files_to_download"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0986865-907b-473b-8524-93e36c4564ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Full list the science files to download\n",
+    "if demo_mode:\n",
+    "    sci_files_to_download = sw_sci_files_to_download + lw_sci_files_to_download\n",
+    "    sci_files_to_download"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c36a54be",
+   "metadata": {},
+   "source": [
+    "Download all the uncal files and place them into the appropriate\n",
+    "directories.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Warning: If this notebook is halted during this step the downloaded file\n",
+    "may be incomplete, and cause crashes later on!\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "764fa682",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Download the demo data if it does not already exist\n",
+    "if demo_mode:\n",
+    "    for filename in sci_files_to_download:\n",
+    "        sci_manifest = Observations.download_file(filename,\n",
+    "                                                  local_path=os.path.join(uncal_dir, Path(filename).name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "112a7c4f",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6c51254-6295-4f98-bc25-d07300e0d8f4",
+   "metadata": {},
+   "source": [
+    "## 4. Directory Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71f2740f-925d-4139-93f7-9f00cb9820b8",
+   "metadata": {},
+   "source": [
+    "------------------\n",
+    "Set up detailed paths to input/output stages here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bffbedc3-fbe3-4c56-ad18-85b5d0c7d880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define output subdirectories to keep science data products organized\n",
+    "uncal_dir = os.path.join(sci_dir, 'uncal')  # Uncalibrated pipeline inputs should be here\n",
+    "det1_dir = os.path.join(sci_dir, 'stage1')  # calwebb_detector1 pipeline outputs will go here\n",
+    "image2_dir = os.path.join(sci_dir, 'stage2')  # calwebb_spec2 pipeline outputs will go here\n",
+    "image3_dir = os.path.join(sci_dir, 'stage3')  # calwebb_spec3 pipeline outputs will go here\n",
+    "\n",
+    "# We need to check that the desired output directories exist, and if not\n",
+    "# create them\n",
+    "if not os.path.exists(det1_dir):\n",
+    "    os.makedirs(det1_dir)\n",
+    "if not os.path.exists(image2_dir):\n",
+    "    os.makedirs(image2_dir)\n",
+    "if not os.path.exists(image3_dir):\n",
+    "    os.makedirs(image3_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cd8e6a7-433d-4e5b-a832-46f0bc96a0fe",
+   "metadata": {},
+   "source": [
+    "Look at the first file to determine exposure parameters and practice using\n",
+    "JWST datamodels¶"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f767a7fa-50cb-4411-8aef-a32b7fde8917",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List uncal files\n",
+    "uncal_files = sorted(glob.glob(os.path.join(uncal_dir, '*_uncal.fits')))\n",
+    "    \n",
+    "# Separate SW from LW files\n",
+    "sw_uncal_files = [uncfile for uncfile in uncal_files if 'long' not in uncfile]\n",
+    "lw_uncal_files = [uncfile for uncfile in uncal_files if 'long' in uncfile]\n",
+    "\n",
+    "colnames = ('Instrument', 'Filter', 'Pupil', 'Number of Integrations', 'Number of Groups',\n",
+    "            'Readout pattern', 'Dither position number')\n",
+    "dtypes = ('S7', 'S10', 'S10', 'i4', 'i4', 'S15', 'i4')\n",
+    "meta_check = Table(names=(colnames), dtype=dtypes)\n",
+    "\n",
+    "# Open example files and get metadata for display\n",
+    "if len(sw_uncal_files) > 0:\n",
+    "    sw_examine = datamodels.open(sw_uncal_files[0])\n",
+    "    sw_row = [sw_examine.meta.instrument.name, sw_examine.meta.instrument.filter,\n",
+    "              sw_examine.meta.instrument.pupil, sw_examine.meta.exposure.nints,\n",
+    "              sw_examine.meta.exposure.ngroups, sw_examine.meta.exposure.readpatt,\n",
+    "              sw_examine.meta.dither.position_number]\n",
+    "    meta_check.add_row(sw_row)\n",
+    "\n",
+    "if len(lw_uncal_files) > 0:\n",
+    "    lw_examine = datamodels.open(lw_uncal_files[0])\n",
+    "    lw_row = [lw_examine.meta.instrument.name, lw_examine.meta.instrument.filter,\n",
+    "              lw_examine.meta.instrument.pupil, lw_examine.meta.exposure.nints,\n",
+    "              lw_examine.meta.exposure.ngroups, lw_examine.meta.exposure.readpatt,\n",
+    "              lw_examine.meta.dither.position_number]\n",
+    "    meta_check.add_row(lw_row)\n",
+    "\n",
+    "# Print out exposure info\n",
+    "meta_check"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0469a648-9bb1-40f9-9f8b-fb3a29bc5c7f",
+   "metadata": {},
+   "source": [
+    "The table above shows basic exposure information from the first shortwave as well as the first longwave file. When using\n",
+    "the demo data, we confirm that the data file is for the NIRCam instrument\n",
+    "using the `F200W` and `F444W` filters in the [Filter Wheel](https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-instrumentation/nircam-pupil-and-filter-wheels)\n",
+    "crossed with the `CLEAR` filter in the Pupil Wheel. This observation uses\n",
+    "the [`BRIGHT1` readout pattern](https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-instrumentation/nircam-detector-overview/nircam-detector-readout-patterns),\n",
+    "8 groups per integration, and 1 integration per exposure. This data file\n",
+    "is the 1st dither position in this exposure sequence. For more information\n",
+    "about how JWST exposures are defined by up-the-ramp sampling, see the\n",
+    "[Understanding Exposure Times JDox article](https://jwst-docs.stsci.edu/understanding-exposure-times).\n",
+    "\n",
+    "This metadata will be the same for all exposures in this observation, except for the dither position number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f843ff7f-58b6-4294-bfaa-606c29abc524",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time_det1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time_det1 - time0:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fac2959",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "267e28e0-a63f-4790-b8a0-3ad4bff5a167",
+   "metadata": {},
+   "source": [
+    "## 5. Detector1 Pipeline\n",
+    "Run the datasets through the\n",
+    "[Detector1](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline-overview/stages-of-jwst-data-processing/calwebb_detector1)\n",
+    "stage of the pipeline to apply detector level calibrations and create a\n",
+    "countrate data product where slopes are fitted to the integration ramps.\n",
+    "These `*_rate.fits` products are 2D (nrows x ncols), averaged over all\n",
+    "integrations. 3D countrate data products (`*_rateints.fits`) are also\n",
+    "created (nintegrations x nrows x ncols) which have the fitted ramp slopes\n",
+    "for each integration.\n",
+    "\n",
+    "By default, all steps in the `Detector1` stage of the pipeline are run for\n",
+    "NIRCam except the `ipc` correction step and the `gain_scale` step. Note\n",
+    "that the [`persistence` step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/persistence/description.html)\n",
+    "has been turned off by default starting with CRDS context `jwst_1264.pmap`.\n",
+    "This step does not automatically correct the science data for persistence.\n",
+    "The `persistence` step creates a `*_trapsfilled.fits` file which is a model\n",
+    "that records the number of traps filled at each pixel at the end of an exposure.\n",
+    "This file would be used as an input to the `persistence` step, via the `input_trapsfilled`\n",
+    "argument, to correct the subsequent science exposure for persistence. Since persistence\n",
+    "is not well calibrated for NIRCam, the step has been turned off in order to speed up\n",
+    "calibration and to not create empty `*_trapsfilled.fits` files. This step\n",
+    "can be turned on when running the pipeline in Python by doing:\n",
+    "```\n",
+    "rate_result = Detector1Pipeline.call(uncal, steps={'persistence': {'skip': False}})\n",
+    "```\n",
+    "or as indicated in the cell bellow using a dictionary.\n",
+    "\n",
+    "As of CRDS context `jwst_1155.pmap` and later, the \n",
+    "[`jump` step](https://jwst-pipeline.readthedocs.io/en/latest/api/jwst.jump.JumpStep.html)\n",
+    "of the `Detector1` stage of the pipeline will remove signal associated\n",
+    "with [snowballs](https://jwst-docs.stsci.edu/known-issues-with-jwst-data/shower-and-snowball-artifacts)\n",
+    "in the NIRCam imaging mode. This correction is turned on using the parameter\n",
+    "`expand_large_events=True`. This and other parameters related to the snowball correction\n",
+    "are specified in the `pars-jumpstep` parameter reference file. Users may wish to alter\n",
+    "parameters to optimize removal of snowball residuals. Available parameters are discussed\n",
+    "in the [Detection and Flagging of Showers and Snowballs in JWST Technical Report (Regan 2023)](https://www.stsci.edu/files/live/sites/www/files/home/jwst/documentation/technical-documents/_documents/JWST-STScI-008545.pdf)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3592ee58-b424-4bd6-973b-88fd081b81d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Detector1 pipeline should be configured\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "det1dict = {}\n",
+    "det1dict['group_scale'], det1dict['dq_init'], det1dict['saturation'] = {}, {}, {}\n",
+    "det1dict['ipc'], det1dict['superbias'], det1dict['refpix'] = {}, {}, {}\n",
+    "det1dict['linearity'], det1dict['persistence'], det1dict['dark_current'], = {}, {}, {}\n",
+    "det1dict['charge_migration'], det1dict['jump'], det1dict['clean_flicker_noise'] = {}, {}, {}\n",
+    "det1dict['ramp_fit'], det1dict['gain_scale'] = {}, {}\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped\n",
+    "# skipping the persistence step\n",
+    "det1dict['persistence']['skip'] = True\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#det1dict['dq_init']['override_mask'] = 'myfile.fits' # Bad pixel mask\n",
+    "#det1dict['saturation']['override_saturation'] = 'myfile.fits'  # Saturation\n",
+    "#det1dict['reset']['override_reset'] = 'myfile.fits'  # Reset\n",
+    "#det1dict['linearity']['override_linearity'] = 'myfile.fits'  # Linearity\n",
+    "#det1dict['rscd']['override_rscd'] = 'myfile.fits'  # RSCD\n",
+    "#det1dict['dark_current']['override_dark'] = 'myfile.fits'  # Dark current subtraction\n",
+    "#det1dict['jump']['override_gain'] = 'myfile.fits'  # Gain used by jump step\n",
+    "#det1dict['ramp_fit']['override_gain'] = 'myfile.fits'  # Gain used by ramp fitting step\n",
+    "#det1dict['jump']['override_readnoise'] = 'myfile.fits'  # Read noise used by jump step\n",
+    "#det1dict['ramp_fit']['override_readnoise'] = 'myfile.fits'  # Read noise used by ramp fitting step\n",
+    "\n",
+    "# Turn on multi-core processing (This is off by default). Choose what fraction\n",
+    "# of cores to use (quarter, half, all, or an integer number)\n",
+    "det1dict['jump']['maximum_cores'] = 'half'\n",
+    "\n",
+    "# Explicitly turn on snowball correction. (Even though it is on by default)\n",
+    "det1dict['jump']['expand_large_events'] = True\n",
+    "\n",
+    "# Turn on 1/f correction if desired\n",
+    "# For guidance see https://jwst-docs.stsci.edu/known-issues-with-jwst-data/1-f-noise\n",
+    "#det1dict['clean_flicker_noise']['skip'] = False\n",
+    "#det1dict['clean_flicker_noise']['fit_method'] = 'median' # 'median' or 'fft'\n",
+    "#det1dict['clean_flicker_noise']['background_method'] = 'median' # 'median' or 'model'\n",
+    "#det1dict['clean_flicker_noise']['fit_by_channel'] = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1495ec7-633d-425d-a9e7-cbf9f8a6580d",
+   "metadata": {},
+   "source": [
+    "Run the `Detector1` pipeline on all input data, regardless of filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f8f107b-5f80-4674-bc34-2d88791e4409",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Run Detector1 stage of pipeline, specifying:\n",
+    "# output directory to save *_rate.fits files\n",
+    "# save_results flag set to True so the rate files are saved\n",
+    "if dodet1:\n",
+    "    for uncal in uncal_files:\n",
+    "        rate_result = Detector1Pipeline.call(uncal, output_dir=det1_dir, steps=det1dict, save_results=True)\n",
+    "else:\n",
+    "    print('Skipping Detector1 processing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4cc2b48-7ec7-4b59-b3ee-2dfdf0782c01",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.0f} seconds\")\n",
+    "print(f\"Runtime for Detector1: {time1 - time_det1:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fc5520a-6097-482b-b3e0-a6bf94cf7af3",
+   "metadata": {},
+   "source": [
+    "### Exploring the data\n",
+    "\n",
+    "Identify `*_rate.fits` files and verify which pipeline steps were run and\n",
+    "which calibration reference files were applied.\n",
+    "\n",
+    "The header contains information about which calibration steps were\n",
+    "completed and skipped and which reference files were used to process the\n",
+    "data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c122766-a545-4042-93e8-f68c18f62fdf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if dodet1:\n",
+    "    # find rate files\n",
+    "    rate_files = sorted(glob.glob(os.path.join(det1_dir, '*_rate.fits')))\n",
+    "\n",
+    "    # Read in file as datamodel\n",
+    "    rate_f = datamodels.open(rate_files[0])\n",
+    "\n",
+    "    # Check which steps were run\n",
+    "    rate_f.meta.cal_step.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f2396cc-939f-44a6-878c-b33955796da8",
+   "metadata": {},
+   "source": [
+    "For this particular rate file, show which reference files were used to calibrate the dataset. Note that these files will be different for each NIRCam detector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c525e133-d875-4ea7-9552-d7f0df05747c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if dodet1:\n",
+    "    rate_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf557837",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "350808ee-9579-4cb5-8f02-a74904c91449",
+   "metadata": {},
+   "source": [
+    "## 6. Image2 Pipeline \n",
+    "\n",
+    "In the [Image2 stage of the pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image2.html),\n",
+    "calibrated unrectified data products are created (`*_cal.fits` or\n",
+    "`*_calints.fits` files, depending on whether the input files are\n",
+    "`*_rate.fits` or `*_rateints.fits`). \n",
+    "\n",
+    "In this pipeline processing stage, the [world coordinate system (WCS)](https://jwst-pipeline.readthedocs.io/en/latest/jwst/assign_wcs/index.html#assign-wcs-step)\n",
+    "is assigned, the data are [flat fielded](https://jwst-pipeline.readthedocs.io/en/latest/jwst/flatfield/index.html#flatfield-step),\n",
+    "and a [photometric calibration](https://jwst-pipeline.readthedocs.io/en/latest/jwst/photom/index.html#photom-step)\n",
+    "is applied to convert from units of countrate (ADU/s) to surface brightness (MJy/sr).\n",
+    "\n",
+    "By default, the [background subtraction step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/background_step/index.html#background-step)\n",
+    "and the [resampling step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step)\n",
+    "are turned off for NIRCam. The background\n",
+    "subtraction is turned off since there is no background template for the\n",
+    "imaging mode and the local background is subtracted as part of the photometry\n",
+    "perfoemd in the source catalog step in the `Image3` pipeline. \n",
+    "\n",
+    "The\n",
+    "resampling step occurs during the `Image3` stage by default. \n",
+    "\n",
+    "While the\n",
+    "resampling step can be run on individual images in the `Image2` stage, e.g., \n",
+    "to prepare for generating a source catalog for each image, the default behavior\n",
+    "is to run the step only in the `Image3` stage, where multiple images are \n",
+    "combined into a final mosaic after the [outlier detection step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/index.html)\n",
+    "flags bad pixels.\n",
+    "\n",
+    "To turn on the resampling step in the `Image2` stage, uncomment the line in the\n",
+    "dicitionary below which sets `image2dict['resample']['skip'] = False`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a091817-7a3c-4a60-a914-f9ac54d36e56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_image2 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b00fda2-a7c0-445a-bf23-0d9b4f050419",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Image2 pipeline should be configured.\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "image2dict = {}\n",
+    "image2dict['assign_wcs'], image2dict['flat_field'] = {}, {}\n",
+    "image2dict['photom'], image2dict['resample'] = {}, {}\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped (example)\n",
+    "#image2dict['resample']['skip'] = False\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#image2dict['assign_wcs']['override_distortion'] = 'myfile.asdf' # Spatial distortion (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_filteroffset'] = 'myfile.asdf' # Imager filter offsets (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_specwcs'] = 'myfile.asdf' # Spectral distortion (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_wavelengthrange'] = 'myfile.asdf' # Wavelength channel mapping (ASDF file)\n",
+    "#image2dict['flat_field']['override_flat'] = 'myfile.fits' # Pixel flatfield\n",
+    "#image2dict['photom']['override_photom'] = 'myfile.fits' # Photometric calibration array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247170cd-a3ee-4d9d-b8b3-f930727f8abc",
+   "metadata": {},
+   "source": [
+    "Find and sort all of the input files, ensuring use of absolute paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d19cd4e6-cc38-4e26-8e8b-7fb143856940",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sstring = os.path.join(det1_dir, 'jw*rate.fits')  # Use files from the detector1 output folder\n",
+    "rate_files = sorted(glob.glob(sstring))\n",
+    "rate_files = [os.path.abspath(fname) for fname in rate_files]\n",
+    "\n",
+    "print(f\"Found  {len(rate_files)} science files\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bddc9789-9048-4c2f-826d-69c36fcd1352",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List rate files\n",
+    "rate_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2e93d96-08be-42ac-bb34-8502d199e8ab",
+   "metadata": {},
+   "source": [
+    "Run the Image2 pipeline on all of the rate files, regardless of filter. Note that if you have exposures with multiple integrations and you wish to keep the integrations separate, you should call the pipeline on the *rateints.fits files, rather than the *rate.fits files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81d916e5-dd5d-472d-9aff-b2b4c86decf8",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Run Image2 stage of pipeline, specifying:\n",
+    "# output directory to save *_cal.fits files\n",
+    "# save_results flag set to True so the rate files are saved\n",
+    "\n",
+    "if doimage2:\n",
+    "    for rate in rate_files:\n",
+    "        cal_result = Image2Pipeline.call(rate, output_dir=image2_dir, steps=image2dict, save_results=True)\n",
+    "else:\n",
+    "    print(\"Skipping Image2 processing.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d58b94d-e1d7-4b73-b598-756c99d81174",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.0f} seconds\")\n",
+    "print(f\"Runtime for Image2: {time1 - time_image2:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da57b7d0-95ef-4227-b730-6f54a3eaaa16",
+   "metadata": {},
+   "source": [
+    "### Verify which pipeline steps were run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27390bbd-ae2d-49e7-977a-59d3765c0946",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage2:\n",
+    "    # Identify *_cal.fits file products\n",
+    "    cal_files = sorted(glob.glob(os.path.join(image2_dir, '*_cal.fits')))\n",
+    "\n",
+    "    # Select first file to gather information\n",
+    "    cal_f = datamodels.open(cal_files[0])\n",
+    "\n",
+    "    # Check which steps were run:\n",
+    "    cal_f.meta.cal_step.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b77293ab-4eaa-4ebd-9f9b-bef8f6a2300f",
+   "metadata": {},
+   "source": [
+    "Check which reference files were used to calibrate the first file. Some of these will be detector-dependent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6544744b-804e-4583-8311-e47b5e16c7fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage2:\n",
+    "    cal_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7159a021",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cfbb244-7af9-4cbf-90d9-08598378c16a",
+   "metadata": {},
+   "source": [
+    "## 7. Image3 Pipeline\n",
+    "\n",
+    "In the [Image3 stage of the pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image3.html), the individual `*_cal.fits` files for each filter are combined to one single distortion corrected image. Unlike the previous stages, we must run the `Image3` stage separately for the files from each filter as well as channel (i.e. shortwave vs longwave).\n",
+    "\n",
+    "First, we need to create [Associations](https://jwst-pipeline.readthedocs.io/en/latest/jwst/associations/overview.html), to inform the pipeline which files are linked together for each filter.\n",
+    "\n",
+    "By default, the `Image3` stage of the pipeline performs the following steps on NIRCam data: \n",
+    "- [tweakreg](https://jwst-pipeline.readthedocs.io/en/latest/jwst/tweakreg/index.html#tweakreg-step) - creates source catalogs of pointlike sources for each input image. The source catalog for each input image is compared to each other to derive coordinate transforms to align the images relative to each other.\n",
+    "   - `tweakreg` has many [input parameters](https://jwst-pipeline.readthedocs.io/en/latest/jwst/tweakreg/README.html#step-arguments) that can be adjusted to improve the image alignment in cases where the default values do not perform well.\n",
+    "   - One tweakreg parameter that is not set by default but can be very useful is `abs_refcat`. When this parameter is set to `GAIADR3`, the tweakreg step performs an absolute astrometric correction of the data using the GAIA data release 3 catalog. In cases where multiple unsaturated GAIA stars are present in the input images, this can improve the absolute astrometric alignment. However, in sparse or very crowded fields, this can potentially result in poor performance, so users are encouraged to check astrometric accuracy and revisit this step if necessary.\n",
+    "   - As of pipeline version 1.14.0, the default source finding algorithm in the `tweakreg step` is `IRAFStarFinder`. Other options include `DAOStarFinder`, whose results are not as good in cases where the PSF is undersampled, such as in the blue filters of the NIRCam shortwave channel. Finally [photutils segmentation SourceFinder](https://photutils.readthedocs.io/en/latest/api/photutils.segmentation.SourceFinder.html), which does not assume sources are point-like.\n",
+    "- [skymatch](https://jwst-pipeline.readthedocs.io/en/latest/jwst/skymatch/index.html#skymatch-step) - measures the background level from the sky to use as input into the subsequent `outlier detection` and `resample` steps.\n",
+    "- [outlier detection](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/index.html#outlier-detection-step) - flags any remaining cosmic rays, bad pixels, or other artifacts not already flagged during the `Detector1` stage of the pipeline, using all input images to create a median image so that outliers in individual images can be identified.\n",
+    "- [resample](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step) - resamples each input image based on its WCS and distortion information and creates a single undistorted image.\n",
+    "- [source catalog](https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/index.html#source-catalog-step) - creates a catalog of detected sources along with photometric results and morphologies (i.e., point-like vs extended). These catalogs are generally useful for quick checks, but optimization is likely needed for specific science cases. Users may wish to experiment with changing the `snr_threshold` and `deblend` options. Modifications to the following parameters will not significantly improve data quality and it is advised to keep them at their default values: `aperture_ee1`, `aperture_ee2`, `aperture_ee3`, `ci1_star_threshold`, `ci2_star_threshold`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8e81dc9-78dd-4bba-879c-9dfa2a4da69c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_image3 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8159e63d-3c89-44ef-9a43-caaccd1abb4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Image3 pipeline should be configured\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "image3dict = {}\n",
+    "image3dict['assign_mtwcs'], image3dict['tweakreg'], image3dict['skymatch'] = {}, {}, {}\n",
+    "image3dict['outlier_detection'], image3dict['resample'], image3dict['source_catalog'] = {}, {}, {}\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped (example)\n",
+    "#image3dict['outlier_detection']['skip'] = True\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#image3dict['source_catalog']['override_apcorr'] = 'myfile.fits'  # Aperture correction parameters\n",
+    "#image3dict['source_catalog']['override_abvegaoffset'] = 'myfile.asdf'  # Data to convert from AB to Vega magnitudes (ASDF file)\n",
+    "\n",
+    "# Turn on alignment to GAIA in the tweakreg step\n",
+    "# For data such as these demo data, where there are some heavily saturated stars in the field\n",
+    "# of view, alignment to GAIA sometimes does not work well due to tweakreg doing a poor job\n",
+    "# finding the centroids of the sources.\n",
+    "#image3dict['tweakreg']['abs_refcat'] = 'GAIADR3'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e10da872-21ae-46c2-a3b1-f9cdefae3b36",
+   "metadata": {},
+   "source": [
+    "Find and sort all of the input files, ensuring use of absolute paths.\n",
+    "Keep files for the two filters separated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f0b5b47-62e9-4593-abc4-7ec630492e96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Science Files need the cal.fits files\n",
+    "sw_sstring = os.path.join(image2_dir, 'jw*nrc??_cal.fits')     # shortwave files. Detectors a1-a4, b1-b4\n",
+    "lw_sstring = os.path.join(image2_dir, 'jw*nrc*long_cal.fits')  # longwave files. Detectors along, blong \n",
+    "\n",
+    "# Identify SW and LW cal files\n",
+    "sw_cal_files = sorted(glob.glob(sw_sstring))\n",
+    "lw_cal_files = sorted(glob.glob(lw_sstring))\n",
+    "\n",
+    "# Expand the relative paths into absolute paths\n",
+    "sw_cal_files = [os.path.abspath(fname) for fname in sw_cal_files]\n",
+    "lw_cal_files = [os.path.abspath(fname) for fname in lw_cal_files]\n",
+    "\n",
+    "print(f'Found {len(sw_cal_files)} shortwave science files to process')\n",
+    "print(f'Found {len(lw_cal_files)} longwave science files to process')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db5cb6f5-44a1-4f28-95dc-b23a97451465",
+   "metadata": {},
+   "source": [
+    "### Create Association File\n",
+    "\n",
+    "An association file lists the files to calibrate together in `Stage3` of the pipeline. Note that association files are available for download from MAST, with filenames of `*_asn.json`. Here we show how to create an association file to point to the data products created in the steps above. This is useful in cases where you want to work with a set of data that is different than that in the association files from MAST.\n",
+    "\n",
+    "Note that the output products will have a rootname that is specified by the `product_name` in the association file. For this tutorial, the rootnames of the output products will be `image3_sw` for filter `F200W` and `image3_lw` for filter `F444W`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6550a4a-f924-410b-a945-effcef431e88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List of data to use\n",
+    "print('List of SW cal files to use:')\n",
+    "sw_cal_files\n",
+    "print('\\nList of LW cal files to use:')\n",
+    "lw_cal_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b31f80f-8d7b-45ae-8537-15d0208637df",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create Level 3 Association for SW products\n",
+    "do_swimage3 = False\n",
+    "if doimage3:\n",
+    "    if len(sw_cal_files) > 0:\n",
+    "        # Only create an association file if there are SW data files to process\n",
+    "        do_swimage3 = True\n",
+    "        sw_product_name = 'image3_sw'\n",
+    "        sw_association = asn_from_list.asn_from_list(sw_cal_files,\n",
+    "                                                     rule=DMS_Level3_Base,\n",
+    "                                                     product_name=sw_product_name)\n",
+    "    \n",
+    "        sw_association.data['asn_type'] = 'image3'\n",
+    "        program = datamodels.open(sw_cal_files[0]).meta.observation.program_number\n",
+    "        sw_association.data['program'] = program\n",
+    "    \n",
+    "        # Format association as .json file\n",
+    "        sw_asn_filename, sw_serialized = sw_association.dump(format=\"json\")\n",
+    "\n",
+    "        # Write out association file\n",
+    "        sw_association_im3 = os.path.join(sci_dir, sw_asn_filename)\n",
+    "        with open(sw_association_im3, \"w\") as fd:\n",
+    "            fd.write(sw_serialized)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23ba8977-dc92-4aea-b245-bb2554a41612",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create Level 3 Associations for LW products\n",
+    "do_lwimage3 = False\n",
+    "if doimage3:\n",
+    "    if len(lw_cal_files) > 0:\n",
+    "        # Only create an association file if there are LW data files to process\n",
+    "        do_lwimage3 = True\n",
+    "        lw_product_name = 'image3_lw'\n",
+    "        lw_association = asn_from_list.asn_from_list(lw_cal_files,\n",
+    "                                                     rule=DMS_Level3_Base,\n",
+    "                                                     product_name=lw_product_name)\n",
+    "    \n",
+    "        lw_association.data['asn_type'] = 'image3'\n",
+    "        program = datamodels.open(lw_cal_files[0]).meta.observation.program_number\n",
+    "        lw_association.data['program'] = program\n",
+    "    \n",
+    "        # Format association as .json file\n",
+    "        lw_asn_filename, lw_serialized = lw_association.dump(format=\"json\")\n",
+    "\n",
+    "        # Write out association file. Note that you can use your own filename in\n",
+    "        # place of lw_asn_filename and everything will still work.\n",
+    "        lw_association_im3 = os.path.join(sci_dir, lw_asn_filename)\n",
+    "        with open(lw_association_im3, \"w\") as fd:\n",
+    "            fd.write(lw_serialized)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "629cad5b-e5a7-473e-8583-ad12cda55fa4",
+   "metadata": {},
+   "source": [
+    "### Run Image3 stage of the pipeline\n",
+    "\n",
+    "For each set of  grouped exposures in an association file, the `Image3` stage of the pipeline will produce:\n",
+    "- a `*_crf.fits` file produced by the `outlier_detection` step, where the `DQ` array marks the pixels flagged as outliers.\n",
+    "- a final combined, rectified image with name `*_i2d.fits`,\n",
+    "- a source catalog with name `*_cat.ecsv`,\n",
+    "- a segmentation map file (`*_segm.fits`) which has integer values at the pixel locations where a source is detected where the pixel values match the source ID number in the catalog."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1d41c32-265e-4ecd-859a-1ece2c2b9ea5",
+   "metadata": {},
+   "source": [
+    "#### Run Image3 on the LW data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1add92ce-d686-43cb-beaf-927d6a027d92",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Run Stage3 on the LW data\n",
+    "if doimage3 and do_lwimage3:\n",
+    "    lw_i2d_result = Image3Pipeline.call(lw_association_im3, output_dir=image3_dir, steps=image3dict, save_results=True)\n",
+    "else:\n",
+    "    print('Skipping Image3 LW processing')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "616ce5b0-1fac-44ca-a7d5-1390e20fa35d",
+   "metadata": {},
+   "source": [
+    "Some users wish to resample data from multiple filters onto the same WCS and pixel grid in order to create color images or help with subsequent analyses. In order to do that, we'll save the gWCS from the *i2d.fits file created with the LW data above. The gWCS will be saved into an asdf file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a4e3b96-9098-4734-b683-3ae8abacbd42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3 and do_lwimage3:\n",
+    "    # First we identify the dataset and read it using datamodels.\n",
+    "    lw_i2d_file = os.path.join(image3_dir, f'{lw_product_name}_i2d.fits')\n",
+    "    lw_data = datamodels.open(lw_i2d_file)\n",
+    "    \n",
+    "    # Pull out the resulting gWCS and save it in an asdf file\n",
+    "    tree = {\"wcs\": lw_data.meta.wcs}\n",
+    "    wcs_file = AsdfFile(tree)\n",
+    "    gwcs_filename = os.path.join(image3_dir + 'lw_gwcs.asdf')\n",
+    "    print(f'Saving gWCS into {gwcs_filename}')\n",
+    "    wcs_file.write_to(gwcs_filename)\n",
+    "\n",
+    "    # Get the size of the mosaic image\n",
+    "    ysize, xsize = lw_data.data.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dee03fe9-d13c-4477-91fb-799b783291bc",
+   "metadata": {},
+   "source": [
+    "#### Run Image3 on the SW data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00d4b708-66e8-485c-add2-95f7dd29af50",
+   "metadata": {},
+   "source": [
+    "Prepare to call the Image3 pipeline on the SW data. If you wish to resample the SW data onto the same pixel grid as the LW data above, uncomment the lines below. This will tell the resample step to use the gWCS and the array size from the LW data when resampling the SW data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d10f0588-1149-4de5-897d-a9ecaefa40c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncoment this cell in order to resample the SW data onto the same pixel grid as the LW data\n",
+    "#if doimage3:\n",
+    "#    image3dict['resample']['output_wcs'] = gwcs_filename\n",
+    "#    image3dict['resample']['output_shape'] = (xsize, ysize)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7821f99-66ce-44b2-9e21-4b26891d38ea",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "if doimage3 and do_swimage3:\n",
+    "    sw_i2d_result = Image3Pipeline.call(sw_association_im3, output_dir=image3_dir, steps=image3dict, save_results=True)\n",
+    "else:\n",
+    "    print('Skipping Image3 SW processing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f67d2c65-4614-4592-aa67-daa2de985013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.0f} seconds\")\n",
+    "print(f\"Runtime for Image3: {time1 - time_image3:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bcb6c40-fbb8-4226-b620-64b0c02c8ceb",
+   "metadata": {},
+   "source": [
+    "### Verify which pipeline steps were run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c754530a-d4e2-493b-bf8b-bf8d1ad08770",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Identify *_i2d file and open as datamodel\n",
+    "if doimage3:\n",
+    "    if do_swimage3:\n",
+    "        sw_i2d_file = os.path.join(image3_dir, f'{sw_product_name}_i2d.fits')\n",
+    "        i2d_sw_model = datamodels.open(sw_i2d_file)\n",
+    "        step_check_model = i2d_sw_model\n",
+    "        \n",
+    "    if do_lwimage3:\n",
+    "        lw_i2d_file = os.path.join(image3_dir, f'{lw_product_name}_i2d.fits')\n",
+    "        i2d_lw_model = datamodels.open(lw_i2d_file)\n",
+    "        step_check_model = i2d_lw_model\n",
+    "\n",
+    "    # Check which steps were run. This should be the same regardless of whether\n",
+    "    # a sw or lw file is used.\n",
+    "    step_check_model.meta.cal_step.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f73c5280-69a5-4796-b78f-724078a94d2b",
+   "metadata": {},
+   "source": [
+    "Check which reference files were used to calibrate the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abb20ca7-2e14-4e2e-85fb-33f8ec057716",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3:\n",
+    "    step_check_model.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ade57bb3",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46be5421-7fc8-4d96-b2cd-2484f294e082",
+   "metadata": {},
+   "source": [
+    "## 8. Visualize the resampled images\n",
+    "\n",
+    "If you specified that the LW and SW outputs should be resampled onto the same pixel grid, you should be able to open the two i2d files and overlay them and see that the sources and pixel grids line up. If there is any misalignment, you may need to adjust tweakreg parameters in the calls to the Image3 pipeline in order to improve the alignment.\n",
+    "\n",
+    "Below we use the [Imviz tool](https://jdaviz.readthedocs.io/en/latest/imviz/index.html) within the `jdaviz` package to visualize the images, one filter at a time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc5426a1-3932-4add-8e65-40939a9ee140",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an Imviz instance and set up default viewer for the F200W data\n",
+    "if doimage3 and do_swimage3:\n",
+    "    imviz_sw_i2d = Imviz()\n",
+    "    viewer_sw_i2d = imviz_sw_i2d.default_viewer\n",
+    "\n",
+    "    # Read in the science array for our visualization dataset:\n",
+    "    i2d_sw_science = i2d_sw_model.data\n",
+    "\n",
+    "    # Load the dataset into Imviz\n",
+    "    imviz_sw_i2d.load_data(i2d_sw_science)\n",
+    "\n",
+    "    # Visualize the dataset:\n",
+    "    imviz_sw_i2d.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4654602-c6e9-4178-9b3d-9a219a1471df",
+   "metadata": {},
+   "source": [
+    "Remember that in this mosaic we have only two detectors: NRC2 and NRC4 (left and right, respectively). The dither is not large enough to cover the gap between the detectors, and so that gap is still visible in the mosaic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d22a117-e4cf-4d2f-9fec-f52545c8aa5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3 and do_swimage3:\n",
+    "    viewer_sw_i2d.stretch = 'sqrt'\n",
+    "    viewer_sw_i2d.set_colormap('Viridis')\n",
+    "    viewer_sw_i2d.cuts = '95%'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06402509-0353-415e-bf1b-5f88af4547f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an Imviz instance and set up default viewer for the F444W data\n",
+    "if doimage3 and do_lwimage3:\n",
+    "    imviz_lw_i2d = Imviz()\n",
+    "    viewer_lw_i2d = imviz_lw_i2d.default_viewer\n",
+    "\n",
+    "    # Read in the science array for our visualization dataset:\n",
+    "    i2d_lw_science = i2d_lw_model.data\n",
+    "\n",
+    "    # Load the dataset into Imviz\n",
+    "    imviz_lw_i2d.load_data(i2d_lw_science)\n",
+    "\n",
+    "    # Visualize the dataset:\n",
+    "    imviz_lw_i2d.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50b0f7b4-129e-4277-b1b2-608850a6262c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3 and do_lwimage3:\n",
+    "    viewer_lw_i2d.stretch = 'sqrt'\n",
+    "    viewer_lw_i2d.set_colormap('Viridis')\n",
+    "    viewer_lw_i2d.cuts = '95%'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4797288-5db3-4c4e-bcd3-a1215527fab5",
+   "metadata": {},
+   "source": [
+    "### Ovelaying the LW and SW images\n",
+    "\n",
+    "Let's try putting the SW and LW images on top of one another to create a color image. This should work regardless of whether you resampled the two images onto the same pixel grid.\n",
+    "\n",
+    "Let's get the data first"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f80f5fc7-a555-4201-88d5-e08318bd7e57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3 and do_swimage3 and do_lwimage3:\n",
+    "    imviz_color = Imviz()\n",
+    "    viewer_color = imviz_color.default_viewer\n",
+    "\n",
+    "    # Load the datasets into Imviz\n",
+    "    imviz_color.load_data(sw_i2d_file, data_label='sw')\n",
+    "    imviz_color.load_data(lw_i2d_file, data_label='lw')\n",
+    "\n",
+    "    # Link images by WCS\n",
+    "    imviz_color.link_data(align_by='wcs')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b8d63a9-ecab-4164-b6bb-1fb82a7b73c6",
+   "metadata": {},
+   "source": [
+    "Now define some options to make the picture look nice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "709f92eb-beda-438a-90ec-340a7ac303a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the colors for the two images. \n",
+    "if doimage3 and do_swimage3 and do_lwimage3:\n",
+    "    plot_options = imviz_color.plugins['Plot Options']\n",
+    "    plot_options.image_color_mode = 'Color'\n",
+    "    img_settings = {'sw': {'image_color': '#61d3e1',\n",
+    "                           #'stretch_vmin': 0,\n",
+    "                           #'stretch_vmax': 4,\n",
+    "                           #'image_opacity': 0.32,\n",
+    "                           #'image_contrast': 0.69,\n",
+    "                           #'image_bias': 0.39\n",
+    "                           },\n",
+    "                    'lw': {'image_color': '#ff767c',\n",
+    "                           #'stretch_vmin': 0,\n",
+    "                           #'stretch_vmax': 16,\n",
+    "                           #'image_opacity': 0.4,\n",
+    "                           #'image_contrast': 0.94,\n",
+    "                           #'image_bias': 0.74\n",
+    "                           }\n",
+    "                    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd7c00b6-8a84-4d4d-a0dd-b73a1f355f17",
+   "metadata": {},
+   "source": [
+    "Populate the imviz instance with the settings in the cell above and visualize the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c108af5-e54d-456f-bc30-d94901376c35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now populate the imviz instance with the settings in the cell above.\n",
+    "if doimage3 and do_swimage3 and do_lwimage3:\n",
+    "    for layer, settings in img_settings.items():\n",
+    "        plot_options.layer = f'{layer}[SCI,1]'\n",
+    "        for k, v in settings.items():\n",
+    "            setattr(plot_options, k, v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1186623-2ae7-4f21-87e2-be852af291fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the dataset\n",
+    "if doimage3 and do_swimage3 and do_lwimage3:\n",
+    "    imviz_color.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fca90333",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "018733eb-07ec-44a4-a5a7-d6d2f27d193a",
+   "metadata": {},
+   "source": [
+    "## 9. Visualize Detected Sources\n",
+    "Using the source catalogs created by the `Image3` stage of the pipeline, mark the detected sources, using different markers for point sources and extended sources. The source catalogs are saved in `image3/image3_sw_cat.ecsv` and `image3/image3_lw_cat.ecsv`. This time, we will provide the i2d filename to the `imviz` `load_data` function, rather than just the array of pixel values. This way, `imviz` will be able to make use of the WCS in the file. This will allow the sources in the source catalog to be accurately marked in the display."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ad6ee55-f940-4be3-96c9-114bc83eb784",
+   "metadata": {},
+   "source": [
+    "### Read in catalog file and identify point/extended sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32235fdc-4ec2-42e6-89e7-b9f62824e179",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3:\n",
+    "    if do_swimage3:\n",
+    "        sw_catalog_file = sw_i2d_file.replace('i2d.fits', 'cat.ecsv')\n",
+    "        sw_catalog = Table.read(sw_catalog_file)\n",
+    "    \n",
+    "        # To identify point/extended sources, use the 'is_extended' column in the source catalog\n",
+    "        sw_pt_src, = np.where(~sw_catalog['is_extended'])\n",
+    "        sw_ext_src, = np.where(sw_catalog['is_extended'])\n",
+    "    \n",
+    "        # Define coordinates of point and extended sources\n",
+    "        sw_pt_coord = Table({'coord': [SkyCoord(ra=sw_catalog['sky_centroid'][sw_pt_src].ra,\n",
+    "                                                dec=sw_catalog['sky_centroid'][sw_pt_src].dec)]})\n",
+    "        sw_ext_coord = Table({'coord': [SkyCoord(ra=sw_catalog['sky_centroid'][sw_ext_src].ra,\n",
+    "                                                 dec=sw_catalog['sky_centroid'][sw_ext_src].dec)]})\n",
+    "\n",
+    "    if do_lwimage3:\n",
+    "        lw_catalog_file = lw_i2d_file.replace('i2d.fits', 'cat.ecsv')\n",
+    "        lw_catalog = Table.read(lw_catalog_file)\n",
+    "\n",
+    "        # To identify point/extended sources, use the 'is_extended' column in the source catalog\n",
+    "        lw_pt_src, = np.where(~lw_catalog['is_extended'])\n",
+    "        lw_ext_src, = np.where(lw_catalog['is_extended'])\n",
+    "\n",
+    "        # Define coordinates of point and extended sources\n",
+    "        lw_pt_coord = Table({'coord': [SkyCoord(ra=lw_catalog['sky_centroid'][lw_pt_src].ra,\n",
+    "                                                dec=lw_catalog['sky_centroid'][lw_pt_src].dec)]})\n",
+    "        lw_ext_coord = Table({'coord': [SkyCoord(ra=lw_catalog['sky_centroid'][lw_ext_src].ra,\n",
+    "                                                 dec=lw_catalog['sky_centroid'][lw_ext_src].dec)]})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be9e9069-375d-431b-bbfb-e84e6cefc2d4",
+   "metadata": {},
+   "source": [
+    "### Mark the extended and point sources on the images\n",
+    "\n",
+    "Display the image with sources indicated by circles. Point sources will be marked by small pink circles and extended sources will be marked by white circles. Looking at the entire mosaic, there are so many sources found that it's hard to see much of anything. To get a clearer view, try zooming in on various areas using the magnifying glass icon on the banner immediately above the image. \n",
+    "\n",
+    "First we visualize the data without the point sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3126f030-973e-4bf9-972c-fcac9818c451",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in SW i2d file to Imviz\n",
+    "if doimage3 and do_swimage3:\n",
+    "    imviz_sw_cat = Imviz()\n",
+    "    viewer_sw_cat = imviz_sw_cat.default_viewer\n",
+    "    imviz_sw_cat.load_data(sw_i2d_file)\n",
+    "\n",
+    "    # Adjust settings for viewer\n",
+    "    viewer_sw_cat.stretch = 'sqrt'\n",
+    "    viewer_sw_cat.set_colormap('Viridis')\n",
+    "    viewer_sw_cat.cuts = '95%'\n",
+    "\n",
+    "    imviz_sw_cat.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afdddbdd-e01b-43c6-b827-d4683d017466",
+   "metadata": {},
+   "source": [
+    "Now we add the point sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcb8f619-3807-44d1-a8d9-fbf41abb5522",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add marker for point sources:\n",
+    "if doimage3 and do_swimage3:\n",
+    "    viewer_sw_cat.marker = {'color': 'pink', 'markersize': 50, 'fill': False}\n",
+    "\n",
+    "    viewer_sw_cat.add_markers(sw_pt_coord, use_skycoord=True, marker_name='point_sources')\n",
+    "\n",
+    "    # Add marker for extended sources:\n",
+    "    viewer_sw_cat.marker = {'color': 'white', 'markersize': 100, 'fill': False}\n",
+    "\n",
+    "    viewer_sw_cat.add_markers(sw_ext_coord, use_skycoord=True, marker_name='extended_sources')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6ce5589-5aa9-414e-ab43-adce292ef11c",
+   "metadata": {},
+   "source": [
+    "We do the same with the LW file. First we visualize the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59a7cce1-4437-4529-8073-9da93e8700d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Repeat using the LW file\n",
+    "if doimage3 and do_lwimage3:\n",
+    "    imviz_lw_cat = Imviz()\n",
+    "    viewer_lw_cat = imviz_lw_cat.default_viewer\n",
+    "    imviz_lw_cat.load_data(lw_i2d_file)\n",
+    "\n",
+    "    # Adjust settings for viewer\n",
+    "    viewer_lw_cat.stretch = 'sqrt'\n",
+    "    viewer_lw_cat.set_colormap('Viridis')\n",
+    "    viewer_lw_cat.cuts = '95%'\n",
+    "\n",
+    "    imviz_lw_cat.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45a77115-4be8-4b5e-9a45-15a78da35774",
+   "metadata": {},
+   "source": [
+    "Now we mark the point sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47a1aa48-1104-416b-aa48-e4247498d696",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add marker for point sources:\n",
+    "if doimage3 and do_lwimage3:\n",
+    "    viewer_lw_cat.marker = {'color': 'pink', 'markersize': 50, 'fill': False}\n",
+    "\n",
+    "    viewer_lw_cat.add_markers(lw_pt_coord, use_skycoord=True, marker_name='point_sources')\n",
+    "\n",
+    "    # Add marker for extended sources:\n",
+    "    viewer_lw_cat.marker = {'color': 'white', 'markersize': 100, 'fill': False}\n",
+    "\n",
+    "    viewer_lw_cat.add_markers(lw_ext_coord, use_skycoord=True, marker_name='extended_sources')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2e3c58e",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85105f12-83ac-4c19-8f52-3ed2a5e08e27",
+   "metadata": {},
+   "source": [
+    "## 10. Notes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f45a68de-194e-4b0d-9ee9-b7ef4d7def42",
+   "metadata": {},
+   "source": [
+    "- Note that the strategy presented in this notebook for placing the SW data onto the same pixel grid as the LW data can be applied to data from any two datasets, regardless of filter or channel. By saving the gWCS from the first dataset into an asdf file and providing that file to the `Image3` call with the second dataset, the resulting i2d images will be aligned onto the same pixel grid.\n",
+    "\n",
+    "- If you notice poor alignment across tiles within a single i2d image, or between i2d images that you expect to be aligned, try adjusting the parameters in the `tweakreg` step. With these, you can customize which sources `tweakreg` identifies and uses for the alignment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f9a45cd",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cde191a9-cc88-4584-8524-780d245b469f",
+   "metadata": {},
+   "source": [
+    "<img style=\"float: center;\" src='https://github.com/spacetelescope/jwst-pipeline-notebooks/raw/main/_static/stsci_footer.png' alt=\"stsci_logo\" width=\"400px\"/> "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/processing-engine/tests/fixtures/jwpipenb/JWPipeNB-niriss-imaging.ipynb
+++ b/processing-engine/tests/fixtures/jwpipenb/JWPipeNB-niriss-imaging.ipynb
@@ -1,0 +1,1370 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "095a295c",
+   "metadata": {},
+   "source": [
+    "<img style=\"float: center;\" src='https://github.com/spacetelescope/jwst-pipeline-notebooks/raw/main/_static/stsci_header.png' alt=\"stsci_logo\" width=\"900px\"/> "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0393e357-9d9d-4516-b28d-4d335fad33a0",
+   "metadata": {},
+   "source": [
+    "# NIRISS Imaging Pipeline Notebook\n",
+    "\n",
+    "**Authors**: S. LaMassa, R. Diaz<br>\n",
+    "**Last Updated**: April 17, 2026<br>\n",
+    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7da2029f",
+   "metadata": {},
+   "source": [
+    "# **Purpose**:\n",
+    "\n",
+    "This notebook provides a framework for processing generic Near-Infrared\n",
+    "Imager and Slitless Spectrograph (NIRISS) Imaging data through all\n",
+    "three James Webb Space Telescope (JWST) pipeline stages.  Data is assumed\n",
+    "to be located in one observation folder according to paths set up below.\n",
+    "It should not be necessary to edit any cells other than in the\n",
+    "[Configuration](#1.-Configuration) section unless modifying the standard\n",
+    "pipeline processing options.\n",
+    "\n",
+    "**Data**:\n",
+    "This example is set up to use an example dataset is from\n",
+    "[Program ID](https://www.stsci.edu/jwst/science-execution/program-information)\n",
+    "1475 (PI: Boyer, CoI: Volk) which is a sky flat calibration program.\n",
+    "NIRCam is used as the primary instrument with NIRISS as a\n",
+    "[coordinated parallel instrument](https://jwst-docs.stsci.edu/methods-and-roadmaps/jwst-parallel-observations/jwst-coordinated-parallels-roadmap).\n",
+    "The NIRISS imaging dataset uses a 17-step dither pattern.\n",
+    "\n",
+    "Example input data to use will be downloaded automatically unless\n",
+    "disabled (i.e., to use local files instead).\n",
+    "\n",
+    "**JWST pipeline version and CRDS context** This notebook was written for the\n",
+    "calibration pipeline version given above. It sets the CRDS context\n",
+    "to use the most recent version available in the JWST Calibration\n",
+    "Reference Data System (CRDS). If you use different pipeline versions or\n",
+    "CRDS context, please read the relevant release notes\n",
+    "([here for pipeline](https://github.com/spacetelescope/jwst),\n",
+    "[here for CRDS](https://jwst-crds.stsci.edu/)) for possibly relevant\n",
+    "changes.<BR>\n",
+    "\n",
+    "**Updates**:\n",
+    "This notebook is regularly updated as improvements are made to the\n",
+    "pipeline. Find the most up to date version of this notebook at:\n",
+    "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
+    "\n",
+    "**Recent Changes**:<br>\n",
+    "January 24, 2024: original notebook released<br>\n",
+    "Septemer 3, 2024: Updated text to highlight that `IRAFStarFinder` is the default\n",
+    "centroiding algorithm used in the `Image3` tweakreg step of the pipeline for NIRISS imaging, as of \n",
+    "pipeline version 1.14.0 (build 10.2).<br>\n",
+    "November 22, 2024: Updates to workflow when skipping pipeline modules<br>\n",
+    "January 31, 2025: Update to build 11.2, no significant changes.<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes).<br>\n",
+    "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
+    "December 10 2025: Updated to jwst 1.20.2 (no significant changes)<br>\n",
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "453945c7",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5291c2f1",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Table of Contents\n",
+    "1. [Configuration](#1.-Configuration) \n",
+    "2. [Package Imports](#2.-Package-Imports)\n",
+    "3. [Demo Mode Setup (ignore if not using demo data)](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
+    "4. [Directory Setup](#4.-Directory-Setup)\n",
+    "3. [Detector 1 Pipeline](#5.-Detector1-Pipeline)\n",
+    "4. [Image2 Pipeline](#6.-Image2-Pipeline)\n",
+    "5. [Image3 Pipeline](#7.-Image3-Pipeline)\n",
+    "6. [Visualize the data](#8.-Visualize-the-drizzle-combined-image)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5a88584",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43bd07d7",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration\n",
+    "------------------\n",
+    "Set basic configuration for running notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026a649d-a0d2-4e3f-ab6d-cf8c26e6ce1d",
+   "metadata": {},
+   "source": [
+    "#### Install dependencies and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84b6c02c-a7cd-4999-96a0-87ce398d7e9a",
+   "metadata": {},
+   "source": [
+    "To make sure that the pipeline version is compatabile with the steps\n",
+    "discussed below and the required dependencies and packages are installed,\n",
+    "you can create a fresh conda environment and install the provided\n",
+    "`requirements.txt` file:\n",
+    "```\n",
+    "conda create -n niriss_imaging_pipeline python=3.13\n",
+    "conda activate niriss_imaging_pipeline\n",
+    "pip install -r requirements.txt\n",
+    "```\n",
+    "\n",
+    "Set the basic parameters to use with this notebook. These will affect\n",
+    "what data is used, where data is located (if already in disk), and\n",
+    "pipeline modules run in this data. The list of parameters are:\n",
+    "\n",
+    "* demo_mode\n",
+    "* directories with data\n",
+    "* pipeline modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06ea414c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic import necessary for configuration\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61bb14e6",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Note that <code>demo_mode</code> must be set appropriately below.\n",
+    "</div>\n",
+    "\n",
+    "Set <code>demo_mode = True </code> to run in demonstration mode. In this\n",
+    "mode this notebook will download example data from the Barbara A.\n",
+    "Mikulski Archive for Space Telescopes (MAST) and process it through the\n",
+    "pipeline. This will all happen in a local directory unless modified\n",
+    "in [Section 3](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
+    "below.\n",
+    "\n",
+    "Set <code>demo_mode = False</code> if you want to process your own data\n",
+    "that has already been downloaded and provide the location of the data.<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "323f87d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set parameters for demo_mode, channel, band, data mode directories, and \n",
+    "# processing steps.\n",
+    "\n",
+    "# -----------------------------Demo Mode---------------------------------\n",
+    "demo_mode = True\n",
+    "\n",
+    "if demo_mode:\n",
+    "    print('Running in demonstration mode using online example data!')\n",
+    "\n",
+    "# --------------------------User Mode Directories------------------------\n",
+    "# If demo_mode = False, look for user data in these paths\n",
+    "if not demo_mode:\n",
+    "    # Set directory paths for processing specific data; these will need\n",
+    "    # to be changed to your local directory setup (below are given as\n",
+    "    # examples)\n",
+    "    user_home_dir = os.path.expanduser('~')\n",
+    "\n",
+    "    # Point to where science observation data are\n",
+    "    # Assumes uncalibrated data in sci_dir/uncal/ and results in stage1,\n",
+    "    # stage2, stage3 directories\n",
+    "    sci_dir = os.path.join(user_home_dir, 'FlightData/APT1475/data/Obs006/')\n",
+    "\n",
+    "# --------------------------Set Processing Steps--------------------------\n",
+    "# Individual pipeline stages can be turned on/off here.  Note that a later\n",
+    "# stage won't be able to run unless data products have already been\n",
+    "# produced from the prior stage.\n",
+    "\n",
+    "# Science processing\n",
+    "dodet1 = True  # calwebb_detector1\n",
+    "doimage2 = True  # calwebb_image2\n",
+    "doimage3 = True  # calwebb_image3\n",
+    "doviz = True # Visualize calwebb_image3 output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1070079a",
+   "metadata": {},
+   "source": [
+    "### Set CRDS context and server\n",
+    "Before importing <code>CRDS</code> and <code>JWST</code> modules, we need\n",
+    "to configure our environment. This includes defining a CRDS cache\n",
+    "directory in which to keep the reference files that will be used by the\n",
+    "calibration pipeline.\n",
+    "\n",
+    "If the root directory for the local CRDS cache directory has not been set\n",
+    "already, it will be set to create one in the home directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baf7070d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ------------------------Set CRDS context and paths----------------------\n",
+    "\n",
+    "# Set CRDS context (if overriding to use a specific version of reference\n",
+    "# files; leave commented out to use latest reference files by default)\n",
+    "#%env CRDS_CONTEXT  jwst_1254.pmap\n",
+    "\n",
+    "# Check whether the local CRDS cache directory has been set.\n",
+    "# If not, set it to the user home directory\n",
+    "if (os.getenv('CRDS_PATH') is None):\n",
+    "    os.environ['CRDS_PATH'] = os.path.join(os.path.expanduser('~'), 'crds')\n",
+    "# Check whether the CRDS server URL has been set.  If not, set it.\n",
+    "if (os.getenv('CRDS_SERVER_URL') is None):\n",
+    "    os.environ['CRDS_SERVER_URL'] = 'https://jwst-crds.stsci.edu'\n",
+    "\n",
+    "# Echo CRDS path in use\n",
+    "print(f\"CRDS local filepath: {os.environ['CRDS_PATH']}\")\n",
+    "print(f\"CRDS file server: {os.environ['CRDS_SERVER_URL']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "165cb98d",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "575588c8",
+   "metadata": {},
+   "source": [
+    "## 2. Package Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4415f6d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the entire available screen width for this notebook\n",
+    "from IPython.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:95% !important; }</style>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb9f7f54-ff98-428b-9fa9-b39c50210c3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic system utilities for interacting with files\n",
+    "# ----------------------General Imports------------------------------------\n",
+    "import glob\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "#import urllib.request\n",
+    "\n",
+    "# Numpy for doing calculations\n",
+    "import numpy as np\n",
+    "\n",
+    "# -----------------------Astroquery Imports--------------------------------\n",
+    "# ASCII files, and downloading demo files\n",
+    "from astroquery.mast import Observations\n",
+    "\n",
+    "# For visualizing images\n",
+    "from jdaviz import Imviz\n",
+    "\n",
+    "# Astropy routines for visualizing detected sources:\n",
+    "from astropy.table import Table\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "# for JWST calibration pipeline\n",
+    "import jwst\n",
+    "import crds\n",
+    "\n",
+    "from jwst.pipeline import Detector1Pipeline\n",
+    "from jwst.pipeline import Image2Pipeline\n",
+    "from jwst.pipeline import Image3Pipeline\n",
+    "\n",
+    "# JWST pipeline utilities\n",
+    "from jwst import datamodels\n",
+    "from jwst.associations import asn_from_list  # Tools for creating association files\n",
+    "from jwst.associations.lib.rules_level3_base import DMS_Level3_Base  # Definition of a Lvl3 association file\n",
+    "\n",
+    "# Echo pipeline version and CRDS context in use\n",
+    "print(f\"JWST Calibration Pipeline Version: {jwst.__version__}\")\n",
+    "print(f\"Using CRDS Context: {crds.get_context_name('jwst')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5844d476-f8b3-4c24-9c79-091d6016314d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start a timer to keep track of runtime\n",
+    "time0 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "987d3f75",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ef8050f",
+   "metadata": {},
+   "source": [
+    "## 3. Demo Mode Setup (ignore if not using demo data)\n",
+    "------------------\n",
+    "If running in demonstration mode, set up the program information to\n",
+    "retrieve the uncalibrated data automatically from MAST using\n",
+    "[astroquery](https://astroquery.readthedocs.io/en/latest/mast/mast.html).\n",
+    "MAST allows for flexibility of searching by the proposal ID and the\n",
+    "observation ID instead of just filenames.<br>\n",
+    "\n",
+    "For illustrative purposes, we focus on data taken through the NIRISS\n",
+    "[F150W filter](https://jwst-docs.stsci.edu/jwst-near-infrared-imager-and-slitless-spectrograph/niriss-instrumentation/niriss-filters)\n",
+    "and start with uncalibrated data products. The files are named\n",
+    "`jw01475006001_02201_000nn_nis_uncal.fits`, where *nn* refers to the\n",
+    " dither step number which ranges from 01 - 17.\n",
+    "\n",
+    "More information about the JWST file naming conventions can be found at:\n",
+    "https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/file_naming.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d595f1e-2590-4f01-bb92-13bb43a22b3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up the program information and paths for demo program\n",
+    "if demo_mode:\n",
+    "    print('Running in demonstration mode and will download example data from MAST!')\n",
+    "    program = '01475'\n",
+    "    sci_observtn = \"006\"\n",
+    "    visit = \"001\"\n",
+    "    data_dir = os.path.join('.', 'nis_im_demo_data')\n",
+    "    download_dir = data_dir\n",
+    "    sci_dir = os.path.join(data_dir, 'Obs' + sci_observtn)\n",
+    "    uncal_dir = os.path.join(sci_dir, 'uncal')\n",
+    "\n",
+    "    # Ensure filepaths for input data exist\n",
+    "    if not os.path.exists(uncal_dir):\n",
+    "        os.makedirs(uncal_dir)\n",
+    "        \n",
+    "    # Create directory if it does not exist\n",
+    "    if not os.path.isdir(data_dir):\n",
+    "        os.mkdir(data_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6674a8b8",
+   "metadata": {},
+   "source": [
+    "Identify list of science (SCI) uncalibrated files associated with visits.\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Selects only filter <i>f150w</i> data\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4b22375",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Obtain a list of observation IDs for the specified demo program\n",
+    "if demo_mode:\n",
+    "    # Science data\n",
+    "    sci_obs_id_table = Observations.query_criteria(instrument_name=[\"NIRISS/IMAGE\"],\n",
+    "                                                   provenance_name=[\"CALJWST\"],  # Executed observations\n",
+    "                                                   filters=['F150W'],  # Data for Specific Filter\n",
+    "                                                   obs_id=['jw' + program + '-o' + sci_observtn + '*']\n",
+    "                                                   )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a666350e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Turn the list of visits into a list of uncalibrated data files\n",
+    "if demo_mode:\n",
+    "    # Define types of files to select\n",
+    "    file_dict = {'uncal': {'product_type': 'SCIENCE',\n",
+    "                           'productSubGroupDescription': 'UNCAL',\n",
+    "                           'calib_level': [1]}}\n",
+    "\n",
+    "    # Science files\n",
+    "    sci_files_to_download = []\n",
+    "    # Loop over visits identifying uncalibrated files that are associated\n",
+    "    # with them\n",
+    "    for exposure in (sci_obs_id_table):\n",
+    "        products = Observations.get_product_list(exposure)\n",
+    "        for filetype, query_dict in file_dict.items():\n",
+    "            filtered_products = Observations.filter_products(products, productType=query_dict['product_type'],\n",
+    "                                                             productSubGroupDescription=query_dict['productSubGroupDescription'],\n",
+    "                                                             calib_level=query_dict['calib_level'])\n",
+    "            sci_files_to_download.extend(filtered_products['dataURI'])\n",
+    " \n",
+    "    sci_files_to_download = sorted(sci_files_to_download)\n",
+    "    print(f\"Science files selected for downloading: {len(sci_files_to_download)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c36a54be",
+   "metadata": {},
+   "source": [
+    "Download all the uncal files and place them into the appropriate\n",
+    "directories.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Warning: If this notebook is halted during this step the downloaded file\n",
+    "may be incomplete, and cause crashes later on!\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "764fa682",
+   "metadata": {
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "if demo_mode:\n",
+    "    for filename in sci_files_to_download:\n",
+    "        sci_manifest = Observations.download_file(filename,\n",
+    "                                                  local_path=os.path.join(uncal_dir, Path(filename).name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b14864b",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6c51254-6295-4f98-bc25-d07300e0d8f4",
+   "metadata": {},
+   "source": [
+    "## 4. Directory Setup\n",
+    "---------------------\n",
+    "Set up detailed paths to input/output stages here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bffbedc3-fbe3-4c56-ad18-85b5d0c7d880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define output subdirectories to keep science data products organized\n",
+    "uncal_dir = os.path.join(sci_dir, 'uncal')  # Uncalibrated pipeline inputs should be here\n",
+    "det1_dir = os.path.join(sci_dir, 'stage1')  # calwebb_detector1 pipeline outputs will go here\n",
+    "image2_dir = os.path.join(sci_dir, 'stage2')  # calwebb_spec2 pipeline outputs will go here\n",
+    "image3_dir = os.path.join(sci_dir, 'stage3')  # calwebb_spec3 pipeline outputs will go here\n",
+    "\n",
+    "# We need to check that the desired output directories exist, and if not\n",
+    "# create them\n",
+    "if not os.path.exists(det1_dir):\n",
+    "    os.makedirs(det1_dir)\n",
+    "if not os.path.exists(image2_dir):\n",
+    "    os.makedirs(image2_dir)\n",
+    "if not os.path.exists(image3_dir):\n",
+    "    os.makedirs(image3_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cd8e6a7-433d-4e5b-a832-46f0bc96a0fe",
+   "metadata": {},
+   "source": [
+    "Look at the first file to determine exposure parameters and practice using\n",
+    "JWST datamodels¶"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f767a7fa-50cb-4411-8aef-a32b7fde8917",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uncal_files = sorted(glob.glob(os.path.join(uncal_dir, '*_uncal.fits')))\n",
+    "\n",
+    "# print file name\n",
+    "print(uncal_files[0])\n",
+    "\n",
+    "# Open file as JWST datamodel\n",
+    "examine = datamodels.open(uncal_files[0])\n",
+    "\n",
+    "# Print out exposure info\n",
+    "print(f\"Instrument: {examine.meta.instrument.name}\")\n",
+    "print(f\"Filter: {examine.meta.instrument.filter}\")\n",
+    "print(f\"Pupil: {examine.meta.instrument.pupil}\")\n",
+    "print(f\"Number of integrations: {examine.meta.exposure.nints}\")\n",
+    "print(f\"Number of groups: {examine.meta.exposure.ngroups}\")\n",
+    "print(f\"Readout pattern: {examine.meta.exposure.readpatt}\")\n",
+    "print(f\"Dither position number: {examine.meta.dither.position_number}\")\n",
+    "print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0469a648-9bb1-40f9-9f8b-fb3a29bc5c7f",
+   "metadata": {},
+   "source": [
+    "From the above, we confirm that the data file is for the NIRISS instrument\n",
+    "using the `F150W` filter in the [Pupil Wheel](https://jwst-docs.stsci.edu/jwst-near-infrared-imager-and-slitless-spectrograph/niriss-instrumentation/niriss-pupil-and-filter-wheels)\n",
+    "crossed with the `CLEAR` filter in the Filter Wheel. This observation uses\n",
+    "the [`NIS` readout pattern](https://jwst-docs.stsci.edu/jwst-near-infrared-imager-and-slitless-spectrograph/niriss-instrumentation/niriss-detector-overview/niriss-detector-readout-patterns),\n",
+    "16 groups per integration, and 1 integration per exposure. This data file\n",
+    "is the 1st dither position in this exposure sequence. For more information\n",
+    "about how JWST exposures are defined by up-the-ramp sampling, see the\n",
+    "[Understanding Exposure Times JDox article](https://jwst-docs.stsci.edu/understanding-exposure-times).\n",
+    "\n",
+    "This metadata will be the same for all exposures in this observation other\n",
+    "than the dither position number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f843ff7f-58b6-4294-bfaa-606c29abc524",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97528f9b",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "267e28e0-a63f-4790-b8a0-3ad4bff5a167",
+   "metadata": {},
+   "source": [
+    "## 5. Detector1 Pipeline\n",
+    "Run the datasets through the\n",
+    "[Detector1](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline-overview/stages-of-jwst-data-processing/calwebb_detector1)\n",
+    "stage of the pipelineto apply detector level calibrations and create a\n",
+    "countrate data product where slopes are fitted to the integration ramps.\n",
+    "These `*_rate.fits` products are 2D (nrows x ncols), averaged over all\n",
+    "integrations. 3D countrate data products (`*_rateints.fits`) are also\n",
+    "created (nintegrations x nrows x ncols) which have the fitted ramp slopes\n",
+    "for each integration.\n",
+    "\n",
+    "By default, all steps in the Detector1 stage of the pipeline are run for\n",
+    "NIRISS except: the `ipc` correction step and the `gain_scale` step. Note\n",
+    "that while the [`persistence` step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/persistence/description.html)\n",
+    "is set to run by default, this step does not automatically correct the\n",
+    "science data for persistence. The `persistence` step creates a\n",
+    "`*_trapsfilled.fits` file which is a model that records the number\n",
+    "of traps filled at each pixel at the end of an exposure. This file would be\n",
+    "used as an input to the `persistence` step, via the `input_trapsfilled`\n",
+    "argument, to correct a science exposure for persistence. Since persistence\n",
+    "is not well calibrated for NIRISS, we do not perform a persistence\n",
+    "correction and thus turn off this step to speed up calibration and to not\n",
+    "create files that will not be used in the subsequent analysis. This step\n",
+    "can be turned off when running the pipeline in Python by doing:\n",
+    "```\n",
+    "rate_result = Detector1Pipeline.call(uncal,steps={'persistence': {'skip': True}})\n",
+    "```\n",
+    "or as indicated in the cell bellow using a dictionary.\n",
+    "\n",
+    "The [charge_migration step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/charge_migration/index.html#charge-migration-step)\n",
+    "is particularly important for NIRISS images to mitigate apparent flux loss\n",
+    "in resampled images due to the spilling of charge from a central pixel into\n",
+    "its neighboring pixels (see [Goudfrooij et al. 2023](https://ui.adsabs.harvard.edu/abs/2023arXiv231116301G/abstract)\n",
+    "for details). Charge migration occurs when the accumulated charge in a\n",
+    "central pixel exceeds a certain signal limit, which is ~25,000 ADU. This\n",
+    "step is turned on by default for NIRISS imaging mode when using CRDS\n",
+    "contexts of `jwst_1159.pmap` or later. Different signal limits for each filter are provided by the\n",
+    "[pars-chargemigrationstep parameter files](https://jwst-crds.stsci.edu).\n",
+    "Users can specify a different signal limit by running this step with the\n",
+    "`signal_threshold` flag and entering another signal limit in units of ADU.\n",
+    "\n",
+    "As of CRDS context `jwst_1155.pmap` and later, the\n",
+    "[`jump` step](https://jwst-pipeline.readthedocs.io/en/latest/api/jwst.jump.JumpStep.html)\n",
+    "of the `DETECTOR1` stage of the pipeline will remove residuals associated\n",
+    "with [snowballs](https://jwst-docs.stsci.edu/known-issues-with-jwst-data/shower-and-snowball-artifacts)\n",
+    "for the NIRISS imaging mode. The default parameters for this correction,\n",
+    "where `expand_large_events` set to `True` turns on the snowball halo\n",
+    "removal algorithm, are specified in the `pars-jumpstep` parameter\n",
+    "reference files. Users may wish to alter parameters to optimize removal of\n",
+    "snowball residuals. Available parameters are discussed in the\n",
+    "[Detection and Flagging of Showers and Snowballs in JWST Technical Report (Regan 2023)](https://www.stsci.edu/files/live/sites/www/files/home/jwst/documentation/technical-documents/_documents/JWST-STScI-008545.pdf)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3592ee58-b424-4bd6-973b-88fd081b81d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Detector1 pipeline should be configured\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "det1dict = {}\n",
+    "det1dict['group_scale'], det1dict['dq_init'], det1dict['saturation'] = {}, {}, {}\n",
+    "det1dict['ipc'], det1dict['superbias'], det1dict['refpix'] = {}, {}, {}\n",
+    "det1dict['linearity'], det1dict['persistence'], det1dict['dark_current'], = {}, {}, {}\n",
+    "det1dict['charge_migration'], det1dict['jump'], det1dict['ramp_fit'] = {}, {}, {}\n",
+    "det1dict['gain_scale'] = {}\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped\n",
+    "# skipping the persistence step\n",
+    "det1dict['persistence']['skip'] = True\n",
+    "#det1dict['jump']['find_showers'] = False # Turn off detection of cosmic ray showers\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#det1dict['dq_init']['override_mask'] = 'myfile.fits' # Bad pixel mask\n",
+    "#det1dict['saturation']['override_saturation'] = 'myfile.fits' # Saturation\n",
+    "#det1dict['reset']['override_reset'] = 'myfile.fits' # Reset\n",
+    "#det1dict['linearity']['override_linearity'] = 'myfile.fits' # Linearity\n",
+    "#det1dict['rscd']['override_rscd'] = 'myfile.fits' # RSCD\n",
+    "#det1dict['dark_current']['override_dark'] = 'myfile.fits' # Dark current subtraction\n",
+    "#det1dict['jump']['override_gain'] = 'myfile.fits' # Gain used by jump step\n",
+    "#det1dict['ramp_fit']['override_gain'] = 'myfile.fits' # Gain used by ramp fitting step\n",
+    "#det1dict['jump']['override_readnoise'] = 'myfile.fits' # Read noise used by jump step\n",
+    "#det1dict['ramp_fit']['override_readnoise'] = 'myfile.fits' # Read noise used by ramp fitting step\n",
+    "\n",
+    "# Turn on multi-core processing (off by default).  Choose what fraction of cores to use (quarter, half, or all)\n",
+    "det1dict['jump']['maximum_cores'] = 'half'\n",
+    "\n",
+    "# Alter parameters to optimize removal of snowball residuals (example)\n",
+    "#det1dict['jump']['expand_large_events'] = True\n",
+    "#det1dict['charge_migration']['signal_threshold'] = X"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f8f107b-5f80-4674-bc34-2d88791e4409",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Run Detector1 stage of pipeline, specifying:\n",
+    "# output directory to save *_rate.fits files\n",
+    "# save_results flag set to True so the rate files are saved\n",
+    "\n",
+    "if dodet1:\n",
+    "    for uncal in uncal_files:\n",
+    "        rate_result = Detector1Pipeline.call(uncal, output_dir=det1_dir, steps=det1dict, save_results=True,)\n",
+    "else:\n",
+    "    print('Skipping Detector1 processing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4cc2b48-7ec7-4b59-b3ee-2dfdf0782c01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime for Detector1: {time1 - time0:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fc5520a-6097-482b-b3e0-a6bf94cf7af3",
+   "metadata": {},
+   "source": [
+    "### Exploring the data\n",
+    "\n",
+    "Identify `*_rate.fits` files and verify which pipeline steps were run and\n",
+    "which calibration reference files were applied.\n",
+    "\n",
+    "The header contains information about which calibration steps were\n",
+    "completed and skipped and which reference files were used to process the\n",
+    "data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c122766-a545-4042-93e8-f68c18f62fdf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if dodet1:\n",
+    "    # find rate files\n",
+    "    rate_files = sorted(glob.glob(os.path.join(det1_dir, '*_rate.fits')))\n",
+    "\n",
+    "    # Read in file as datamodel\n",
+    "    rate_f = datamodels.open(rate_files[0])\n",
+    "\n",
+    "    # Check which steps were run\n",
+    "    rate_f.meta.cal_step.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f2396cc-939f-44a6-878c-b33955796da8",
+   "metadata": {},
+   "source": [
+    "Check which reference files were used to calibrate the dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c525e133-d875-4ea7-9552-d7f0df05747c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if dodet1:\n",
+    "    rate_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b06450da",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "350808ee-9579-4cb5-8f02-a74904c91449",
+   "metadata": {},
+   "source": [
+    "## 6. Image2 Pipeline \n",
+    "\n",
+    "In the [Image2 stage of the pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image2.html),\n",
+    "calibrated unrectified data products are created (`*_cal.fits` or\n",
+    "`*_calints.fits` files, depending on whether the input files are\n",
+    "`*_rate.fits` or `*_rateints.fits`). \n",
+    "\n",
+    "In this pipeline processing stage, the [world coordinate system (WCS)](https://jwst-pipeline.readthedocs.io/en/latest/jwst/assign_wcs/index.html#assign-wcs-step)\n",
+    "is assigned, the data are [flat fielded](https://jwst-pipeline.readthedocs.io/en/latest/jwst/flatfield/index.html#flatfield-step),\n",
+    "and a [photometric calibration](https://jwst-pipeline.readthedocs.io/en/latest/jwst/photom/index.html#photom-step)\n",
+    "is applied to convert from units of countrate (ADU/s) to surface brightness (MJy/sr).\n",
+    "\n",
+    "By default, the [background subtraction step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/background_step/index.html#background-step)\n",
+    "and the [resampling step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step)\n",
+    "are turned off for NIRISS at this stage of the pipeline. The background\n",
+    "subtraction is turned off since there is no background template for the\n",
+    "imaging mode and the local background is removed during the background\n",
+    "correction for photometric measurements around individual sources. The\n",
+    "resampling step occurs during the `Image3` stage by default. While the\n",
+    "resampling step can be turned on during the `Image2` stage to, e.g., \n",
+    "generate a source catalog for each image, the data quality from the\n",
+    "`Image3` stage will be better since the bad pixels, which adversely affect\n",
+    "both the centroids and photometry in individual images, will be mostly\n",
+    "removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a091817-7a3c-4a60-a914-f9ac54d36e56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_image2 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b00fda2-a7c0-445a-bf23-0d9b4f050419",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Image2 pipeline should be configured.\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "image2dict = {}\n",
+    "image2dict['assign_wcs'], image2dict['flat_field'] = {}, {}\n",
+    "image2dict['photom'], image2dict['resample'] = {}, {}\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped (example)\n",
+    "#image2dict['resample']['skip'] = False\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#image2dict['assign_wcs']['override_distortion'] = 'myfile.asdf'  # Spatial distortion (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_filteroffset'] = 'myfile.asdf'  # Imager filter offsets (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_specwcs'] = 'myfile.asdf'  # Spectral distortion (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_wavelengthrange'] = 'myfile.asdf'  # Wavelength channel mapping (ASDF file)\n",
+    "#image2dict['flat_field']['override_flat'] = 'myfile.fits'  # Pixel flatfield\n",
+    "#image2dict['photom']['override_photom'] = 'myfile.fits'  # Photometric calibration array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247170cd-a3ee-4d9d-b8b3-f930727f8abc",
+   "metadata": {},
+   "source": [
+    "Find and sort all of the input files, ensuring use of absolute paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d19cd4e6-cc38-4e26-8e8b-7fb143856940",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sstring = os.path.join(det1_dir, 'jw*rate.fits')  # Use files from the detector1 output folder\n",
+    "rate_files = sorted(glob.glob(sstring))\n",
+    "for ii in range(0, len(rate_files)):\n",
+    "    rate_files[ii] = os.path.abspath(rate_files[ii])\n",
+    "rate_files = np.array(rate_files)\n",
+    "print(f\"Found  {str(len(rate_files))} science files\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81d916e5-dd5d-472d-9aff-b2b4c86decf8",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Run Image2 stage of pipeline, specifying:\n",
+    "# output directory to save *_cal.fits files\n",
+    "# save_results flag set to True so the rate files are saved\n",
+    "\n",
+    "if doimage2:\n",
+    "    for rate in rate_files:\n",
+    "        cal_result = Image2Pipeline.call(rate, output_dir=image2_dir, steps=image2dict, save_results=True)\n",
+    "else:\n",
+    "    print(\"Skipping Image2 processing.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d58b94d-e1d7-4b73-b598-756c99d81174",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.0f} seconds\")\n",
+    "print(f\"Runtime for Image2: {time1 - time_image2:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da57b7d0-95ef-4227-b730-6f54a3eaaa16",
+   "metadata": {},
+   "source": [
+    "### Verify which pipeline steps were run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27390bbd-ae2d-49e7-977a-59d3765c0946",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage2:\n",
+    "    # Identify *_cal.fits files\n",
+    "    cal_files = sorted(glob.glob(os.path.join(image2_dir, '*_cal.fits')))\n",
+    "\n",
+    "    cal_f = datamodels.open(cal_files[0])\n",
+    "\n",
+    "    # Check which steps were run:\n",
+    "    cal_f.meta.cal_step.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b77293ab-4eaa-4ebd-9f9b-bef8f6a2300f",
+   "metadata": {},
+   "source": [
+    "Check which reference files were used to calibrate the dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6544744b-804e-4583-8311-e47b5e16c7fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage2:\n",
+    "    cal_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ef9155e",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cfbb244-7af9-4cbf-90d9-08598378c16a",
+   "metadata": {},
+   "source": [
+    "## 7. Image3 Pipeline\n",
+    "\n",
+    "In the [Image3 stage of the pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image3.html),\n",
+    "the individual `*_cal.fits` files for each of the dither positions are combined to one single\n",
+    "distortion corrected image. First, an [Association](https://jwst-pipeline.readthedocs.io/en/latest/jwst/associations/overview.html)\n",
+    "needs to be created to inform the pipeline that these individual exposures are linked together.\n",
+    "\n",
+    "By default, the `Image3` stage of the pipeline performs the following steps on NIRISS data:\n",
+    "* [tweakreg](https://jwst-pipeline.readthedocs.io/en/latest/jwst/tweakreg/index.html#tweakreg-step) -\n",
+    "  creates source catalogs of pointlike sources for each input image. The source catalog for each input image is compared to each other to derive coordinate transforms to align the images relative to each other.\n",
+    "* As of CRDS context `jwst_1156.pmap` and later, the `pars-tweakreg` parameter reference file for NIRISS performs an absolute astrometric correction to GAIA data release 3 by default (i.e., the `abs_refcat` parameter is set to `GAIADR3`). Though this default correction generally improves results compared with not doing this alignment, it could potentially result in poor performance in crowded or sparse fields, so users are encouraged to check astrometric accuracy and revisit this step if necessary.\n",
+    "* As of pipeline version 1.14.0, the default source finding algorithm for NIRISS is `IRAFStarFinder` which testing shows returns good accuracy for undersampled NIRISS PSFs at short wavelengths [(Goudfrooij 2022)](https://www.stsci.edu/files/live/sites/www/files/home/jwst/documentation/technical-documents/_documents/JWST-STScI-008116.pdf). \n",
+    "* [skymatch](https://jwst-pipeline.readthedocs.io/en/latest/jwst/skymatch/index.html#skymatch-step) - measures the background level from the sky to use as input into the subsequent `outlier detection` and `resample` steps.\n",
+    "* [outlier detection](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/index.html#outlier-detection-step) - flags any remaining cosmic rays, bad pixels, or other artifacts not already flagged during the `DETECTOR1` stage of the pipeline, using all input images to create a median image so that outliers in individual images can be identified.\n",
+    "* [resample](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step) - resamples each input image based on its WCS and distortion information and creates a single undistorted image.\n",
+    "* [source catalog](https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/index.html#source-catalog-step) - creates a catalog of detected sources along with measured photometries and morphologies (i.e., point-like vs extended). Useful for quicklooks, but optimization is likely needed for specific science cases, which is an on-going investigation for the NIRISS team. Users may wish to experiment with changing the `snr_threshold` and `deblend` options. Modifications to the following parameters will not significantly improve data quality and it is advised to keep them at their default values: `aperture_ee1`, `aperture_ee2`, `aperture_ee3`, `ci1_star_threshold`, `ci2_star_threshold`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8e81dc9-78dd-4bba-879c-9dfa2a4da69c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_image3 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8159e63d-3c89-44ef-9a43-caaccd1abb4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Image3 pipeline should be configured\n",
+    "# Boilerplate dictionary setup\n",
+    "image3dict = {}\n",
+    "image3dict['assign_mtwcs'], image3dict['tweakreg'], image3dict['skymatch'] = {}, {}, {}\n",
+    "image3dict['outlier_detection'], image3dict['resample'], image3dict['source_catalog'] = {}, {}, {}\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped (example)\n",
+    "#image3dict['outlier_detection']['skip'] = True\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#image3dict['source_catalog']['override_apcorr'] = 'myfile.fits'  # Aperture correction parameters\n",
+    "#image3dict['source_catalog']['override_abvegaoffset'] = 'myfile.asdf'  # Data to convert from AB to Vega magnitudes (ASDF file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e10da872-21ae-46c2-a3b1-f9cdefae3b36",
+   "metadata": {},
+   "source": [
+    "Find and sort all of the input files, ensuring use of absolute paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f0b5b47-62e9-4593-abc4-7ec630492e96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Science Files need the cal.fits files\n",
+    "sstring = os.path.join(image2_dir, 'jw*cal.fits')\n",
+    "cal_files = sorted(glob.glob(sstring))\n",
+    "for ii in range(0, len(cal_files)):\n",
+    "    cal_files[ii] = os.path.abspath(cal_files[ii])\n",
+    "calfiles = np.array(cal_files)\n",
+    "\n",
+    "print(f'Found {str(len(cal_files))} science files to process')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db5cb6f5-44a1-4f28-95dc-b23a97451465",
+   "metadata": {},
+   "source": [
+    "### Create Association File\n",
+    "\n",
+    "An association file lists the exposures to calibrated together in `Stage 3`\n",
+    "of the pipeline. Note that an association file is available for download\n",
+    "from MAST, with a filename of `*_asn.json`. Here we show how to create an\n",
+    "association file to point to the data products created when processing data\n",
+    "through the pipeline. Note that the output products will have a rootname\n",
+    "that is specified by the `product_name` in the association file. For\n",
+    "this tutorial, the rootname of the output products will be\n",
+    "`image3_association`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b31f80f-8d7b-45ae-8537-15d0208637df",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create a Level 3 Association\n",
+    "if doimage3:\n",
+    "    associations = asn_from_list.asn_from_list(cal_files,\n",
+    "                                               rule=DMS_Level3_Base,\n",
+    "                                               product_name='image3_association')\n",
+    "    \n",
+    "    associations.data['asn_type'] = 'image3'\n",
+    "    program = datamodels.open(cal_files[0]).meta.observation.program_number\n",
+    "    associations.data['program'] = program\n",
+    "    \n",
+    "    # Format association as .json file\n",
+    "    asn_filename, serialized = associations.dump(format=\"json\")\n",
+    "\n",
+    "    # Write out association file\n",
+    "    association_im3 = os.path.join(sci_dir, asn_filename)\n",
+    "    with open(association_im3, \"w\") as fd:\n",
+    "        fd.write(serialized)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "629cad5b-e5a7-473e-8583-ad12cda55fa4",
+   "metadata": {},
+   "source": [
+    "### Run Image3 stage of the pipeline\n",
+    "\n",
+    "Given the grouped exposures in the association file, the\n",
+    "`Image3` stage of the pipeline will produce:\n",
+    "* a `*_cr.fits` file produced by the `outlier_detection` step, where the `DQ` array marks the pixels flagged as outliers.\n",
+    "* a final combined, rectified image with name `*_i2d.fits`,\n",
+    "* a source catalog with name `*_cat.ecsv`,\n",
+    "* a segmentation map file (`*_segm.fits`) which has integer values at the pixel locations where a source is detected where the pixel values match the source ID number in the catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0cebfd8-a650-41a3-8ff0-a8fd43e079d6",
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Run Stage 3\n",
+    "if doimage3:\n",
+    "    i2d_result = Image3Pipeline.call(association_im3, output_dir=image3_dir, steps=image3dict, save_results=True)\n",
+    "else:\n",
+    "    print('Skipping Spec3 processing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f67d2c65-4614-4592-aa67-daa2de985013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.0f} seconds\")\n",
+    "print(f\"Runtime for Image3: {time1 - time_image3:0.0f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bcb6c40-fbb8-4226-b620-64b0c02c8ceb",
+   "metadata": {},
+   "source": [
+    "### Verify which pipeline steps were run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c754530a-d4e2-493b-bf8b-bf8d1ad08770",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3:\n",
+    "    # Identify *_i2d file and open as datamodel\n",
+    "    i2d = glob.glob(os.path.join(image3_dir, \"*_i2d.fits\"))[0]\n",
+    "    i2d_f = datamodels.open(i2d)\n",
+    "\n",
+    "    # Check which steps were run\n",
+    "    i2d_f.meta.cal_step.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f73c5280-69a5-4796-b78f-724078a94d2b",
+   "metadata": {},
+   "source": [
+    "Check which reference files were used to calibrate the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cfb0842-cc95-42d5-8852-593b85032c52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doimage3:\n",
+    "    i2d_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80362ba8",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46be5421-7fc8-4d96-b2cd-2484f294e082",
+   "metadata": {},
+   "source": [
+    "## 8. Visualize the drizzle-combined image\n",
+    "\n",
+    "We are using the [Imviz tool](https://jdaviz.readthedocs.io/en/latest/imviz/index.html)\n",
+    "within the `jdaviz` package to visualize the NIRISS image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6f1ed63-0bed-412b-ab04-54caa7d61bbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doviz:\n",
+    "    # Identify *_i2d file and open as datamodel\n",
+    "    i2d = glob.glob(os.path.join(image3_dir, \"*_i2d.fits\"))[0]\n",
+    "    i2d_f = datamodels.open(i2d)\n",
+    "    \n",
+    "    # Create an Imviz instance and set up default viewer\n",
+    "    imviz_i2d = Imviz()\n",
+    "    viewer_i2d = imviz_i2d.default_viewer\n",
+    "\n",
+    "    # Read in the science array for our visualization dataset:\n",
+    "    i2d_science = i2d_f.data\n",
+    "\n",
+    "    # Load the dataset into Imviz\n",
+    "    imviz_i2d.load_data(i2d_science)\n",
+    "\n",
+    "    # Visualize the dataset:\n",
+    "    imviz_i2d.show()\n",
+    "    \n",
+    "    viewer_i2d.stretch = 'sqrt'\n",
+    "    viewer_i2d.set_colormap('Viridis')\n",
+    "    viewer_i2d.cuts = '95%'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "018733eb-07ec-44a4-a5a7-d6d2f27d193a",
+   "metadata": {},
+   "source": [
+    "## <a id='detections'>Visualize Detected Sources</a>\n",
+    "Using the source catalog created by the `IMAGE3` stage of the pipeline,\n",
+    "mark the detected sources, using different markers for point sources\n",
+    "and extended sources. The source catalog is saved in\n",
+    "`image3/image3_association_cat.ecsv` file. We will need to\n",
+    "read in the `i2d` file again to make sure the world\n",
+    "coordinate system (WCS) info is read in."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ad6ee55-f940-4be3-96c9-114bc83eb784",
+   "metadata": {},
+   "source": [
+    "### Read in catalog file and identify point/extended sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32235fdc-4ec2-42e6-89e7-b9f62824e179",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doviz:\n",
+    "    catalog_file = glob.glob(os.path.join(image3_dir, \"*_cat.ecsv\"))[0]\n",
+    "    catalog = Table.read(catalog_file)\n",
+    "\n",
+    "    # To identify point/extended sources, use the 'is_extended' column in the source catalog\n",
+    "    pt_src, = np.where(~catalog['is_extended'])\n",
+    "    ext_src, = np.where(catalog['is_extended'])\n",
+    "\n",
+    "    # Define coordinates of point and extended sources\n",
+    "    pt_coord = Table({'coord': [SkyCoord(ra=catalog['sky_centroid'][pt_src].ra,\n",
+    "                                         dec=catalog['sky_centroid'][pt_src].dec)]})\n",
+    "    ext_coord = Table({'coord': [SkyCoord(ra=catalog['sky_centroid'][ext_src].ra,\n",
+    "                                          dec=catalog['sky_centroid'][ext_src].dec)]})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be9e9069-375d-431b-bbfb-e84e6cefc2d4",
+   "metadata": {},
+   "source": [
+    "### Mark the extended and point sources on the image\n",
+    "\n",
+    "Display combined image; point sources will be marked by small pink circles and extended sources will be marked by larger white circles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "302bc3ce-358d-4ea8-a533-37b9a9a2152c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doviz:\n",
+    "    # Read in i2d file to Imviz\n",
+    "    imviz_cat = Imviz()\n",
+    "    viewer_cat = imviz_cat.default_viewer\n",
+    "    imviz_cat.load_data(i2d)\n",
+    "\n",
+    "    # Adjust settings for viewer\n",
+    "    viewer_cat.stretch = 'sqrt'\n",
+    "    viewer_cat.set_colormap('Viridis')\n",
+    "    viewer_cat.cuts = '95%'\n",
+    "\n",
+    "    # Show the plot\n",
+    "    imviz_cat.show()\n",
+    "    \n",
+    "    # Add marker for point sources:\n",
+    "    viewer_cat.marker = {'color': 'pink', 'markersize': 50, 'fill': False}\n",
+    "    viewer_cat.add_markers(pt_coord, use_skycoord=True, marker_name='point_sources')\n",
+    "\n",
+    "    # Add marker for extended sources:\n",
+    "    viewer_cat.marker = {'color': 'white', 'markersize': 100, 'fill': False}\n",
+    "    viewer_cat.add_markers(ext_coord, use_skycoord=True, marker_name='extended_sources')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89ee8944",
+   "metadata": {},
+   "source": [
+    "<hr style=\"border:1px solid gray\"> </hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6303c0e7-13af-4e4c-bed7-8b85cc8e3645",
+   "metadata": {},
+   "source": [
+    "<img style=\"float: center;\" src=\"https://github.com/spacetelescope/jwst-pipeline-notebooks/raw/main/_static/stsci_footer.png\" alt=\"stsci_logo\" width=\"200px\"/> "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/processing-engine/tests/test_calibration_importer.py
+++ b/processing-engine/tests/test_calibration_importer.py
@@ -1,0 +1,282 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+Tests for the JWPipeNB notebook importer: golden parses of the three real
+STScI imaging notebooks (fixtures), adversarial/fail-closed cases, and the
+import endpoint. The importer must NEVER execute notebook code — adversarial
+fixtures prove hostile notebooks are data, not behavior.
+"""
+
+import json
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+import jwt as pyjwt
+import pytest
+
+from app.calibration.importer import (
+    NotebookImportError,
+    import_notebook,
+    parse_notebook,
+)
+from app.calibration.routes import get_recipe_store
+from app.calibration.store import RecipeStore
+from app.db.client import get_database, reset_client
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "jwpipenb"
+
+SECRET = "unit-test-secret-key-at-least-32-chars!!"
+ROLE_URI = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+USER = "user-a"
+
+
+def notebook_of(cells: list[str]) -> bytes:
+    return json.dumps(
+        {
+            "cells": [{"cell_type": "code", "source": [text], "outputs": []} for text in cells],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+    ).encode()
+
+
+TEMPLATE_PREAMBLE = """
+demo_mode = True
+dodet1 = True
+doimage2 = True
+doimage3 = True
+program = "02739"
+sci_observtn = "001"
+"""
+
+TEMPLATE_QUERY = """
+sci_obs_id_table = Observations.query_criteria(
+    instrument_name=["NIRCAM/IMAGE"], filters=["F200W"],
+    obs_id=["jw" + program + "-o" + sci_observtn + "*"],
+)
+"""
+
+
+class TestGoldenNotebooks:
+    @pytest.mark.parametrize(
+        ("fixture", "instrument", "program", "jump_override"),
+        [
+            (
+                "JWPipeNB-nircam-imaging.ipynb",
+                "nircam",
+                "2739",
+                {"maximum_cores": "half", "expand_large_events": True},
+            ),
+            ("JWPipeNB-niriss-imaging.ipynb", "niriss", "1475", {"maximum_cores": "half"}),
+            ("JWPipeNB-MIRI-imaging.ipynb", "miri", "1040", {"maximum_cores": "half"}),
+        ],
+    )
+    def test_real_notebooks_parse_to_seed_equivalents(
+        self, fixture: str, instrument: str, program: str, jump_override: dict
+    ) -> None:
+        raw = (FIXTURES / fixture).read_bytes()
+        fields, warnings = parse_notebook(raw, fixture)
+        assert fields["instrument"] == instrument
+        assert fields["input_source"]["proposal_id"] == program
+        det1 = next(s for s in fields["stages"] if s["name"] == "detector1")
+        # Cross-check against the hand-written seed recipes' overrides.
+        assert det1["step_overrides"].get("jump") == jump_override
+        assert all(s["enabled"] for s in fields["stages"])
+        assert isinstance(warnings, list)
+
+    def test_custom_code_reported_as_warning(self) -> None:
+        raw = notebook_of(
+            [TEMPLATE_PREAMBLE, TEMPLATE_QUERY, "def writel2asn(files):\n    return files"]
+        )
+        _, warnings = parse_notebook(raw, "helpers.ipynb")
+        assert any("custom code" in w for w in warnings)
+
+    def test_miri_bkg_sigma_extracted(self) -> None:
+        raw = (FIXTURES / "JWPipeNB-MIRI-imaging.ipynb").read_bytes()
+        fields, _ = parse_notebook(raw, "miri.ipynb")
+        image2 = next(s for s in fields["stages"] if s["name"] == "image2")
+        assert image2["step_overrides"].get("bkg_subtract") == {"sigma": 2}
+
+
+class TestFailClosed:
+    def test_random_python_rejected(self) -> None:
+        raw = notebook_of(["import os\nos.system('echo pwned')\nx = 1"])
+        with pytest.raises(NotebookImportError, match="not a recognizable JWPipeNB"):
+            parse_notebook(raw, "evil.ipynb")
+
+    def test_non_literal_override_rejected(self) -> None:
+        raw = notebook_of(
+            [
+                TEMPLATE_PREAMBLE,
+                TEMPLATE_QUERY,
+                "det1dict['jump']['maximum_cores'] = os.environ['X']",
+            ]
+        )
+        with pytest.raises(NotebookImportError, match="non-literal value"):
+            parse_notebook(raw, "sneaky.ipynb")
+
+    def test_non_literal_program_never_captured(self) -> None:
+        # Identity fields: non-literals are ignored (first literal wins);
+        # with no literal at all the essentials check rejects the notebook.
+        raw = notebook_of([TEMPLATE_QUERY, "dodet1 = True\nprogram = get_program()"])
+        with pytest.raises(NotebookImportError, match="'program' assignment"):
+            parse_notebook(raw, "sneaky.ipynb")
+
+    def test_later_non_literal_program_does_not_override(self) -> None:
+        raw = notebook_of(
+            [
+                TEMPLATE_PREAMBLE,
+                TEMPLATE_QUERY,
+                "program = datamodels.open(f).meta.observation.program_number",
+            ]
+        )
+        fields, _ = parse_notebook(raw, "reuse.ipynb")
+        assert fields["input_source"]["proposal_id"] == "2739"
+
+    def test_reference_file_override_rejected(self) -> None:
+        raw = notebook_of(
+            [TEMPLATE_PREAMBLE, TEMPLATE_QUERY, "image3dict['resample']['override_drizpars'] = 'x'"]
+        )
+        with pytest.raises(NotebookImportError, match="unsafe override"):
+            parse_notebook(raw, "refs.ipynb")
+
+    def test_hook_param_rejected(self) -> None:
+        raw = notebook_of(
+            [
+                TEMPLATE_PREAMBLE,
+                TEMPLATE_QUERY,
+                "image3dict['resample']['post_hooks'] = 'evil.module'",
+            ]
+        )
+        with pytest.raises(NotebookImportError, match="unsafe override"):
+            parse_notebook(raw, "hooks.ipynb")
+
+    def test_spectroscopy_mode_rejected(self) -> None:
+        raw = notebook_of(
+            [TEMPLATE_PREAMBLE, 'Observations.query_criteria(instrument_name=["MIRI/MRS"])']
+        )
+        with pytest.raises(NotebookImportError, match="only\\s+imaging|imaging modes"):
+            parse_notebook(raw, "mrs.ipynb")
+
+    def test_null_byte_cell_skipped_not_500(self) -> None:
+        # Null bytes make ast.parse raise ValueError, not SyntaxError — the
+        # cell is skipped, and the notebook still parses if the essentials
+        # live in other cells.
+        raw = notebook_of([TEMPLATE_PREAMBLE, TEMPLATE_QUERY, "x = '\x00'"])
+        fields, warnings = parse_notebook(raw, "nul.ipynb")
+        assert fields["instrument"] == "nircam"
+        assert any("unparseable" in w for w in warnings)
+
+    def test_corrupt_ipynb_rejected(self) -> None:
+        with pytest.raises(NotebookImportError, match="not a valid .ipynb"):
+            parse_notebook(b"{truncated", "broken.ipynb")
+
+    def test_oversized_rejected(self) -> None:
+        raw = b" " * (5 * 1024 * 1024 + 1)
+        with pytest.raises(NotebookImportError, match="5MB"):
+            parse_notebook(raw, "big.ipynb")
+
+    def test_exec_eval_never_run(self, tmp_path: Path) -> None:
+        # Executing this notebook would create the sentinel file; parsing
+        # must not.
+        sentinel = tmp_path / "pwned"
+        raw = notebook_of(
+            [TEMPLATE_PREAMBLE, TEMPLATE_QUERY, f"open({str(sentinel)!r}, 'w').write('x')"]
+        )
+        fields, _ = parse_notebook(raw, "exec.ipynb")
+        assert fields["instrument"] == "nircam"
+        assert not sentinel.exists()
+
+
+class TestImportedRecipeValidation:
+    def test_import_produces_valid_private_recipe(self) -> None:
+        raw = notebook_of([TEMPLATE_PREAMBLE, TEMPLATE_QUERY])
+        recipe, warnings = import_notebook(raw, "mini.ipynb", USER, "user-abc123")
+        assert recipe.source == "imported"
+        assert recipe.is_public is False
+        assert recipe.created_by == USER
+        assert recipe.input_source.proposal_id == "2739"
+        assert warnings == []
+
+
+@pytest.fixture(autouse=True)
+def _jwt_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JWT_SECRET_KEY", SECRET)
+    reset_client()
+    yield
+    reset_client()
+
+
+def bearer(user_id: str = USER) -> dict[str, str]:
+    now = int(time.time())
+    token = pyjwt.encode(
+        {
+            "sub": user_id,
+            ROLE_URI: "User",
+            "iss": "JwstDataAnalysis",
+            "aud": "JwstDataAnalysisClient",
+            "iat": now,
+            "exp": now + 900,
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+async def client():
+    from main import app
+
+    collection = get_database()[f"recipes_test_{uuid.uuid4().hex}"]
+    store = RecipeStore(collection)
+    app.dependency_overrides[get_recipe_store] = lambda: store
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as async_client:
+            yield async_client
+    finally:
+        app.dependency_overrides.pop(get_recipe_store, None)
+        await collection.drop()
+
+
+class TestImportEndpoint:
+    async def test_requires_auth(self, client: httpx.AsyncClient) -> None:
+        response = await client.post(
+            "/api/calibration/recipes/import",
+            json={"filename": "x.ipynb", "notebook": "{}"},
+        )
+        assert response.status_code == 401
+
+    async def test_golden_import_roundtrip(self, client: httpx.AsyncClient) -> None:
+        raw = (FIXTURES / "JWPipeNB-MIRI-imaging.ipynb").read_text(encoding="utf-8")
+        response = await client.post(
+            "/api/calibration/recipes/import",
+            json={"filename": "JWPipeNB-MIRI-imaging.ipynb", "notebook": raw},
+            headers=bearer(),
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["recipe"]["instrument"] == "miri"
+        assert body["recipe"]["source"] == "imported"
+        assert body["recipe"]["created_by"] == USER
+        assert any("custom code" in w for w in body["warnings"])
+        # Imported recipe is fetchable through the normal recipe API.
+        got = await client.get(f"/api/calibration/recipes/{body['recipe']['id']}", headers=bearer())
+        assert got.status_code == 200
+
+    async def test_reject_reports_reason(self, client: httpx.AsyncClient) -> None:
+        response = await client.post(
+            "/api/calibration/recipes/import",
+            json={"filename": "x.ipynb", "notebook": json.dumps({"cells": []})},
+            headers=bearer(),
+        )
+        assert response.status_code == 422
+        assert "JWPipeNB" in response.json()["detail"]

--- a/tests/mock-processing-engine/server.py
+++ b/tests/mock-processing-engine/server.py
@@ -174,6 +174,13 @@ class MockHandler(BaseHTTPRequestHandler):
         if self.path == "/api/calibration/runs":
             self._json({"jobId": "mock-job-1"}, status=202)
 
+        elif self.path == "/api/calibration/recipes/import":
+            self._json({
+                "recipe": {**CALIBRATION_RECIPES[0], "id": "user-imported",
+                           "name": "Imported: mock.ipynb", "source": "imported"},
+                "warnings": ["cell 7: custom code is not carried into the recipe"],
+            }, status=201)
+
         elif self.path == "/composite/generate-nchannel":
             self._blob(TINY_PNG, "image/png")
 


### PR DESCRIPTION
## Summary

PR 9 of the Calibration Recipes feature (plan: `docs/plans/features/1709-calibration-recipes.md`) — the **notebook importer**, the capability that motivated the whole feature: let users bring STScI JWPipeNB notebooks into the app **without ever executing user Python**.

## Changes Made

- **`app/calibration/importer.py`** (new): a static `ast`-based parser. The notebook is treated as **data** — `json.loads` + `ast.parse` + `ast.walk`, no `exec`/`eval`/`import`/`literal_eval`/pickle/yaml. Extracts the template's config assignments, `do<stage>` toggles, `<stage>dict['step']['param'] = <literal>` overrides, and the imaging MAST query.
  - **Fail-closed**: a non-literal value on a stage override rejects the import (those feed `Pipeline.call`); identity fields (`program`/`observation`) are first-literal-wins with a warning (real notebooks reassign `program` to a computed value in association cells); spectroscopy/other modes rejected; custom `def`/`class` cells reported as warnings so the user knows what did NOT carry over.
  - Extracted overrides pass the **executor allowlist** (`validate_step_overrides`) at parse time and again at run time — an imported override can't smuggle `output_dir`/`pre_hooks`/`override_*`.
  - Parse path hardened against attacker input: null bytes / pathological nesting are skipped per-cell, never a 500.
- **`app/calibration/routes.py`**: `POST /api/calibration/recipes/import` (auth; 5MB → 413; `NotebookImportError` → 422). Imported recipes are **private** (`is_public=False`), `source=imported`, owned by the uploader.
- **Golden fixtures**: the 3 real STScI NIRCam/NIRISS/MIRI imaging notebooks (`tests/fixtures/jwpipenb/`, ruff-excluded as verbatim test data), parsed and **cross-checked against the hand-written seed recipes** — the strongest possible proof the parser matches production notebooks.
- **Frontend**: import button + warnings display on the gallery; client-side 5MB guard.
- **`tests/mock-processing-engine/server.py`**: import route for E2E.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_calibration_importer.py` — 20/20 (golden parses, adversarial fail-closed incl. an exec-sentinel proving no execution, endpoint)
- [x] Full engine suite — 1712 passed
- [x] `vitest run` — 1182/1182
- [ ] Reviewer: on `/calibrate`, Import notebook… → pick any STScI JWPipeNB imaging `.ipynb` → new "Imported: …" recipe appears with warnings listing the custom cells not carried over; upload a random `.py`-as-`.ipynb` → clean 422

## Documentation Checklist

- [x] Importer security model documented in the module docstring
- [ ] docs sweep — PR 10

## Tech Debt Impact

- [x] Follow-up filed: #1727 (upstream request-body size cap — pre-existing, platform-wide; the 5MB check runs after Starlette buffers the body)

## Risk & Rollback

- **Risk: MED — parses untrusted uploads.** Mitigated: pure static parse (never executes; sentinel-tested), executor allowlist on extracted overrides, private-by-default output, auth + 413/422, hardened parse path. Security review: 2 rounds, all-clear.
- **Rollback:** revert; imported recipes are ordinary private recipe documents.

Part of #1709 (umbrella stays open). No linked issue to close.

https://claude.ai/code/session_01W5ZRaEbzFmit1DQs1nfP66
