### PR TITLE
fix: repair the backend pre-commit gate (8 StyleCop errors on main)

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/CompositeServiceTests.cs
@@ -828,7 +828,6 @@ public class CompositeServiceTests
     // #1471 — streaming consumer tests. Engine returns NDJSON; backend reads
     // line-by-line, calls onProgress per progress event, decodes b64 image on
     // complete, throws on error/malformed/incomplete.
-
     [Fact]
     public async Task GenerateNChannelComposite_Streaming_ReturnsImageBytesAndCallsOnProgress()
     {
@@ -872,6 +871,7 @@ public class CompositeServiceTests
         progressCalls[0].Stage.Should().Be("reproject");
         progressCalls[1].Stage.Should().Be("stretch");
         progressCalls[2].Stage.Should().Be("encode");
+
         // Per-channel reproject is interpolated within its stage window (10-50);
         // index 1/3 should land in the lower half.
         progressCalls[0].Pct.Should().BeInRange(10, 30);

--- a/backend/JwstDataAnalysis.API.Tests/Services/JobTrackerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/JobTrackerTests.cs
@@ -214,6 +214,7 @@ public class JobTrackerTests
 
         var updated = await sut.GetJobAsync(job.JobId, TestUserId);
         updated!.Messages.Should().HaveCount(JobTracker.MaxMessages);
+
         // Oldest 10 should have been dropped — first remaining is "step 10".
         updated.Messages[0].Should().Be("step 10");
         updated.Messages[^1].Should().Be("step 59");
@@ -256,19 +257,22 @@ public class JobTrackerTests
             for (var i = 0; i < iterations; i++)
             {
                 var snapshot = await sut.GetJobAsync(job.JobId, TestUserId);
-                if (snapshot is null) continue;
+                if (snapshot is null)
+                {
+                    continue;
+                }
 
                 // Force enumeration of both fields — these are the paths
                 // System.Text.Json takes when serializing the response.
                 _ = snapshot.Messages.Count;
-                foreach (var _msg in snapshot.Messages)
+                foreach (var msg in snapshot.Messages)
                 {
                     // observe each entry — would throw on torn enumeration
                 }
 
                 if (snapshot.Metadata is not null)
                 {
-                    foreach (var _kv in snapshot.Metadata)
+                    foreach (var kv in snapshot.Metadata)
                     {
                         // ditto for the byte-progress dictionary
                     }

--- a/backend/JwstDataAnalysis.API/Services/JobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/JobTracker.cs
@@ -361,6 +361,44 @@ namespace JwstDataAnalysis.API.Services
             return job is null ? null : WithMessagesSnapshot(job);
         }
 
+        public async Task<List<JobStatus>> GetJobsForUserAsync(string userId, string? status = null, string? type = null)
+        {
+            var filterBuilder = Builders<JobStatus>.Filter;
+            var filter = filterBuilder.Eq(j => j.OwnerUserId, userId);
+
+            if (status is not null)
+            {
+                filter &= filterBuilder.Eq(j => j.State, status);
+            }
+
+            if (type is not null)
+            {
+                filter &= filterBuilder.Eq(j => j.JobType, type);
+            }
+
+            return await jobsCollection
+                .Find(filter)
+                .SortByDescending(j => j.CreatedAt)
+                .Limit(100)
+                .ToListAsync();
+        }
+
+        public async Task RecordResultAccessAsync(string jobId)
+        {
+            var job = await GetFromCacheOrDb(jobId);
+            if (job is null)
+            {
+                return;
+            }
+
+            var now = DateTime.UtcNow;
+            job.LastAccessedAt = now;
+            job.ExpiresAt = now + resultTtl;
+            job.UpdatedAt = now;
+
+            await PersistJob(job);
+        }
+
         // #1471 — Return a copy of `job` whose `Messages` list is a defensive
         // snapshot, so JSON serialization (or any other enumeration) can't be
         // hit by a concurrent `UpdateProgressAsync` mutation on the same
@@ -398,6 +436,7 @@ namespace JwstDataAnalysis.API.Services
                     ResultFilename = job.ResultFilename,
                     ResultDataId = job.ResultDataId,
                     ResultWarningHeaders = job.ResultWarningHeaders,
+
                     // Shallow copy of the Metadata dictionary so JSON
                     // serialization can iterate the snapshot without being
                     // hit by a concurrent UpdateByteProgressAsync write.
@@ -406,44 +445,6 @@ namespace JwstDataAnalysis.API.Services
                     Metadata = job.Metadata is null ? null : new Dictionary<string, object>(job.Metadata),
                 };
             }
-        }
-
-        public async Task<List<JobStatus>> GetJobsForUserAsync(string userId, string? status = null, string? type = null)
-        {
-            var filterBuilder = Builders<JobStatus>.Filter;
-            var filter = filterBuilder.Eq(j => j.OwnerUserId, userId);
-
-            if (status is not null)
-            {
-                filter &= filterBuilder.Eq(j => j.State, status);
-            }
-
-            if (type is not null)
-            {
-                filter &= filterBuilder.Eq(j => j.JobType, type);
-            }
-
-            return await jobsCollection
-                .Find(filter)
-                .SortByDescending(j => j.CreatedAt)
-                .Limit(100)
-                .ToListAsync();
-        }
-
-        public async Task RecordResultAccessAsync(string jobId)
-        {
-            var job = await GetFromCacheOrDb(jobId);
-            if (job is null)
-            {
-                return;
-            }
-
-            var now = DateTime.UtcNow;
-            job.LastAccessedAt = now;
-            job.ExpiresAt = now + resultTtl;
-            job.UpdatedAt = now;
-
-            await PersistJob(job);
         }
 
         private static bool IsTerminal(string state) =>


### PR DESCRIPTION
## Summary

**The backend pre-commit gate is broken on `main`, and has been silently bypassed.**

`dotnet build --warnaserror` — the exact command the pre-commit hook runs (`.git/hooks/pre-commit:204`) — fails on `main` with **8 StyleCop errors**. So every backend commit today needs the verification-skip flag, which doesn't skip *one* check: it skips the **entire** gate — ESLint, Prettier, tsc, vitest, dotnet build, dotnet test and ruff.

## The recorded reason was wrong

This surfaced while auditing whether the workaround noted for #1558 (NuGet audit `NU1902`/`NU1903` from transitive `SharpCompress`/`Snappier`) was still needed. It isn't — and it wasn't the cause:

```
$ dotnet list JwstDataAnalysis.sln package --vulnerable --include-transitive
The given project `JwstDataAnalysis.API` has no vulnerable packages given the current sources.
The given project `JwstDataAnalysis.API.Tests` has no vulnerable packages given the current sources.

$ dotnet build JwstDataAnalysis.sln --warnaserror
    0 Warning(s)
    8 Error(s)
```

**Zero NuGet warnings.** The gate was broken by formatting violations, not the audit. #1558's premise no longer holds and it should be re-checked or closed.

## Changes Made

All real fixes — **no suppressions**:

| File | Rule | Fix |
|---|---|---|
| `JobTracker.cs` | SA1202 | Move the private `WithMessagesSnapshot` helper out from between public members into the private block |
| `JobTracker.cs` | SA1515 | Blank line before the Shallow-copy comment |
| `CompositeServiceTests.cs` | SA1512, SA1515 | Comment spacing |
| `JobTrackerTests.cs` | SA1515 | Comment spacing |
| `JobTrackerTests.cs` | SA1503 | Brace the `if (snapshot is null) continue;` |
| `JobTrackerTests.cs` | SA1312 ×2 | `_msg`/`_kv` renamed — discard-style names must not start with an underscore |

Only comments, ordering, braces and two local names moved. **No behavior change.**

I deliberately did **not** add `<NoWarn>NU1902;NU1903</NoWarn>` or `WarningsNotAsErrors`, which was my first instinct and was wrong: dependency advisories should stay loud and get fixed, not silenced. There is nothing to silence anyway.

## Test Plan

- [x] `dotnet build JwstDataAnalysis.sln --verbosity quiet --warnaserror` — **0 Warning(s), 0 Error(s)** (was 8 errors).
- [x] `dotnet test JwstDataAnalysis.API.Tests` — **1137 passed, 0 failed**.
- [x] `dotnet list package --vulnerable --include-transitive` — no vulnerable packages, confirming NU190x is not in play.
- [x] **The commit had to pass the repaired gate to exist** — the pre-commit hook ran the full backend build + 1137 tests before accepting it. That is the end-to-end proof.
- [ ] **Reviewer:** make any trivial backend edit and commit it *without* the skip flag; it should now pass instead of failing on StyleCop.

## Documentation Checklist

- [x] No docs change needed — formatting only, no API or behavior surface.
- [ ] **Follow-up:** #1558 and the `project_nuget_audit_precommit_block.md` memory both record a cause that no longer holds; they should be corrected or closed separately.

## Tech Debt Impact

- [x] **Removes** tech debt: restores a quality gate that was being routinely bypassed, and removes the standing reason to reach for the skip flag.
- [x] No suppressions added; the analyzer set is untouched.

## Risk & Rollback

- **Risk: Very low.** Comments, member ordering, braces, and two local variable names. No logic touched. Full backend suite green.
- The one non-cosmetic-looking change is moving `WithMessagesSnapshot` within its class — a pure relocation, no signature or body change.
- **Rollback:** revert the commit.

## Linked Issue

No linked issue to close. Related to #1558, which this shows to be based on a stale premise; that issue needs its own follow-up rather than being closed here.
