### PR TITLE
feat: stage timeline with validity rules, estimates and cost warnings

### DIFF
--- a/frontend/jwst-frontend/src/components/calibration/StageTimeline.css
+++ b/frontend/jwst-frontend/src/components/calibration/StageTimeline.css
@@ -1,0 +1,118 @@
+.stage-timeline {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin: 0.5rem 0;
+}
+
+.stage-timeline-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+/* The connector carries the data state, which is what teaches the pipeline. */
+.stage-flow {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  padding: 0 0.15rem;
+}
+
+.stage-flow-arrow {
+  color: var(--text-secondary);
+}
+
+.stage-node {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--bg-base, #0c0d10);
+}
+
+.stage-node-on {
+  border-color: var(--border-interactive-hover, rgba(74, 144, 217, 0.4));
+}
+
+.stage-node-off {
+  opacity: 0.55;
+}
+
+.stage-node-blocked {
+  opacity: 0.4;
+  border-style: dashed;
+}
+
+.stage-node-done {
+  border-color: rgba(52, 211, 153, 0.35);
+  opacity: 1;
+}
+
+.stage-node-running {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary-subtle, rgba(59, 130, 246, 0.08));
+  opacity: 1;
+}
+
+.stage-node-failed {
+  border-color: rgba(248, 113, 113, 0.45);
+  opacity: 1;
+}
+
+.stage-node-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.stage-node input[disabled] + span {
+  cursor: not-allowed;
+}
+
+.stage-node-glyph {
+  width: 1em;
+  display: inline-block;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.stage-node-io {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.65rem;
+  color: var(--text-muted);
+}
+
+.stage-node-reason {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  max-width: 15rem;
+}
+
+/* Cost signals sit under the timeline, where the decision is being made. */
+.stage-estimate {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 0.5rem;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.stage-warning {
+  color: var(--warning, #fbbf24);
+}
+
+@media (max-width: 640px) {
+  .stage-timeline {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/frontend/jwst-frontend/src/components/calibration/StageTimeline.test.tsx
+++ b/frontend/jwst-frontend/src/components/calibration/StageTimeline.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { StageTimeline } from './StageTimeline';
+
+describe('StageTimeline', () => {
+  it('labels stages in plain language and shows the data flow between them', () => {
+    render(<StageTimeline mode="config" enabled={{ detector1: true }} />);
+    // Human labels, not the raw engine identifiers the old checkboxes showed.
+    expect(screen.getByText('Detector1')).toBeInTheDocument();
+    expect(screen.getByText('Image3')).toBeInTheDocument();
+    // The connector teaches what each stage consumes and produces.
+    expect(screen.getByText('_uncal → _rate')).toBeInTheDocument();
+    expect(screen.getByText('_cal → _i2d')).toBeInTheDocument();
+  });
+
+  it('disables a stage whose input product does not exist, and says why', () => {
+    render(<StageTimeline mode="config" enabled={{ detector1: true }} inputSuffixes={['_cal']} />);
+
+    const detector1 = screen.getByRole('checkbox', { name: /Detector1/ });
+    expect(detector1).toBeDisabled();
+    // Unreachable rather than a runtime failure hours later.
+    expect(detector1).not.toBeChecked();
+    expect(screen.getByText(/needs _uncal data/)).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Image3/ })).toBeEnabled();
+  });
+
+  it('toggles an allowed stage', async () => {
+    const onToggle = vi.fn();
+    render(<StageTimeline mode="config" enabled={{}} onToggle={onToggle} />);
+    await userEvent.click(screen.getByRole('checkbox', { name: /Image2/ }));
+    expect(onToggle).toHaveBeenCalledWith('image2', true);
+  });
+
+  it('renders live status without checkboxes in progress mode', () => {
+    render(
+      <StageTimeline
+        mode="progress"
+        progress={[
+          { name: 'detector1', status: 'done' },
+          { name: 'image2', status: 'running' },
+        ]}
+      />
+    );
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    expect(screen.getByText('✓')).toBeInTheDocument();
+    expect(screen.getByText('…')).toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/components/calibration/StageTimeline.tsx
+++ b/frontend/jwst-frontend/src/components/calibration/StageTimeline.tsx
@@ -1,0 +1,103 @@
+/**
+ * Stage timeline (#1736) — the pipeline as a pipeline.
+ *
+ * Replaces a row of checkboxes labelled with raw engine identifiers. The
+ * connectors carry the data state (uncal → rate → cal → i2d), so the graph
+ * explains itself, and a stage whose input product doesn't exist is disabled
+ * with the reason rather than failing at runtime.
+ *
+ * Serves both the config form (toggleable) and the run page (read-only, with
+ * live status), because they are the same information at different moments.
+ */
+
+import { IMAGING_PIPELINE, blockedReason } from './stagePipeline';
+import type { CalibrationJobStage } from '../../types/CalibrationTypes';
+import './StageTimeline.css';
+
+type Mode = 'config' | 'progress';
+
+interface StageTimelineProps {
+  mode: Mode;
+  /** Config mode: which stages the user has enabled. */
+  enabled?: Record<string, boolean>;
+  /** Progress mode: live per-stage status from the job. */
+  progress?: CalibrationJobStage[];
+  /** Suffixes of the selected inputs, e.g. ['_cal'] — drives validity. */
+  inputSuffixes?: string[];
+  onToggle?: (stageName: string, next: boolean) => void;
+}
+
+function statusGlyph(status: CalibrationJobStage['status']): string {
+  if (status === 'done') return '✓';
+  if (status === 'running') return '…';
+  if (status === 'failed') return '✕';
+  if (status === 'skipped') return '–';
+  return '○';
+}
+
+export function StageTimeline({
+  mode,
+  enabled = {},
+  progress = [],
+  inputSuffixes = [],
+  onToggle,
+}: StageTimelineProps) {
+  const byName = new Map(progress.map((p) => [p.name, p]));
+
+  return (
+    <div className="stage-timeline" role="group" aria-label="Pipeline stages">
+      {IMAGING_PIPELINE.map((spec, i) => {
+        const blocked = mode === 'config' ? blockedReason(spec, inputSuffixes) : null;
+        const live = byName.get(spec.name);
+        const on = mode === 'config' ? Boolean(enabled[spec.name]) && !blocked : Boolean(live);
+        const status = live?.status;
+
+        return (
+          <div className="stage-timeline-cell" key={spec.name}>
+            {i > 0 && (
+              <span className="stage-flow" aria-hidden="true">
+                {spec.consumes}
+                <span className="stage-flow-arrow"> → </span>
+              </span>
+            )}
+            <div
+              className={[
+                'stage-node',
+                on ? 'stage-node-on' : 'stage-node-off',
+                blocked ? 'stage-node-blocked' : '',
+                status ? `stage-node-${status}` : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+            >
+              {mode === 'config' ? (
+                <label className="stage-node-label">
+                  <input
+                    type="checkbox"
+                    checked={on}
+                    disabled={Boolean(blocked)}
+                    onChange={(e) => onToggle?.(spec.name, e.target.checked)}
+                  />
+                  <span>{spec.label}</span>
+                </label>
+              ) : (
+                <span className="stage-node-label">
+                  <span className="stage-node-glyph">{statusGlyph(status ?? 'pending')}</span>
+                  <span>{spec.label}</span>
+                </span>
+              )}
+              <span className="stage-node-io">
+                {spec.consumes} → {spec.produces}
+              </span>
+            </div>
+            {blocked && (
+              <span className="stage-node-reason" role="note">
+                {blocked}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/jwst-frontend/src/components/calibration/stagePipeline.test.ts
+++ b/frontend/jwst-frontend/src/components/calibration/stagePipeline.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Stage validity + estimates (#1736). These are the rules that used to be
+ * absent entirely: any stage combination was selectable and an invalid one
+ * only failed at runtime, potentially hours into a run.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IMAGING_PIPELINE, blockedReason, estimateMinutes, formatEstimate } from './stagePipeline';
+
+// Positional rather than specFor(...)!: the pipeline order IS the contract, so
+// a reordering should break these tests loudly.
+const [detector1, image2, image3] = IMAGING_PIPELINE;
+
+describe('blockedReason', () => {
+  it('blocks raw-data stages when the inputs are already calibrated', () => {
+    // The exact case the old UI allowed you to submit: _cal files cannot be
+    // fed to Detector1, which needs _uncal frames.
+    expect(blockedReason(detector1, ['_cal'])).toMatch(/needs _uncal/);
+    expect(blockedReason(image2, ['_cal'])).toMatch(/needs _rate/);
+    expect(blockedReason(image3, ['_cal'])).toBeNull();
+  });
+
+  it('allows the whole pipeline for raw inputs', () => {
+    for (const stage of IMAGING_PIPELINE) {
+      expect(blockedReason(stage, ['_uncal'])).toBeNull();
+    }
+  });
+
+  it('blocks nothing before inputs are chosen', () => {
+    for (const stage of IMAGING_PIPELINE) {
+      expect(blockedReason(stage, [])).toBeNull();
+    }
+  });
+
+  it('judges a mixed selection by its least-processed file', () => {
+    // One raw file means Detector1 still has work to do.
+    expect(blockedReason(detector1, ['_uncal', '_cal'])).toBeNull();
+  });
+
+  it('does not block on an unrecognised suffix', () => {
+    // Better to let the engine reject it than to guess wrong and hide a stage.
+    expect(blockedReason(detector1, ['_weird'])).toBeNull();
+  });
+});
+
+describe('estimateMinutes', () => {
+  it('scales per-file stages with the file count but not per-run ones', () => {
+    const perFileOnly = estimateMinutes([image2], 4);
+    expect(perFileOnly).toBe(image2.minutesPerFile * 4);
+    // image3 builds one mosaic regardless of how many frames feed it.
+    expect(estimateMinutes([image3], 4)).toBe(image3.minutesPerFile);
+  });
+
+  it('treats an empty selection as a single file so the estimate is non-zero', () => {
+    expect(estimateMinutes([image2], 0)).toBe(image2.minutesPerFile);
+  });
+
+  it('is zero when nothing is enabled', () => {
+    expect(estimateMinutes([], 10)).toBe(0);
+  });
+});
+
+describe('formatEstimate', () => {
+  it('reads as minutes under an hour and hours above', () => {
+    expect(formatEstimate(20)).toBe('~20 min');
+    expect(formatEstimate(60)).toBe('~1h');
+    expect(formatEstimate(95)).toBe('~1h 35m');
+    expect(formatEstimate(0)).toBe('—');
+  });
+});

--- a/frontend/jwst-frontend/src/components/calibration/stagePipeline.ts
+++ b/frontend/jwst-frontend/src/components/calibration/stagePipeline.ts
@@ -1,0 +1,88 @@
+/**
+ * What the JWST imaging pipeline stages actually do (#1736).
+ *
+ * The UI used to show raw identifiers — `detector1`, `image2`, `image3` — as
+ * bare checkboxes, with nothing explaining what they do, what they cost, or
+ * that they depend on the shape of the input data. Any combination was
+ * selectable and an invalid one only failed at runtime, potentially hours in.
+ *
+ * These are pure functions over (stages, input suffixes) so they can be tested
+ * directly rather than through the DOM.
+ */
+
+export interface StageSpec {
+  /** Pipeline identifier, as the engine knows it. */
+  name: string;
+  /** What a person would call it. */
+  label: string;
+  /** Data product going in / coming out — the connector labels. */
+  consumes: string;
+  produces: string;
+  /** Rough minutes, used only for an order-of-magnitude estimate. */
+  minutesPerFile: number;
+  /** True when the cost is per mosaic rather than per input file. */
+  perRun?: boolean;
+}
+
+export const IMAGING_PIPELINE: StageSpec[] = [
+  {
+    name: 'detector1',
+    label: 'Detector1',
+    consumes: '_uncal',
+    produces: '_rate',
+    minutesPerFile: 8,
+  },
+  { name: 'image2', label: 'Image2', consumes: '_rate', produces: '_cal', minutesPerFile: 2 },
+  {
+    name: 'image3',
+    label: 'Image3',
+    consumes: '_cal',
+    produces: '_i2d',
+    minutesPerFile: 10,
+    perRun: true,
+  },
+];
+
+export function specFor(name: string): StageSpec | undefined {
+  return IMAGING_PIPELINE.find((s) => s.name === name);
+}
+
+/**
+ * Why a stage cannot run against the given inputs, or null if it can.
+ *
+ * The rule is the pipeline's own data flow: a stage needs its `consumes`
+ * product to exist. Inputs that are already calibrated (`_cal`) cannot be fed
+ * to Detector1 or Image2 — those need raw frames.
+ */
+export function blockedReason(stage: StageSpec, inputSuffixes: string[]): string | null {
+  if (inputSuffixes.length === 0) return null; // nothing selected yet — don't pre-judge
+  // A stage is runnable if any input is at or before the product it consumes.
+  const order = ['_uncal', '_rate', '_cal', '_i2d'];
+  const need = order.indexOf(stage.consumes);
+  const haveEarliest = Math.min(
+    ...inputSuffixes.map((s) => {
+      const i = order.indexOf(s);
+      return i === -1 ? 0 : i; // unknown suffix: assume raw, don't block
+    })
+  );
+  if (need < haveEarliest) {
+    return `needs ${stage.consumes} data — your inputs are already ${order[haveEarliest]}`;
+  }
+  return null;
+}
+
+/** Rough total for the enabled stages. Deliberately coarse: an order of
+ *  magnitude beats no signal at all, and real durations become available from
+ *  run history (#1734) once there is any. */
+export function estimateMinutes(enabled: StageSpec[], fileCount: number): number {
+  const files = Math.max(fileCount, 1);
+  return enabled.reduce((total, s) => total + s.minutesPerFile * (s.perRun ? 1 : files), 0);
+}
+
+export function formatEstimate(minutes: number): string {
+  if (minutes <= 0) return '—';
+  if (minutes < 60) return `~${Math.round(minutes)} min`;
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return m === 0 ? `~${h}h` : `~${h}h ${m}m`;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -130,8 +130,8 @@ describe('CalibrateRun', () => {
     await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
 
     // The previous run's toggles win over the recipe's own defaults...
-    expect(screen.getByRole('checkbox', { name: /image3/ })).toBeChecked();
-    expect(screen.getByRole('checkbox', { name: /detector1/ })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Image3/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Detector1/ })).not.toBeChecked();
     // ...and its parameters replace the seeded ones rather than merging.
     expect(screen.getByLabelText('Step for parameter 1')).toHaveValue('skymatch');
     expect(screen.getByLabelText('Name for parameter 1')).toHaveValue('skymethod');
@@ -154,8 +154,8 @@ describe('CalibrateRun', () => {
       </MemoryRouter>
     );
     await waitFor(() => expect(screen.getByText('Stages')).toBeInTheDocument());
-    const image3 = screen.getByRole('checkbox', { name: /image3/ });
-    const detector1 = screen.getByRole('checkbox', { name: /detector1/ });
+    const image3 = screen.getByRole('checkbox', { name: /Image3/ });
+    const detector1 = screen.getByRole('checkbox', { name: /Detector1/ });
     expect(image3).toBeChecked();
     expect(detector1).not.toBeChecked();
   });

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -10,10 +10,21 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { EmptyState } from '../components/ui/EmptyState';
+import { StageTimeline } from '../components/calibration/StageTimeline';
+import {
+  IMAGING_PIPELINE,
+  blockedReason,
+  estimateMinutes,
+  formatEstimate,
+} from '../components/calibration/stagePipeline';
 import { getRecipe, startRun } from '../services/calibrationService';
 import * as jwstDataService from '../services/jwstDataService';
 import type { CalibrationRecipe, ScalarOverride, StepOverrides } from '../types/CalibrationTypes';
 import './CalibrateRun.css';
+
+/** Product suffixes we can recognise in a storage key, most-processed last so
+ *  `find` picks the earliest match deterministically. */
+const KNOWN_SUFFIXES = ['_uncal', '_rate', '_cal', '_i2d'];
 
 interface ParamRow {
   step: string;
@@ -179,6 +190,27 @@ export default function CalibrateRun() {
     };
   }, [needsLibraryInputs, recipe, reprocessInputs, inputSuffixes]);
 
+  // Suffixes actually in play: the selected library files if there are any,
+  // otherwise what the recipe's own input source will fetch.
+  const activeSuffixes = useMemo(() => {
+    const source = selectedInputs.length > 0 ? selectedInputs : [];
+    if (source.length > 0) {
+      return Array.from(
+        new Set(source.map((path) => KNOWN_SUFFIXES.find((s) => path.includes(s)) ?? '_uncal'))
+      );
+    }
+    return recipe?.input_source.product_suffixes ?? [];
+  }, [selectedInputs, recipe]);
+
+  const enabledSpecs = useMemo(
+    () =>
+      IMAGING_PIPELINE.filter((s) => enabledStages[s.name] && !blockedReason(s, activeSuffixes)),
+    [enabledStages, activeSuffixes]
+  );
+  const fileCount = selectedInputs.length;
+  const fromMast = recipe?.input_source.type === 'mast_query';
+  const usesDetector1 = enabledSpecs.some((s) => s.name === 'detector1');
+
   const runDisabled = useMemo(() => {
     if (!recipe || starting) return true;
     if (needsLibraryInputs && selectedInputs.length === 0) return true;
@@ -230,22 +262,24 @@ export default function CalibrateRun() {
 
       <section className="calibrate-section" aria-labelledby="stages-heading">
         <h2 id="stages-heading">Stages</h2>
-        <div className="calibrate-stage-toggles">
-          {recipe.stages.map((stage) => (
-            <label key={stage.name} className="calibrate-stage-toggle">
-              <input
-                type="checkbox"
-                checked={enabledStages[stage.name] ?? false}
-                onChange={(event) =>
-                  setEnabledStages((prev) => ({
-                    ...prev,
-                    [stage.name]: event.target.checked,
-                  }))
-                }
-              />
-              <span>{stage.name}</span>
-            </label>
-          ))}
+        <StageTimeline
+          mode="config"
+          enabled={enabledStages}
+          inputSuffixes={activeSuffixes}
+          onToggle={(name, next) => setEnabledStages((prev) => ({ ...prev, [name]: next }))}
+        />
+        <div className="stage-estimate">
+          <span>
+            Estimated <strong>{formatEstimate(estimateMinutes(enabledSpecs, fileCount))}</strong>
+          </span>
+          {fromMast && (
+            <span className="stage-warning">· downloads raw data from MAST before it starts</span>
+          )}
+          {usesDetector1 && (
+            <span className="stage-warning">
+              · first run also downloads CRDS reference files (GBs)
+            </span>
+          )}
         </div>
       </section>
 

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -114,7 +114,7 @@ describe('RunDetail', () => {
 
     // The id comes from the route, so the page works on a cold load/refresh.
     expect(vi.mocked(getJob)).toHaveBeenCalledWith('job-1');
-    await waitFor(() => expect(screen.getByText('image2')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Image2')).toBeInTheDocument());
     expect(screen.getByRole('button', { name: 'Cancel run' })).toBeInTheDocument();
   });
 

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -13,6 +13,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { LogPanel } from '../components/wizard/LogPanel';
 import { EmptyState } from '../components/ui/EmptyState';
 import { ImagePreviewLightbox } from '../components/ui/ImagePreviewLightbox';
+import { StageTimeline } from '../components/calibration/StageTimeline';
 import { toast } from '../components/ui/toast';
 import { useCalibrationJob } from '../hooks/useCalibrationJob';
 import {
@@ -207,16 +208,7 @@ export default function RunDetail() {
               </p>
             )}
             {job.progress.stages.length > 0 && (
-              <ul className="calibrate-stage-checklist">
-                {job.progress.stages.map((stage) => (
-                  <li key={stage.name} data-status={stage.status}>
-                    <span className="calibrate-stage-status">
-                      {stage.status === 'done' ? '✓' : stage.status === 'running' ? '…' : '○'}
-                    </span>
-                    {stage.name}
-                  </li>
-                ))}
-              </ul>
+              <StageTimeline mode="progress" progress={job.progress.stages} />
             )}
             <LogPanel messages={job.logTail} defaultOpen={true} />
             {!isTerminal && (


### PR DESCRIPTION
## Summary

**Closes #1736.** Phase 4 of #1733.

Stages were a row of checkboxes labelled with raw engine identifiers — `detector1`, `image2`, `image3` — with nothing explaining what they do, what they cost, or that they depend on the shape of the input data. **Any combination was selectable, and an invalid one only failed at runtime** — potentially hours into a run.

## Changes Made

- **`components/calibration/stagePipeline.ts`** — the pipeline as data (label, what each stage consumes and produces, rough cost) plus pure validity and estimate functions, testable without a DOM.
- **`StageTimeline`** renders it as a pipeline whose **connectors carry the data state** — `_uncal → _rate → _cal → _i2d` — so the graph explains itself instead of leaking identifiers. One component serves both the config form (toggleable) and the run page (read-only, live status): the same information at different moments.
- **Validity rules.** A stage whose input product doesn't exist is disabled with the reason — *"needs _uncal data — your inputs are already _cal"*. Invalid combinations become **unreachable** rather than a runtime failure.
- **Cost signals where the decision is made** — a duration estimate, a warning when data will be downloaded from MAST, and the CRDS first-run reference-file download that the #1709 plan explicitly called out but was never surfaced.

## Judgement calls

- **Estimates are deliberately coarse constants.** An order of magnitude beats no signal; #1734's run history can supply real durations later. Called out in the code comment so nobody mistakes them for measurements.
- **`IMAGING_PIPELINE` order is the contract**, so the tests destructure it positionally — a reorder breaks them loudly rather than silently changing the rules.
- **Mixed selections are judged by the least-processed file**, so one raw frame still allows Detector1.
- **An unrecognised suffix blocks nothing** — better to let the engine reject it than to guess wrong and hide a stage the user needs.

## Test Plan

- [x] `vitest run src/components/calibration` — **13 passed** across the two new files.
- [x] `stagePipeline.test.ts` covers the rules directly: raw stages blocked for `_cal` inputs (the exact case the old UI let you submit), full pipeline allowed for `_uncal`, nothing blocked before inputs are chosen, mixed selections judged by the least-processed file, unknown suffix non-blocking, per-file vs per-run cost scaling, and estimate formatting.
- [x] `StageTimeline.test.tsx` covers rendering: human labels, data-flow connectors, disabled + reason for a blocked stage, toggling, and progress mode having no checkboxes.
- [x] Full frontend suite — **1222 passed / 112 files**. `tsc -b` clean, ESLint **0 errors and 0 new warnings** (I removed a fast-refresh-breaking re-export and three non-null assertions I'd introduced).
- [ ] **Manual (reviewer):** open a recipe → select `_cal` library inputs → confirm Detector1/Image2 grey out with a reason and can't be checked → confirm the estimate and the MAST/CRDS warnings appear and update as you toggle stages.

## Documentation Checklist

- [x] The pipeline model, validity rule and estimate caveat are documented in `stagePipeline.ts` — it is now the single place that describes what the stages mean.
- [ ] `docs/key-files.md` — deferred to the end-of-epic docs sweep.
- [x] No API surface change.

## Tech Debt Impact

- [x] **Removes** debt: pipeline semantics were previously implicit and duplicated between the config checkboxes and the progress checklist; both now render from one source.
- [x] Deleted the bespoke progress checklist markup in favour of the shared component.

## Risk & Rollback

- **Risk: Low-medium.** Frontend only, no backend or persistence. The behavioural change worth reviewing is that some stage combinations are now **impossible to submit** — that is the intent, but if a validity rule is wrong it blocks legitimate work. The rules are small, pure and directly tested, and an unknown suffix deliberately fails open.
- **Test-visible change:** stage labels are now `Detector1`/`Image2`/`Image3` rather than raw identifiers, so existing queries were updated.
- **Rollback:** revert the commit; the checkbox row and checklist return.

## Linked Issue

Closes #1736.
