### PR TITLE
feat: durable calibration runs — job id in the URL + run history

### DIFF
--- a/frontend/jwst-frontend/src/App.tsx
+++ b/frontend/jwst-frontend/src/App.tsx
@@ -42,6 +42,8 @@ const SearchPage = lazy(() =>
 );
 const CalibrationGallery = lazy(() => import('./pages/CalibrationGallery'));
 const CalibrateRun = lazy(() => import('./pages/CalibrateRun'));
+const CalibrationRuns = lazy(() => import('./pages/CalibrationRuns'));
+const RunDetail = lazy(() => import('./pages/RunDetail'));
 const ArchivePage = lazy(() =>
   import('./pages/ArchivePage').then((m) => ({ default: m.ArchivePage }))
 );
@@ -90,6 +92,10 @@ function App() {
               {/* semantic search is out of CE v1 (its API never mounts) */}
               {!CE_MODE && <Route path="search" element={<SearchPage />} />}
               {!CE_MODE && <Route path="calibrate" element={<CalibrationGallery />} />}
+              {/* `runs` must precede `:recipeId` — otherwise the dynamic
+                  segment swallows /calibrate/runs as a recipe id. */}
+              {!CE_MODE && <Route path="calibrate/runs" element={<CalibrationRuns />} />}
+              {!CE_MODE && <Route path="calibrate/runs/:jobId" element={<RunDetail />} />}
               {!CE_MODE && <Route path="calibrate/:recipeId" element={<CalibrateRun />} />}
               <Route path="archive" element={<ArchivePage />} />
               {/* CE review decision 2026-07-06: /library is a public

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -3,28 +3,17 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import CalibrateRun from './CalibrateRun';
-import type { CalibrationJob, CalibrationRecipe } from '../types/CalibrationTypes';
+import type { CalibrationRecipe } from '../types/CalibrationTypes';
 
 vi.mock('../services/calibrationService', () => ({
   getRecipe: vi.fn(),
   startRun: vi.fn(),
-  cancelJob: vi.fn(),
-  getJob: vi.fn(),
-  getJobOutputPreview: vi.fn(),
-  saveJobOutputToLibrary: vi.fn(),
-  downloadJobOutput: vi.fn(),
 }));
 vi.mock('../services/jwstDataService', () => ({
   getAll: vi.fn().mockResolvedValue([]),
 }));
 
-import {
-  getJob,
-  getJobOutputPreview,
-  getRecipe,
-  saveJobOutputToLibrary,
-  startRun,
-} from '../services/calibrationService';
+import { getRecipe, startRun } from '../services/calibrationService';
 import { getAll } from '../services/jwstDataService';
 
 const recipe: CalibrationRecipe = {
@@ -57,53 +46,13 @@ const recipe: CalibrationRecipe = {
   updated_at: '2026-07-23T00:00:00Z',
 };
 
-function runningJob(): CalibrationJob {
-  return {
-    jobId: 'job-1',
-    type: 'calibration',
-    status: 'running',
-    cancelRequested: false,
-    createdAt: '2026-07-24T00:00:00Z',
-    startedAt: '2026-07-24T00:00:01Z',
-    finishedAt: null,
-    progress: {
-      stages: [
-        { name: 'detector1', status: 'done' },
-        { name: 'image2', status: 'running' },
-        { name: 'image3', status: 'pending' },
-      ],
-      currentStage: 'image2',
-      message: 'running image2',
-      downloadPct: null,
-    },
-    logTail: ['Step flat_field running'],
-    result: null,
-    error: null,
-    request: {},
-  };
-}
-
-function succeededJob(): CalibrationJob {
-  return {
-    ...runningJob(),
-    status: 'succeeded',
-    finishedAt: '2026-07-24T00:05:00Z',
-    result: {
-      outputs: [
-        { storageKey: 'calibration/job-1/jw001_i2d.fits', suffix: '_i2d', sizeBytes: 5242880 },
-        { storageKey: 'calibration/job-1/jw001_cat.ecsv', suffix: '_cat', sizeBytes: 2048 },
-      ],
-      jwstVersion: '1.14.0',
-      crdsContext: 'jwst_1234.pmap',
-    },
-  };
-}
-
-function renderPage() {
+/** Renders the page alongside a stub run route so navigation is observable. */
+function renderPage(initialEntry: string | object = '/calibrate/seed-nircam-imaging') {
   return render(
-    <MemoryRouter initialEntries={['/calibrate/seed-nircam-imaging']}>
+    <MemoryRouter initialEntries={[initialEntry as string]}>
       <Routes>
         <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+        <Route path="/calibrate/runs/:jobId" element={<div>run detail stub</div>} />
       </Routes>
     </MemoryRouter>
   );
@@ -124,32 +73,37 @@ describe('CalibrateRun', () => {
     expect(screen.getByRole('button', { name: 'Run calibration' })).toBeEnabled();
   });
 
-  it('starts a run and shows live progress', async () => {
+  it('starts a run and hands off to the run URL', async () => {
     vi.mocked(startRun).mockResolvedValue({ jobId: 'job-1' });
-    vi.mocked(getJob).mockResolvedValue(runningJob());
     renderPage();
     await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
+
     await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
-    await waitFor(() => expect(screen.getByText('Run progress')).toBeInTheDocument());
+
     expect(vi.mocked(startRun)).toHaveBeenCalledWith({
       recipeId: 'seed-nircam-imaging',
       inputs: [],
       runOverrides: { jump: { maximum_cores: 'half' } },
       enabledStages: { detector1: true, image2: true, image3: true },
     });
-    await waitFor(() => expect(screen.getByText('image2')).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: 'Cancel run' })).toBeInTheDocument();
+    // The run lives at its own URL from the moment it starts (#1734) — the
+    // config page no longer owns the job id.
+    expect(await screen.findByText('run detail stub')).toBeInTheDocument();
   });
 
-  it('shows the failure state', async () => {
-    vi.mocked(startRun).mockResolvedValue({ jobId: 'job-1' });
-    const failed = { ...runningJob(), status: 'failed' as const, error: 'boom' };
-    vi.mocked(getJob).mockResolvedValue(failed);
+  it('keeps the form usable when the run fails to start', async () => {
+    vi.mocked(startRun).mockRejectedValue(new Error('engine down'));
     renderPage();
     await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
+
     await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
-    await waitFor(() => expect(screen.getByText(/Run failed: boom/)).toBeInTheDocument());
-    expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument();
+
+    expect(await screen.findByText(/engine down/)).toBeInTheDocument();
+    // Still on the config page, and the button is live again for a retry.
+    expect(screen.getByText('Stages')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Run calibration' })).toBeEnabled()
+    );
   });
 
   it('reprocess state selects stage-3 only and pre-fills inputs', async () => {
@@ -168,7 +122,6 @@ describe('CalibrateRun', () => {
       </MemoryRouter>
     );
     await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
-    // Only image3 is checked; the raw stages are unchecked for the fast path.
     const image3 = screen.getByRole('checkbox', { name: /image3/ });
     const detector1 = screen.getByRole('checkbox', { name: /detector1/ });
     expect(image3).toBeChecked();
@@ -195,104 +148,10 @@ describe('CalibrateRun', () => {
       </MemoryRouter>
     );
     await waitFor(() => expect(screen.getByText('Inputs')).toBeInTheDocument());
-    // Both _cal files listed; the pre-selected one is checked.
     const a = await screen.findByRole('checkbox', { name: /a_cal\.fits/ });
     const b = screen.getByRole('checkbox', { name: /b_cal\.fits/ });
     expect(a).toBeChecked();
     expect(b).not.toBeChecked();
     expect(screen.queryByText(/No matching library files/)).not.toBeInTheDocument();
-  });
-
-  describe('output previews', () => {
-    beforeEach(() => {
-      // jsdom has no object-URL support.
-      vi.stubGlobal('URL', {
-        ...URL,
-        createObjectURL: vi.fn(() => 'blob:preview'),
-        revokeObjectURL: vi.fn(),
-      });
-    });
-
-    async function renderSucceeded() {
-      vi.mocked(startRun).mockResolvedValue({ jobId: 'job-1' });
-      vi.mocked(getJob).mockResolvedValue(succeededJob());
-      renderPage();
-      await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
-      await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
-      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
-    }
-
-    it('renders FITS outputs as buttons and non-FITS as plain text', async () => {
-      await renderSucceeded();
-      expect(screen.getByRole('button', { name: /jw001_i2d\.fits/ })).toBeInTheDocument();
-      // The catalog output is not clickable.
-      expect(screen.queryByRole('button', { name: /jw001_cat\.ecsv/ })).not.toBeInTheDocument();
-      // Copy says "not an image" rather than "not previewable": the catalog is
-      // still downloadable, so the reason is the format, not a missing action.
-      expect(screen.getByText(/not an image/)).toBeInTheDocument();
-    });
-
-    it('opens the lightbox with the rendered preview when an output is clicked', async () => {
-      vi.mocked(getJobOutputPreview).mockResolvedValue(new Blob(['png'], { type: 'image/png' }));
-      await renderSucceeded();
-
-      await userEvent.click(screen.getByRole('button', { name: /jw001_i2d\.fits/ }));
-
-      // Fetched by jobId + output index (index 0), never by raw storage key.
-      expect(vi.mocked(getJobOutputPreview)).toHaveBeenCalledWith('job-1', 0);
-      const dialog = await screen.findByRole('dialog', { name: 'jw001_i2d.fits' });
-      expect(dialog).toBeInTheDocument();
-      const img = await screen.findByAltText('jw001_i2d.fits');
-      expect(img).toHaveAttribute('src', 'blob:preview');
-
-      // Esc closes it.
-      await userEvent.keyboard('{Escape}');
-      await waitFor(() =>
-        expect(screen.queryByRole('dialog', { name: 'jw001_i2d.fits' })).not.toBeInTheDocument()
-      );
-    });
-  });
-
-  describe('saving outputs to the library', () => {
-    async function renderSucceeded() {
-      vi.mocked(startRun).mockResolvedValue({ jobId: 'job-1' });
-      vi.mocked(getJob).mockResolvedValue(succeededJob());
-      renderPage();
-      await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
-      await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
-      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
-    }
-
-    it('saves a FITS output and then offers the compositor hop', async () => {
-      vi.mocked(saveJobOutputToLibrary).mockResolvedValue({ dataId: 'abc123', created: true });
-      await renderSucceeded();
-
-      // Before saving there is no compositor route — the output has no library id yet.
-      expect(screen.queryByRole('button', { name: 'Open in compositor' })).not.toBeInTheDocument();
-
-      await userEvent.click(screen.getByRole('button', { name: 'Save to library' }));
-
-      expect(vi.mocked(saveJobOutputToLibrary)).toHaveBeenCalledWith('job-1', 0);
-      expect(await screen.findByText('✓ In library')).toBeInTheDocument();
-      expect(await screen.findByRole('button', { name: 'Open in compositor' })).toBeInTheDocument();
-    });
-
-    it('keeps the run usable when saving fails', async () => {
-      vi.mocked(saveJobOutputToLibrary).mockRejectedValue(new Error('mongo is down'));
-      await renderSucceeded();
-
-      await userEvent.click(screen.getByRole('button', { name: 'Save to library' }));
-
-      // The button returns to its resting state so the user can retry.
-      expect(await screen.findByRole('button', { name: 'Save to library' })).toBeEnabled();
-      expect(screen.queryByText('✓ In library')).not.toBeInTheDocument();
-    });
-
-    it('offers download for a catalog, which cannot be saved as an image', async () => {
-      await renderSucceeded();
-      // Two outputs: the FITS gets save + download, the catalog download only.
-      expect(screen.getAllByRole('button', { name: 'Download' })).toHaveLength(2);
-      expect(screen.getAllByRole('button', { name: 'Save to library' })).toHaveLength(1);
-    });
   });
 });

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -1,38 +1,19 @@
 /**
- * Calibration run configuration + live progress (#1709 PR 8).
+ * Calibration run configuration — /calibrate/:recipeId.
  *
- * /calibrate/:recipeId — stage toggles, per-step parameter editor (seeded
- * from the recipe's own overrides), input selection (recipe MAST query or
- * library _cal files), then a live progress view: per-stage checklist,
- * download %, log tail, cancel.
+ * Stage toggles, per-step parameter editor (seeded from the recipe's own
+ * overrides) and input selection. Starting a run navigates to
+ * /calibrate/runs/:jobId (#1734): a run outlives this page, so its progress
+ * belongs at a durable URL rather than in this component's state.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
-import { LogPanel } from '../components/wizard/LogPanel';
 import { EmptyState } from '../components/ui/EmptyState';
-import { ImagePreviewLightbox } from '../components/ui/ImagePreviewLightbox';
-import { useCalibrationJob } from '../hooks/useCalibrationJob';
-import {
-  cancelJob,
-  downloadJobOutput,
-  getJobOutputPreview,
-  getRecipe,
-  saveJobOutputToLibrary,
-  startRun,
-} from '../services/calibrationService';
-import { toast } from '../components/ui/toast';
+import { getRecipe, startRun } from '../services/calibrationService';
 import * as jwstDataService from '../services/jwstDataService';
 import type { CalibrationRecipe, ScalarOverride, StepOverrides } from '../types/CalibrationTypes';
 import './CalibrateRun.css';
-
-/** Only FITS image products can be rendered by the preview endpoint; catalogs
- *  (.ecsv) and ASDF outputs are shown but not clickable. */
-// Kept in lockstep with the backend allowlist _PREVIEWABLE_SUFFIXES
-// (.fits, .fit, .fits.gz) in processing-engine/app/jobs/routes.py.
-const PREVIEWABLE_RE = /\.(fits(\.gz)?|fit)$/i;
-const isPreviewable = (storageKey: string): boolean => PREVIEWABLE_RE.test(storageKey);
-const basename = (key: string): string => key.split('/').pop() ?? key;
 
 interface ParamRow {
   step: string;
@@ -101,26 +82,9 @@ export default function CalibrateRun() {
   const [libraryFiles, setLibraryFiles] = useState<string[]>([]);
   const [selectedInputs, setSelectedInputs] = useState<string[]>([]);
 
-  const [jobId, setJobId] = useState<string | null>(null);
-  const [cancelling, setCancelling] = useState(false);
+  const [starting, setStarting] = useState(false);
   const [startError, setStartError] = useState<string | null>(null);
-  const { job, isTerminal, error: pollError } = useCalibrationJob(jobId);
-
-  // Output index -> library id, for outputs saved during this visit. Drives the
-  // "Saved" affordance and unlocks the compositor hop, which is keyed by that id.
-  const [savedIds, setSavedIds] = useState<Record<number, string>>({});
-  const [savingIndex, setSavingIndex] = useState<number | null>(null);
   const navigate = useNavigate();
-
-  // Index of the output currently shown in the ephemeral preview lightbox.
-  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
-  const loadPreview = useCallback(
-    () => getJobOutputPreview(jobId ?? '', previewIndex ?? 0),
-    [jobId, previewIndex]
-  );
-  // Stable identity so the lightbox's fetch/keydown effects don't re-run on
-  // every job-poll re-render of this page.
-  const closePreview = useCallback(() => setPreviewIndex(null), []);
 
   useEffect(() => {
     if (!recipeId) return undefined;
@@ -188,51 +152,15 @@ export default function CalibrateRun() {
   }, [needsLibraryInputs, recipe, reprocessInputs, inputSuffixes]);
 
   const runDisabled = useMemo(() => {
-    if (!recipe || jobId) return true;
+    if (!recipe || starting) return true;
     if (needsLibraryInputs && selectedInputs.length === 0) return true;
     return !Object.values(enabledStages).some(Boolean);
-  }, [recipe, jobId, needsLibraryInputs, selectedInputs, enabledStages]);
-
-  const handleSave = async (index: number) => {
-    if (!jobId) return;
-    setSavingIndex(index);
-    try {
-      const { dataId, created } = await saveJobOutputToLibrary(jobId, index);
-      setSavedIds((prev) => ({ ...prev, [index]: dataId }));
-      toast.success(created ? 'Saved to library' : 'Already in your library', {
-        description: created
-          ? 'Opens in the full viewer, and can be used in a composite.'
-          : 'This output was saved earlier — reusing that record.',
-      });
-    } catch (err: unknown) {
-      toast.error('Could not save to library', {
-        description: err instanceof Error ? err.message : 'Unexpected error',
-      });
-    } finally {
-      setSavingIndex(null);
-    }
-  };
-
-  const handleDownload = async (index: number, storageKey: string) => {
-    if (!jobId) return;
-    try {
-      const blob = await downloadJobOutput(jobId, index);
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
-      anchor.href = url;
-      anchor.download = basename(storageKey);
-      anchor.click();
-      URL.revokeObjectURL(url);
-    } catch (err: unknown) {
-      toast.error('Download failed', {
-        description: err instanceof Error ? err.message : 'Unexpected error',
-      });
-    }
-  };
+  }, [recipe, starting, needsLibraryInputs, selectedInputs, enabledStages]);
 
   const handleRun = async () => {
     if (!recipe) return;
     setStartError(null);
+    setStarting(true);
     try {
       const response = await startRun({
         recipeId: recipe.id,
@@ -240,8 +168,11 @@ export default function CalibrateRun() {
         runOverrides: overridesFromRows(paramRows),
         enabledStages,
       });
-      setJobId(response.jobId);
+      // Hand off to the run's own URL — it survives refresh and stays
+      // reachable from the history once we navigate away.
+      navigate(`/calibrate/runs/${response.jobId}`);
     } catch (err: unknown) {
+      setStarting(false);
       setStartError(err instanceof Error ? err.message : 'Failed to start run');
     }
   };
@@ -269,279 +200,130 @@ export default function CalibrateRun() {
       <h1>{recipe.name}</h1>
       <p className="calibrate-run-description">{recipe.description}</p>
 
-      {!jobId && (
-        <>
-          <section className="calibrate-section" aria-labelledby="stages-heading">
-            <h2 id="stages-heading">Stages</h2>
-            <div className="calibrate-stage-toggles">
-              {recipe.stages.map((stage) => (
-                <label key={stage.name} className="calibrate-stage-toggle">
-                  <input
-                    type="checkbox"
-                    checked={enabledStages[stage.name] ?? false}
-                    onChange={(event) =>
-                      setEnabledStages((prev) => ({
-                        ...prev,
-                        [stage.name]: event.target.checked,
-                      }))
-                    }
-                  />
-                  <span>{stage.name}</span>
-                </label>
-              ))}
-            </div>
-          </section>
+      <section className="calibrate-section" aria-labelledby="stages-heading">
+        <h2 id="stages-heading">Stages</h2>
+        <div className="calibrate-stage-toggles">
+          {recipe.stages.map((stage) => (
+            <label key={stage.name} className="calibrate-stage-toggle">
+              <input
+                type="checkbox"
+                checked={enabledStages[stage.name] ?? false}
+                onChange={(event) =>
+                  setEnabledStages((prev) => ({
+                    ...prev,
+                    [stage.name]: event.target.checked,
+                  }))
+                }
+              />
+              <span>{stage.name}</span>
+            </label>
+          ))}
+        </div>
+      </section>
 
-          <section className="calibrate-section" aria-labelledby="params-heading">
-            <h2 id="params-heading">Parameters</h2>
-            <p className="calibrate-hint">
-              Values are jwst step parameters; run values override the recipe. Numbers/booleans are
-              auto-detected — wrap a value in quotes (&quot;010&quot;) to force a string; lists use
-              JSON ([1.0, 2.0]).
-            </p>
-            {paramRows.map((row, index) => (
-              <div className="calibrate-param-row" key={`${row.step}-${row.param}-${index}`}>
-                <input
-                  aria-label={`Step for parameter ${index + 1}`}
-                  value={row.step}
-                  onChange={(e) =>
-                    setParamRows((rows) =>
-                      rows.map((r, i) => (i === index ? { ...r, step: e.target.value } : r))
-                    )
-                  }
-                />
-                <input
-                  aria-label={`Name for parameter ${index + 1}`}
-                  value={row.param}
-                  onChange={(e) =>
-                    setParamRows((rows) =>
-                      rows.map((r, i) => (i === index ? { ...r, param: e.target.value } : r))
-                    )
-                  }
-                />
-                <input
-                  aria-label={`Value for parameter ${index + 1}`}
-                  value={row.value}
-                  onChange={(e) =>
-                    setParamRows((rows) =>
-                      rows.map((r, i) => (i === index ? { ...r, value: e.target.value } : r))
-                    )
-                  }
-                />
-                <button
-                  type="button"
-                  className="btn-base btn-compact"
-                  onClick={() => setParamRows((rows) => rows.filter((_, i) => i !== index))}
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
+      <section className="calibrate-section" aria-labelledby="params-heading">
+        <h2 id="params-heading">Parameters</h2>
+        <p className="calibrate-hint">
+          Values are jwst step parameters; run values override the recipe. Numbers/booleans are
+          auto-detected — wrap a value in quotes (&quot;010&quot;) to force a string; lists use JSON
+          ([1.0, 2.0]).
+        </p>
+        {paramRows.map((row, index) => (
+          <div className="calibrate-param-row" key={`${row.step}-${row.param}-${index}`}>
+            <input
+              aria-label={`Step for parameter ${index + 1}`}
+              value={row.step}
+              onChange={(e) =>
+                setParamRows((rows) =>
+                  rows.map((r, i) => (i === index ? { ...r, step: e.target.value } : r))
+                )
+              }
+            />
+            <input
+              aria-label={`Name for parameter ${index + 1}`}
+              value={row.param}
+              onChange={(e) =>
+                setParamRows((rows) =>
+                  rows.map((r, i) => (i === index ? { ...r, param: e.target.value } : r))
+                )
+              }
+            />
+            <input
+              aria-label={`Value for parameter ${index + 1}`}
+              value={row.value}
+              onChange={(e) =>
+                setParamRows((rows) =>
+                  rows.map((r, i) => (i === index ? { ...r, value: e.target.value } : r))
+                )
+              }
+            />
             <button
               type="button"
               className="btn-base btn-compact"
-              onClick={() => setParamRows((rows) => [...rows, { step: '', param: '', value: '' }])}
+              onClick={() => setParamRows((rows) => rows.filter((_, i) => i !== index))}
             >
-              Add parameter
+              Remove
             </button>
-          </section>
+          </div>
+        ))}
+        <button
+          type="button"
+          className="btn-base btn-compact"
+          onClick={() => setParamRows((rows) => [...rows, { step: '', param: '', value: '' }])}
+        >
+          Add parameter
+        </button>
+      </section>
 
-          <section className="calibrate-section" aria-labelledby="inputs-heading">
-            <h2 id="inputs-heading">Inputs</h2>
-            {needsLibraryInputs ? (
-              libraryFiles.length === 0 ? (
-                <p className="calibrate-hint">
-                  No matching library files found (looking for {inputSuffixes.join(', ')}).
-                </p>
-              ) : (
-                <ul className="calibrate-input-list">
-                  {libraryFiles.map((file) => (
-                    <li key={file}>
-                      <label>
-                        <input
-                          type="checkbox"
-                          checked={selectedInputs.includes(file)}
-                          onChange={(event) =>
-                            setSelectedInputs((prev) =>
-                              event.target.checked
-                                ? [...prev, file]
-                                : prev.filter((f) => f !== file)
-                            )
-                          }
-                        />
-                        <span className="calibrate-input-file">{file}</span>
-                      </label>
-                    </li>
-                  ))}
-                </ul>
-              )
-            ) : (
-              <p className="calibrate-hint">
-                Data is fetched from MAST (proposal{' '}
-                {recipe.input_source.type === 'mast_query' ? recipe.input_source.proposal_id : ''})
-                when the run starts.
-              </p>
-            )}
-          </section>
-
-          {startError && (
-            <p className="calibrate-error" role="alert">
-              {startError}
+      <section className="calibrate-section" aria-labelledby="inputs-heading">
+        <h2 id="inputs-heading">Inputs</h2>
+        {needsLibraryInputs ? (
+          libraryFiles.length === 0 ? (
+            <p className="calibrate-hint">
+              No matching library files found (looking for {inputSuffixes.join(', ')}).
             </p>
-          )}
-          <button
-            type="button"
-            className="btn-base btn-standard calibrate-run-button"
-            disabled={runDisabled}
-            onClick={() => void handleRun()}
-          >
-            Run calibration
-          </button>
-        </>
-      )}
+          ) : (
+            <ul className="calibrate-input-list">
+              {libraryFiles.map((file) => (
+                <li key={file}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={selectedInputs.includes(file)}
+                      onChange={(event) =>
+                        setSelectedInputs((prev) =>
+                          event.target.checked ? [...prev, file] : prev.filter((f) => f !== file)
+                        )
+                      }
+                    />
+                    <span className="calibrate-input-file">{file}</span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )
+        ) : (
+          <p className="calibrate-hint">
+            Data is fetched from MAST (proposal{' '}
+            {recipe.input_source.type === 'mast_query' ? recipe.input_source.proposal_id : ''}) when
+            the run starts.
+          </p>
+        )}
+      </section>
 
-      {jobId && (
-        <section className="calibrate-section" aria-labelledby="progress-heading">
-          <h2 id="progress-heading">Run progress</h2>
-          {pollError && (
-            <p className="calibrate-hint" role="alert">
-              {pollError} (retrying…)
-            </p>
-          )}
-          {job && (
-            <>
-              <p className="calibrate-status" role="status">
-                Status: <strong>{job.status}</strong>
-                {job.progress.message ? ` — ${job.progress.message}` : ''}
-                {job.status === 'downloading' && job.progress.downloadPct !== null
-                  ? ` (${job.progress.downloadPct}%)`
-                  : ''}
-              </p>
-              {job.progress.stages.length > 0 && (
-                <ul className="calibrate-stage-checklist">
-                  {job.progress.stages.map((stage) => (
-                    <li key={stage.name} data-status={stage.status}>
-                      <span className="calibrate-stage-status">
-                        {stage.status === 'done' ? '✓' : stage.status === 'running' ? '…' : '○'}
-                      </span>
-                      {stage.name}
-                    </li>
-                  ))}
-                </ul>
-              )}
-              <LogPanel messages={job.logTail} defaultOpen={true} />
-              {!isTerminal && (
-                <button
-                  type="button"
-                  className="btn-base btn-compact"
-                  onClick={() => {
-                    setCancelling(true);
-                    cancelJob(job.jobId).catch(() => setCancelling(false));
-                  }}
-                  disabled={cancelling || job.cancelRequested}
-                >
-                  {cancelling || job.cancelRequested ? 'Cancelling…' : 'Cancel run'}
-                </button>
-              )}
-              {job.status === 'succeeded' && job.result && (
-                <div className="calibrate-result" role="status">
-                  <h3>Outputs</h3>
-                  <ul className="calibrate-output-list">
-                    {job.result.outputs.map((output, i) => {
-                      const sizeMb = (output.sizeBytes / 1024 / 1024).toFixed(1);
-                      const previewable = isPreviewable(output.storageKey);
-                      const savedId = savedIds[i];
-                      return (
-                        <li key={output.storageKey}>
-                          <div className="calibrate-output-line">
-                            {previewable ? (
-                              <button
-                                type="button"
-                                className="btn-base calibrate-output-preview"
-                                onClick={() => setPreviewIndex(i)}
-                                title="Preview this output"
-                              >
-                                <code>{output.storageKey}</code>
-                              </button>
-                            ) : (
-                              <code>{output.storageKey}</code>
-                            )}{' '}
-                            ({sizeMb} MB)
-                            {!previewable && (
-                              <span className="calibrate-hint"> · not an image</span>
-                            )}
-                          </div>
-                          <div className="calibrate-output-actions">
-                            {previewable &&
-                              (savedId ? (
-                                <>
-                                  <span className="calibrate-saved-badge">✓ In library</span>
-                                  <button
-                                    type="button"
-                                    className="btn-base btn-compact"
-                                    onClick={() =>
-                                      navigate('/composite', {
-                                        state: { initialSelection: [savedId] },
-                                      })
-                                    }
-                                  >
-                                    Open in compositor
-                                  </button>
-                                </>
-                              ) : (
-                                <button
-                                  type="button"
-                                  className="btn-base btn-compact"
-                                  onClick={() => void handleSave(i)}
-                                  disabled={savingIndex === i}
-                                >
-                                  {savingIndex === i ? 'Saving…' : 'Save to library'}
-                                </button>
-                              ))}
-                            <button
-                              type="button"
-                              className="btn-base btn-compact"
-                              onClick={() => void handleDownload(i, output.storageKey)}
-                            >
-                              Download
-                            </button>
-                          </div>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                  {job.result.jwstVersion && (
-                    <p className="calibrate-hint">
-                      jwst {job.result.jwstVersion}
-                      {job.result.crdsContext ? ` · CRDS ${job.result.crdsContext}` : ''}
-                    </p>
-                  )}
-                </div>
-              )}
-              {job.status === 'failed' && (
-                <p className="calibrate-error" role="alert">
-                  Run failed: {job.error ?? 'unknown error'}
-                </p>
-              )}
-              {job.status === 'cancelled' && (
-                <p className="calibrate-hint" role="status">
-                  Run cancelled.
-                </p>
-              )}
-            </>
-          )}
-        </section>
+      {startError && (
+        <p className="calibrate-error" role="alert">
+          {startError}
+        </p>
       )}
-
-      {previewIndex !== null && job?.result?.outputs[previewIndex] && (
-        <ImagePreviewLightbox
-          key={job.result.outputs[previewIndex].storageKey}
-          open
-          title={basename(job.result.outputs[previewIndex].storageKey)}
-          onClose={closePreview}
-          loadImage={loadPreview}
-        />
-      )}
+      <button
+        type="button"
+        className="btn-base btn-standard calibrate-run-button"
+        disabled={runDisabled}
+        onClick={() => void handleRun()}
+      >
+        Run calibration
+      </button>
     </div>
   );
 }

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.css
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.css
@@ -136,3 +136,17 @@
   color: var(--text-muted);
   font-size: 0.85rem;
 }
+
+/* Title + "View runs" share a row so run history is reachable from the
+   gallery without hunting for it in the nav. */
+.calibration-gallery-titlerow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.calibration-gallery-titlerow h1 {
+  margin: 0;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
@@ -121,7 +121,12 @@ export default function CalibrationGallery() {
   return (
     <div className="calibration-gallery">
       <header className="calibration-gallery-header">
-        <h1>Calibration Recipes</h1>
+        <div className="calibration-gallery-titlerow">
+          <h1>Calibration Recipes</h1>
+          <Link className="btn-base btn-compact" to="/calibrate/runs">
+            View runs
+          </Link>
+        </div>
         <p className="calibration-gallery-subtitle">
           Run the official JWST calibration pipeline with curated, editable settings — from quick
           Stage&nbsp;3 re-mosaics of library data to full raw-data reductions.

--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.css
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.css
@@ -1,0 +1,109 @@
+.calibration-runs {
+  padding: 1.5rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.calibration-runs-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+
+.calibration-runs-header h1 {
+  margin: 0 0 0.25rem;
+}
+
+.calibration-runs-section {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  margin: 1.25rem 0 0.5rem;
+}
+
+.runs-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.runs-row {
+  display: grid;
+  grid-template-columns: 92px 1fr auto;
+  gap: 0.85rem;
+  align-items: center;
+  padding: 0.7rem 0.85rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+}
+
+/* Active runs get a visible edge so they read as "still happening". */
+.runs-row-running,
+.runs-row-downloading {
+  border-color: var(--border-interactive-hover, rgba(74, 144, 217, 0.4));
+}
+
+.runs-pill {
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.45rem;
+  border-radius: 3px;
+  text-align: center;
+}
+
+.runs-pill-running,
+.runs-pill-downloading {
+  color: var(--accent-primary);
+  background: var(--accent-primary-subtle, rgba(59, 130, 246, 0.12));
+}
+
+.runs-pill-queued {
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.runs-pill-succeeded {
+  color: var(--success, #34d399);
+  background: var(--success-subtle, rgba(52, 211, 153, 0.12));
+}
+
+.runs-pill-failed {
+  color: var(--error, #f87171);
+  background: var(--error-subtle, rgba(248, 113, 113, 0.12));
+}
+
+.runs-pill-cancelled {
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.runs-row-link {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85rem;
+}
+
+.runs-row-meta {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  margin-top: 0.15rem;
+  overflow-wrap: anywhere;
+}
+
+.runs-row-right {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .runs-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Run history (#1734) — the first consumer of the engine's job list.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import CalibrationRuns from './CalibrationRuns';
+import type { CalibrationJob } from '../types/CalibrationTypes';
+
+vi.mock('../services/calibrationService', () => ({
+  listJobs: vi.fn(),
+}));
+
+import { listJobs } from '../services/calibrationService';
+
+function job(over: Partial<CalibrationJob> & { jobId: string }): CalibrationJob {
+  return {
+    type: 'calibration',
+    status: 'succeeded',
+    cancelRequested: false,
+    createdAt: '2026-07-24T00:00:00Z',
+    startedAt: '2026-07-24T00:00:00Z',
+    finishedAt: '2026-07-24T00:30:00Z',
+    progress: { stages: [], currentStage: null, message: null, downloadPct: null },
+    logTail: [],
+    result: { outputs: [], jwstVersion: null, crdsContext: null },
+    error: null,
+    request: {},
+    ...over,
+  } as CalibrationJob;
+}
+
+function renderRuns() {
+  return render(
+    <MemoryRouter>
+      <CalibrationRuns />
+    </MemoryRouter>
+  );
+}
+
+describe('CalibrationRuns', () => {
+  it('separates active runs from history and links each to its own URL', async () => {
+    vi.mocked(listJobs).mockResolvedValue([
+      job({ jobId: 'run-active', status: 'running', finishedAt: null }),
+      job({ jobId: 'run-done' }),
+    ]);
+    renderRuns();
+
+    await waitFor(() => expect(screen.getByText('Active')).toBeInTheDocument());
+    expect(screen.getByText('History')).toBeInTheDocument();
+    // Each run is reachable at a durable URL — the point of the page.
+    expect(screen.getByRole('link', { name: 'run-active' })).toHaveAttribute(
+      'href',
+      '/calibrate/runs/run-active'
+    );
+    expect(screen.getByRole('link', { name: 'run-done' })).toHaveAttribute(
+      'href',
+      '/calibrate/runs/run-done'
+    );
+  });
+
+  it('explains that a queued run is waiting on the single-run limit', async () => {
+    vi.mocked(listJobs).mockResolvedValue([
+      job({ jobId: 'run-q', status: 'queued', startedAt: null, finishedAt: null }),
+    ]);
+    renderRuns();
+    expect(await screen.findByText(/one calibration at a time/)).toBeInTheDocument();
+  });
+
+  it('invites a first run when there is no history', async () => {
+    vi.mocked(listJobs).mockResolvedValue([]);
+    renderRuns();
+    expect(await screen.findByText('No calibration runs yet')).toBeInTheDocument();
+  });
+
+  it('surfaces a load failure instead of rendering an empty list', async () => {
+    vi.mocked(listJobs).mockRejectedValue(new Error('engine unreachable'));
+    renderRuns();
+    expect(await screen.findByText("Couldn't load runs")).toBeInTheDocument();
+    expect(screen.getByText('engine unreachable')).toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.tsx
@@ -1,0 +1,140 @@
+/**
+ * Calibration run history — /calibrate/runs (#1734).
+ *
+ * Runs are long (up to the 4h CALIBRATION_TIMEOUT_S) and only one executes at
+ * a time, so they need a durable home. Before this page the engine's job list
+ * had no consumer at all: a run you navigated away from was unreachable.
+ */
+
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { EmptyState } from '../components/ui/EmptyState';
+import { listJobs } from '../services/calibrationService';
+import type { CalibrationJob } from '../types/CalibrationTypes';
+import './CalibrationRuns.css';
+
+const ACTIVE: ReadonlySet<CalibrationJob['status']> = new Set(['queued', 'downloading', 'running']);
+
+function elapsed(job: CalibrationJob): string {
+  const start = job.startedAt ?? job.createdAt;
+  const end = job.finishedAt ?? new Date().toISOString();
+  const ms = Date.parse(end) - Date.parse(start);
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  const mins = Math.round(ms / 60000);
+  if (mins < 1) return '<1m';
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+export function RunRow({ job }: { job: CalibrationJob }) {
+  const outputs = job.result?.outputs.length ?? 0;
+  return (
+    <li className={`runs-row runs-row-${job.status}`}>
+      <span className={`runs-pill runs-pill-${job.status}`}>{job.status}</span>
+      <div className="runs-row-main">
+        <Link className="runs-row-link" to={`/calibrate/runs/${job.jobId}`}>
+          {job.jobId}
+        </Link>
+        <div className="runs-row-meta">
+          {job.status === 'queued'
+            ? 'Waiting — the engine runs one calibration at a time'
+            : (job.progress.message ??
+              (job.status === 'succeeded'
+                ? `${outputs} output${outputs === 1 ? '' : 's'}`
+                : (job.error ?? '—')))}
+        </div>
+      </div>
+      <div className="runs-row-right">{elapsed(job)}</div>
+    </li>
+  );
+}
+
+export default function CalibrationRuns() {
+  const [jobs, setJobs] = useState<CalibrationJob[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      listJobs()
+        .then((list) => {
+          if (!cancelled) setJobs(list);
+        })
+        .catch((err: unknown) => {
+          if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load runs');
+        });
+    };
+    load();
+    // Keep the list fresh while something is still running, without a socket.
+    const timer = setInterval(load, 10000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="calibration-runs">
+        <EmptyState title="Couldn't load runs" description={error} />
+      </div>
+    );
+  }
+
+  const active = jobs?.filter((j) => ACTIVE.has(j.status)) ?? [];
+  const past = jobs?.filter((j) => !ACTIVE.has(j.status)) ?? [];
+
+  return (
+    <div className="calibration-runs">
+      <header className="calibration-runs-header">
+        <div>
+          <h1>Calibration runs</h1>
+          <p className="calibrate-hint">
+            {jobs === null ? 'Loading…' : `${active.length} active · ${past.length} completed`}
+          </p>
+        </div>
+        <Link className="btn-base btn-compact" to="/calibrate">
+          Browse recipes
+        </Link>
+      </header>
+
+      {jobs !== null && jobs.length === 0 && (
+        <EmptyState
+          title="No calibration runs yet"
+          description="Pick a recipe and start one — it'll show up here, and stay here even if you navigate away."
+          actions={
+            <Link className="btn-base btn-standard" to="/calibrate">
+              Browse recipes
+            </Link>
+          }
+        />
+      )}
+
+      {active.length > 0 && (
+        <section aria-labelledby="active-heading">
+          <h2 id="active-heading" className="calibration-runs-section">
+            Active
+          </h2>
+          <ul className="runs-list">
+            {active.map((job) => (
+              <RunRow key={job.jobId} job={job} />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {past.length > 0 && (
+        <section aria-labelledby="history-heading">
+          <h2 id="history-heading" className="calibration-runs-section">
+            History
+          </h2>
+          <ul className="runs-list">
+            {past.map((job) => (
+              <RunRow key={job.jobId} job={job} />
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Run detail (#1734). These cases moved here from CalibrateRun.test.tsx along
+ * with the progress/outputs UI — the run now has its own page and URL.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import RunDetail from './RunDetail';
+import type { CalibrationJob } from '../types/CalibrationTypes';
+
+vi.mock('../services/calibrationService', () => ({
+  getJob: vi.fn(),
+  cancelJob: vi.fn(),
+  getJobOutputPreview: vi.fn(),
+  saveJobOutputToLibrary: vi.fn(),
+  downloadJobOutput: vi.fn(),
+}));
+
+import {
+  getJob,
+  getJobOutputPreview,
+  saveJobOutputToLibrary,
+} from '../services/calibrationService';
+
+function runningJob(): CalibrationJob {
+  return {
+    jobId: 'job-1',
+    type: 'calibration',
+    status: 'running',
+    cancelRequested: false,
+    createdAt: '2026-07-24T00:00:00Z',
+    startedAt: '2026-07-24T00:00:01Z',
+    finishedAt: null,
+    progress: {
+      stages: [
+        { name: 'detector1', status: 'done' },
+        { name: 'image2', status: 'running' },
+        { name: 'image3', status: 'pending' },
+      ],
+      currentStage: 'image2',
+      message: 'running image2',
+      downloadPct: null,
+    },
+    logTail: ['Step flat_field running'],
+    result: null,
+    error: null,
+    request: {},
+  };
+}
+
+function succeededJob(): CalibrationJob {
+  return {
+    ...runningJob(),
+    status: 'succeeded',
+    finishedAt: '2026-07-24T00:05:00Z',
+    result: {
+      outputs: [
+        { storageKey: 'calibration/job-1/jw001_i2d.fits', suffix: '_i2d', sizeBytes: 5242880 },
+        { storageKey: 'calibration/job-1/jw001_cat.ecsv', suffix: '_cat', sizeBytes: 2048 },
+      ],
+      jwstVersion: '1.14.0',
+      crdsContext: 'jwst_1234.pmap',
+    },
+  };
+}
+
+function renderRun() {
+  return render(
+    <MemoryRouter initialEntries={['/calibrate/runs/job-1']}>
+      <Routes>
+        <Route path="/calibrate/runs/:jobId" element={<RunDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('RunDetail', () => {
+  beforeEach(() => {
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:preview'),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  it('reads the job id from the URL and shows live progress', async () => {
+    vi.mocked(getJob).mockResolvedValue(runningJob());
+    renderRun();
+
+    // The id comes from the route, so the page works on a cold load/refresh.
+    expect(vi.mocked(getJob)).toHaveBeenCalledWith('job-1');
+    await waitFor(() => expect(screen.getByText('image2')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Cancel run' })).toBeInTheDocument();
+  });
+
+  it('explains why a queued run is waiting', async () => {
+    vi.mocked(getJob).mockResolvedValue({ ...runningJob(), status: 'queued' });
+    renderRun();
+    expect(await screen.findByText(/one calibration at a time/)).toBeInTheDocument();
+  });
+
+  it('shows the failure state', async () => {
+    vi.mocked(getJob).mockResolvedValue({
+      ...runningJob(),
+      status: 'failed' as const,
+      error: 'boom',
+    });
+    renderRun();
+    await waitFor(() => expect(screen.getByText(/Run failed: boom/)).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument();
+  });
+
+  describe('outputs', () => {
+    beforeEach(() => {
+      vi.mocked(getJob).mockResolvedValue(succeededJob());
+    });
+
+    it('renders FITS outputs as buttons and non-FITS as plain text', async () => {
+      renderRun();
+      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+      expect(screen.getByRole('button', { name: /jw001_i2d\.fits/ })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /jw001_cat\.ecsv/ })).not.toBeInTheDocument();
+      expect(screen.getByText(/not an image/)).toBeInTheDocument();
+    });
+
+    it('opens the lightbox with the rendered preview when an output is clicked', async () => {
+      vi.mocked(getJobOutputPreview).mockResolvedValue(new Blob(['png'], { type: 'image/png' }));
+      renderRun();
+      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+
+      await userEvent.click(screen.getByRole('button', { name: /jw001_i2d\.fits/ }));
+
+      expect(vi.mocked(getJobOutputPreview)).toHaveBeenCalledWith('job-1', 0);
+      expect(await screen.findByRole('dialog', { name: 'jw001_i2d.fits' })).toBeInTheDocument();
+
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() =>
+        expect(screen.queryByRole('dialog', { name: 'jw001_i2d.fits' })).not.toBeInTheDocument()
+      );
+    });
+
+    it('saves a FITS output and then offers the compositor hop', async () => {
+      vi.mocked(saveJobOutputToLibrary).mockResolvedValue({ dataId: 'abc123', created: true });
+      renderRun();
+      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+
+      expect(screen.queryByRole('link', { name: 'Open in compositor' })).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Save to library' }));
+
+      expect(vi.mocked(saveJobOutputToLibrary)).toHaveBeenCalledWith('job-1', 0);
+      expect(await screen.findByText('✓ In library')).toBeInTheDocument();
+      expect(await screen.findByRole('link', { name: 'Open in compositor' })).toBeInTheDocument();
+    });
+
+    it('keeps the run usable when saving fails', async () => {
+      vi.mocked(saveJobOutputToLibrary).mockRejectedValue(new Error('mongo is down'));
+      renderRun();
+      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+
+      await userEvent.click(screen.getByRole('button', { name: 'Save to library' }));
+
+      expect(await screen.findByRole('button', { name: 'Save to library' })).toBeEnabled();
+      expect(screen.queryByText('✓ In library')).not.toBeInTheDocument();
+    });
+
+    it('offers download for a catalog, which cannot be saved as an image', async () => {
+      renderRun();
+      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+      expect(screen.getAllByRole('button', { name: 'Download' })).toHaveLength(2);
+      expect(screen.getAllByRole('button', { name: 'Save to library' })).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -1,0 +1,247 @@
+/**
+ * Calibration run detail — /calibrate/runs/:jobId (#1734).
+ *
+ * A run can take hours and only one executes at a time, so its handle belongs
+ * in the URL rather than in component state: this page survives a refresh, can
+ * be bookmarked, and can be reopened from the run history. Previously the job
+ * id lived in `useState` on CalibrateRun, so navigating away orphaned the run
+ * with no way back to it.
+ */
+
+import { useCallback, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { LogPanel } from '../components/wizard/LogPanel';
+import { EmptyState } from '../components/ui/EmptyState';
+import { ImagePreviewLightbox } from '../components/ui/ImagePreviewLightbox';
+import { toast } from '../components/ui/toast';
+import { useCalibrationJob } from '../hooks/useCalibrationJob';
+import {
+  cancelJob,
+  downloadJobOutput,
+  getJobOutputPreview,
+  saveJobOutputToLibrary,
+} from '../services/calibrationService';
+import './CalibrateRun.css';
+
+/** Only FITS image products can be rendered or saved as library images;
+ *  catalogs (.ecsv) and ASDF outputs are download-only. */
+// Kept in lockstep with the backend allowlist _PREVIEWABLE_SUFFIXES
+// (.fits, .fit, .fits.gz) in processing-engine/app/jobs/routes.py.
+const PREVIEWABLE_RE = /\.(fits(\.gz)?|fit)$/i;
+const isPreviewable = (storageKey: string): boolean => PREVIEWABLE_RE.test(storageKey);
+const basename = (key: string): string => key.split('/').pop() ?? key;
+
+export default function RunDetail() {
+  const { jobId } = useParams<{ jobId: string }>();
+  const { job, isTerminal, error: pollError } = useCalibrationJob(jobId ?? null);
+
+  const [cancelling, setCancelling] = useState(false);
+  const [savedIds, setSavedIds] = useState<Record<number, string>>({});
+  const [savingIndex, setSavingIndex] = useState<number | null>(null);
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+
+  const loadPreview = useCallback(
+    () => getJobOutputPreview(jobId ?? '', previewIndex ?? 0),
+    [jobId, previewIndex]
+  );
+  // Stable identity so the lightbox's effects don't re-run on every poll tick.
+  const closePreview = useCallback(() => setPreviewIndex(null), []);
+
+  const handleSave = async (index: number) => {
+    if (!jobId) return;
+    setSavingIndex(index);
+    try {
+      const { dataId, created } = await saveJobOutputToLibrary(jobId, index);
+      setSavedIds((prev) => ({ ...prev, [index]: dataId }));
+      toast.success(created ? 'Saved to library' : 'Already in your library', {
+        description: created
+          ? 'Opens in the full viewer, and can be used in a composite.'
+          : 'This output was saved earlier — reusing that record.',
+      });
+    } catch (err: unknown) {
+      toast.error('Could not save to library', {
+        description: err instanceof Error ? err.message : 'Unexpected error',
+      });
+    } finally {
+      setSavingIndex(null);
+    }
+  };
+
+  const handleDownload = async (index: number, storageKey: string) => {
+    if (!jobId) return;
+    try {
+      const blob = await downloadJobOutput(jobId, index);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = basename(storageKey);
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch (err: unknown) {
+      toast.error('Download failed', {
+        description: err instanceof Error ? err.message : 'Unexpected error',
+      });
+    }
+  };
+
+  if (!jobId) {
+    return (
+      <div className="calibrate-run">
+        <EmptyState title="No run selected" description="Pick a run from the history." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="calibrate-run">
+      <nav className="calibrate-run-breadcrumb">
+        <Link to="/calibrate/runs">← All runs</Link>
+      </nav>
+      <h1>Calibration run</h1>
+      <p className="calibrate-hint calibrate-run-id">
+        <code>{jobId}</code>
+      </p>
+
+      <section className="calibrate-section" aria-labelledby="progress-heading">
+        <h2 id="progress-heading">Run progress</h2>
+        {pollError && (
+          <p className="calibrate-hint" role="alert">
+            {pollError} (retrying…)
+          </p>
+        )}
+        {!job && !pollError && <p role="status">Loading run…</p>}
+        {job && (
+          <>
+            <p className="calibrate-status" role="status">
+              Status: <strong>{job.status}</strong>
+              {job.progress.message ? ` — ${job.progress.message}` : ''}
+              {job.status === 'downloading' && job.progress.downloadPct !== null
+                ? ` (${job.progress.downloadPct}%)`
+                : ''}
+            </p>
+            {job.status === 'queued' && (
+              <p className="calibrate-hint">
+                Waiting to start — the engine runs one calibration at a time.
+              </p>
+            )}
+            {job.progress.stages.length > 0 && (
+              <ul className="calibrate-stage-checklist">
+                {job.progress.stages.map((stage) => (
+                  <li key={stage.name} data-status={stage.status}>
+                    <span className="calibrate-stage-status">
+                      {stage.status === 'done' ? '✓' : stage.status === 'running' ? '…' : '○'}
+                    </span>
+                    {stage.name}
+                  </li>
+                ))}
+              </ul>
+            )}
+            <LogPanel messages={job.logTail} defaultOpen={true} />
+            {!isTerminal && (
+              <button
+                type="button"
+                className="btn-base btn-compact"
+                onClick={() => {
+                  setCancelling(true);
+                  cancelJob(job.jobId).catch(() => setCancelling(false));
+                }}
+                disabled={cancelling || job.cancelRequested}
+              >
+                {cancelling || job.cancelRequested ? 'Cancelling…' : 'Cancel run'}
+              </button>
+            )}
+            {job.status === 'succeeded' && job.result && (
+              <div className="calibrate-result" role="status">
+                <h3>Outputs</h3>
+                <ul className="calibrate-output-list">
+                  {job.result.outputs.map((output, i) => {
+                    const sizeMb = (output.sizeBytes / 1024 / 1024).toFixed(1);
+                    const previewable = isPreviewable(output.storageKey);
+                    const savedId = savedIds[i];
+                    return (
+                      <li key={output.storageKey}>
+                        <div className="calibrate-output-line">
+                          {previewable ? (
+                            <button
+                              type="button"
+                              className="btn-base calibrate-output-preview"
+                              onClick={() => setPreviewIndex(i)}
+                              title="Preview this output"
+                            >
+                              <code>{output.storageKey}</code>
+                            </button>
+                          ) : (
+                            <code>{output.storageKey}</code>
+                          )}{' '}
+                          ({sizeMb} MB)
+                          {!previewable && <span className="calibrate-hint"> · not an image</span>}
+                        </div>
+                        <div className="calibrate-output-actions">
+                          {previewable &&
+                            (savedId ? (
+                              <>
+                                <span className="calibrate-saved-badge">✓ In library</span>
+                                <Link
+                                  className="btn-base btn-compact"
+                                  to="/composite"
+                                  state={{ initialSelection: [savedId] }}
+                                >
+                                  Open in compositor
+                                </Link>
+                              </>
+                            ) : (
+                              <button
+                                type="button"
+                                className="btn-base btn-compact"
+                                onClick={() => void handleSave(i)}
+                                disabled={savingIndex === i}
+                              >
+                                {savingIndex === i ? 'Saving…' : 'Save to library'}
+                              </button>
+                            ))}
+                          <button
+                            type="button"
+                            className="btn-base btn-compact"
+                            onClick={() => void handleDownload(i, output.storageKey)}
+                          >
+                            Download
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+                {job.result.jwstVersion && (
+                  <p className="calibrate-hint">
+                    jwst {job.result.jwstVersion}
+                    {job.result.crdsContext ? ` · CRDS ${job.result.crdsContext}` : ''}
+                  </p>
+                )}
+              </div>
+            )}
+            {job.status === 'failed' && (
+              <p className="calibrate-error" role="alert">
+                Run failed: {job.error ?? 'unknown error'}
+              </p>
+            )}
+            {job.status === 'cancelled' && (
+              <p className="calibrate-hint" role="status">
+                Run cancelled.
+              </p>
+            )}
+          </>
+        )}
+      </section>
+
+      {previewIndex !== null && job?.result?.outputs[previewIndex] && (
+        <ImagePreviewLightbox
+          key={job.result.outputs[previewIndex].storageKey}
+          open
+          title={basename(job.result.outputs[previewIndex].storageKey)}
+          onClose={closePreview}
+          loadImage={loadPreview}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/jwst-frontend/src/services/calibrationService.ts
+++ b/frontend/jwst-frontend/src/services/calibrationService.ts
@@ -8,6 +8,7 @@ import { ENGINE_BASE_URL } from '../config/engine';
 import { ApiClient } from './apiClient';
 import type {
   CalibrationCapabilities,
+  CalibrationJob,
   CalibrationRecipe,
   StartRunRequest,
   StartRunResponse,
@@ -39,6 +40,16 @@ export async function startRun(request: StartRunRequest): Promise<StartRunRespon
 /** Generic jobs API lives on the engine too (poll from the run UI, PR 8). */
 export async function getJob<T = Record<string, unknown>>(jobId: string): Promise<T> {
   return engineClient.get<T>(`/api/jobs/${encodeURIComponent(jobId)}`);
+}
+
+/**
+ * Recent calibration runs for the signed-in user, newest first.
+ * The engine has exposed this since the jobs slice landed; nothing consumed it
+ * until the run-history page (#1734), which is why a run could be orphaned.
+ */
+export async function listJobs(limit = 50): Promise<CalibrationJob[]> {
+  const response = await engineClient.get<{ jobs: CalibrationJob[] }>(`/api/jobs?limit=${limit}`);
+  return response.jobs;
 }
 
 export async function cancelJob(jobId: string): Promise<{ cancelRequested: boolean }> {


### PR DESCRIPTION
## Summary

**Closes #1734.** Phase 2 of #1733.

A calibration run can take up to 4 hours (`CALIBRATION_TIMEOUT_S=14400`) and only one executes at a time — but its only handle was `useState` on `CalibrateRun`. Refresh or navigate away and the run kept executing on the server with **no way to ever see it again**. Meanwhile `GET /api/jobs` had existed since the jobs slice landed with **zero frontend consumers**.

This gives a run a durable address and a home.

## Changes Made

- **New — `RunDetail` at `/calibrate/runs/:jobId`.** Progress, stage checklist, log tail, cancel, and the outputs with their save / download / compositor actions all move here from `CalibrateRun`. The job id now comes from the route, so the page survives a refresh, can be bookmarked, shared, and reopened from history.
- **New — `CalibrationRuns` at `/calibrate/runs`.** Active vs. history, polling every 10s while anything is running. First consumer of the engine's job list.
- **Better queue feedback.** A queued run now says *why* it's waiting — "the engine runs one calibration at a time" — instead of a bare `queued` with no explanation.
- **`CalibrateRun` becomes configuration-only.** It navigates to the run URL on start; its config no longer unmounts the moment a run begins, which is what clears the way for re-run (#1735).
- **Gallery** gains a "View runs" link.
- **Route order matters** and is commented in `App.tsx`: `calibrate/runs` is registered **before** `calibrate/:recipeId`, or the dynamic segment swallows it as a recipe id.
- **Backend unchanged** — the endpoint already existed.

## Scope note

#1734 proposed putting run history at `/calibrate`. It lives at `/calibrate/runs` instead: moving the gallery off `/calibrate` is #1738's job, and doing it here would create a disruptive intermediate state for no gain. #1738 can do the swap in one move.

## Test Plan

- [x] `vitest run src/pages/CalibrateRun.test.tsx src/pages/RunDetail.test.tsx src/pages/CalibrationRuns.test.tsx` — **17 passed**.
- [x] **Run-detail tests moved with the code they cover** (they failed loudly against the split, which is how the boundary got verified). `RunDetail.test.tsx` adds: id read from the URL (`getJob` called with the route param — the refresh-survival property), queued-reason copy, failure state, and all the outputs/preview/save cases.
- [x] `CalibrationRuns.test.tsx` is new: active/history split, each run linking to its own URL, the queued explanation, empty state, and load-failure state.
- [x] `CalibrateRun.test.tsx` now asserts the **hand-off** — after `startRun`, the stub run route renders — plus a new case that a failed start keeps the form usable for a retry.
- [x] Full frontend suite — **1205 passed / 110 files**. `tsc -b` clean. ESLint 0 errors (3 pre-existing warnings in `CalibrateRun.tsx`, untouched). Prettier clean.
- [ ] **Manual (reviewer):** start a run → you land on `/calibrate/runs/<id>` → **refresh the page** and confirm progress is still there → go to `/calibrate/runs` and confirm the run is listed under Active → let it finish and confirm it moves to History.

> The refresh-survival property is the whole point of this PR and is covered in tests by asserting the id comes from the route rather than state; a live end-to-end run is still worth the manual pass.

## Documentation Checklist

- [x] Behaviour and the route-ordering constraint documented inline.
- [ ] `docs/key-files.md` — deferred to the end-of-epic docs sweep so all six phases land together.
- [x] No API surface change.

## Tech Debt Impact

- [x] **Removes** debt: a long-running job no longer depends on a component staying mounted, and an unused endpoint gains its consumer.
- [x] Run-detail code moved rather than duplicated — `CalibrateRun` shed ~140 lines.
- [x] Unblocks #1735 (re-run), which needs config to survive a run starting.

## Risk & Rollback

- **Risk: Low-medium.** No backend change and no new data, but this moves a lot of UI between pages. The main hazard is a missed import or a route-order mistake; both are covered by tsc plus the three test files, and the route order has an explicit test-visible consequence (the stub route resolving).
- Polling every 10s on the history page is a deliberate choice over a socket — cheap, and the endpoint is already there.
- **Rollback:** revert the commit; `/calibrate/:recipeId` returns to owning the run.

## Linked Issue

Closes #1734.
