### PR TITLE
feat: library Reprocess action + docs sweep (#1709 PR 10)

### DIFF
--- a/docs/architecture/adr/0001-collapse-to-python-single-backend.md
+++ b/docs/architecture/adr/0001-collapse-to-python-single-backend.md
@@ -89,6 +89,17 @@ deletes the gateway.
 | 7 | Infrastructure simplification (SeaweedFS → volume/S3, collapse compose files) |
 | 8 | In-tier cleanup (god-files, duplication) |
 
+> **Progress note (2026-07, #1709):** Calibration Recipes landed the first real
+> slices of Phases 1 and 3 in the engine — a JWT-validation dependency
+> (`app/auth/deps.py`, validating .NET-issued tokens) and a Mongo-persisted
+> generic **job store** with `/api/jobs` (`app/jobs/`), with calibration as its
+> first consumer. Two deliberate divergences from the sketch above: progress is
+> delivered by **HTTP polling** of `GET /api/jobs/{id}` rather than the Phase-3
+> `/ws/jobs` WebSocket, and the frontend calls the engine **directly**
+> (`VITE_ENGINE_URL` + engine CORS) for this surface rather than waiting for the
+> full Phase-5 cutover. Token *issuance* and the write persistence layer remain
+> in .NET. See [calibration-pipeline-flow](../calibration-pipeline-flow.md).
+
 ## References
 
 - `CODEBASE_REVIEW.md` — full-stack review and issue inventory

--- a/docs/architecture/calibration-pipeline-flow.md
+++ b/docs/architecture/calibration-pipeline-flow.md
@@ -1,0 +1,110 @@
+# Calibration Pipeline Flow
+
+How **Calibration Recipes** (#1709) run the official STScI `jwst` calibration
+pipeline inside the processing engine, driven by declarative recipes and
+delivered as tracked jobs.
+
+> **Architecture note (ADR 0001):** Calibration is **Python-native** and
+> advances the single-backend migration. It builds the ADR-0001 Phase-3 jobs
+> slice (a Mongo-persisted job store) and a minimal Phase-1 JWT-validation
+> dependency in the engine. The frontend calls the engine **directly**
+> (`VITE_ENGINE_URL`), not through the `.NET` gateway. Progress is delivered by
+> **HTTP polling** of `GET /api/jobs/{id}` — a deliberate divergence from the
+> ADR's sketched `/ws/jobs` WebSocket (calibration jobs change state on the
+> order of seconds, and the frontend job hooks already poll).
+
+## Concept
+
+A **CalibrationRecipe** is pure data: a versioned document describing which
+pipeline stages to run (`detector1` → `image2` → `image3`) and which step
+parameters to override. Recipes never contain executable code — the "pure
+data, never code" invariant is enforced by a scalar-only validator on
+`step_overrides` and, at execution time, by an allowlist of step/parameter
+names. See [domain model](domain-model.md) for the schema.
+
+Three curated **seed recipes** (NIRCam/NIRISS/MIRI imaging) are hand-derived
+from the STScI JWPipeNB notebooks and loaded idempotently at engine startup.
+Users can also **import** JWPipeNB notebooks: the importer statically parses the
+`.ipynb` with Python's `ast` module and never executes it.
+
+## Full run (uncal → i2d)
+
+```
+Frontend (/calibrate/:recipeId)                 Engine                      External
+        │                                          │                            │
+        │  POST /api/calibration/runs              │                            │
+        │  {recipeId, inputs, runOverrides,        │                            │
+        │   enabledStages}                         │                            │
+        ├─────────────────────────────────────────►                            │
+        │           (require_user; validate        │                            │
+        │            overrides per enabled stage)  │                            │
+        │                                          │  create job (Mongo)        │
+        │  202 {jobId}                             │  asyncio.create_task       │
+        ◄─────────────────────────────────────────┤                            │
+        │                                          │                            │
+        │  poll GET /api/jobs/{jobId} (1.5s)       │  ── downloading ──►  MAST  │
+        ├─────────────────────────────────────────►  per-file, progress %      │
+        │  {status, progress.stages, logTail}      │                            │
+        ◄─────────────────────────────────────────┤  ── running ──             │
+        │        stage checklist + log tail        │  semaphore (1 slot)        │
+        │                                          │  detector1 → image2 →      │
+        │                                          │  image3, per-stage timeout │
+        │                                          │  stpipe logs ─► CRDS ◄─────┤
+        │  {status: succeeded,                      │  outputs → StorageProvider │
+        │   result.outputs: [_i2d]}                │  (calibration/<job_id>/)   │
+        ◄─────────────────────────────────────────┤                            │
+```
+
+- **Stage-3 fast path**: when `inputs` are library `_cal` keys and only
+  `image3` is enabled, the download and detector1/image2 stages are skipped —
+  the pipeline re-combines already-calibrated exposures into a fresh mosaic in
+  minutes. This is what the library **Reprocess** action triggers.
+- **File handoff** between stages is by suffix inside the per-job workdir:
+  `_uncal` → `_rate` → `_cal` → `_i2d`.
+- **Cancellation** is cooperative at stage boundaries (the monolithic
+  `Pipeline.call` is not killed mid-flight in v1). A **timeout** likewise cannot
+  kill the worker thread, so the concurrency permit is deliberately *retained*
+  to keep `MAX_CONCURRENT_CALIBRATIONS` bounding memory (killable-subprocess
+  isolation is tracked as a follow-up).
+
+## Security posture
+
+- **Recipes are data**: `step_overrides` values are scalars or flat scalar
+  lists only (schema validator). At execution the executor allowlists step
+  *names* per stage and rejects `override_<ref>` reference-file params,
+  `pre_hooks`/`post_hooks` (code-reference vectors), run-control params
+  (`output_dir`, `suffix`, …), and path-like values.
+- **Notebook import** is static `ast` parsing — the notebook is read, never
+  executed. Non-literal stage overrides reject the import; imported recipes are
+  private (`is_public=False`), owned by the uploader.
+- **Recipe visibility** follows the documented data model: seeds and public
+  recipes are visible to all; user recipes are private until shared. Reads are
+  visibility-filtered; unknown/inaccessible ids return 404 (anti-enumeration).
+- **Full-mode only**: the calibration router and job store never mount in
+  Community Edition (deny-by-default; regression-guarded by
+  `tests/test_ce_mode_mounting.py`).
+
+## Feature gates
+
+- **Build-time**: the Docker `INSTALL_CALIBRATION` arg controls whether the
+  ~2GB `jwst` layer is installed (CE builds pass `false`).
+- **Run-time**: `CALIBRATION_ENABLED` × `jwst` importability. When off, run
+  endpoints return 501 and recipes stay browsable. The frontend gates the
+  gallery/nav and the library Reprocess action on
+  `GET /api/calibration/capabilities`.
+
+## Key files
+
+- `processing-engine/app/calibration/` — models, validation, store, seeds,
+  executor, importer, flags, routes
+- `processing-engine/app/jobs/` — Mongo job store, runner, `/api/jobs` routes
+- `processing-engine/app/auth/deps.py` — JWT validation dependency
+- `frontend/jwst-frontend/src/pages/CalibrationGallery.tsx`, `CalibrateRun.tsx`
+- `frontend/jwst-frontend/src/services/calibrationService.ts`,
+  `src/hooks/useCalibrationJob.ts`
+
+## Related
+
+- [Domain Model](domain-model.md) · [Job Queue & SignalR](job-queue-signalr.md)
+  (the .NET job pattern this diverges from) · [Security Model](security-model.md)
+  · [ADR 0001](adr/0001-collapse-to-python-single-backend.md)

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -52,6 +52,7 @@ Runtime behavior: concurrency, async jobs, real-time communication, and error ha
 - **[GuidedCreate Flow](guidedcreate-flow.md)** — End-to-end user journey from recipe selection to composite result
 - **[MAST Import Flow](mast-import-flow.md)** — Searching and importing data from the MAST portal with chunked downloads
 - **[Local Upload Flow](local-upload-flow.md)** — Uploading JWST data files directly to the application
+- **[Calibration Pipeline Flow](calibration-pipeline-flow.md)** — Running the STScI `jwst` pipeline via declarative recipes as tracked engine jobs (#1709)
 
 ## Development View
 

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -224,6 +224,20 @@ Remaining features, tech debt, CI improvements, and release process.
 
 ---
 
+## Calibration Recipes (#1709)
+
+Run the official STScI `jwst` calibration pipeline via declarative recipes,
+delivered as tracked engine jobs. Ships the ADR-0001 Phase-3 jobs slice
+(Mongo job store + `/api/jobs`) and a Phase-1 JWT-validation dependency in the
+engine. Includes a curated gallery (NIRCam/NIRISS/MIRI imaging), a fail-closed
+JWPipeNB **notebook importer** (static parse — never executes notebook code),
+stage-3 fast path + full uncal reduction, live per-stage progress, and a library
+**Reprocess** action. Full-mode only (not in CE). See
+[calibration-pipeline-flow](architecture/calibration-pipeline-flow.md).
+Follow-ups: #1710 (recipe sharing), #1711 (IFU cubes), #1712 (spectroscopy),
+#1713 (disk quotas), #1715 (job resume), #1721 (subprocess isolation),
+#1719/#1727 (input authz / body-size cap).
+
 ## Community Edition (v1)
 
 **Plan of record:**

--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -191,11 +191,23 @@ Quick reference for finding important files in the codebase.
 - `frontend/jwst-frontend/src/types/DiscoveryTypes.ts` - Discovery and recipe suggestion types
 - `frontend/jwst-frontend/src/types/SearchTypes.ts` - Semantic search response types
 
+- `frontend/jwst-frontend/src/pages/CalibrationGallery.tsx` - Recipe gallery + notebook import (#1709)
+- `frontend/jwst-frontend/src/pages/CalibrateRun.tsx` - Run config (stage toggles, param editor) + live progress (#1709)
+- `frontend/jwst-frontend/src/services/calibrationService.ts` - Engine-bound API client (VITE_ENGINE_URL); `src/hooks/useCalibrationJob.ts` - polling hook (#1709)
+- `frontend/jwst-frontend/src/config/engine.ts` - ENGINE_BASE_URL for direct frontend->engine calls (#1709)
+
 ## Processing Engine
 
 - `processing-engine/main.py` - FastAPI application entry point (image processing: composites, mosaics, analysis)
 - `processing-engine/main_mast.py` - FastAPI entry point for MAST proxy service (search, download)
 - `processing-engine/app/exceptions.py` - Custom exception hierarchy and error handler middleware
+- `processing-engine/app/auth/deps.py` - JWT validation dependency (validates .NET-issued HS256 tokens; require_user/optional_user/require_role) (#1709)
+- `processing-engine/app/jobs/store.py` - Mongo-persisted job store (first write-capable repo; atomic $set/$push); `runner.py` - fire-and-forget executor; `routes.py` - /api/jobs status/cancel (#1709)
+- `processing-engine/app/calibration/models.py` - CalibrationRecipe schema (scalar-only step_overrides); `validation.py`, `store.py`, `seeds/*.json` (curated NIRCam/NIRISS/MIRI recipes) (#1709)
+- `processing-engine/app/calibration/executor.py` - runs Detector1->Image2->Image3 / stage-3 fast path; step/param allowlist; MAST download; per-stage progress from stpipe logs (#1709)
+- `processing-engine/app/calibration/importer.py` - static ast parser turning JWPipeNB notebooks into recipes (never executes notebook code) (#1709)
+- `processing-engine/app/calibration/flags.py`, `routes.py` - CALIBRATION_ENABLED gate + capabilities; /api/calibration recipe CRUD, runs, import (#1709)
+- `processing-engine/requirements-calibration.txt` - pinned `jwst` dependency (installed behind INSTALL_CALIBRATION build arg) (#1709)
 - `processing-engine/app/db/client.py` - Lazy motor (MongoDB) client for the single-backend migration (ADR 0001)
 - `processing-engine/app/db/repository.py` - Read-only jwst_data repository (anonymous/IsPublic semantics)
 - `processing-engine/app/db/projection.py` - Mongo doc -> camelCase DataResponse projection (.NET MapToDataResponse parity)

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -138,6 +138,16 @@ CE env vars: `CE_MODE`, `MONGODB_URI` (read-only credentials suffice), `MONGODB_
 - **MAST Import**: `/mast/import` (supports `downloadSource`: "auto"/"s3"/"http"), `/import-progress/{jobId}`, `/import/resume/{jobId}`, `/import/cancel/{jobId}`, `/import/from-existing/{obsId}`, `/import/check-files/{obsId}`, `POST /import/dismiss/{jobId}`
 - **MAST Metadata**: `POST /mast/refresh-metadata/{obsId}`, `POST /mast/refresh-metadata-all`
 
+**Calibration Recipes** (#1709 — Python engine directly, `VITE_ENGINE_URL`; full-mode only, not in CE):
+- `GET /api/calibration/capabilities` - `{calibrationEnabled, jwstVersion}` (anonymous; drives frontend gating)
+- `GET /api/calibration/recipes` - List visible recipes (seeds + public + own) | `GET /api/calibration/recipes/{id}` - Get one
+- `POST /api/calibration/recipes` - Create (auth) | `PUT`/`DELETE .../{id}` - Update/delete own; seeds immutable (403)
+- `POST /api/calibration/recipes/import` - Import a JWPipeNB `.ipynb` (auth; static parse, never executes; 5MB cap)
+- `POST /api/calibration/runs` - Start a run (auth; 501 when disabled) -> `{jobId}`
+
+**Jobs** (#1709 — generic job store, ADR-0001 Phase 3):
+- `GET /api/jobs` - Own jobs | `GET /api/jobs/{id}` - Status/progress/logTail (poll for live updates) | `POST /api/jobs/{id}/cancel`
+
 ## Troubleshooting
 
 **MongoDB Connection Issues**:
@@ -203,3 +213,19 @@ See [`docs/mast-usage.md`](mast-usage.md) for detailed API examples, metadata fi
 **Quick Start**: Open the public `/archive` page (via the Discover home CTA or the library toolbar's "Search MAST" link) -> Select search type (target/coordinates/observation/program) -> Search -> Import selected observations (login required to import).
 
 **FITS File Types**: Image files (`*_cal`, `*_i2d`, `*_rate`) are viewable; table files (`*_asn`, `*_x1d`, `*_cat`) show data badge only.
+
+### Calibration environment variables (#1709)
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `CALIBRATION_ENABLED` | `true` (dev) | Runtime gate for pipeline runs; off -> run endpoints 501, recipes still browsable |
+| `MAX_CONCURRENT_CALIBRATIONS` | `1` | Concurrent pipeline runs (heavy CPU/RAM) |
+| `CALIBRATION_TIMEOUT_S` | `14400` | Per-stage ceiling (relaxed posture; deep exposures take hours) |
+| `CRDS_PATH` | `/app/data/crds` | CRDS reference-file cache (grows to GBs; never delete casually) |
+| `CRDS_SERVER_URL` | `https://jwst-crds.stsci.edu` | CRDS server for lazy reference-file downloads |
+| `JWT_SECRET_KEY` | (shared with .NET) | Engine validates .NET-issued tokens; must match `Jwt__SecretKey` |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:3000,http://localhost:5173` | Origins allowed to call the engine directly |
+| `VITE_ENGINE_URL` (frontend) | `http://localhost:8000` | Engine base URL for direct calibration calls |
+
+Build arg `INSTALL_CALIBRATION` (default `true`; CE builds pass `false`) gates the ~2GB `jwst` layer.
+

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -110,6 +110,22 @@ All services are in `frontend/jwst-frontend/src/services/`.
   - Max array elements: 200M pixels (`MAX_FITS_ARRAY_ELEMENTS`)
   - Max mosaic output: 64M pixels (`MAX_MOSAIC_OUTPUT_PIXELS`)
 
+#### Calibration Recipes (#1709)
+
+The engine can run the official STScI `jwst` calibration pipeline. The ~2GB
+`jwst` layer is installed via the Docker build arg `INSTALL_CALIBRATION` (default
+`true`; Community Edition builds pass `false`). Runtime is gated by
+`CALIBRATION_ENABLED`.
+
+- **First-run slowness**: the first calibration run for a given instrument
+  lazily downloads CRDS reference files (several GB) into the `CRDS_PATH` volume
+  (`/app/data/crds`). This is a one-time cost per instrument context — do not
+  delete the CRDS volume casually.
+- **Runs are heavy**: `MAX_CONCURRENT_CALIBRATIONS` (default 1) bounds memory;
+  full raw-data reductions download real MAST data and can take hours.
+- The frontend calls the engine directly for calibration — set `VITE_ENGINE_URL`
+  (default `http://localhost:8000`).
+
 ### Documentation (MkDocs)
 
 Project documentation is served at <http://localhost:8001>. It includes architecture docs, development plan, tech debt tracking, coding standards, and more. The docs auto-reload when you edit files in the `docs/` directory.
@@ -135,6 +151,13 @@ VITE_API_URL=http://localhost:5001
 # Processing Engine
 MAST_DOWNLOAD_DIR=/app/data/mast
 MAST_DOWNLOAD_TIMEOUT=3600
+
+# Calibration Recipes (#1709)
+CALIBRATION_ENABLED=true
+MAX_CONCURRENT_CALIBRATIONS=1
+CALIBRATION_TIMEOUT_S=14400
+CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+VITE_ENGINE_URL=http://localhost:8000
 ```
 
 The `.env` file is gitignored and should never be committed. Default values in `docker-compose.yml` work for local development if `.env` is missing.

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -1,5 +1,7 @@
-import React, { useState, useMemo, useEffect, useRef } from 'react';
+import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { CE_MODE } from '../config/ce';
+import { getCapabilities } from '../services/calibrationService';
 import { toast } from './ui/toast';
 import {
   JwstDataModel,
@@ -29,6 +31,53 @@ interface JwstDataDashboardProps {
 
 const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdate }) => {
   const navigate = useNavigate();
+
+  // Calibration Reprocess (#1709 PR 10): only offered when the engine has
+  // calibration enabled; navigates to the instrument's curated recipe with
+  // this observation's calibrated exposures preselected (stage-3 fast path).
+  const [calibrationEnabled, setCalibrationEnabled] = useState(false);
+  useEffect(() => {
+    if (CE_MODE) return undefined;
+    let cancelled = false;
+    getCapabilities()
+      .then((caps) => {
+        if (!cancelled) setCalibrationEnabled(caps.calibrationEnabled);
+      })
+      .catch(() => {
+        if (!cancelled) setCalibrationEnabled(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleReprocess = useCallback(
+    (item: JwstDataModel) => {
+      const instrument = (item.imageInfo?.instrument ?? '').toLowerCase().split('/')[0];
+      // v1 curated recipes are imaging-only.
+      if (!['nircam', 'niriss', 'miri'].includes(instrument)) {
+        toast.info('Calibration recipes currently support imaging data only.');
+        return;
+      }
+      const recipeId = `seed-${instrument}-imaging`;
+      const siblings = data.filter(
+        (d) =>
+          d.observationBaseId === item.observationBaseId &&
+          d.fileName.includes('_cal') &&
+          d.filePath
+      );
+      const inputs = (siblings.length > 0 ? siblings : [item])
+        .map((d) => d.filePath)
+        .filter((p): p is string => Boolean(p));
+      if (inputs.length === 0) {
+        toast.info('No downloaded calibrated exposures to reprocess for this observation.');
+        return;
+      }
+      navigate(`/calibrate/${recipeId}`, { state: { inputs, stage3Only: true } });
+    },
+    [data, navigate]
+  );
+
   const [selectedDataType, setSelectedDataType] = useState<string>('all');
   const [selectedProcessingLevel, setSelectedProcessingLevel] = useState<string>('all');
   const [selectedViewability, setSelectedViewability] = useState<string>('all');
@@ -557,6 +606,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
             onArchive={handleArchive}
             onTagClick={setSelectedTag}
             onClearFilters={handleClearFilters}
+            onReprocess={calibrationEnabled ? handleReprocess : undefined}
           />
         ) : (
           <LineageView

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.test.tsx
@@ -69,7 +69,12 @@ describe('DataCard', () => {
 
   const renderCard = (
     overrides: Partial<JwstDataModel> = {},
-    props: Partial<{ isSelected: boolean; isArchiving: boolean; selectedTag: string }> = {}
+    props: Partial<{
+      isSelected: boolean;
+      isArchiving: boolean;
+      selectedTag: string;
+      onReprocess: (item: JwstDataModel) => void;
+    }> = {}
   ) => {
     const item = { ...mockItem, ...overrides };
     return render(
@@ -216,5 +221,25 @@ describe('DataCard', () => {
   it('shows "Unarchiving..." for archived items when isArchiving', () => {
     renderCard({ isArchived: true }, { isArchiving: true });
     expect(screen.getByText('Unarchiving...')).toBeInTheDocument();
+  });
+
+  it('shows Reprocess only when onReprocess is provided and file is _cal', () => {
+    const onReprocess = vi.fn<(item: JwstDataModel) => void>();
+    renderCard({}, { onReprocess });
+    const button = screen.getByRole('button', { name: 'Reprocess' });
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(onReprocess).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides Reprocess when onReprocess is not provided', () => {
+    renderCard();
+    expect(screen.queryByRole('button', { name: 'Reprocess' })).not.toBeInTheDocument();
+  });
+
+  it('hides Reprocess for non-_cal files', () => {
+    const onReprocess = vi.fn<(item: JwstDataModel) => void>();
+    renderCard({ fileName: 'test_i2d.fits' }, { onReprocess });
+    expect(screen.queryByRole('button', { name: 'Reprocess' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -16,6 +16,8 @@ interface DataCardProps {
   onView: (item: JwstDataModel) => void;
   onArchive: (dataId: string, isArchived: boolean) => void;
   onTagClick: (tag: string) => void;
+  /** Present only when calibration is available (non-CE + engine enabled). */
+  onReprocess?: (item: JwstDataModel) => void;
 }
 
 const DataCard: React.FC<DataCardProps> = ({
@@ -27,6 +29,7 @@ const DataCard: React.FC<DataCardProps> = ({
   onView,
   onArchive,
   onTagClick,
+  onReprocess,
 }) => {
   const fitsInfo = getFitsFileInfo(item.fileName);
   const hasFile = item.isViewable !== false || isSpectralFile(item.fileName);
@@ -152,6 +155,15 @@ const DataCard: React.FC<DataCardProps> = ({
         >
           {isSpectralFile(item.fileName) ? 'Spectrum' : fitsInfo.viewable ? 'View' : 'Table'}
         </button>
+        {!CE_MODE && onReprocess && item.fileName.includes('_cal') && (
+          <button
+            className="btn-base btn-compact reprocess-btn"
+            onClick={() => onReprocess(item)}
+            title="Re-combine this observation's calibrated exposures with the official JWST pipeline"
+          >
+            Reprocess
+          </button>
+        )}
         {!CE_MODE && (
           <button
             className="btn-base btn-compact archive-btn"

--- a/frontend/jwst-frontend/src/components/dashboard/TargetGroupView.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/TargetGroupView.tsx
@@ -19,6 +19,7 @@ interface TargetGroupViewProps {
   onArchive: (dataId: string, isArchived: boolean) => void;
   onTagClick: (tag: string) => void;
   onClearFilters: () => void;
+  onReprocess?: (item: JwstDataModel) => void;
 }
 
 const TargetGroupView: React.FC<TargetGroupViewProps> = ({
@@ -35,6 +36,7 @@ const TargetGroupView: React.FC<TargetGroupViewProps> = ({
   onArchive,
   onTagClick,
   onClearFilters,
+  onReprocess,
 }) => {
   const groupedEntries = Object.entries(
     filteredData.reduce(
@@ -108,6 +110,7 @@ const TargetGroupView: React.FC<TargetGroupViewProps> = ({
                     onView={onView}
                     onArchive={onArchive}
                     onTagClick={onTagClick}
+                    onReprocess={onReprocess}
                   />
                 ))}
               </div>

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../services/jwstDataService', () => ({
 }));
 
 import { getJob, getRecipe, startRun } from '../services/calibrationService';
+import { getAll } from '../services/jwstDataService';
 
 const recipe: CalibrationRecipe = {
   id: 'seed-nircam-imaging',
@@ -86,6 +87,7 @@ function renderPage() {
 describe('CalibrateRun', () => {
   beforeEach(() => {
     vi.mocked(getRecipe).mockResolvedValue(recipe);
+    vi.mocked(getAll).mockResolvedValue([]);
   });
 
   it('renders stage toggles and seeded parameters', async () => {
@@ -123,5 +125,56 @@ describe('CalibrateRun', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
     await waitFor(() => expect(screen.getByText(/Run failed: boom/)).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument();
+  });
+
+  it('reprocess state selects stage-3 only and pre-fills inputs', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: { inputs: ['mast/jw1/a_cal.fits'], stage3Only: true },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
+    // Only image3 is checked; the raw stages are unchecked for the fast path.
+    const image3 = screen.getByRole('checkbox', { name: /image3/ });
+    const detector1 = screen.getByRole('checkbox', { name: /detector1/ });
+    expect(image3).toBeChecked();
+    expect(detector1).not.toBeChecked();
+  });
+
+  it('reprocess shows pre-selected _cal inputs as checked despite the recipe _uncal suffix', async () => {
+    vi.mocked(getAll).mockResolvedValue([
+      { id: 'a', fileName: 'a_cal.fits', filePath: 'mast/jw1/a_cal.fits' },
+      { id: 'b', fileName: 'b_cal.fits', filePath: 'mast/jw1/b_cal.fits' },
+    ] as never);
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: { inputs: ['mast/jw1/a_cal.fits'], stage3Only: true },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText('Inputs')).toBeInTheDocument());
+    // Both _cal files listed; the pre-selected one is checked.
+    const a = await screen.findByRole('checkbox', { name: /a_cal\.fits/ });
+    const b = screen.getByRole('checkbox', { name: /b_cal\.fits/ });
+    expect(a).toBeChecked();
+    expect(b).not.toBeChecked();
+    expect(screen.queryByText(/No matching library files/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { LogPanel } from '../components/wizard/LogPanel';
 import { EmptyState } from '../components/ui/EmptyState';
 import { useCalibrationJob } from '../hooks/useCalibrationJob';
@@ -67,8 +67,15 @@ function overridesFromRows(rows: ParamRow[]): StepOverrides {
   return overrides;
 }
 
+interface ReprocessState {
+  inputs?: string[];
+  stage3Only?: boolean;
+}
+
 export default function CalibrateRun() {
   const { recipeId } = useParams<{ recipeId: string }>();
+  // Library "Reprocess" pre-fills inputs and narrows to the stage-3 path.
+  const reprocess = (useLocation().state ?? {}) as ReprocessState;
   const [recipe, setRecipe] = useState<CalibrationRecipe | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -89,8 +96,16 @@ export default function CalibrateRun() {
       .then((loaded) => {
         if (cancelled) return;
         setRecipe(loaded);
-        setEnabledStages(Object.fromEntries(loaded.stages.map((s) => [s.name, s.enabled])));
+        setEnabledStages(
+          Object.fromEntries(
+            loaded.stages.map((s) => [
+              s.name,
+              reprocess.stage3Only ? s.name === 'image3' : s.enabled,
+            ])
+          )
+        );
         setParamRows(rowsFromRecipe(loaded));
+        if (reprocess.inputs?.length) setSelectedInputs(reprocess.inputs);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -101,7 +116,18 @@ export default function CalibrateRun() {
     };
   }, [recipeId]);
 
-  const needsLibraryInputs = recipe?.input_source.type === 'library_products';
+  const reprocessInputs = reprocess.inputs;
+  const needsLibraryInputs =
+    recipe?.input_source.type === 'library_products' || Boolean(reprocessInputs?.length);
+  // Reprocess supplies calibrated (_cal) files regardless of the recipe's own
+  // input suffix (seed recipes are _uncal MAST queries), so the library list
+  // must match _cal here. Memoized so the library-fetch effect below fires
+  // only when the recipe or reprocess inputs change, not on every render.
+  const inputSuffixes = useMemo(
+    () =>
+      reprocessInputs?.length ? ['_cal'] : (recipe?.input_source.product_suffixes ?? ['_cal']),
+    [reprocessInputs, recipe]
+  );
 
   useEffect(() => {
     if (!needsLibraryInputs) return undefined;
@@ -110,21 +136,23 @@ export default function CalibrateRun() {
       .getAll(false)
       .then((items) => {
         if (cancelled) return;
-        const suffixes = recipe?.input_source.product_suffixes ?? ['_cal'];
         const files = items
           .map((item) => item.filePath)
           .filter((path): path is string =>
-            Boolean(path && suffixes.some((s) => path.includes(s)))
+            Boolean(path && inputSuffixes.some((s) => path.includes(s)))
           );
-        setLibraryFiles(files);
+        // Always surface the pre-selected reprocess inputs, even if getAll
+        // doesn't return them, so the user can see and deselect them.
+        const union = Array.from(new Set([...(reprocessInputs ?? []), ...files]));
+        setLibraryFiles(union);
       })
       .catch(() => {
-        if (!cancelled) setLibraryFiles([]);
+        if (!cancelled) setLibraryFiles(reprocessInputs ?? []);
       });
     return () => {
       cancelled = true;
     };
-  }, [needsLibraryInputs, recipe]);
+  }, [needsLibraryInputs, recipe, reprocessInputs, inputSuffixes]);
 
   const runDisabled = useMemo(() => {
     if (!recipe || jobId) return true;
@@ -253,8 +281,7 @@ export default function CalibrateRun() {
             {needsLibraryInputs ? (
               libraryFiles.length === 0 ? (
                 <p className="calibrate-hint">
-                  No matching library files found (looking for{' '}
-                  {recipe.input_source.product_suffixes.join(', ')}).
+                  No matching library files found (looking for {inputSuffixes.join(', ')}).
                 </p>
               ) : (
                 <ul className="calibrate-input-list">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
           - GuidedCreate Flow: architecture/guidedcreate-flow.md
           - MAST Import Flow: architecture/mast-import-flow.md
           - Local Upload Flow: architecture/local-upload-flow.md
+          - Calibration Pipeline Flow: architecture/calibration-pipeline-flow.md
       - Development View:
         - Module Dependencies: architecture/module-dependencies.md
         - Build Pipeline: architecture/build-pipeline.md


### PR DESCRIPTION
## Summary

PR 10 — the final slice of the Calibration Recipes feature (#1709). Adds the library **Reprocess** action and completes the documentation sweep. With this merged, the feature is fully shipped end to end.

## Changes Made

- **Library Reprocess action**: `DataCard` gains an optional `onReprocess` prop; a **Reprocess** button appears only for `_cal` files, when calibration is enabled, and outside CE. It navigates to the observation's instrument seed recipe pre-filled with that observation's calibrated exposures for a **stage-3 fast-path** run (image3-only). Threaded via `TargetGroupView`; the dashboard fetches `/api/calibration/capabilities` on mount (skipped in CE) and only wires the handler when enabled.
- **Guards** (self-review): non-imaging instruments and empty resolved inputs toast an explanation instead of navigating into an unrunnable state; the run-config page shows and lets you deselect the pre-selected `_cal` inputs (suffix handling fixed so they're visible despite the seed recipe's `_uncal` query); the library-fetch effect is memoized to avoid per-keystroke refetching.
- **Docs sweep**:
  - New `docs/architecture/calibration-pipeline-flow.md` (flow diagram, security posture, feature gates) + index and mkdocs nav entries
  - `docs/key-files.md`: `app/calibration/`, `app/jobs/`, `app/auth/deps.py`, frontend calibration files
  - `docs/quick-reference.md`: `/api/calibration/*` and `/api/jobs/*` endpoints + a calibration env-var table
  - `docs/setup-guide.md`: CRDS volume + first-run reference-file expectations + `INSTALL_CALIBRATION` build arg
  - `docs/development-plan.md`: feature status entry with follow-up issues
  - `adr/0001`: progress note (the Phase-1 auth + Phase-3 jobs slices landed; HTTP-polling and direct-frontend→engine divergences documented)

## Test Plan

- [x] `tsc --noEmit` clean; `vitest run` — 1187/1187 (4 new: reprocess button shown/hidden/non-cal, reprocess state → image3-only, pre-selected `_cal` inputs shown checked)
- [x] `scripts/check-docs-consistency.sh` passes
- [ ] Reviewer: in `My Library`, a calibrated (`_cal`) imaging observation shows **Reprocess** → click it → lands on the recipe with image3-only and the observation's `_cal` files pre-selected → Run produces a fresh mosaic

## Documentation Checklist

- [x] Architecture flow page + index + mkdocs nav
- [x] key-files, quick-reference, setup-guide, development-plan, ADR note
- [x] docs-consistency check green

## Tech Debt Impact

- [x] No new tech debt. Feature follow-ups tracked: #1710/#1711/#1712 (deferred scope), #1713/#1715/#1719/#1721/#1727 (hardening).

## Risk & Rollback

- **Risk: LOW.** Additive UI (one gated button + navigation state) and docs. No engine or contract changes.
- **Rollback:** revert.

Completes #1709. No linked issue to close (umbrella tracks the full set).

https://claude.ai/code/session_01W5ZRaEbzFmit1DQs1nfP66
