### PR TITLE
feat: save calibration outputs to the library, download, open in compositor

### DIFF
--- a/frontend/jwst-frontend/src/pages/CalibrateRun.css
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.css
@@ -151,3 +151,25 @@
 .calibrate-output-preview:focus-visible {
   background: var(--bg-surface-hover, rgba(255, 255, 255, 0.06));
 }
+
+.calibrate-output-line {
+  word-break: break-all;
+}
+
+/* Actions sit under the filename so long storage keys don't squeeze them. */
+.calibrate-output-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.3rem 0 0.6rem;
+}
+
+.calibrate-saved-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: var(--success, #34d399);
+  background: var(--success-subtle, rgba(52, 211, 153, 0.12));
+}

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -11,12 +11,20 @@ vi.mock('../services/calibrationService', () => ({
   cancelJob: vi.fn(),
   getJob: vi.fn(),
   getJobOutputPreview: vi.fn(),
+  saveJobOutputToLibrary: vi.fn(),
+  downloadJobOutput: vi.fn(),
 }));
 vi.mock('../services/jwstDataService', () => ({
   getAll: vi.fn().mockResolvedValue([]),
 }));
 
-import { getJob, getJobOutputPreview, getRecipe, startRun } from '../services/calibrationService';
+import {
+  getJob,
+  getJobOutputPreview,
+  getRecipe,
+  saveJobOutputToLibrary,
+  startRun,
+} from '../services/calibrationService';
 import { getAll } from '../services/jwstDataService';
 
 const recipe: CalibrationRecipe = {
@@ -219,7 +227,9 @@ describe('CalibrateRun', () => {
       expect(screen.getByRole('button', { name: /jw001_i2d\.fits/ })).toBeInTheDocument();
       // The catalog output is not clickable.
       expect(screen.queryByRole('button', { name: /jw001_cat\.ecsv/ })).not.toBeInTheDocument();
-      expect(screen.getByText(/not previewable/)).toBeInTheDocument();
+      // Copy says "not an image" rather than "not previewable": the catalog is
+      // still downloadable, so the reason is the format, not a missing action.
+      expect(screen.getByText(/not an image/)).toBeInTheDocument();
     });
 
     it('opens the lightbox with the rendered preview when an output is clicked', async () => {
@@ -240,6 +250,49 @@ describe('CalibrateRun', () => {
       await waitFor(() =>
         expect(screen.queryByRole('dialog', { name: 'jw001_i2d.fits' })).not.toBeInTheDocument()
       );
+    });
+  });
+
+  describe('saving outputs to the library', () => {
+    async function renderSucceeded() {
+      vi.mocked(startRun).mockResolvedValue({ jobId: 'job-1' });
+      vi.mocked(getJob).mockResolvedValue(succeededJob());
+      renderPage();
+      await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
+      await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+    }
+
+    it('saves a FITS output and then offers the compositor hop', async () => {
+      vi.mocked(saveJobOutputToLibrary).mockResolvedValue({ dataId: 'abc123', created: true });
+      await renderSucceeded();
+
+      // Before saving there is no compositor route — the output has no library id yet.
+      expect(screen.queryByRole('button', { name: 'Open in compositor' })).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Save to library' }));
+
+      expect(vi.mocked(saveJobOutputToLibrary)).toHaveBeenCalledWith('job-1', 0);
+      expect(await screen.findByText('✓ In library')).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: 'Open in compositor' })).toBeInTheDocument();
+    });
+
+    it('keeps the run usable when saving fails', async () => {
+      vi.mocked(saveJobOutputToLibrary).mockRejectedValue(new Error('mongo is down'));
+      await renderSucceeded();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Save to library' }));
+
+      // The button returns to its resting state so the user can retry.
+      expect(await screen.findByRole('button', { name: 'Save to library' })).toBeEnabled();
+      expect(screen.queryByText('✓ In library')).not.toBeInTheDocument();
+    });
+
+    it('offers download for a catalog, which cannot be saved as an image', async () => {
+      await renderSucceeded();
+      // Two outputs: the FITS gets save + download, the catalog download only.
+      expect(screen.getAllByRole('button', { name: 'Download' })).toHaveLength(2);
+      expect(screen.getAllByRole('button', { name: 'Save to library' })).toHaveLength(1);
     });
   });
 });

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -8,17 +8,20 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { LogPanel } from '../components/wizard/LogPanel';
 import { EmptyState } from '../components/ui/EmptyState';
 import { ImagePreviewLightbox } from '../components/ui/ImagePreviewLightbox';
 import { useCalibrationJob } from '../hooks/useCalibrationJob';
 import {
   cancelJob,
+  downloadJobOutput,
   getJobOutputPreview,
   getRecipe,
+  saveJobOutputToLibrary,
   startRun,
 } from '../services/calibrationService';
+import { toast } from '../components/ui/toast';
 import * as jwstDataService from '../services/jwstDataService';
 import type { CalibrationRecipe, ScalarOverride, StepOverrides } from '../types/CalibrationTypes';
 import './CalibrateRun.css';
@@ -103,6 +106,12 @@ export default function CalibrateRun() {
   const [startError, setStartError] = useState<string | null>(null);
   const { job, isTerminal, error: pollError } = useCalibrationJob(jobId);
 
+  // Output index -> library id, for outputs saved during this visit. Drives the
+  // "Saved" affordance and unlocks the compositor hop, which is keyed by that id.
+  const [savedIds, setSavedIds] = useState<Record<number, string>>({});
+  const [savingIndex, setSavingIndex] = useState<number | null>(null);
+  const navigate = useNavigate();
+
   // Index of the output currently shown in the ephemeral preview lightbox.
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const loadPreview = useCallback(
@@ -183,6 +192,43 @@ export default function CalibrateRun() {
     if (needsLibraryInputs && selectedInputs.length === 0) return true;
     return !Object.values(enabledStages).some(Boolean);
   }, [recipe, jobId, needsLibraryInputs, selectedInputs, enabledStages]);
+
+  const handleSave = async (index: number) => {
+    if (!jobId) return;
+    setSavingIndex(index);
+    try {
+      const { dataId, created } = await saveJobOutputToLibrary(jobId, index);
+      setSavedIds((prev) => ({ ...prev, [index]: dataId }));
+      toast.success(created ? 'Saved to library' : 'Already in your library', {
+        description: created
+          ? 'Opens in the full viewer, and can be used in a composite.'
+          : 'This output was saved earlier — reusing that record.',
+      });
+    } catch (err: unknown) {
+      toast.error('Could not save to library', {
+        description: err instanceof Error ? err.message : 'Unexpected error',
+      });
+    } finally {
+      setSavingIndex(null);
+    }
+  };
+
+  const handleDownload = async (index: number, storageKey: string) => {
+    if (!jobId) return;
+    try {
+      const blob = await downloadJobOutput(jobId, index);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = basename(storageKey);
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch (err: unknown) {
+      toast.error('Download failed', {
+        description: err instanceof Error ? err.message : 'Unexpected error',
+      });
+    }
+  };
 
   const handleRun = async () => {
     if (!recipe) return;
@@ -403,24 +449,63 @@ export default function CalibrateRun() {
                   <ul className="calibrate-output-list">
                     {job.result.outputs.map((output, i) => {
                       const sizeMb = (output.sizeBytes / 1024 / 1024).toFixed(1);
+                      const previewable = isPreviewable(output.storageKey);
+                      const savedId = savedIds[i];
                       return (
                         <li key={output.storageKey}>
-                          {isPreviewable(output.storageKey) ? (
+                          <div className="calibrate-output-line">
+                            {previewable ? (
+                              <button
+                                type="button"
+                                className="btn-base calibrate-output-preview"
+                                onClick={() => setPreviewIndex(i)}
+                                title="Preview this output"
+                              >
+                                <code>{output.storageKey}</code>
+                              </button>
+                            ) : (
+                              <code>{output.storageKey}</code>
+                            )}{' '}
+                            ({sizeMb} MB)
+                            {!previewable && (
+                              <span className="calibrate-hint"> · not an image</span>
+                            )}
+                          </div>
+                          <div className="calibrate-output-actions">
+                            {previewable &&
+                              (savedId ? (
+                                <>
+                                  <span className="calibrate-saved-badge">✓ In library</span>
+                                  <button
+                                    type="button"
+                                    className="btn-base btn-compact"
+                                    onClick={() =>
+                                      navigate('/composite', {
+                                        state: { initialSelection: [savedId] },
+                                      })
+                                    }
+                                  >
+                                    Open in compositor
+                                  </button>
+                                </>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className="btn-base btn-compact"
+                                  onClick={() => void handleSave(i)}
+                                  disabled={savingIndex === i}
+                                >
+                                  {savingIndex === i ? 'Saving…' : 'Save to library'}
+                                </button>
+                              ))}
                             <button
                               type="button"
-                              className="btn-base calibrate-output-preview"
-                              onClick={() => setPreviewIndex(i)}
-                              title="Preview this output"
+                              className="btn-base btn-compact"
+                              onClick={() => void handleDownload(i, output.storageKey)}
                             >
-                              <code>{output.storageKey}</code>
+                              Download
                             </button>
-                          ) : (
-                            <code>{output.storageKey}</code>
-                          )}{' '}
-                          ({sizeMb} MB)
-                          {!isPreviewable(output.storageKey) && (
-                            <span className="calibrate-hint"> · not previewable</span>
-                          )}
+                          </div>
                         </li>
                       );
                     })}

--- a/frontend/jwst-frontend/src/services/calibrationService.ts
+++ b/frontend/jwst-frontend/src/services/calibrationService.ts
@@ -59,6 +59,33 @@ export async function getJobOutputPreview(jobId: string, index: number): Promise
   return engineClient.getBlob(`/api/jobs/${encodeURIComponent(jobId)}/outputs/${index}/preview`);
 }
 
+export interface SaveOutputResponse {
+  /** Mongo id of the library record — what the viewer and compositor are keyed by. */
+  dataId: string;
+  /** False when this output was already saved; the same record is returned. */
+  created: boolean;
+}
+
+/**
+ * Persist a calibration output as a library record.
+ * Saving is explicit (not automatic) so the tweak-and-regenerate loop doesn't
+ * flood /library with throwaway versions. Idempotent per output.
+ */
+export async function saveJobOutputToLibrary(
+  jobId: string,
+  index: number
+): Promise<SaveOutputResponse> {
+  return engineClient.post<SaveOutputResponse>(
+    `/api/jobs/${encodeURIComponent(jobId)}/outputs/${index}/save`,
+    {}
+  );
+}
+
+/** Raw output bytes (FITS or catalog) as a Blob — the endpoint needs a bearer token. */
+export async function downloadJobOutput(jobId: string, index: number): Promise<Blob> {
+  return engineClient.getBlob(`/api/jobs/${encodeURIComponent(jobId)}/outputs/${index}/download`);
+}
+
 export interface ImportRecipeResponse {
   recipe: CalibrationRecipe;
   warnings: string[];

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -14,12 +14,15 @@ Wire shape is camelCase (``app.db.casing``); documents are snake_case.
 import asyncio
 
 from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi.responses import FileResponse
 
 from app.auth.deps import AuthenticatedUser, require_user
 from app.db.casing import snake_to_camel_keys
 from app.db.client import get_database
 from app.jobs.store import COLLECTION_NAME, JobStore
+from app.library.writer import JwstDataWriteRepository
 from app.render.routes import generate_preview as engine_preview
+from app.storage.helpers import resolve_fits_path
 
 
 router = APIRouter(prefix="/api/jobs", tags=["Jobs"])
@@ -28,9 +31,53 @@ router = APIRouter(prefix="/api/jobs", tags=["Jobs"])
 # .ecsv, .asdf) are not previewable.
 _PREVIEWABLE_SUFFIXES = (".fits", ".fit", ".fits.gz")
 
+# Library thumbnails are small; the full-size render is a separate concern.
+_THUMBNAIL_PX = 256
+
 
 def get_job_store() -> JobStore:
     return JobStore(get_database()[COLLECTION_NAME])
+
+
+def get_library_writer() -> JwstDataWriteRepository:
+    return JwstDataWriteRepository(get_database()["jwst_data"])
+
+
+async def _resolve_any_output(
+    store: JobStore, job_id: str, user: AuthenticatedUser, index: int
+) -> tuple[dict, dict, str]:
+    """Ownership + bounds checks shared by the output-scoped routes.
+
+    404 covers both "unknown" and "not yours" so the endpoints don't leak job
+    existence (``get_job`` parity). The storage key is read server-side from the
+    job's own result, so a client can never supply a raw path.
+
+    No format check: download serves catalogs (.ecsv) too, which is the only
+    useful action for a non-image product.
+    """
+    job = await store.get(job_id)
+    if job is None or (job.get("user_id") != user.user_id and user.role != "Admin"):
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    outputs = (job.get("result") or {}).get("outputs") or []
+    if index < 0 or index >= len(outputs):
+        raise HTTPException(status_code=404, detail="Output not found")
+
+    output = outputs[index]
+    storage_key = output.get("storage_key")
+    if not storage_key:
+        raise HTTPException(status_code=404, detail="Output not found")
+    return job, output, storage_key
+
+
+async def _resolve_output(
+    store: JobStore, job_id: str, user: AuthenticatedUser, index: int
+) -> tuple[dict, dict, str]:
+    """As ``_resolve_any_output``, restricted to renderable FITS images."""
+    job, output, storage_key = await _resolve_any_output(store, job_id, user, index)
+    if not storage_key.lower().endswith(_PREVIEWABLE_SUFFIXES):
+        raise HTTPException(status_code=415, detail="Output is not a previewable FITS image")
+    return job, output, storage_key
 
 
 def to_wire(job: dict) -> dict:
@@ -84,20 +131,7 @@ async def get_output_preview(
     ``library.routes.get_preview``; the response (incl. X-Cube-Slices /
     X-Cube-Current headers) is forwarded verbatim.
     """
-    job = await store.get(job_id)
-    # 404 for both "unknown" and "not yours" — don't leak job existence (get_job parity).
-    if job is None or (job.get("user_id") != user.user_id and user.role != "Admin"):
-        raise HTTPException(status_code=404, detail="Job not found")
-
-    outputs = (job.get("result") or {}).get("outputs") or []
-    if index < 0 or index >= len(outputs):
-        raise HTTPException(status_code=404, detail="Output not found")
-
-    storage_key = outputs[index].get("storage_key")
-    if not storage_key:
-        raise HTTPException(status_code=404, detail="Output not found")
-    if not storage_key.lower().endswith(_PREVIEWABLE_SUFFIXES):
-        raise HTTPException(status_code=415, detail="Output is not a previewable FITS image")
+    _job, _output, storage_key = await _resolve_output(store, job_id, user, index)
 
     return await asyncio.to_thread(
         engine_preview,
@@ -107,6 +141,92 @@ async def get_output_preview(
         stretch=stretch,
         slice_index=sliceIndex,
     )
+
+
+async def _render_thumbnail(job_id: str, storage_key: str) -> bytes | None:
+    """Small PNG for the library card, or None if it can't be produced.
+
+    A thumbnail is cosmetic — /library and the viewer both cope without one — so
+    a render failure must never cost the user the save itself.
+    """
+    try:
+        response = await asyncio.to_thread(
+            engine_preview,
+            data_id=job_id,
+            file_path=storage_key,
+            width=_THUMBNAIL_PX,
+            height=_THUMBNAIL_PX,
+        )
+    except Exception:  # noqa: BLE001 -- cosmetic thumbnail; never fail the save over it
+        return None
+    body = getattr(response, "body", None)
+    return bytes(body) if body else None
+
+
+@router.get("/{job_id}/outputs/{index}/download")
+async def download_output(
+    job_id: str,
+    index: int,
+    user: AuthenticatedUser = Depends(require_user),
+    store: JobStore = Depends(get_job_store),
+) -> FileResponse:
+    """Serve the raw output file. Unlike preview, this covers catalogs too."""
+    _job, _output, storage_key = await _resolve_any_output(store, job_id, user, index)
+    local_path = await asyncio.to_thread(resolve_fits_path, storage_key)
+    return FileResponse(
+        path=local_path,
+        filename=storage_key.rsplit("/", 1)[-1],
+        media_type="application/octet-stream",
+    )
+
+
+@router.post("/{job_id}/outputs/{index}/save", status_code=201)
+async def save_output_to_library(
+    job_id: str,
+    index: int,
+    user: AuthenticatedUser = Depends(require_user),
+    store: JobStore = Depends(get_job_store),
+    writer: JwstDataWriteRepository = Depends(get_library_writer),
+) -> dict:
+    """Persist a calibration output as a library record and return its id.
+
+    Saving is explicit rather than automatic: calibration is a generate → view →
+    tweak → regenerate loop, and auto-persisting every attempt would flood
+    ``/library``. Once saved the output has a real Mongo ``_id``, which is what
+    the full ImageViewer and the compositor are keyed by.
+    """
+    job, output, storage_key = await _resolve_output(store, job_id, user, index)
+
+    # Always file under the job's owner, never the caller: an Admin saving
+    # someone else's output must not claim it into their own library.
+    owner_id = job["user_id"]
+
+    existing = await writer.find_by_path(storage_key, owner_id)
+    if existing is not None:
+        return {"dataId": str(existing["_id"]), "created": False}
+
+    result = job.get("result") or {}
+    request = job.get("request") or {}
+    metadata = {
+        "source": "calibration",
+        "job_id": job_id,
+        "recipe_id": request.get("recipe_id"),
+        "suffix": output.get("suffix"),
+        # Provenance the run page shows and the library record should keep:
+        # which pipeline and reference files produced this image.
+        "jwst_version": result.get("jwst_version"),
+        "crds_context": result.get("crds_context"),
+    }
+
+    data_id = await writer.create_from_calibration_output(
+        file_path=storage_key,
+        file_name=storage_key.rsplit("/", 1)[-1],
+        size_bytes=int(output.get("size_bytes") or 0),
+        user_id=owner_id,
+        metadata=metadata,
+        thumbnail=await _render_thumbnail(job_id, storage_key),
+    )
+    return {"dataId": data_id, "created": True}
 
 
 @router.post("/{job_id}/cancel")

--- a/processing-engine/app/library/writer.py
+++ b/processing-engine/app/library/writer.py
@@ -1,0 +1,75 @@
+"""Write path into the .NET-era ``jwst_data`` collection.
+
+Deliberately separate from ``app/db/repository.py``: that class is read-only and
+every accessor there enforces ``IsPublic``, an invariant worth keeping intact.
+This module is the only place the engine creates library records.
+
+Documents are PascalCase (no convention pack) — see the repository docstring.
+Field names and types here are matched against live records so the .NET tier can
+still deserialize them; in particular ``FileSize`` is written as an explicit
+BSON Int64 because the C# model types it as ``long``.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from bson import Int64
+
+
+class JwstDataWriteRepository:
+    def __init__(self, collection) -> None:
+        self._col = collection
+
+    async def find_by_path(self, file_path: str, user_id: str) -> dict | None:
+        """Existing record for this storage key and owner, if any.
+
+        Saving is idempotent: a double-click, or re-saving the same output from
+        a second browser tab, should return the record already created rather
+        than litter the library with duplicates.
+        """
+        return await self._col.find_one({"FilePath": file_path, "UserId": user_id})
+
+    async def create_from_calibration_output(
+        self,
+        *,
+        file_path: str,
+        file_name: str,
+        size_bytes: int,
+        user_id: str,
+        metadata: dict[str, Any],
+        thumbnail: bytes | None = None,
+    ) -> str:
+        """Insert a calibration output as a library record; returns its id.
+
+        Private by default (``IsPublic: False``). The .NET read path filters to
+        owner-or-public, so the owner sees it in ``/library`` and the full
+        ImageViewer while nobody else does — calibration outputs are personal
+        working products, not published data.
+        """
+        now = datetime.now(UTC)
+        doc: dict[str, Any] = {
+            "FileName": file_name,
+            "DataType": "image",
+            "UploadDate": now,
+            "Description": "Calibration pipeline output",
+            "Metadata": metadata,
+            "FilePath": file_path,
+            "FileSize": Int64(size_bytes),
+            "ProcessingStatus": "completed",
+            "Tags": ["calibration"],
+            "UserId": user_id,
+            "FileFormat": "fits",
+            "IsValidated": False,
+            "IsPublic": False,
+            "SharedWith": [],
+            "IsArchived": False,
+            "Version": 1,
+            "DerivedFrom": [],
+            "IsViewable": True,
+        }
+        if thumbnail is not None:
+            doc["ThumbnailData"] = thumbnail
+            doc["ThumbnailGeneratedAt"] = now
+
+        result = await self._col.insert_one(doc)
+        return str(result.inserted_id)

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -21,8 +21,9 @@ from fastapi import Response
 
 from app.db.client import get_database, reset_client
 from app.jobs.models import JobOutput, JobRecord, JobResult
-from app.jobs.routes import get_job_store
+from app.jobs.routes import get_job_store, get_library_writer
 from app.jobs.store import JobStore
+from app.library.writer import JwstDataWriteRepository
 
 
 SECRET = "unit-test-secret-key-at-least-32-chars!!"
@@ -71,10 +72,24 @@ async def store():
 
 
 @pytest.fixture()
-async def client(store: JobStore):
+async def library():
+    """Throwaway stand-in for the .NET-era ``jwst_data`` collection.
+
+    Save tests must never write to the real library, so the writer dependency is
+    always overridden — including for tests that don't save, which keeps a
+    mistake from silently landing in the shared collection.
+    """
+    collection = get_database()[f"jwst_data_test_{uuid.uuid4().hex}"]
+    yield collection
+    await collection.drop()
+
+
+@pytest.fixture()
+async def client(store: JobStore, library):
     from main import app
 
     app.dependency_overrides[get_job_store] = lambda: store
+    app.dependency_overrides[get_library_writer] = lambda: JwstDataWriteRepository(library)
     transport = httpx.ASGITransport(app=app)
     try:
         async with httpx.AsyncClient(
@@ -83,6 +98,7 @@ async def client(store: JobStore):
             yield async_client
     finally:
         app.dependency_overrides.pop(get_job_store, None)
+        app.dependency_overrides.pop(get_library_writer, None)
 
 
 async def seed_job(store: JobStore, user_id: str = USER) -> str:
@@ -273,6 +289,150 @@ class TestOutputPreview:
             f"/api/jobs/{job_id}/outputs/0/preview", headers=bearer(USER, role="Admin")
         )
         assert response.status_code == 200
+
+
+class TestDownloadOutput:
+    async def test_requires_token(self, client: httpx.AsyncClient) -> None:
+        assert (await client.get("/api/jobs/some-id/outputs/0/download")).status_code == 401
+
+    async def test_foreign_job_is_404(self, client: httpx.AsyncClient, store: JobStore) -> None:
+        job_id = await seed_succeeded_job(store, user_id=OTHER, outputs=[_fits_output()])
+        response = await client.get(f"/api/jobs/{job_id}/outputs/0/download", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_serves_a_catalog(
+        self, client: httpx.AsyncClient, store: JobStore, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        # Catalogs are 415 for preview; download is their only useful action.
+        local = tmp_path / "jw001_cat.ecsv"
+        local.write_text("# catalog\n")
+        monkeypatch.setattr("app.jobs.routes.resolve_fits_path", lambda _key: local)
+
+        catalog = JobOutput(
+            storage_key="calibration/job-1/jw001_cat.ecsv", suffix="_cat", size_bytes=10
+        )
+        job_id = await seed_succeeded_job(store, outputs=[catalog])
+        response = await client.get(f"/api/jobs/{job_id}/outputs/0/download", headers=bearer(USER))
+        assert response.status_code == 200
+        assert "jw001_cat.ecsv" in response.headers["content-disposition"]
+
+
+class TestSaveOutputToLibrary:
+    @staticmethod
+    def _stub_render(monkeypatch: pytest.MonkeyPatch, body: bytes = b"\x89PNG") -> None:
+        monkeypatch.setattr(
+            "app.jobs.routes.engine_preview",
+            lambda **_: Response(content=body, media_type="image/png"),
+        )
+
+    async def test_requires_token(self, client: httpx.AsyncClient) -> None:
+        assert (await client.post("/api/jobs/some-id/outputs/0/save")).status_code == 401
+
+    async def test_foreign_job_is_404(self, client: httpx.AsyncClient, store: JobStore) -> None:
+        job_id = await seed_succeeded_job(store, user_id=OTHER, outputs=[_fits_output()])
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_index_out_of_range_is_404(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        job_id = await seed_succeeded_job(store, outputs=[_fits_output()])
+        response = await client.post(f"/api/jobs/{job_id}/outputs/9/save", headers=bearer(USER))
+        assert response.status_code == 404
+
+    async def test_non_fits_output_is_415(self, client: httpx.AsyncClient, store: JobStore) -> None:
+        catalog = JobOutput(
+            storage_key="calibration/job-1/jw001_cat.ecsv", suffix="_cat", size_bytes=64
+        )
+        job_id = await seed_succeeded_job(store, outputs=[catalog])
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        assert response.status_code == 415
+
+    async def test_creates_a_private_viewable_library_record(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_render(monkeypatch)
+        job_id = await seed_succeeded_job(store, outputs=[_fits_output()])
+
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        assert response.status_code == 201
+        assert response.json()["created"] is True
+
+        doc = await library.find_one({"FilePath": "calibration/job-1/jw001_cal.fits"})
+        assert doc is not None
+        assert str(doc["_id"]) == response.json()["dataId"]
+        assert doc["UserId"] == USER
+        # Private to its owner: the .NET read path filters owner-or-public, so
+        # the owner still sees it in /library and the full viewer.
+        assert doc["IsPublic"] is False
+        assert doc["IsViewable"] is True
+        assert doc["FileName"] == "jw001_cal.fits"
+        assert doc["DataType"] == "image"
+        assert "calibration" in doc["Tags"]
+        # Provenance travels with the record, not just the run page.
+        assert doc["Metadata"]["job_id"] == job_id
+        assert doc["Metadata"]["source"] == "calibration"
+        assert doc["ThumbnailData"] is not None
+
+    async def test_saving_twice_is_idempotent(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_render(monkeypatch)
+        job_id = await seed_succeeded_job(store, outputs=[_fits_output()])
+
+        first = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        second = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+
+        assert first.json()["dataId"] == second.json()["dataId"]
+        assert second.json()["created"] is False
+        # A double-click must not litter the library with duplicates.
+        assert await library.count_documents({}) == 1
+
+    async def test_admin_save_files_under_the_job_owner(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_render(monkeypatch)
+        job_id = await seed_succeeded_job(store, user_id=OTHER, outputs=[_fits_output()])
+
+        response = await client.post(
+            f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER, role="Admin")
+        )
+        assert response.status_code == 201
+        doc = await library.find_one({})
+        # An Admin acting on someone else's run must not claim the output.
+        assert doc["UserId"] == OTHER
+
+    async def test_thumbnail_failure_still_saves(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def boom(**_: object) -> Response:
+            raise RuntimeError("render exploded")
+
+        monkeypatch.setattr("app.jobs.routes.engine_preview", boom)
+        job_id = await seed_succeeded_job(store, outputs=[_fits_output()])
+
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        # The thumbnail is cosmetic — losing it must not cost the user the save.
+        assert response.status_code == 201
+        doc = await library.find_one({})
+        assert doc is not None
+        assert "ThumbnailData" not in doc
 
 
 class TestCors:


### PR DESCRIPTION
## Summary

**Closes #1730.** Phase 1 of #1733 — the keystone: until a calibration output can become a library record, a run is a dead end and every other improvement polishes one.

Before this, a succeeded run listed outputs as storage keys with a size and an ephemeral preview. There was no save, no download, and no route to the compositor. The #1709 plan's own manual test says *"verify i2d lands in library storage and renders in compositor"* — that route was never built.

Saving stays **explicit rather than automatic**: auto-persisting every attempt would flood `/library`, which is exactly why outputs were made ephemeral in the first place (PR #1731). This adds the "keep this one" step that was missing.

## Changes Made

**Engine**

- **`app/library/writer.py`** — the engine's first write path into the .NET-era `jwst_data` collection. Deliberately separate from `app/db/repository.py` so that class keeps its "every accessor enforces `IsPublic`" invariant intact. Field names and types were matched against live records; `FileSize` is written as an explicit BSON `Int64` because the C# model types it as `long`.
- **`POST /api/jobs/{job_id}/outputs/{index}/save`** → `{dataId, created}`. The id is what the full `ImageViewer` and the compositor are keyed by.
  - **Idempotent** — a second save (double-click, second tab) returns the existing record instead of duplicating.
  - **Private by default** (`IsPublic: false`). The .NET read path filters owner-or-public, so the owner sees it in `/library` and the viewer while nobody else does.
  - **Filed under the job owner, never the caller** — an Admin acting on someone else's run must not claim the output into their own library.
  - Thumbnail render is best-effort; a failure must not cost the user the save.
- **`GET /api/jobs/{job_id}/outputs/{index}/download`** — serves the raw file, **catalogs included**, since download is the only useful action for a non-image product.
- Ownership/bounds checks factored into `_resolve_any_output` so preview, download and save can't drift apart. Only preview and save apply the FITS restriction.

**Frontend**

- `calibrationService`: `saveJobOutputToLibrary`, `downloadJobOutput`.
- `CalibrateRun`: per-output **Save to library · Download**, and after a save the row shows **✓ In library** plus **Open in compositor**, which navigates with the new id as `initialSelection` (the shape `/composite` already accepts).
- Catalog copy changed from "not previewable" to **"not an image"** — it *is* downloadable, so the format is the reason, not a missing action. The existing assertion was updated to match this deliberate copy change.

## Test Plan

- [x] Engine (`docker exec jwst-processing python -m pytest tests/test_jobs_routes.py`) — **34 passed** (23 existing + 11 new). New: download auth/foreign-404/catalog-served; save auth, foreign-404, out-of-range-404, non-FITS-415, record shape (private, viewable, tagged, provenance in `Metadata`), idempotency (one document after two saves), admin-files-under-owner, and thumbnail-failure-still-saves.
- [x] Engine regression (`tests/test_ce_mode_mounting.py tests/contract`) — **58 passed**; the new routes stay out of CE.
- [x] Frontend (`vitest run src/pages/CalibrateRun.test.tsx`) — **10 passed** (7 existing + 3 new: save then compositor hop appears; save failure leaves the button retryable; catalog gets download but no save).
- [x] Full frontend suite — **1198 passed / 108 files**. `tsc -b` clean, ESLint clean, ruff + ruff format clean.
- [ ] **Manual (reviewer, needs a completed run):** run a calibration → **Save to library** → confirm it appears in `/library`, opens in the full `ImageViewer` (cube/pixel/histogram), and that **Open in compositor** carries it in pre-selected. Save the same output twice and confirm only one library entry.

> A real calibration needs MAST data and is slow, so the end-to-end path is **unverified** here; automated coverage stands in. The record shape was matched against live documents in the running Mongo rather than assumed.

## Documentation Checklist

- [x] Endpoints documented inline (module + route docstrings), including why the write path is separate from the read repository.
- [ ] `docs/quick-reference.md` endpoint list — deferred to the end of the epic so the docs sweep covers all six phases at once.
- [x] No user-facing docs needed yet; the flow changes land in later phases.

## Tech Debt Impact

- [x] No new tech debt. Shared resolver means preview/download/save cannot drift apart.
- [x] **New surface worth knowing about:** this is the first Python write into `jwst_data`. Confined to one module with one caller.
- [x] Follow-ups unchanged: #1734, #1735, #1736, #1737, #1738.

## Risk & Rollback

- **Risk: Medium — the only write path in the epic.** A malformed record would surface in `/library` for the owner. Mitigated by matching live document shape, the explicit `Int64` for `FileSize`, and tests asserting the stored document field-by-field. Records are private, so a bad one is never visible to other users.
- **Security:** storage key is server-derived by index (no client-supplied paths), ownership parity with `get_job` (404 hides existence), and saves are filed under the job owner so Admin read-access can't be used to claim data.
- **Rollback:** revert the commit. Any records already created remain valid library items — nothing to unwind.

## Linked Issue

Closes #1730.
