### PR TITLE
feat: re-run a calibration with changes, and show what a run used

### DIFF
--- a/frontend/jwst-frontend/src/pages/CalibrateRun.css
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.css
@@ -173,3 +173,36 @@
   color: var(--success, #34d399);
   background: var(--success-subtle, rgba(52, 211, 153, 0.12));
 }
+
+/* Run configuration summary (#1735) — visible while the run is in flight and
+   the source for "Re-run with changes". */
+.calibrate-config-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.calibrate-config-head h2 {
+  margin: 0;
+}
+
+.calibrate-config-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
+.calibrate-config-list strong {
+  color: var(--text-primary);
+}
+
+.calibrate-run-id {
+  margin-top: -0.4rem;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -106,6 +106,38 @@ describe('CalibrateRun', () => {
     );
   });
 
+  it('rehydrates the form from a re-run hand-off (#1735)', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: {
+              rerun: {
+                enabledStages: { detector1: false, image2: false, image3: true },
+                runOverrides: { skymatch: { skymethod: 'global+match' } },
+                inputs: ['mast/jw1/a_cal.fits'],
+              },
+            },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
+
+    // The previous run's toggles win over the recipe's own defaults...
+    expect(screen.getByRole('checkbox', { name: /image3/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /detector1/ })).not.toBeChecked();
+    // ...and its parameters replace the seeded ones rather than merging.
+    expect(screen.getByLabelText('Step for parameter 1')).toHaveValue('skymatch');
+    expect(screen.getByLabelText('Name for parameter 1')).toHaveValue('skymethod');
+    expect(screen.queryByDisplayValue('maximum_cores')).not.toBeInTheDocument();
+  });
+
   it('reprocess state selects stage-3 only and pre-fills inputs', async () => {
     render(
       <MemoryRouter

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -68,6 +68,24 @@ function overridesFromRows(rows: ParamRow[]): StepOverrides {
 interface ReprocessState {
   inputs?: string[];
   stage3Only?: boolean;
+  /** Settings carried back from a finished run (#1735). The engine stores a
+   *  recipe snapshot per job with the run's stage toggles already applied, so
+   *  a re-run can rebuild this form exactly as it was submitted. */
+  rerun?: {
+    enabledStages?: Record<string, boolean>;
+    runOverrides?: StepOverrides;
+    inputs?: string[];
+  };
+}
+
+function rowsFromOverrides(overrides: StepOverrides): ParamRow[] {
+  const rows: ParamRow[] = [];
+  for (const [step, params] of Object.entries(overrides)) {
+    for (const [param, value] of Object.entries(params)) {
+      rows.push({ step, param, value: JSON.stringify(value) });
+    }
+  }
+  return rows;
 }
 
 export default function CalibrateRun() {
@@ -93,16 +111,26 @@ export default function CalibrateRun() {
       .then((loaded) => {
         if (cancelled) return;
         setRecipe(loaded);
+        const rerun = reprocess.rerun;
         setEnabledStages(
           Object.fromEntries(
             loaded.stages.map((s) => [
               s.name,
-              reprocess.stage3Only ? s.name === 'image3' : s.enabled,
+              // Precedence: a re-run's own toggles, then the Reprocess
+              // stage-3 fast path, then the recipe's defaults.
+              rerun?.enabledStages
+                ? (rerun.enabledStages[s.name] ?? false)
+                : reprocess.stage3Only
+                  ? s.name === 'image3'
+                  : s.enabled,
             ])
           )
         );
-        setParamRows(rowsFromRecipe(loaded));
-        if (reprocess.inputs?.length) setSelectedInputs(reprocess.inputs);
+        setParamRows(
+          rerun?.runOverrides ? rowsFromOverrides(rerun.runOverrides) : rowsFromRecipe(loaded)
+        );
+        const presetInputs = rerun?.inputs ?? reprocess.inputs;
+        if (presetInputs?.length) setSelectedInputs(presetInputs);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -113,7 +141,7 @@ export default function CalibrateRun() {
     };
   }, [recipeId]);
 
-  const reprocessInputs = reprocess.inputs;
+  const reprocessInputs = reprocess.rerun?.inputs ?? reprocess.inputs;
   const needsLibraryInputs =
     recipe?.input_source.type === 'library_products' || Boolean(reprocessInputs?.length);
   // Reprocess supplies calibrated (_cal) files regardless of the recipe's own

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -5,8 +5,9 @@
 
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
 import RunDetail from './RunDetail';
 import type { CalibrationJob } from '../types/CalibrationTypes';
 
@@ -66,11 +67,33 @@ function succeededJob(): CalibrationJob {
   };
 }
 
-function renderRun() {
+/** A run's stored request: the engine embeds the snapshot with the run's own
+ *  stage toggles already applied, which is what makes re-run possible. */
+function withRequest(job: CalibrationJob, enabled: Record<string, boolean>): CalibrationJob {
+  return {
+    ...job,
+    request: {
+      recipe_id: 'seed-nircam-imaging',
+      recipe_snapshot: {
+        name: 'NIRCam Imaging',
+        stages: Object.entries(enabled).map(([name, en]) => ({
+          name,
+          enabled: en,
+          step_overrides: {},
+        })),
+      } as never,
+      run_overrides: { jump: { maximum_cores: 'half' } },
+      inputs: [{ path: 'mast/jw1/a_cal.fits', role: 'science' }],
+    },
+  };
+}
+
+function renderRun(extraRoutes?: ReactNode) {
   return render(
     <MemoryRouter initialEntries={['/calibrate/runs/job-1']}>
       <Routes>
         <Route path="/calibrate/runs/:jobId" element={<RunDetail />} />
+        {extraRoutes}
       </Routes>
     </MemoryRouter>
   );
@@ -110,6 +133,58 @@ describe('RunDetail', () => {
     renderRun();
     await waitFor(() => expect(screen.getByText(/Run failed: boom/)).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument();
+  });
+
+  describe('configuration summary and re-run', () => {
+    it('shows what the run was started with, while it is still running', async () => {
+      vi.mocked(getJob).mockResolvedValue(
+        withRequest(runningJob(), { detector1: false, image2: false, image3: true })
+      );
+      renderRun();
+
+      await waitFor(() => expect(screen.getByText('Configuration')).toBeInTheDocument());
+      // Scope to the summary: the progress checklist also lists stage names.
+      const stagesRow = screen.getByText('Stages:').closest('li');
+      expect(stagesRow).toHaveTextContent('image3');
+      // Only the stages that actually ran — the disabled ones are omitted.
+      expect(stagesRow).not.toHaveTextContent('detector1');
+      expect(screen.getByText(/jump\.maximum_cores/)).toBeInTheDocument();
+      expect(screen.getByText(/1 file/)).toBeInTheDocument();
+      // Re-run is for finished runs only — this one is still going.
+      expect(screen.queryByRole('button', { name: 'Re-run with changes' })).not.toBeInTheDocument();
+    });
+
+    it('offers re-run once the job is terminal and carries the settings across', async () => {
+      vi.mocked(getJob).mockResolvedValue(
+        withRequest(succeededJob(), { detector1: false, image2: false, image3: true })
+      );
+      let handedOff: unknown = null;
+      function ConfigStub() {
+        handedOff = (useLocation().state as { rerun?: unknown } | null)?.rerun ?? null;
+        return <div>config stub</div>;
+      }
+      renderRun(<Route path="/calibrate/:recipeId" element={<ConfigStub />} />);
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Re-run with changes' }));
+
+      expect(await screen.findByText('config stub')).toBeInTheDocument();
+      // The snapshot's toggles, overrides and inputs all travel to the form.
+      expect(handedOff).toEqual({
+        enabledStages: { detector1: false, image2: false, image3: true },
+        runOverrides: { jump: { maximum_cores: 'half' } },
+        inputs: ['mast/jw1/a_cal.fits'],
+      });
+    });
+
+    it('offers re-run on a failed run too — that is when you most want to tweak', async () => {
+      vi.mocked(getJob).mockResolvedValue(
+        withRequest({ ...runningJob(), status: 'failed', error: 'boom' }, { image3: true })
+      );
+      renderRun();
+      expect(
+        await screen.findByRole('button', { name: 'Re-run with changes' })
+      ).toBeInTheDocument();
+    });
   });
 
   describe('outputs', () => {

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useCallback, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { LogPanel } from '../components/wizard/LogPanel';
 import { EmptyState } from '../components/ui/EmptyState';
 import { ImagePreviewLightbox } from '../components/ui/ImagePreviewLightbox';
@@ -21,6 +21,7 @@ import {
   getJobOutputPreview,
   saveJobOutputToLibrary,
 } from '../services/calibrationService';
+import type { CalibrationJob, StepOverrides } from '../types/CalibrationTypes';
 import './CalibrateRun.css';
 
 /** Only FITS image products can be rendered or saved as library images;
@@ -31,9 +32,31 @@ const PREVIEWABLE_RE = /\.(fits(\.gz)?|fit)$/i;
 const isPreviewable = (storageKey: string): boolean => PREVIEWABLE_RE.test(storageKey);
 const basename = (key: string): string => key.split('/').pop() ?? key;
 
+const TERMINAL: ReadonlySet<CalibrationJob['status']> = new Set([
+  'succeeded',
+  'failed',
+  'cancelled',
+]);
+
+/** Flatten run overrides into display rows, in the shape the config form uses. */
+function overrideRows(overrides: StepOverrides | undefined): {
+  step: string;
+  param: string;
+  value: string;
+}[] {
+  const rows: { step: string; param: string; value: string }[] = [];
+  for (const [step, params] of Object.entries(overrides ?? {})) {
+    for (const [param, value] of Object.entries(params)) {
+      rows.push({ step, param, value: JSON.stringify(value) });
+    }
+  }
+  return rows;
+}
+
 export default function RunDetail() {
   const { jobId } = useParams<{ jobId: string }>();
   const { job, isTerminal, error: pollError } = useCalibrationJob(jobId ?? null);
+  const navigate = useNavigate();
 
   const [cancelling, setCancelling] = useState(false);
   const [savedIds, setSavedIds] = useState<Record<number, string>>({});
@@ -97,10 +120,69 @@ export default function RunDetail() {
       <nav className="calibrate-run-breadcrumb">
         <Link to="/calibrate/runs">← All runs</Link>
       </nav>
-      <h1>Calibration run</h1>
+      <h1>{job?.request?.recipe_snapshot?.name ?? 'Calibration run'}</h1>
       <p className="calibrate-hint calibrate-run-id">
         <code>{jobId}</code>
       </p>
+
+      {job?.request?.recipe_snapshot && (
+        <section className="calibrate-section" aria-labelledby="config-heading">
+          <div className="calibrate-config-head">
+            <h2 id="config-heading">Configuration</h2>
+            {TERMINAL.has(job.status) && job.request.recipe_id && (
+              <button
+                type="button"
+                className="btn-base btn-compact"
+                onClick={() =>
+                  navigate(`/calibrate/${job.request.recipe_id}`, {
+                    state: {
+                      rerun: {
+                        enabledStages: Object.fromEntries(
+                          (job.request.recipe_snapshot?.stages ?? []).map((s) => [
+                            s.name,
+                            s.enabled,
+                          ])
+                        ),
+                        runOverrides: job.request.run_overrides ?? {},
+                        inputs: (job.request.inputs ?? []).map((i) => i.path),
+                      },
+                    },
+                  })
+                }
+              >
+                Re-run with changes
+              </button>
+            )}
+          </div>
+          <p className="calibrate-hint">
+            What this run was started with — kept so you can see it while the run is in flight, and
+            reuse it afterwards.
+          </p>
+          <ul className="calibrate-config-list">
+            <li>
+              <strong>Stages:</strong>{' '}
+              {job.request.recipe_snapshot.stages
+                .filter((s) => s.enabled)
+                .map((s) => s.name)
+                .join(' → ') || 'none'}
+            </li>
+            <li>
+              <strong>Parameters:</strong>{' '}
+              {overrideRows(job.request.run_overrides).length === 0
+                ? 'pipeline defaults'
+                : overrideRows(job.request.run_overrides)
+                    .map((r) => `${r.step}.${r.param}=${r.value}`)
+                    .join(', ')}
+            </li>
+            <li>
+              <strong>Inputs:</strong>{' '}
+              {job.request.inputs?.length
+                ? `${job.request.inputs.length} file${job.request.inputs.length === 1 ? '' : 's'}`
+                : 'fetched from MAST'}
+            </li>
+          </ul>
+        </section>
+      )}
 
       <section className="calibrate-section" aria-labelledby="progress-heading">
         <h2 id="progress-heading">Run progress</h2>

--- a/frontend/jwst-frontend/src/types/CalibrationTypes.ts
+++ b/frontend/jwst-frontend/src/types/CalibrationTypes.ts
@@ -105,7 +105,24 @@ export interface CalibrationJob {
     crdsContext: string | null;
   } | null;
   error: string | null;
-  request: Record<string, unknown>;
+  request: CalibrationJobRequest;
+}
+
+/**
+ * What a run was started with. The engine embeds a full recipe snapshot per job
+ * for reproducibility, and applies the per-run stage toggles to that snapshot
+ * BEFORE storing it — so `recipeSnapshot.stages[].enabled` is what actually
+ * ran, not the recipe's defaults. That makes the snapshot enough to rebuild the
+ * form for a re-run (#1735).
+ *
+ * Keys inside `request` stay snake_case on the wire: it is opaque, job-type
+ * owned data that the jobs facade deliberately does not camelCase.
+ */
+export interface CalibrationJobRequest {
+  recipe_id?: string;
+  recipe_snapshot?: CalibrationRecipe;
+  inputs?: { path: string; role: string }[];
+  run_overrides?: StepOverrides;
 }
 
 export const TERMINAL_JOB_STATUSES = ['succeeded', 'failed', 'cancelled'] as const;


### PR DESCRIPTION
## Summary

**Closes #1735.** Phase 3 of #1733.

Two halves of the same gap. Configuration vanished the moment a run started (`{!jobId && …}`), so you could neither see what was executing nor tweak it and try again without navigating away and losing every setting — despite the feature being justified by exactly that *generate → view → tweak → regenerate* loop.

## Changes Made

- **`RunDetail` gains a Configuration summary** — enabled stages in order, the run's parameter overrides, and the input count. Shown **while the run is in flight**, which is when "what did I actually submit?" matters most.
- **Terminal runs gain "Re-run with changes"** — succeeded, failed **and** cancelled. Failed runs get it deliberately: that's precisely when you want to adjust and retry.
- **`CalibrateRun` rehydrates from the hand-off** with explicit precedence: a re-run's toggles beat the Reprocess stage-3 fast path, which beats the recipe defaults. Re-run parameters **replace** the seeded ones rather than merging, so the form matches the previous run exactly.
- **`request` is now typed** (`CalibrationJobRequest`) instead of `Record<string, unknown>`. Its keys stay snake_case because the jobs facade deliberately leaves that blob verbatim — documented on the type.
- **No backend change.**

## Why this is cheap

The engine already embeds a full recipe snapshot per job **and applies the run's stage toggles to it before storing** (`app/calibration/routes.py:140-150`, comment: *"so the job's embedded snapshot reflects what actually ran"*). So `recipeSnapshot.stages[].enabled` is the run's real configuration, not the recipe's defaults — enough to rebuild the form with no new persistence.

## Test Plan

- [x] `vitest run src/pages/RunDetail.test.tsx src/pages/CalibrateRun.test.tsx` — **17 passed**.
- [x] **Round trip asserted end to end:** a stub config route captures the router state, and the test asserts the exact payload — `enabledStages`, `runOverrides` and `inputs` — arrives from the snapshot.
- [x] Config summary shows only the stages that ran (asserts `image3` present **and** `detector1` absent), scoped to the summary since the progress checklist also lists stage names.
- [x] Re-run hidden while running, present on succeeded, present on **failed**.
- [x] `CalibrateRun` rehydration: re-run toggles beat recipe defaults, and re-run parameters replace the seeded `maximum_cores` rather than merging with it.
- [x] Full frontend suite — **1209 passed / 110 files**. `tsc -b` clean, ESLint 0 errors, Prettier clean.
- [ ] **Manual (reviewer):** finish a run → **Re-run with changes** → confirm the form matches what that run used → change one parameter → run → confirm the new run's summary reflects the change.

## Documentation Checklist

- [x] Precedence rules and the snapshot's role documented inline on `ReprocessState` and `CalibrationJobRequest`.
- [ ] `docs/key-files.md` — deferred to the end-of-epic docs sweep.
- [x] No API surface change.

## Tech Debt Impact

- [x] **Removes** debt: `request` was an untyped blob at the point three call sites read it.
- [x] Delivers the loop the feature was justified by, closing the gap PR #1731 named but couldn't satisfy.
- [x] Compare-two-runs remains a natural follow-on from the same snapshot; deliberately out of scope.

## Risk & Rollback

- **Risk: Low.** Additive UI plus a type narrowing. No backend, no persistence, no new endpoints.
- The one behavioural subtlety is precedence when both `rerun` and Reprocess state are present. That can't happen in practice (they come from different entry points), but the order is explicit in code and covered by tests rather than left implicit.
- **Rollback:** revert the commit.

## Linked Issue

Closes #1735.
