### PR TITLE
feat: data-first calibration entry flow (closes the #1733 epic)

### DIFF
--- a/frontend/jwst-frontend/e2e/calibrate.spec.ts
+++ b/frontend/jwst-frontend/e2e/calibrate.spec.ts
@@ -13,7 +13,10 @@ test.describe('Calibration', () => {
   test('/calibrate is the run ledger', async ({ page }) => {
     // Data-first IA (#1738): runs are the unit, not the recipe catalog.
     await page.goto('/calibrate');
-    await expect(page.getByRole('heading', { name: 'Calibration runs' })).toBeVisible();
+    // exact: the signed-out empty state also contains "calibration runs".
+    await expect(
+      page.getByRole('heading', { name: 'Calibration runs', exact: true })
+    ).toBeVisible();
     await expect(page.getByRole('link', { name: '+ New run' })).toBeVisible();
   });
 
@@ -36,7 +39,10 @@ test.describe('Calibration', () => {
     await expect(page).toHaveURL(/\/calibrate\/seed-miri-imaging$/);
     await expect(page.getByRole('heading', { name: 'Stages' })).toBeVisible();
     // Seeded parameters render as curated controls now (#1737), not raw rows.
-    await expect(page.getByLabel('Jump detection — CPU cores')).toHaveValue('half');
+    // exact: the row's Remove button is aria-labelled "Remove <param label>".
+    await expect(page.getByLabel('Jump detection — CPU cores', { exact: true })).toHaveValue(
+      'half'
+    );
     // The stage timeline explains the pipeline rather than listing identifiers (#1736).
     await expect(page.getByText('_uncal → _rate')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Run calibration' })).toBeEnabled();

--- a/frontend/jwst-frontend/e2e/calibrate.spec.ts
+++ b/frontend/jwst-frontend/e2e/calibrate.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Calibration recipes (#1709 PRs 7-8).
+ * Calibration (#1709 PRs 7-8, reshaped by the #1733 data-first redesign).
  *
  * The gallery reads the engine's seeded recipes (loaded at engine startup),
  * so no auth or mocking is needed for browse/config. The run itself is
@@ -9,9 +9,16 @@ import { test, expect } from '@playwright/test';
  * out of scope for E2E.
  */
 
-test.describe('Calibration recipes', () => {
-  test('gallery lists the seeded recipes', async ({ page }) => {
+test.describe('Calibration', () => {
+  test('/calibrate is the run ledger', async ({ page }) => {
+    // Data-first IA (#1738): runs are the unit, not the recipe catalog.
     await page.goto('/calibrate');
+    await expect(page.getByRole('heading', { name: 'Calibration runs' })).toBeVisible();
+    await expect(page.getByRole('link', { name: '+ New run' })).toBeVisible();
+  });
+
+  test('recipes live on their own surface and list the seeded recipes', async ({ page }) => {
+    await page.goto('/calibrate/recipes');
     await expect(page.getByRole('heading', { name: 'Calibration Recipes' })).toBeVisible();
     const cards = page.getByTestId('calibration-recipe-card');
     await expect(cards).toHaveCount(3);
@@ -20,7 +27,7 @@ test.describe('Calibration recipes', () => {
   });
 
   test('recipe card opens the run configuration page', async ({ page }) => {
-    await page.goto('/calibrate');
+    await page.goto('/calibrate/recipes');
     await page
       .getByTestId('calibration-recipe-card')
       .filter({ hasText: 'MIRI Imaging' })
@@ -28,12 +35,14 @@ test.describe('Calibration recipes', () => {
       .click();
     await expect(page).toHaveURL(/\/calibrate\/seed-miri-imaging$/);
     await expect(page.getByRole('heading', { name: 'Stages' })).toBeVisible();
-    // Seeded parameters are editable rows.
-    await expect(page.getByLabel('Step for parameter 1')).toHaveValue('jump');
+    // Seeded parameters render as curated controls now (#1737), not raw rows.
+    await expect(page.getByLabel('Jump detection — CPU cores')).toHaveValue('half');
+    // The stage timeline explains the pipeline rather than listing identifiers (#1736).
+    await expect(page.getByText('_uncal → _rate')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Run calibration' })).toBeEnabled();
   });
 
-  test('mocked run start shows the progress view', async ({ page }) => {
+  test('starting a run hands off to the run URL and shows progress', async ({ page }) => {
     // Intercept engine calls so no real pipeline job starts.
     await page.route('**/api/calibration/runs', (route) =>
       route.fulfill({ json: { jobId: 'e2e-job-1' }, status: 202 })
@@ -68,6 +77,9 @@ test.describe('Calibration recipes', () => {
     await page.goto('/calibrate/seed-nircam-imaging');
     await expect(page.getByRole('button', { name: 'Run calibration' })).toBeEnabled();
     await page.getByRole('button', { name: 'Run calibration' }).click();
+
+    // The run gets its own durable URL (#1734) rather than living in page state.
+    await expect(page).toHaveURL(/\/calibrate\/runs\/e2e-job-1$/);
     await expect(page.getByRole('heading', { name: 'Run progress' })).toBeVisible();
     await expect(page.getByText('running image2')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Cancel run' })).toBeVisible();

--- a/frontend/jwst-frontend/src/App.tsx
+++ b/frontend/jwst-frontend/src/App.tsx
@@ -44,6 +44,7 @@ const CalibrationGallery = lazy(() => import('./pages/CalibrationGallery'));
 const CalibrateRun = lazy(() => import('./pages/CalibrateRun'));
 const CalibrationRuns = lazy(() => import('./pages/CalibrationRuns'));
 const RunDetail = lazy(() => import('./pages/RunDetail'));
+const CalibrateNew = lazy(() => import('./pages/CalibrateNew'));
 const ArchivePage = lazy(() =>
   import('./pages/ArchivePage').then((m) => ({ default: m.ArchivePage }))
 );
@@ -91,9 +92,13 @@ function App() {
               <Route path="create" element={<GuidedCreate />} />
               {/* semantic search is out of CE v1 (its API never mounts) */}
               {!CE_MODE && <Route path="search" element={<SearchPage />} />}
-              {!CE_MODE && <Route path="calibrate" element={<CalibrationGallery />} />}
-              {/* `runs` must precede `:recipeId` — otherwise the dynamic
-                  segment swallows /calibrate/runs as a recipe id. */}
+              {/* Data-first IA (#1738): /calibrate is the run ledger, recipes
+                  are a managed surface, and a run starts from your data. */}
+              {!CE_MODE && <Route path="calibrate" element={<CalibrationRuns />} />}
+              {/* Static segments must precede `:recipeId` — otherwise the
+                  dynamic segment swallows them as recipe ids. */}
+              {!CE_MODE && <Route path="calibrate/new" element={<CalibrateNew />} />}
+              {!CE_MODE && <Route path="calibrate/recipes" element={<CalibrationGallery />} />}
               {!CE_MODE && <Route path="calibrate/runs" element={<CalibrationRuns />} />}
               {!CE_MODE && <Route path="calibrate/runs/:jobId" element={<RunDetail />} />}
               {!CE_MODE && <Route path="calibrate/:recipeId" element={<CalibrateRun />} />}

--- a/frontend/jwst-frontend/src/components/calibration/dataGrouping.test.ts
+++ b/frontend/jwst-frontend/src/components/calibration/dataGrouping.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Data grouping + recipe matching (#1738). These replace `path.includes('_cal')`
+ * over a flat list, which is what the old input picker amounted to.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fitRecipes, formatBytes, groupByTarget, instrumentOf, suffixOf } from './dataGrouping';
+import type { JwstDataModel } from '../../types/JwstDataTypes';
+import type { CalibrationRecipe } from '../../types/CalibrationTypes';
+
+function item(over: Partial<JwstDataModel> & { id: string }): JwstDataModel {
+  return {
+    fileName: 'file_cal.fits',
+    dataType: 'image',
+    uploadDate: '',
+    metadata: {},
+    fileSize: 1024 ** 2,
+    processingStatus: 'completed',
+    tags: [],
+    isArchived: false,
+    processingResults: [],
+    ...over,
+  } as JwstDataModel;
+}
+
+function recipe(id: string, instrument: string): CalibrationRecipe {
+  return { id, name: id, instrument, description: '' } as CalibrationRecipe;
+}
+
+describe('groupByTarget', () => {
+  it('groups by target name and collects filters and instruments', () => {
+    const groups = groupByTarget([
+      item({
+        id: 'a',
+        metadata: {
+          mast_target_name: 'NGC 3132',
+          mast_filters: 'F090W;F187N',
+          mast_instrument_name: 'NIRCAM/IMAGE',
+        },
+      }),
+      item({
+        id: 'b',
+        metadata: {
+          mast_target_name: 'NGC 3132',
+          mast_filters: 'F090W',
+          mast_instrument_name: 'NIRCAM',
+        },
+      }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('NGC 3132');
+    expect(groups[0].items).toHaveLength(2);
+    // Filters de-duplicate across files in the group.
+    expect(groups[0].filters).toEqual(['F090W', 'F187N']);
+    // "NIRCAM/IMAGE" and "NIRCAM" are the same instrument.
+    expect(groups[0].instruments).toEqual(['NIRCAM']);
+  });
+
+  it('falls back to the observation id, then a catch-all group', () => {
+    const groups = groupByTarget([
+      item({ id: 'a', observationBaseId: 'jw02733-o001' }),
+      item({ id: 'b' }),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['jw02733-o001', 'Other files']);
+  });
+
+  it('sorts the catch-all group last even when alphabetically early', () => {
+    const groups = groupByTarget([
+      item({ id: 'a' }),
+      item({ id: 'b', metadata: { mast_target_name: 'ZZ Top' } }),
+    ]);
+    expect(groups[groups.length - 1].label).toBe('Other files');
+  });
+});
+
+describe('suffixOf / instrumentOf', () => {
+  it('reads the product suffix from the path', () => {
+    expect(suffixOf(item({ id: 'a', filePath: 'mast/x/a_uncal.fits' }))).toBe('_uncal');
+    expect(suffixOf(item({ id: 'b', filePath: 'mast/x/b_i2d.fits' }))).toBe('_i2d');
+    expect(
+      suffixOf(item({ id: 'c', filePath: 'mast/x/mystery.fits', fileName: 'mystery.fits' }))
+    ).toBeNull();
+  });
+
+  it('normalises the instrument name', () => {
+    expect(instrumentOf(item({ id: 'a', metadata: { mast_instrument_name: 'MIRI/IMAGE' } }))).toBe(
+      'MIRI'
+    );
+    expect(instrumentOf(item({ id: 'b' }))).toBeNull();
+  });
+});
+
+describe('fitRecipes', () => {
+  const recipes = [recipe('miri-imaging', 'miri'), recipe('nircam-imaging', 'nircam')];
+
+  it('marks instrument mismatches inapplicable and sorts them last', () => {
+    const fits = fitRecipes(recipes, [
+      item({ id: 'a', metadata: { mast_instrument_name: 'NIRCAM' } }),
+    ]);
+    expect(fits[0].recipe.id).toBe('nircam-imaging');
+    expect(fits[0].applicable).toBe(true);
+    expect(fits[1].applicable).toBe(false);
+    expect(fits[1].reason).toMatch(/MIRI/);
+  });
+
+  it('treats everything as applicable when the instrument is unknown', () => {
+    // Hand-uploaded files carry no MAST metadata; don't hide every recipe.
+    const fits = fitRecipes(recipes, [item({ id: 'a' })]);
+    expect(fits.every((f) => f.applicable)).toBe(true);
+  });
+
+  it("does not disqualify on product suffix — that is the timeline's job", () => {
+    // _i2d data can't usefully run anything, but the recipe still matches the
+    // instrument; #1736's stage rules explain what can actually run.
+    const fits = fitRecipes(recipes, [
+      item({ id: 'a', filePath: 'x/a_i2d.fits', metadata: { mast_instrument_name: 'MIRI' } }),
+    ]);
+    expect(fits[0].applicable).toBe(true);
+  });
+});
+
+describe('formatBytes', () => {
+  it('switches to GB above a gigabyte', () => {
+    expect(formatBytes(0)).toBe('—');
+    expect(formatBytes(5 * 1024 ** 2)).toBe('5 MB');
+    expect(formatBytes(2.5 * 1024 ** 3)).toBe('2.5 GB');
+  });
+});

--- a/frontend/jwst-frontend/src/components/calibration/dataGrouping.ts
+++ b/frontend/jwst-frontend/src/components/calibration/dataGrouping.ts
@@ -1,0 +1,121 @@
+/**
+ * Data-first entry: grouping library files and matching recipes to them (#1738).
+ *
+ * The old flow was recipe-first — a gallery of 3 recipes at /calibrate, and
+ * inputs chosen afterwards from a flat checkbox list of raw paths matched by
+ * `path.includes('_cal')`. That answers "what recipes exist?", which is not a
+ * question people ask: they arrive holding data.
+ *
+ * Pure functions so the grouping and matching rules are testable without a DOM.
+ */
+
+import type { JwstDataModel } from '../../types/JwstDataTypes';
+import type { CalibrationRecipe } from '../../types/CalibrationTypes';
+
+const SUFFIXES = ['_uncal', '_rate', '_cal', '_i2d'];
+
+export interface DataGroup {
+  /** Target name where known, else the observation id, else a catch-all. */
+  key: string;
+  label: string;
+  items: JwstDataModel[];
+  filters: string[];
+  instruments: string[];
+  totalBytes: number;
+}
+
+export function suffixOf(item: JwstDataModel): string | null {
+  const path = item.filePath ?? item.fileName ?? '';
+  return SUFFIXES.find((s) => path.includes(s)) ?? null;
+}
+
+function metaString(item: JwstDataModel, key: string): string | null {
+  const value = item.metadata?.[key];
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+}
+
+/** Split a MAST filters string ("F090W;F187N") into individual filters. */
+function filtersOf(item: JwstDataModel): string[] {
+  const raw = metaString(item, 'mast_filters');
+  if (!raw) return [];
+  return raw
+    .split(/[;,/]/)
+    .map((f) => f.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+export function instrumentOf(item: JwstDataModel): string | null {
+  // e.g. "MIRI/IMAGE" -> "MIRI"
+  const raw = metaString(item, 'mast_instrument_name');
+  return raw ? raw.split('/')[0].trim().toUpperCase() : null;
+}
+
+/**
+ * Group by target so files present as recognisable objects rather than paths.
+ * Falls back to the observation id, then a single catch-all group — a library
+ * of hand-uploaded files still has to be usable.
+ */
+export function groupByTarget(items: JwstDataModel[]): DataGroup[] {
+  const groups = new Map<string, DataGroup>();
+  for (const item of items) {
+    const target = metaString(item, 'mast_target_name');
+    const key = target ?? item.observationBaseId ?? 'ungrouped';
+    const label = target ?? item.observationBaseId ?? 'Other files';
+    let group = groups.get(key);
+    if (!group) {
+      group = { key, label, items: [], filters: [], instruments: [], totalBytes: 0 };
+      groups.set(key, group);
+    }
+    group.items.push(item);
+    group.totalBytes += item.fileSize ?? 0;
+    for (const f of filtersOf(item)) if (!group.filters.includes(f)) group.filters.push(f);
+    const inst = instrumentOf(item);
+    if (inst && !group.instruments.includes(inst)) group.instruments.push(inst);
+  }
+  // Named targets first, then observation ids, catch-all last.
+  return Array.from(groups.values()).sort((a, b) => {
+    if (a.key === 'ungrouped') return 1;
+    if (b.key === 'ungrouped') return -1;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+export interface RecipeFit {
+  recipe: CalibrationRecipe;
+  /** False when the recipe's instrument cannot process the selection. */
+  applicable: boolean;
+  reason: string | null;
+}
+
+/**
+ * Whether a recipe can process the selected files.
+ *
+ * Only the instrument is treated as disqualifying — it is a hard mismatch.
+ * Product suffixes decide which STAGES can run, which the timeline (#1736)
+ * already communicates, so they must not hide an otherwise-valid recipe.
+ */
+export function fitRecipes(recipes: CalibrationRecipe[], selected: JwstDataModel[]): RecipeFit[] {
+  const instruments = Array.from(
+    new Set(selected.map(instrumentOf).filter((i): i is string => Boolean(i)))
+  );
+  return recipes
+    .map((recipe) => {
+      if (instruments.length === 0) return { recipe, applicable: true, reason: null };
+      const match = instruments.some((i) => i === recipe.instrument.toUpperCase());
+      return {
+        recipe,
+        applicable: match,
+        reason: match
+          ? null
+          : `for ${recipe.instrument.toUpperCase()}, your data is ${instruments.join(', ')}`,
+      };
+    })
+    .sort((a, b) => Number(b.applicable) - Number(a.applicable));
+}
+
+export function formatBytes(bytes: number): string {
+  if (!bytes) return '—';
+  const gb = bytes / 1024 ** 3;
+  if (gb >= 1) return `${gb.toFixed(1)} GB`;
+  return `${Math.max(1, Math.round(bytes / 1024 ** 2))} MB`;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrateNew.css
+++ b/frontend/jwst-frontend/src/pages/CalibrateNew.css
@@ -1,0 +1,146 @@
+.calibrate-new {
+  padding: 1.5rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+/* The steps ARE a sequence, so numbering them encodes something true. */
+.calibrate-steps {
+  display: flex;
+  gap: 0.6rem;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.25rem;
+  flex-wrap: wrap;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.calibrate-steps .is-current {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.calibrate-steps .is-done {
+  color: var(--text-secondary);
+}
+
+.calibrate-new-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.calibrate-new-head h1 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.data-group {
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  margin-bottom: 0.6rem;
+  overflow: hidden;
+}
+
+.data-group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  background: var(--bg-surface);
+  flex-wrap: wrap;
+}
+
+.data-group-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.data-group-meta {
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+
+.data-chips {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+  padding: 0.4rem 0.75rem 0;
+}
+
+.data-chip {
+  font-size: 0.68rem;
+  padding: 0.12rem 0.4rem;
+  border-radius: 3px;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+}
+
+.data-files {
+  list-style: none;
+  padding: 0.35rem 0.75rem 0.6rem;
+  margin: 0;
+}
+
+.data-files label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.data-file-suffix {
+  margin-left: auto;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.calibrate-new-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.recipe-fit-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.recipe-fit-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.7rem 0.85rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  flex-wrap: wrap;
+}
+
+/* Not hidden — a mismatched recipe still tells you something. */
+.recipe-fit-off {
+  opacity: 0.5;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrateNew.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateNew.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Data-first entry flow (#1738).
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import CalibrateNew from './CalibrateNew';
+
+vi.mock('../services/calibrationService', () => ({ listRecipes: vi.fn() }));
+vi.mock('../services/jwstDataService', () => ({ getAll: vi.fn() }));
+
+import { listRecipes } from '../services/calibrationService';
+import { getAll } from '../services/jwstDataService';
+
+const nircamFile = {
+  id: 'a',
+  fileName: 'jw02733_nircam_cal.fits',
+  filePath: 'mast/jw02733/a_cal.fits',
+  fileSize: 1024 ** 2,
+  metadata: {
+    mast_target_name: 'NGC 3132',
+    mast_filters: 'F090W',
+    mast_instrument_name: 'NIRCAM/IMAGE',
+  },
+};
+
+const recipes = [
+  { id: 'nircam-imaging', name: 'NIRCam Imaging', instrument: 'nircam', description: 'n' },
+  { id: 'miri-imaging', name: 'MIRI Imaging', instrument: 'miri', description: 'm' },
+];
+
+/** Renders the router state rather than assigning to an outer variable during
+ *  render, so the hand-off is asserted through the DOM. */
+function ConfigStub() {
+  const state = useLocation().state as unknown;
+  return <div data-testid="config-stub">{JSON.stringify(state)}</div>;
+}
+
+function renderNew() {
+  return render(
+    <MemoryRouter initialEntries={['/calibrate/new']}>
+      <Routes>
+        <Route path="/calibrate/new" element={<CalibrateNew />} />
+        <Route path="/calibrate/:recipeId" element={<ConfigStub />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('CalibrateNew', () => {
+  beforeEach(() => {
+    vi.mocked(getAll).mockResolvedValue([nircamFile] as never);
+    vi.mocked(listRecipes).mockResolvedValue(recipes as never);
+  });
+
+  it('leads with data, grouped by target rather than listing raw paths', async () => {
+    renderNew();
+    expect(await screen.findByText('NGC 3132')).toBeInTheDocument();
+    expect(screen.getByText('F090W')).toBeInTheDocument();
+    // Can't advance until data is chosen — the flow is data-first by construction.
+    expect(screen.getByRole('button', { name: /Choose recipe/ })).toBeDisabled();
+  });
+
+  it('offers only instrument-matched recipes, then hands off with the inputs', async () => {
+    renderNew();
+    await screen.findByText('NGC 3132');
+
+    await userEvent.click(screen.getByRole('checkbox', { name: /Select all in NGC 3132/ }));
+    await userEvent.click(screen.getByRole('button', { name: /Choose recipe/ }));
+
+    // NIRCam data: the MIRI recipe is shown but not selectable.
+    const buttons = await screen.findAllByRole('button', { name: /Review & run/ });
+    expect(buttons[0]).toBeEnabled();
+    expect(buttons[1]).toBeDisabled();
+
+    await userEvent.click(buttons[0]);
+    // The chosen files travel to the review step.
+    const stub = await screen.findByTestId('config-stub');
+    expect(JSON.parse(stub.textContent || '{}')).toEqual({
+      inputs: ['mast/jw02733/a_cal.fits'],
+    });
+  });
+
+  it('filters the library by search', async () => {
+    renderNew();
+    await screen.findByText('NGC 3132');
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search library' }), 'nothing');
+    await waitFor(() => expect(screen.queryByText('NGC 3132')).not.toBeInTheDocument());
+  });
+
+  it('explains the empty library instead of showing a bare list', async () => {
+    vi.mocked(getAll).mockResolvedValue([] as never);
+    renderNew();
+    expect(await screen.findByText('Nothing to calibrate yet')).toBeInTheDocument();
+  });
+});

--- a/frontend/jwst-frontend/src/pages/CalibrateNew.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateNew.tsx
@@ -47,6 +47,11 @@ export default function CalibrateNew() {
     };
   }, []);
 
+  // The library DTO does not expose filePath (see #1751), so nothing here is
+  // selectable against the real API. Distinguish "you have no data" from "your
+  // data has no usable path" rather than showing one misleading empty state.
+  const unusable = (items ?? []).length > 0 && (items ?? []).every((i) => !i.filePath);
+
   const groups = useMemo(() => {
     const filtered = (items ?? []).filter((item) => {
       if (!item.filePath) return false;
@@ -113,7 +118,14 @@ export default function CalibrateNew() {
           </div>
 
           {items === null && <p role="status">Loading library…</p>}
-          {items !== null && groups.length === 0 && (
+          {items !== null && groups.length === 0 && unusable && (
+            <EmptyState
+              title="Your library items can't be used as calibration inputs yet"
+              description="The library API doesn't return a file path for these items, so they can't be passed to the pipeline. Tracked in #1751."
+            />
+          )}
+
+          {items !== null && groups.length === 0 && !unusable && (
             <EmptyState
               title="Nothing to calibrate yet"
               description="Import observations from MAST first — they'll show up here grouped by target."

--- a/frontend/jwst-frontend/src/pages/CalibrateNew.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateNew.tsx
@@ -1,0 +1,223 @@
+/**
+ * Start a calibration, data first — /calibrate/new (#1738).
+ *
+ * Inverts the old order. You choose the data you're holding, then the app
+ * offers the recipes that can process it, then hands off to the existing
+ * configuration page (stage timeline, curated parameters, estimate) as the
+ * review step.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { EmptyState } from '../components/ui/EmptyState';
+import {
+  fitRecipes,
+  formatBytes,
+  groupByTarget,
+  suffixOf,
+} from '../components/calibration/dataGrouping';
+import { listRecipes } from '../services/calibrationService';
+import * as jwstDataService from '../services/jwstDataService';
+import type { CalibrationRecipe } from '../types/CalibrationTypes';
+import type { JwstDataModel } from '../types/JwstDataTypes';
+import './CalibrateNew.css';
+
+export default function CalibrateNew() {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<JwstDataModel[] | null>(null);
+  const [recipes, setRecipes] = useState<CalibrationRecipe[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [query, setQuery] = useState('');
+  const [step, setStep] = useState<1 | 2>(1);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([jwstDataService.getAll(false), listRecipes()])
+      .then(([data, recipeList]) => {
+        if (cancelled) return;
+        setItems(data);
+        setRecipes(recipeList);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load library');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const groups = useMemo(() => {
+    const filtered = (items ?? []).filter((item) => {
+      if (!item.filePath) return false;
+      if (!query.trim()) return true;
+      const haystack = `${item.fileName} ${item.metadata?.mast_target_name ?? ''}`.toLowerCase();
+      return haystack.includes(query.trim().toLowerCase());
+    });
+    return groupByTarget(filtered);
+  }, [items, query]);
+
+  const selected = useMemo(
+    () => (items ?? []).filter((i) => selectedIds.includes(i.id)),
+    [items, selectedIds]
+  );
+  const fits = useMemo(() => fitRecipes(recipes, selected), [recipes, selected]);
+
+  const toggle = (id: string) =>
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+
+  const toggleGroup = (ids: string[], allOn: boolean) =>
+    setSelectedIds((prev) =>
+      allOn ? prev.filter((id) => !ids.includes(id)) : Array.from(new Set([...prev, ...ids]))
+    );
+
+  const chooseRecipe = (recipe: CalibrationRecipe) => {
+    // Hand off to the existing config page as the review step, with the
+    // chosen files pre-selected.
+    navigate(`/calibrate/${recipe.id}`, {
+      state: { inputs: selected.map((i) => i.filePath).filter(Boolean) },
+    });
+  };
+
+  if (error) {
+    return (
+      <div className="calibrate-new">
+        <EmptyState title="Couldn't load your library" description={error} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="calibrate-new">
+      <nav className="calibrate-run-breadcrumb">
+        <Link to="/calibrate">← Runs</Link>
+      </nav>
+
+      <ol className="calibrate-steps" aria-label="Progress">
+        <li className={step === 1 ? 'is-current' : 'is-done'}>1 · Choose data</li>
+        <li className={step === 2 ? 'is-current' : ''}>2 · Choose recipe</li>
+        <li>3 · Review &amp; run</li>
+      </ol>
+
+      {step === 1 && (
+        <section aria-labelledby="data-heading">
+          <div className="calibrate-new-head">
+            <h1 id="data-heading">Which data are you calibrating?</h1>
+            <input
+              type="search"
+              aria-label="Search library"
+              placeholder="Search by file or target…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+
+          {items === null && <p role="status">Loading library…</p>}
+          {items !== null && groups.length === 0 && (
+            <EmptyState
+              title="Nothing to calibrate yet"
+              description="Import observations from MAST first — they'll show up here grouped by target."
+            />
+          )}
+
+          {groups.map((group) => {
+            const ids = group.items.map((i) => i.id);
+            const allOn = ids.every((id) => selectedIds.includes(id));
+            return (
+              <div className="data-group" key={group.key}>
+                <div className="data-group-head">
+                  <label className="data-group-title">
+                    <input
+                      type="checkbox"
+                      checked={allOn}
+                      aria-label={`Select all in ${group.label}`}
+                      onChange={() => toggleGroup(ids, allOn)}
+                    />
+                    <strong>{group.label}</strong>
+                  </label>
+                  <span className="data-group-meta">
+                    {group.instruments.join(', ')} · {group.items.length} files ·{' '}
+                    {formatBytes(group.totalBytes)}
+                  </span>
+                </div>
+                {group.filters.length > 0 && (
+                  <div className="data-chips">
+                    {group.filters.map((f) => (
+                      <span className="data-chip" key={f}>
+                        {f}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <ul className="data-files">
+                  {group.items.map((item) => (
+                    <li key={item.id}>
+                      <label>
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.includes(item.id)}
+                          onChange={() => toggle(item.id)}
+                        />
+                        <span>{item.fileName}</span>
+                        <span className="data-file-suffix">{suffixOf(item) ?? '—'}</span>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+
+          <div className="calibrate-new-bar">
+            <span>
+              {selected.length === 0
+                ? 'Nothing selected yet'
+                : `${selected.length} file${selected.length === 1 ? '' : 's'} selected`}
+            </span>
+            <button
+              type="button"
+              className="btn-base btn-standard"
+              disabled={selected.length === 0}
+              onClick={() => setStep(2)}
+            >
+              Choose recipe →
+            </button>
+          </div>
+        </section>
+      )}
+
+      {step === 2 && (
+        <section aria-labelledby="recipe-heading">
+          <div className="calibrate-new-head">
+            <h1 id="recipe-heading">Which recipe?</h1>
+            <button type="button" className="btn-base btn-compact" onClick={() => setStep(1)}>
+              ← Change data
+            </button>
+          </div>
+          <p className="calibrate-hint">
+            {selected.length} file{selected.length === 1 ? '' : 's'} selected. Recipes for a
+            different instrument are shown last and can&apos;t process this data.
+          </p>
+          <ul className="recipe-fit-list">
+            {fits.map(({ recipe, applicable, reason }) => (
+              <li key={recipe.id} className={applicable ? '' : 'recipe-fit-off'}>
+                <div>
+                  <strong>{recipe.name}</strong>
+                  <div className="calibrate-hint">{reason ?? recipe.description}</div>
+                </div>
+                <button
+                  type="button"
+                  className="btn-base btn-compact"
+                  disabled={!applicable}
+                  onClick={() => chooseRecipe(recipe)}
+                >
+                  Review &amp; run →
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
@@ -123,8 +123,8 @@ export default function CalibrationGallery() {
       <header className="calibration-gallery-header">
         <div className="calibration-gallery-titlerow">
           <h1>Calibration Recipes</h1>
-          <Link className="btn-base btn-compact" to="/calibrate/runs">
-            View runs
+          <Link className="btn-base btn-compact" to="/calibrate">
+            ← Runs
           </Link>
         </div>
         <p className="calibration-gallery-subtitle">

--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.css
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.css
@@ -107,3 +107,9 @@
     grid-template-columns: 1fr;
   }
 }
+
+.calibration-runs-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}

--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.test.tsx
@@ -4,13 +4,15 @@
 
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CalibrationRuns from './CalibrationRuns';
 import type { CalibrationJob } from '../types/CalibrationTypes';
 
 vi.mock('../services/calibrationService', () => ({
   listJobs: vi.fn(),
 }));
+const authState = { isAuthenticated: true };
+vi.mock('../context/useAuth', () => ({ useAuth: () => authState }));
 
 import { listJobs } from '../services/calibrationService';
 
@@ -40,6 +42,29 @@ function renderRuns() {
 }
 
 describe('CalibrationRuns', () => {
+  beforeEach(() => {
+    authState.isAuthenticated = true;
+  });
+
+  it('keeps navigation and points anonymous visitors at the public recipes', async () => {
+    // Regression: /calibrate is a public route but runs need auth, so the page
+    // used to dead-end on "Not authenticated" with no way out.
+    authState.isAuthenticated = false;
+    renderRuns();
+
+    expect(await screen.findByText('Sign in to see your calibration runs')).toBeInTheDocument();
+    // The header survives — a failed/By-design-empty fetch must not strip nav.
+    expect(screen.getByRole('heading', { name: 'Calibration runs' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '+ New run' })).toBeInTheDocument();
+    expect(vi.mocked(listJobs)).not.toHaveBeenCalled();
+  });
+
+  it('keeps navigation when the run list fails to load', async () => {
+    vi.mocked(listJobs).mockRejectedValue(new Error('engine unreachable'));
+    renderRuns();
+    expect(await screen.findByText("Couldn't load your runs")).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '+ New run' })).toBeInTheDocument();
+  });
   it('separates active runs from history and links each to its own URL', async () => {
     vi.mocked(listJobs).mockResolvedValue([
       job({ jobId: 'run-active', status: 'running', finishedAt: null }),
@@ -74,10 +99,9 @@ describe('CalibrationRuns', () => {
     expect(await screen.findByText('No calibration runs yet')).toBeInTheDocument();
   });
 
-  it('surfaces a load failure instead of rendering an empty list', async () => {
+  it('surfaces the failure reason', async () => {
     vi.mocked(listJobs).mockRejectedValue(new Error('engine unreachable'));
     renderRuns();
-    expect(await screen.findByText("Couldn't load runs")).toBeInTheDocument();
-    expect(screen.getByText('engine unreachable')).toBeInTheDocument();
+    expect(await screen.findByText('engine unreachable')).toBeInTheDocument();
   });
 });

--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { EmptyState } from '../components/ui/EmptyState';
 import { listJobs } from '../services/calibrationService';
+import { useAuth } from '../context/useAuth';
 import type { CalibrationJob } from '../types/CalibrationTypes';
 import './CalibrationRuns.css';
 
@@ -52,8 +53,13 @@ export function RunRow({ job }: { job: CalibrationJob }) {
 export default function CalibrationRuns() {
   const [jobs, setJobs] = useState<CalibrationJob[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const { isAuthenticated } = useAuth();
 
   useEffect(() => {
+    // Runs are per-user, so an anonymous visitor has none to fetch. Recipes
+    // stay publicly browsable, so this page must still offer a way there
+    // rather than dead-ending on a 401.
+    if (!isAuthenticated) return undefined;
     let cancelled = false;
     const load = () => {
       listJobs()
@@ -71,15 +77,7 @@ export default function CalibrationRuns() {
       cancelled = true;
       clearInterval(timer);
     };
-  }, []);
-
-  if (error) {
-    return (
-      <div className="calibration-runs">
-        <EmptyState title="Couldn't load runs" description={error} />
-      </div>
-    );
-  }
+  }, [isAuthenticated]);
 
   const active = jobs?.filter((j) => ACTIVE.has(j.status)) ?? [];
   const past = jobs?.filter((j) => !ACTIVE.has(j.status)) ?? [];
@@ -90,7 +88,11 @@ export default function CalibrationRuns() {
         <div>
           <h1>Calibration runs</h1>
           <p className="calibrate-hint">
-            {jobs === null ? 'Loading…' : `${active.length} active · ${past.length} completed`}
+            {!isAuthenticated
+              ? 'Signed-out view'
+              : jobs === null
+                ? 'Loading…'
+                : `${active.length} active · ${past.length} completed`}
           </p>
         </div>
         <div className="calibration-runs-actions">
@@ -103,7 +105,21 @@ export default function CalibrationRuns() {
         </div>
       </header>
 
-      {jobs !== null && jobs.length === 0 && (
+      {error && <EmptyState title="Couldn't load your runs" description={error} />}
+
+      {!error && !isAuthenticated && (
+        <EmptyState
+          title="Sign in to see your calibration runs"
+          description="Runs are tied to your account. Recipes are browsable without signing in."
+          actions={
+            <Link className="btn-base btn-standard" to="/calibrate/recipes">
+              Browse recipes
+            </Link>
+          }
+        />
+      )}
+
+      {!error && isAuthenticated && jobs !== null && jobs.length === 0 && (
         <EmptyState
           title="No calibration runs yet"
           description="Start one from your data — it'll show up here, and stay here even if you navigate away."

--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.tsx
@@ -93,18 +93,23 @@ export default function CalibrationRuns() {
             {jobs === null ? 'Loading…' : `${active.length} active · ${past.length} completed`}
           </p>
         </div>
-        <Link className="btn-base btn-compact" to="/calibrate">
-          Browse recipes
-        </Link>
+        <div className="calibration-runs-actions">
+          <Link className="btn-base btn-compact" to="/calibrate/recipes">
+            Recipes
+          </Link>
+          <Link className="btn-base btn-standard" to="/calibrate/new">
+            + New run
+          </Link>
+        </div>
       </header>
 
       {jobs !== null && jobs.length === 0 && (
         <EmptyState
           title="No calibration runs yet"
-          description="Pick a recipe and start one — it'll show up here, and stay here even if you navigate away."
+          description="Start one from your data — it'll show up here, and stay here even if you navigate away."
           actions={
-            <Link className="btn-base btn-standard" to="/calibrate">
-              Browse recipes
+            <Link className="btn-base btn-standard" to="/calibrate/new">
+              Start a calibration
             </Link>
           }
         />


### PR DESCRIPTION
## Summary

**Closes #1738.** Phase 6 — the IA pivot, and the last piece of **#1733**.

The IA was recipe-first: `/calibrate` was a gallery of 3 recipes, and inputs were chosen afterwards from a flat checkbox list of raw paths matched by `path.includes('_cal')`. That answers *"what recipes exist?"*, which is not a question people ask — they arrive holding data.

## Changes Made

- **`/calibrate` is now the run ledger.** Recipes move to `/calibrate/recipes`, which is also where the notebook importer lives.
- **New `/calibrate/new` leads with data** — library files grouped by **target**, with filter chips, per-group select-all, search, sizes and product suffixes. Then it offers the recipes that can process that data, and hands off to the existing configuration page as the review step, where the stage timeline (#1736), curated parameters (#1737) and estimate already live.
- **`components/calibration/dataGrouping.ts`** holds grouping and matching as pure functions.
- **Fixes the E2E regression I introduced in #1749** (see below).

## Judgement calls

- **Only the instrument disqualifies a recipe.** Product suffixes decide which *stages* can run, which the timeline already explains — so they must not hide an otherwise-valid recipe.
- **A mismatched recipe is greyed, not removed.** "MIRI recipe, your data is NIRCAM" is information; an empty list isn't.
- **Unknown instrument ⇒ everything applicable.** Hand-uploaded files carry no MAST metadata; hiding every recipe would be worse than offering all of them.
- **Fallback grouping:** target name → observation id → a single "Other files" group, so a library of hand-uploaded files stays usable.
- **Step 3 is the existing config page**, not a new screen. The review step already existed; rebuilding it would have been churn.

## E2E regression fix (found and fixed here)

`calibrate.spec.ts` failed on #1749 and I merged it because CI Gate treats E2E as informational. That was a real regression, not a flake: the spec asserted `getByLabel('Step for parameter 1')` — a raw input the curated editor replaced with a labelled `<select>`.

The spec is now updated for the whole redesign and covers it end to end: the ledger at `/calibrate`, recipes at `/calibrate/recipes`, the curated control, the stage-timeline connectors, and the run hand-off to `/calibrate/runs/:jobId`.

## Test Plan

- [x] `vitest run src/components/calibration/dataGrouping.test.ts src/pages/CalibrateNew.test.tsx` — **13 passed**.
- [x] Grouping rules tested directly: group by target with de-duplicated filters, `NIRCAM/IMAGE` and `NIRCAM` treated as one instrument, fallback to observation id then "Other files", catch-all sorted last, suffix parsing, instrument normalisation.
- [x] Matching rules: instrument mismatch marked inapplicable **and sorted last**; unknown instrument ⇒ all applicable; **product suffix explicitly does not disqualify**.
- [x] Flow test: data leads (the Choose-recipe button is disabled until files are selected), a MIRI recipe is disabled for NIRCam data, and the selected file paths arrive at the review step — asserted through the DOM rather than a variable reassigned during render.
- [x] Full frontend suite — **1244 passed / 115 files**. `tsc -b` clean, ESLint 0 errors.
- [ ] **Manual (reviewer):** `/calibrate` shows runs → **+ New run** → pick files under a target → only matching recipes are selectable → **Review & run** lands on the config page with those files pre-selected and the timeline reflecting their suffix.

## Documentation Checklist

- [x] IA rationale documented in `dataGrouping.ts` and the route block in `App.tsx` (including why static segments must precede `:recipeId`).
- [ ] `docs/key-files.md` / `architecture/` — the end-of-epic docs sweep is the one deferred item across all six phases; worth its own small PR.
- [x] No API surface change.

## Tech Debt Impact

- [x] **Removes** debt: the flat path-substring input picker is gone from the primary flow.
- [x] Grouping/matching are pure and tested rather than embedded in JSX.
- [x] **Remaining follow-on:** the Reprocess deep-link from the library still lands on the config page directly (which works, and pre-selects its files). Routing it through the new flow isn't needed — it already knows both data and recipe.

## Risk & Rollback

- **Risk: Medium — this moves the front door.** `/calibrate` now shows something different than it did. No backend, no persistence, no data change, and the old pages are all still reachable at their new URLs.
- The nav link still points at `/calibrate`, which is intentional: "Calibrate" now means your runs.
- **Rollback:** revert the commit; routes return to gallery-first.

## Linked Issue

Closes #1738.
