### PR TITLE
test: de-flake TargetDetail authenticated-availability assertion

### DIFF
--- a/frontend/jwst-frontend/src/pages/TargetDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.test.tsx
@@ -70,8 +70,17 @@ describe('TargetDetail recipe grouping', () => {
     await screen.findByText('Suggested Composites');
     expect(screen.queryByText('Ready to render')).not.toBeInTheDocument();
     expect(screen.queryByText('Not in library', { selector: 'h3' })).not.toBeInTheDocument();
-    // page-level batched call is anonymous-only; cards self-check as before
-    expect(checkDataAvailability).toHaveBeenCalledTimes(2);
+    // The page-level batched pass is anonymous-only, so the two calls here come
+    // from the cards self-checking. Those fire in per-card effects that have not
+    // necessarily flushed when the heading appears — assert on them with waitFor
+    // rather than racing them (they were intermittently 0 on loaded CI runners).
+    await waitFor(() => expect(checkDataAvailability).toHaveBeenCalledTimes(2));
+    // Shape, not just count: a batched page-level pass would carry the union of
+    // both recipes' obs ids in ONE call, so per-card self-checks are the only
+    // way to get two single-id calls.
+    for (const [obsIds] of vi.mocked(checkDataAvailability).mock.calls) {
+      expect(obsIds).toHaveLength(1);
+    }
   });
 
   it('mixed availability renders Ready section first, then Not in library', async () => {


### PR DESCRIPTION
## Summary

Fixes a **flaky frontend test that is currently red on `main`**, blocking CI for every open PR.

`TargetDetail recipe grouping > authenticated users keep the flat layout and no page-level availability call (regression)` fails intermittently with:

```
AssertionError: expected "vi.fn()" to be called 2 times, but got 0 times
```

Observed on `main` (run [30104074725](https://github.com/Snoww3d/jwst-data-analysis/actions/runs/30104074725)) and again on the PR #1731 branch. It is a test-only race — no product defect.

## Root cause

The test awaited only the `Suggested Composites` heading, then asserted the call count **synchronously**:

```tsx
await screen.findByText('Suggested Composites');
expect(checkDataAvailability).toHaveBeenCalledTimes(2);
```

Those two calls do not come from the page. `TargetDetail`'s batched availability pass returns early when authenticated (`if (isAuthenticated) return`) — the two calls are `RecipeCard`'s per-card self-check effects. React effects dispatch after paint, so on a loaded CI runner the heading is already in the DOM while the count is still `0`. That is exactly the reported `got 0 times`.

## Changes Made

- `await waitFor(...)` the call count instead of racing it.
- Additionally assert each call carried a **single obs id**. A batched page-level pass would send the union of both recipes' ids in *one* call, so two single-id calls are only reachable via per-card self-checks. This keeps the regression's original intent — "no page-level call" — and makes it about call *shape* rather than a bare count, so the test is now strictly harder to fool than before.

## Test Plan

- [x] `vitest run src/pages/TargetDetail.test.tsx` ×10 consecutive runs — 7/7 passed every time.
- [x] Full frontend suite (`vitest run`) — **1187 passed / 106 files**, no regressions.
- [x] Pre-commit hook (ESLint + Prettier + tsc + full vitest) passed.
- [ ] **Reviewer:** confirm CI `Frontend Tests` is green here, and stays green on the next few `main` runs.

> The race is removed by construction (`waitFor` polls until the effects flush), so this cannot be proven by a local re-run alone — the pre-fix test also passes locally. The evidence is the CI signature `got 0 times` against an unawaited assertion, reproduced on two different branches.

## Documentation Checklist

- [x] No docs required — test-only change, no behavior or API surface change.
- [x] Reasoning captured in an inline comment so the next reader doesn't "simplify" the `waitFor` back out.

## Tech Debt Impact

- [x] No new tech debt. Removes a flaky test that was eroding trust in CI signal.
- [x] No product code touched.

## Risk & Rollback

- **Risk: Very low.** Single test file; assertion strengthened, not weakened.
- **Rollback:** revert the commit.

## Linked Issue

No linked issue — flake surfaced while reviewing PR #1731; fixed immediately per the "never dismiss a bug as pre-existing" rule rather than filed for later.
