### PR TITLE
feat: preview calibration-run outputs in an ephemeral lightbox

### DIFF
--- a/frontend/jwst-frontend/src/components/ui/ImagePreviewLightbox.css
+++ b/frontend/jwst-frontend/src/components/ui/ImagePreviewLightbox.css
@@ -1,0 +1,74 @@
+.preview-lightbox-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal);
+  background: var(--overlay-strong);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.preview-lightbox {
+  display: flex;
+  flex-direction: column;
+  width: min(90vw, 1200px);
+  height: min(90vh, 900px);
+  background: var(--bg-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.preview-lightbox-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+}
+
+.preview-lightbox-title {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preview-lightbox-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.preview-lightbox-close:hover {
+  color: var(--text-primary, #fff);
+}
+
+.preview-lightbox-stage {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: #000;
+}
+
+.preview-lightbox-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  transform-origin: center center;
+  user-select: none;
+  -webkit-user-drag: none;
+}

--- a/frontend/jwst-frontend/src/components/ui/ImagePreviewLightbox.test.tsx
+++ b/frontend/jwst-frontend/src/components/ui/ImagePreviewLightbox.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * ImagePreviewLightbox — focus containment.
+ *
+ * The lightbox declares `aria-modal="true"`, which tells assistive tech the
+ * background is inert. Tab must therefore stay inside the dialog; without a
+ * trap the promise is a lie and keyboard focus walks into the page behind the
+ * backdrop.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ImagePreviewLightbox } from './ImagePreviewLightbox';
+
+function renderLightbox() {
+  return render(
+    <div>
+      <button type="button">background action</button>
+      <ImagePreviewLightbox
+        open
+        title="jw001_i2d.fits"
+        onClose={vi.fn()}
+        loadImage={() => Promise.resolve(new Blob(['png'], { type: 'image/png' }))}
+      />
+    </div>
+  );
+}
+
+describe('ImagePreviewLightbox focus trap', () => {
+  beforeEach(() => {
+    // jsdom has no object-URL support.
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:preview'),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  it('moves focus to the close button on open', async () => {
+    renderLightbox();
+    const close = await screen.findByRole('button', { name: 'Close preview' });
+    await waitFor(() => expect(close).toHaveFocus());
+  });
+
+  it('keeps Tab inside the dialog instead of reaching the page behind it', async () => {
+    renderLightbox();
+    const close = await screen.findByRole('button', { name: 'Close preview' });
+    await waitFor(() => expect(close).toHaveFocus());
+
+    await userEvent.tab();
+
+    expect(screen.getByRole('button', { name: 'background action' })).not.toHaveFocus();
+    expect(close).toHaveFocus();
+  });
+
+  it('keeps Shift+Tab inside the dialog', async () => {
+    renderLightbox();
+    const close = await screen.findByRole('button', { name: 'Close preview' });
+    await waitFor(() => expect(close).toHaveFocus());
+
+    await userEvent.tab({ shift: true });
+
+    expect(screen.getByRole('button', { name: 'background action' })).not.toHaveFocus();
+    expect(close).toHaveFocus();
+  });
+});

--- a/frontend/jwst-frontend/src/components/ui/ImagePreviewLightbox.tsx
+++ b/frontend/jwst-frontend/src/components/ui/ImagePreviewLightbox.tsx
@@ -13,6 +13,7 @@
 
 import { useCallback, useEffect, useRef, useState, type MouseEvent, type WheelEvent } from 'react';
 import { createPortal } from 'react-dom';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { toast } from './toast';
 import './ImagePreviewLightbox.css';
 
@@ -40,6 +41,10 @@ export function ImagePreviewLightbox({
   const [isDragging, setIsDragging] = useState(false);
   const dragStartRef = useRef({ x: 0, y: 0 });
   const closeBtnRef = useRef<globalThis.HTMLButtonElement>(null);
+  const dialogRef = useRef<globalThis.HTMLDivElement>(null);
+
+  // `aria-modal` below claims the background is inert — keep Tab in here.
+  useFocusTrap(dialogRef, open);
 
   // Fetch the image when opened. Owns the object-URL lifecycle: revoke on
   // cleanup to avoid leaks. setState only runs async (in the promise handlers),
@@ -119,6 +124,7 @@ export function ImagePreviewLightbox({
       onWheel={handleWheel}
     >
       <div
+        ref={dialogRef}
         className="preview-lightbox"
         role="dialog"
         aria-modal="true"

--- a/frontend/jwst-frontend/src/components/ui/ImagePreviewLightbox.tsx
+++ b/frontend/jwst-frontend/src/components/ui/ImagePreviewLightbox.tsx
@@ -1,0 +1,178 @@
+/**
+ * ImagePreviewLightbox — JWST Discovery design-system primitive.
+ *
+ * A lightweight, full-bleed image lightbox for ephemeral previews (e.g. a
+ * calibration-run output rendered on the fly). Deliberately NOT the full
+ * ImageViewer: no library ObjectId, no cube/pixel/histogram machinery — just a
+ * zoomable, pannable image with Esc / backdrop / ✕ to close.
+ *
+ * Auth-aware previews can't use a bare <img src> (the endpoint requires a bearer
+ * token), so the caller supplies `loadImage`, which fetches the bytes as a Blob;
+ * this component owns the object-URL lifecycle (create on load, revoke on close).
+ */
+
+import { useCallback, useEffect, useRef, useState, type MouseEvent, type WheelEvent } from 'react';
+import { createPortal } from 'react-dom';
+import { toast } from './toast';
+import './ImagePreviewLightbox.css';
+
+interface ImagePreviewLightboxProps {
+  open: boolean;
+  title: string;
+  onClose: () => void;
+  /** Fetches the image bytes (auth-aware). Memoize in the parent so a change
+   *  in the source — not every render — triggers a refetch. */
+  loadImage: () => Promise<Blob>;
+}
+
+export function ImagePreviewLightbox({
+  open,
+  title,
+  onClose,
+  loadImage,
+}: ImagePreviewLightboxProps) {
+  const [url, setUrl] = useState<string | null>(null);
+  // Starts true: the component is mounted per-open (parent keys it by output),
+  // so it always begins in the loading state — no synchronous reset in-effect.
+  const [loading, setLoading] = useState(true);
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+  const closeBtnRef = useRef<globalThis.HTMLButtonElement>(null);
+
+  // Fetch the image when opened. Owns the object-URL lifecycle: revoke on
+  // cleanup to avoid leaks. setState only runs async (in the promise handlers),
+  // never synchronously in the effect body.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    loadImage()
+      .then((blob) => {
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        toast.error('Preview failed', {
+          description: 'Could not render this output. It may not be a viewable image.',
+        });
+        onClose();
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [open, loadImage, onClose]);
+
+  // Esc to close + body scroll lock while open.
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    closeBtnRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = originalOverflow;
+      previouslyFocused?.focus();
+    };
+  }, [open, onClose]);
+
+  const handleWheel = useCallback((e: WheelEvent) => {
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    setScale((s) => Math.max(0.1, Math.min(10, s * delta)));
+  }, []);
+
+  const handleMouseDown = (e: MouseEvent) => {
+    if (e.button !== 0) return;
+    setIsDragging(true);
+    dragStartRef.current = { x: e.clientX - offset.x, y: e.clientY - offset.y };
+  };
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!isDragging) return;
+    setOffset({ x: e.clientX - dragStartRef.current.x, y: e.clientY - dragStartRef.current.y });
+  };
+
+  const stopDragging = () => setIsDragging(false);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="preview-lightbox-backdrop"
+      onMouseDown={onClose}
+      role="presentation"
+      onWheel={handleWheel}
+    >
+      <div
+        className="preview-lightbox"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <header className="preview-lightbox-header">
+          <span className="preview-lightbox-title" title={title}>
+            {title}
+          </span>
+          <button
+            ref={closeBtnRef}
+            type="button"
+            className="btn-base preview-lightbox-close"
+            onClick={onClose}
+            aria-label="Close preview"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="18"
+              height="18"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </header>
+        <div
+          className="preview-lightbox-stage"
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={stopDragging}
+          onMouseLeave={stopDragging}
+          style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
+        >
+          {loading && <div className="spinner" aria-label="Loading preview" />}
+          {url && (
+            <img
+              src={url}
+              alt={title}
+              className="preview-lightbox-image"
+              draggable={false}
+              style={{
+                transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/jwst-frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/jwst-frontend/src/components/ui/Modal.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Modal — focus containment and Esc handling.
+ *
+ * Modal had no test coverage; these pin the behaviour that moved into the
+ * shared `useFocusTrap` hook so a future change to the hook can't silently
+ * regress the dialogs that depend on it.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Modal } from './Modal';
+
+function renderModal(props: Partial<Parameters<typeof Modal>[0]> = {}) {
+  const onClose = vi.fn();
+  render(
+    <div>
+      <button type="button">background action</button>
+      <Modal
+        open
+        onClose={onClose}
+        title="Export composite image"
+        footer={
+          <button type="button" name="confirm">
+            Start export
+          </button>
+        }
+        {...props}
+      >
+        body content
+      </Modal>
+    </div>
+  );
+  return { onClose };
+}
+
+describe('Modal', () => {
+  it('cycles Tab between its own focusables and never reaches the page behind', async () => {
+    renderModal();
+
+    const close = screen.getByRole('button', { name: 'Close dialog' });
+    const confirm = screen.getByRole('button', { name: 'Start export' });
+    const background = screen.getByRole('button', { name: 'background action' });
+    await waitFor(() => expect(close).toHaveFocus());
+
+    // close -> confirm (last), then wraps back to close.
+    await userEvent.tab();
+    expect(confirm).toHaveFocus();
+    await userEvent.tab();
+    expect(close).toHaveFocus();
+
+    // Shift+Tab off the first element wraps to the last, not out of the dialog.
+    await userEvent.tab({ shift: true });
+    expect(confirm).toHaveFocus();
+    expect(background).not.toHaveFocus();
+  });
+
+  it('closes on Esc', async () => {
+    const { onClose } = renderModal();
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('ignores Esc while blocking', async () => {
+    const { onClose } = renderModal({ blocking: true });
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/jwst-frontend/src/components/ui/Modal.tsx
+++ b/frontend/jwst-frontend/src/components/ui/Modal.tsx
@@ -23,6 +23,7 @@
 
 import { useEffect, useId, useRef, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import './Modal.css';
 
 interface ModalProps {
@@ -52,7 +53,9 @@ export function Modal({
   const dialogRef = useRef<HTMLDivElement>(null);
   const titleId = useId();
 
-  // Esc to close + focus trap + body scroll lock.
+  useFocusTrap(dialogRef, open);
+
+  // Esc to close + body scroll lock.
   useEffect(() => {
     if (!open) return;
 
@@ -72,23 +75,6 @@ export function Modal({
       if (e.key === 'Escape' && !blocking) {
         e.stopPropagation();
         onClose();
-      }
-      if (e.key === 'Tab' && dialogRef.current) {
-        const focusables = Array.from(
-          dialogRef.current.querySelectorAll<HTMLElement>(
-            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-          )
-        );
-        if (focusables.length === 0) return;
-        const first = focusables[0];
-        const last = focusables[focusables.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
       }
     };
     window.addEventListener('keydown', onKey);

--- a/frontend/jwst-frontend/src/components/ui/README.md
+++ b/frontend/jwst-frontend/src/components/ui/README.md
@@ -6,13 +6,14 @@ Your `frontend/jwst-frontend/src/index.css` **already contains every design toke
 
 ## What's here
 
-| File pair | What it gives you |
-|---|---|
-| `Modal.tsx` / `Modal.css` | Dialog with header / body / footer, Esc-to-close, focus trap, body scroll lock, destructive variant, `sm` / `md` / `lg` sizes. Portals to `document.body`. |
-| `EmptyState.tsx` / `EmptyState.css` | Never-blank container pattern. Standard + compact sizes, optional dashed border. |
-| `Progress.tsx` / `Progress.css` | Determinate, indeterminate, semantic tones (`success` / `warning` / `error`) + a `<Steps>` component for wizard progress. |
-| `Tooltip.tsx` / `Tooltip.css` | Hover/focus tooltip, 4 placements. Includes `RichTooltip` for titled/multi-line + keyboard hint. |
-| `toast.tsx` / `toast.css` | Re-export of `sonner` with a `<ToastProvider>` and JWST token overrides. Use `toast.success(...)`, `toast.error(...)`, etc. |
+| File pair                           | What it gives you                                                                                                                                                                                  |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Modal.tsx` / `Modal.css`           | Dialog with header / body / footer, Esc-to-close, focus trap, body scroll lock, destructive variant, `sm` / `md` / `lg` sizes. Portals to `document.body`.                                         |
+| `ImagePreviewLightbox.tsx` / `.css` | Zoom/pan lightbox for _ephemeral_ images (no library record). Fetches bytes via an auth-aware `loadImage` and owns the object-URL lifecycle. Same Esc / backdrop / focus-trap contract as `Modal`. |
+| `EmptyState.tsx` / `EmptyState.css` | Never-blank container pattern. Standard + compact sizes, optional dashed border.                                                                                                                   |
+| `Progress.tsx` / `Progress.css`     | Determinate, indeterminate, semantic tones (`success` / `warning` / `error`) + a `<Steps>` component for wizard progress.                                                                          |
+| `Tooltip.tsx` / `Tooltip.css`       | Hover/focus tooltip, 4 placements. Includes `RichTooltip` for titled/multi-line + keyboard hint.                                                                                                   |
+| `toast.tsx` / `toast.css`           | Re-export of `sonner` with a `<ToastProvider>` and JWST token overrides. Use `toast.success(...)`, `toast.error(...)`, etc.                                                                        |
 
 ## Setup
 
@@ -24,7 +25,7 @@ import { ToastProvider } from './components/ui/toast';
 <>
   <ToastProvider position="bottom-right" />
   <RouterProvider router={router} />
-</>
+</>;
 ```
 
 Auth notifications (session expired, refresh failure) go through the same `toast.*` API — there's no separate `AuthToast` component. `sonner` is the only runtime dep and is already in `package.json`.
@@ -32,6 +33,7 @@ Auth notifications (session expired, refresh failure) go through the same `toast
 ## Usage snippets
 
 ### Modal
+
 ```tsx
 const [open, setOpen] = useState(false);
 
@@ -41,33 +43,48 @@ const [open, setOpen] = useState(false);
   title="Export composite image"
   footer={
     <>
-      <button className="btn-base btn-standard modal-btn-ghost" onClick={() => setOpen(false)}>Cancel</button>
-      <button className="btn-base btn-standard modal-btn-primary" onClick={startExport}>Start export</button>
+      <button className="btn-base btn-standard modal-btn-ghost" onClick={() => setOpen(false)}>
+        Cancel
+      </button>
+      <button className="btn-base btn-standard modal-btn-primary" onClick={startExport}>
+        Start export
+      </button>
     </>
   }
 >
-  Render the Hubble-palette recipe at full resolution (8192 × 8192) and deliver a 16-bit TIFF plus calibrated FITS bundle. Estimated 4 minutes on your quota.
-</Modal>
+  Render the Hubble-palette recipe at full resolution (8192 × 8192) and deliver a 16-bit TIFF plus
+  calibrated FITS bundle. Estimated 4 minutes on your quota.
+</Modal>;
 ```
 
 For destructive actions, pass `destructive` and use `modal-btn-danger` on the primary footer button.
 
 ### EmptyState
+
 ```tsx
 <EmptyState
   icon={<SearchIcon />}
   title="No targets match your search"
-  description={<>We couldn&rsquo;t find a public JWST target for <em>&ldquo;{query}&rdquo;</em>.</>}
+  description={
+    <>
+      We couldn&rsquo;t find a public JWST target for <em>&ldquo;{query}&rdquo;</em>.
+    </>
+  }
   actions={
     <>
-      <button className="btn-base btn-standard empty-cta-primary" onClick={clear}>Browse all targets</button>
-      <button className="btn-base btn-standard empty-cta-ghost" onClick={clear}>Clear search</button>
+      <button className="btn-base btn-standard empty-cta-primary" onClick={clear}>
+        Browse all targets
+      </button>
+      <button className="btn-base btn-standard empty-cta-ghost" onClick={clear}>
+        Clear search
+      </button>
     </>
   }
 />
 ```
 
 ### Progress + Steps
+
 ```tsx
 <Progress label="Stacking F444W frames" value={68} meta="6 of 9 frames · ~1m 12s" />
 <Progress label="Contacting MAST archive…" />  {/* indeterminate */}
@@ -76,6 +93,7 @@ For destructive actions, pass `destructive` and use `modal-btn-danger` on the pr
 ```
 
 ### Tooltip
+
 ```tsx
 <Tooltip content="Download FITS" placement="right">
   <button className="btn-icon"><DownloadIcon /></button>
@@ -87,6 +105,7 @@ For destructive actions, pass `destructive` and use `modal-btn-danger` on the pr
 ```
 
 ### Toast
+
 ```tsx
 import { toast } from './components/ui/toast';
 
@@ -96,7 +115,7 @@ toast.success('Export complete', {
 });
 toast.error('Processing failed', { description: 'MAST returned 504 on frame jw02739-t010.' });
 toast.warning('Filter F187N missing');
-toast('New observations available');  // default info tone
+toast('New observations available'); // default info tone
 ```
 
 ## Invariants

--- a/frontend/jwst-frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/jwst-frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,55 @@
+/**
+ * useFocusTrap — keep Tab inside a container while it is active.
+ *
+ * Any element that declares `aria-modal="true"` promises assistive tech that
+ * the rest of the page is inert; without containment, Tab walks straight out
+ * into the background and the promise is a lie. Shared by the design-system
+ * dialogs (`ui/Modal`, `ui/ImagePreviewLightbox`) so the containment rule has
+ * one implementation rather than one per dialog.
+ *
+ * Scope is deliberately narrow — Tab only. Esc-to-close, body scroll lock and
+ * focus restore stay with the individual dialogs, which vary in how they want
+ * to handle them (e.g. Modal's `blocking` mode ignores Esc).
+ */
+
+import { useEffect, type RefObject } from 'react';
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, active: boolean): void {
+  useEffect(() => {
+    if (!active) return undefined;
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const container = containerRef.current;
+      if (!container) return;
+
+      const focusables = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+      if (focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+
+      // Focus escaped the container (or never entered it) — pull it back in
+      // rather than letting Tab continue through the background.
+      if (!container.contains(document.activeElement)) {
+        e.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [containerRef, active]);
+}

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.css
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.css
@@ -119,3 +119,35 @@
 .calibrate-result code {
   word-break: break-all;
 }
+
+.calibrate-output-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+/* Clickable FITS output — renders inline like the surrounding text but is a
+   focusable button that opens the preview lightbox. */
+.calibrate-output-preview {
+  padding: 0.1rem 0.3rem;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--accent, #7bd8ff);
+  cursor: pointer;
+  text-align: left;
+}
+
+.calibrate-output-preview code {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.calibrate-output-preview:hover,
+.calibrate-output-preview:focus-visible {
+  background: var(--bg-surface-hover, rgba(255, 255, 255, 0.06));
+}

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -10,12 +10,13 @@ vi.mock('../services/calibrationService', () => ({
   startRun: vi.fn(),
   cancelJob: vi.fn(),
   getJob: vi.fn(),
+  getJobOutputPreview: vi.fn(),
 }));
 vi.mock('../services/jwstDataService', () => ({
   getAll: vi.fn().mockResolvedValue([]),
 }));
 
-import { getJob, getRecipe, startRun } from '../services/calibrationService';
+import { getJob, getJobOutputPreview, getRecipe, startRun } from '../services/calibrationService';
 import { getAll } from '../services/jwstDataService';
 
 const recipe: CalibrationRecipe = {
@@ -71,6 +72,22 @@ function runningJob(): CalibrationJob {
     result: null,
     error: null,
     request: {},
+  };
+}
+
+function succeededJob(): CalibrationJob {
+  return {
+    ...runningJob(),
+    status: 'succeeded',
+    finishedAt: '2026-07-24T00:05:00Z',
+    result: {
+      outputs: [
+        { storageKey: 'calibration/job-1/jw001_i2d.fits', suffix: '_i2d', sizeBytes: 5242880 },
+        { storageKey: 'calibration/job-1/jw001_cat.ecsv', suffix: '_cat', sizeBytes: 2048 },
+      ],
+      jwstVersion: '1.14.0',
+      crdsContext: 'jwst_1234.pmap',
+    },
   };
 }
 
@@ -176,5 +193,53 @@ describe('CalibrateRun', () => {
     expect(a).toBeChecked();
     expect(b).not.toBeChecked();
     expect(screen.queryByText(/No matching library files/)).not.toBeInTheDocument();
+  });
+
+  describe('output previews', () => {
+    beforeEach(() => {
+      // jsdom has no object-URL support.
+      vi.stubGlobal('URL', {
+        ...URL,
+        createObjectURL: vi.fn(() => 'blob:preview'),
+        revokeObjectURL: vi.fn(),
+      });
+    });
+
+    async function renderSucceeded() {
+      vi.mocked(startRun).mockResolvedValue({ jobId: 'job-1' });
+      vi.mocked(getJob).mockResolvedValue(succeededJob());
+      renderPage();
+      await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
+      await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+    }
+
+    it('renders FITS outputs as buttons and non-FITS as plain text', async () => {
+      await renderSucceeded();
+      expect(screen.getByRole('button', { name: /jw001_i2d\.fits/ })).toBeInTheDocument();
+      // The catalog output is not clickable.
+      expect(screen.queryByRole('button', { name: /jw001_cat\.ecsv/ })).not.toBeInTheDocument();
+      expect(screen.getByText(/not previewable/)).toBeInTheDocument();
+    });
+
+    it('opens the lightbox with the rendered preview when an output is clicked', async () => {
+      vi.mocked(getJobOutputPreview).mockResolvedValue(new Blob(['png'], { type: 'image/png' }));
+      await renderSucceeded();
+
+      await userEvent.click(screen.getByRole('button', { name: /jw001_i2d\.fits/ }));
+
+      // Fetched by jobId + output index (index 0), never by raw storage key.
+      expect(vi.mocked(getJobOutputPreview)).toHaveBeenCalledWith('job-1', 0);
+      const dialog = await screen.findByRole('dialog', { name: 'jw001_i2d.fits' });
+      expect(dialog).toBeInTheDocument();
+      const img = await screen.findByAltText('jw001_i2d.fits');
+      expect(img).toHaveAttribute('src', 'blob:preview');
+
+      // Esc closes it.
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() =>
+        expect(screen.queryByRole('dialog', { name: 'jw001_i2d.fits' })).not.toBeInTheDocument()
+      );
+    });
   });
 });

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -7,15 +7,29 @@
  * download %, log tail, cancel.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { LogPanel } from '../components/wizard/LogPanel';
 import { EmptyState } from '../components/ui/EmptyState';
+import { ImagePreviewLightbox } from '../components/ui/ImagePreviewLightbox';
 import { useCalibrationJob } from '../hooks/useCalibrationJob';
-import { cancelJob, getRecipe, startRun } from '../services/calibrationService';
+import {
+  cancelJob,
+  getJobOutputPreview,
+  getRecipe,
+  startRun,
+} from '../services/calibrationService';
 import * as jwstDataService from '../services/jwstDataService';
 import type { CalibrationRecipe, ScalarOverride, StepOverrides } from '../types/CalibrationTypes';
 import './CalibrateRun.css';
+
+/** Only FITS image products can be rendered by the preview endpoint; catalogs
+ *  (.ecsv) and ASDF outputs are shown but not clickable. */
+// Kept in lockstep with the backend allowlist _PREVIEWABLE_SUFFIXES
+// (.fits, .fit, .fits.gz) in processing-engine/app/jobs/routes.py.
+const PREVIEWABLE_RE = /\.(fits(\.gz)?|fit)$/i;
+const isPreviewable = (storageKey: string): boolean => PREVIEWABLE_RE.test(storageKey);
+const basename = (key: string): string => key.split('/').pop() ?? key;
 
 interface ParamRow {
   step: string;
@@ -88,6 +102,16 @@ export default function CalibrateRun() {
   const [cancelling, setCancelling] = useState(false);
   const [startError, setStartError] = useState<string | null>(null);
   const { job, isTerminal, error: pollError } = useCalibrationJob(jobId);
+
+  // Index of the output currently shown in the ephemeral preview lightbox.
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const loadPreview = useCallback(
+    () => getJobOutputPreview(jobId ?? '', previewIndex ?? 0),
+    [jobId, previewIndex]
+  );
+  // Stable identity so the lightbox's fetch/keydown effects don't re-run on
+  // every job-poll re-render of this page.
+  const closePreview = useCallback(() => setPreviewIndex(null), []);
 
   useEffect(() => {
     if (!recipeId) return undefined;
@@ -376,13 +400,30 @@ export default function CalibrateRun() {
               {job.status === 'succeeded' && job.result && (
                 <div className="calibrate-result" role="status">
                   <h3>Outputs</h3>
-                  <ul>
-                    {job.result.outputs.map((output) => (
-                      <li key={output.storageKey}>
-                        <code>{output.storageKey}</code> (
-                        {(output.sizeBytes / 1024 / 1024).toFixed(1)} MB)
-                      </li>
-                    ))}
+                  <ul className="calibrate-output-list">
+                    {job.result.outputs.map((output, i) => {
+                      const sizeMb = (output.sizeBytes / 1024 / 1024).toFixed(1);
+                      return (
+                        <li key={output.storageKey}>
+                          {isPreviewable(output.storageKey) ? (
+                            <button
+                              type="button"
+                              className="btn-base calibrate-output-preview"
+                              onClick={() => setPreviewIndex(i)}
+                              title="Preview this output"
+                            >
+                              <code>{output.storageKey}</code>
+                            </button>
+                          ) : (
+                            <code>{output.storageKey}</code>
+                          )}{' '}
+                          ({sizeMb} MB)
+                          {!isPreviewable(output.storageKey) && (
+                            <span className="calibrate-hint"> · not previewable</span>
+                          )}
+                        </li>
+                      );
+                    })}
                   </ul>
                   {job.result.jwstVersion && (
                     <p className="calibrate-hint">
@@ -405,6 +446,16 @@ export default function CalibrateRun() {
             </>
           )}
         </section>
+      )}
+
+      {previewIndex !== null && job?.result?.outputs[previewIndex] && (
+        <ImagePreviewLightbox
+          key={job.result.outputs[previewIndex].storageKey}
+          open
+          title={basename(job.result.outputs[previewIndex].storageKey)}
+          onClose={closePreview}
+          loadImage={loadPreview}
+        />
       )}
     </div>
   );

--- a/frontend/jwst-frontend/src/services/calibrationService.ts
+++ b/frontend/jwst-frontend/src/services/calibrationService.ts
@@ -48,6 +48,17 @@ export async function cancelJob(jobId: string): Promise<{ cancelRequested: boole
   );
 }
 
+/**
+ * Fetch an on-the-fly PNG preview of a succeeded job's output as a Blob.
+ * The engine renders it from the output's storage key server-side (no library
+ * record is created), so the caller only needs the jobId and output index.
+ * Returned as a Blob (via the auth-aware ApiClient) so the UI can build an
+ * object URL — the endpoint requires a bearer token, so a bare <img src> 401s.
+ */
+export async function getJobOutputPreview(jobId: string, index: number): Promise<Blob> {
+  return engineClient.getBlob(`/api/jobs/${encodeURIComponent(jobId)}/outputs/${index}/preview`);
+}
+
 export interface ImportRecipeResponse {
   recipe: CalibrationRecipe;
   warnings: string[];

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -11,15 +11,22 @@ consumer) change state on the order of seconds, not milliseconds.
 Wire shape is camelCase (``app.db.casing``); documents are snake_case.
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+import asyncio
+
+from fastapi import APIRouter, Depends, HTTPException, Response
 
 from app.auth.deps import AuthenticatedUser, require_user
 from app.db.casing import snake_to_camel_keys
 from app.db.client import get_database
 from app.jobs.store import COLLECTION_NAME, JobStore
+from app.render.routes import generate_preview as engine_preview
 
 
 router = APIRouter(prefix="/api/jobs", tags=["Jobs"])
+
+# Only FITS image products are renderable; other job outputs (source catalogs
+# .ecsv, .asdf) are not previewable.
+_PREVIEWABLE_SUFFIXES = (".fits", ".fit", ".fits.gz")
 
 
 def get_job_store() -> JobStore:
@@ -57,6 +64,49 @@ async def get_job(
     if job is None or (job.get("user_id") != user.user_id and user.role != "Admin"):
         raise HTTPException(status_code=404, detail="Job not found")
     return to_wire(job)
+
+
+@router.get("/{job_id}/outputs/{index}/preview")
+async def get_output_preview(
+    job_id: str,
+    index: int,
+    user: AuthenticatedUser = Depends(require_user),
+    store: JobStore = Depends(get_job_store),
+    cmap: str = "grayscale",
+    stretch: str = "zscale",
+    sliceIndex: int = -1,  # noqa: N803 -- camelCase query param matches the frontend/render wire
+) -> Response:
+    """On-the-fly PNG preview of a succeeded job's output — no library record.
+
+    The storage key is read server-side from the job's own result, so the
+    client never supplies a raw path (the outputs list is derived, index-based).
+    Renders via the engine ``generate_preview`` shim in a thread pool, mirroring
+    ``library.routes.get_preview``; the response (incl. X-Cube-Slices /
+    X-Cube-Current headers) is forwarded verbatim.
+    """
+    job = await store.get(job_id)
+    # 404 for both "unknown" and "not yours" — don't leak job existence (get_job parity).
+    if job is None or (job.get("user_id") != user.user_id and user.role != "Admin"):
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    outputs = (job.get("result") or {}).get("outputs") or []
+    if index < 0 or index >= len(outputs):
+        raise HTTPException(status_code=404, detail="Output not found")
+
+    storage_key = outputs[index].get("storage_key")
+    if not storage_key:
+        raise HTTPException(status_code=404, detail="Output not found")
+    if not storage_key.lower().endswith(_PREVIEWABLE_SUFFIXES):
+        raise HTTPException(status_code=415, detail="Output is not a previewable FITS image")
+
+    return await asyncio.to_thread(
+        engine_preview,
+        data_id=job_id,
+        file_path=storage_key,
+        cmap=cmap,
+        stretch=stretch,
+        slice_index=sliceIndex,
+    )
 
 
 @router.post("/{job_id}/cancel")

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -233,9 +233,7 @@ class TestOutputPreview:
         response = await client.get(f"/api/jobs/{job_id}/outputs/5/preview", headers=bearer(USER))
         assert response.status_code == 404
 
-    async def test_non_fits_output_is_415(
-        self, client: httpx.AsyncClient, store: JobStore
-    ) -> None:
+    async def test_non_fits_output_is_415(self, client: httpx.AsyncClient, store: JobStore) -> None:
         catalog = JobOutput(
             storage_key="calibration/job-1/jw001_cat.ecsv", suffix="_cat", size_bytes=64
         )

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -17,9 +17,10 @@ import uuid
 import httpx
 import jwt as pyjwt
 import pytest
+from fastapi import Response
 
 from app.db.client import get_database, reset_client
-from app.jobs.models import JobRecord, JobResult
+from app.jobs.models import JobOutput, JobRecord, JobResult
 from app.jobs.routes import get_job_store
 from app.jobs.store import JobStore
 
@@ -188,6 +189,92 @@ class TestCancel:
         response = await client.post(f"/api/jobs/{job_id}/cancel", headers=bearer(USER))
         assert response.status_code == 200
         assert response.json() == {"cancelRequested": False, "status": "succeeded"}
+
+
+async def seed_succeeded_job(
+    store: JobStore,
+    *,
+    user_id: str = USER,
+    outputs: list[JobOutput] | None = None,
+) -> str:
+    job = JobRecord(type="calibration", user_id=user_id, request={"recipe_id": "r1"})
+    await store.create(job)
+    await store.mark_succeeded(job.job_id, JobResult(outputs=outputs or []))
+    return job.job_id
+
+
+def _fits_output(name: str = "jw001_cal.fits") -> JobOutput:
+    return JobOutput(storage_key=f"calibration/job-1/{name}", suffix="_cal", size_bytes=1024)
+
+
+class TestOutputPreview:
+    async def test_requires_token(self, client: httpx.AsyncClient) -> None:
+        assert (await client.get("/api/jobs/some-id/outputs/0/preview")).status_code == 401
+
+    async def test_foreign_job_is_404(self, client: httpx.AsyncClient, store: JobStore) -> None:
+        job_id = await seed_succeeded_job(store, user_id=OTHER, outputs=[_fits_output()])
+        response = await client.get(f"/api/jobs/{job_id}/outputs/0/preview", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_unknown_job_is_404(self, client: httpx.AsyncClient) -> None:
+        response = await client.get("/api/jobs/nope/outputs/0/preview", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_no_result_is_404(self, client: httpx.AsyncClient, store: JobStore) -> None:
+        # Job exists and is owned, but never succeeded / has no outputs.
+        job_id = await seed_job(store)
+        response = await client.get(f"/api/jobs/{job_id}/outputs/0/preview", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_index_out_of_range_is_404(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        job_id = await seed_succeeded_job(store, outputs=[_fits_output()])
+        response = await client.get(f"/api/jobs/{job_id}/outputs/5/preview", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_non_fits_output_is_415(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        catalog = JobOutput(
+            storage_key="calibration/job-1/jw001_cat.ecsv", suffix="_cat", size_bytes=64
+        )
+        job_id = await seed_succeeded_job(store, outputs=[catalog])
+        response = await client.get(f"/api/jobs/{job_id}/outputs/0/preview", headers=bearer(USER))
+        assert response.status_code == 415
+
+    async def test_fits_output_renders_png(
+        self, client: httpx.AsyncClient, store: JobStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_preview(**kwargs: object) -> Response:
+            captured.update(kwargs)
+            return Response(content=b"\x89PNG", media_type="image/png")
+
+        # Patch the shim as imported into the jobs router — no real FITS render.
+        monkeypatch.setattr("app.jobs.routes.engine_preview", fake_preview)
+        job_id = await seed_succeeded_job(store, outputs=[_fits_output()])
+        response = await client.get(f"/api/jobs/{job_id}/outputs/0/preview", headers=bearer(USER))
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+        assert response.content == b"\x89PNG"
+        # Storage key comes from the job record, not the client.
+        assert captured["file_path"] == "calibration/job-1/jw001_cal.fits"
+        assert captured["data_id"] == job_id
+
+    async def test_admin_can_view_any_output(
+        self, client: httpx.AsyncClient, store: JobStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.jobs.routes.engine_preview",
+            lambda **_: Response(content=b"\x89PNG", media_type="image/png"),
+        )
+        job_id = await seed_succeeded_job(store, user_id=OTHER, outputs=[_fits_output()])
+        response = await client.get(
+            f"/api/jobs/{job_id}/outputs/0/preview", headers=bearer(USER, role="Admin")
+        )
+        assert response.status_code == 200
 
 
 class TestCors:


### PR DESCRIPTION
## Summary

On `/calibrate/:recipeId`, a successful run listed its output files as inert `<code>` text. Clicking one now opens a **lightweight, zoomable image lightbox** showing the rendered output.

Why not "the viewer" (`ImageViewer`)? It's hard-wired to a library-item Mongo `_id` (preview/cubeinfo/pixeldata/histogram all keyed by id) and refuses to render without a valid ObjectId. Calibration outputs aren't library items — the engine only writes files to `calibration/{job_id}/{name}` and returns `{storageKey, suffix, sizeBytes}`, no id/record.

Auto-persisting each run to give it an id was rejected: calibration is a **rapid generate → view → tweak → regenerate loop**, and saving every throwaway version would flood `/library`. So this renders previews **on the fly** and persists nothing. Saving the keeper is tracked as a fast-follow (#1730).

## Changes Made

**Backend** (`processing-engine`, full-mode only — not CE):
- New `GET /api/jobs/{job_id}/outputs/{index}/preview` in `app/jobs/routes.py`, mirroring `app/library/routes.py:get_preview`:
  - `require_user` + `get_job` ownership parity — 404 for unknown/foreign jobs (no existence leak), Admin read bypass.
  - Reads the output's `storage_key` **server-side by index** — the client never supplies a raw key, so there's no path-traversal surface (and `resolve_fits_path` still guards absolute/`..` keys defensively).
  - Bounds-checks the index; returns **415** for non-FITS outputs (catalogs `.ecsv`, `.asdf`).
  - Renders via the engine `generate_preview` shim in a thread pool; forwards the `Response` (incl. `X-Cube-Slices`/`X-Cube-Current`) verbatim.

**Frontend** (`frontend/jwst-frontend`):
- `services/calibrationService.ts`: `getJobOutputPreview(jobId, index)` fetches the PNG as a **Blob** via the auth-aware `ApiClient.getBlob` (a bare `<img src>` would 401).
- New `components/ui/ImagePreviewLightbox.tsx` (+ `.css`): portal-rendered, Esc/backdrop/✕ close, wheel-zoom + drag-pan, owns the object-URL lifecycle (revokes on unmount), `toast.error` on failure. Focuses the close button on open and restores focus on close.
- `pages/CalibrateRun.tsx` (+ `.css`): FITS outputs render as buttons that open the lightbox; non-FITS stay plain text marked "not previewable". The FITS regex is kept in lockstep with the backend allowlist.

**Accessibility follow-up (review finding, commit 3):**
- The lightbox declared `aria-modal="true"` — which tells assistive tech the background is inert — but had no Tab containment, so keyboard focus walked out into the page behind the backdrop. It also reimplemented `ui/Modal`'s dialog shell, minus that trap.
- New `hooks/useFocusTrap.ts`: the Tab-containment half of `Modal`'s keydown handler, extracted and now used by **both** dialogs so the rule has one implementation instead of one per dialog. Scope is deliberately just Tab — Esc-to-close, scroll lock and focus restore stay with each dialog, which differ (`Modal`'s `blocking` mode ignores Esc). The hook additionally pulls focus back when it has escaped the container entirely, which the inline version did not handle.
- `Modal` had **no test coverage at all**; added tests for both consumers so a future change to the shared hook can't silently regress either dialog.
- Added the lightbox to the `ui/README.md` primitive table (it was missing).

## Test Plan

- [x] Backend unit (`docker … python -m pytest tests/test_jobs_routes.py`) — **23 passed** (16 existing + 7 new: token-required, foreign-404, unknown-404, no-result-404, bad-index-404, non-FITS-415, FITS→png-200, admin-bypass).
- [x] Frontend unit (`vitest run src/pages/CalibrateRun.test.tsx`) — **7 passed** (5 existing + 2 new: FITS clickable vs non-FITS inert; click opens lightbox with rendered preview + fetched by `(jobId, index)`, Esc closes).
- [x] **Focus trap** (`vitest run src/components/ui/ImagePreviewLightbox.test.tsx src/components/ui/Modal.test.tsx`) — **6 new passed**. Written red-first: both Tab assertions failed on the pre-fix component (Shift+Tab landed on a background button outside the dialog), then passed after the hook landed. Covers: autofocus on open, Tab and Shift+Tab containment in the lightbox, Tab cycling first↔last in `Modal`, Esc closes, `blocking` ignores Esc.
- [x] **Full frontend suite** — `vitest run`: **1195 passed / 108 files**, no regressions in `Modal`'s existing consumers.
- [x] `tsc -b` clean; ESLint clean on changed files (0 errors/new warnings); ruff clean; Prettier formatted.
- [ ] **Manual (reviewer, needs a completed run):** `docker compose up -d --build` → `http://localhost:3000/calibrate/seed-miri-imaging` → run a calibration → under **Outputs**, click a `.fits` file → lightbox opens with the preview; wheel-zoom, drag-pan, Esc/backdrop close; confirm nothing new appears in `/library`. With the lightbox open, hold **Tab** through several cycles and confirm focus never leaves the dialog (the page behind never shows a focus ring).

> A real MIRI calibration needs MAST data and is slow; end-to-end manual verification against a live run is **unverified** here — automated coverage stands in via the unit tests above.

## Documentation Checklist

- [x] No user-facing docs required (internal feature; endpoint is engine-internal and full-mode only).
- [x] Behavior documented inline (component/endpoint docstrings) and in this PR.
- [x] `components/ui/README.md` primitive table updated with `ImagePreviewLightbox` (it was missing) and its focus-trap contract.
- [ ] N/A — no new public API surface docs / API reference changes.

## Tech Debt Impact

- [x] No new tech debt introduced. The focus-trap commit **removes** some: the Tab-containment rule now has one implementation shared by both dialogs instead of a copy per dialog, and `Modal` gained its first tests.
- [x] Follow-up tracked: #1730 ("Save to library" for the keeper — persist a chosen output as a `JwstData` record → full `ImageViewer`).
- [x] Endpoint exposes `cmap`/`stretch`/`sliceIndex` knobs the lightbox doesn't yet use (intentional headroom for cube-slice/stretch controls; noted in #1730).

## Risk & Rollback

- **Risk: Low.** Additive — one new read-only, auth-gated endpoint and a new UI affordance on one page. No schema changes, no writes, no data persisted. Not mounted in CE.
- **Security:** self-reviewed (code-reviewer, security PASS) — storage key is server-derived by index, ownership parity with `get_job`, traversal guarded end-to-end.
- **Focus-trap commit touches a shared primitive** (`ui/Modal`, used by other pages). Behaviour is intended to be identical — the same Tab logic, relocated — with one deliberate improvement (focus is pulled back if it escaped the container). Mitigated by the full suite (1195 passing) plus `Modal`'s first-ever tests. This is the one part of the PR worth a second reviewer's eye.
- **Rollback:** revert the commits; no migrations or data to unwind. The focus-trap commit reverts independently of the feature.



## Linked Issue

No linked issue — this closes no tracked issue. The follow-up it creates is filed as #1730 ("Save to library" for the keeper), which stays open.
