### PR TITLE
fix: calibration inputs are library ids, resolved server-side (#1751)

### DIFF
--- a/docs/architecture/calibration-pipeline-flow.md
+++ b/docs/architecture/calibration-pipeline-flow.md
@@ -33,7 +33,7 @@ Users can also **import** JWPipeNB notebooks: the importer statically parses the
 Frontend (/calibrate/:recipeId)                 Engine                      External
         │                                          │                            │
         │  POST /api/calibration/runs              │                            │
-        │  {recipeId, inputs, runOverrides,        │                            │
+        │  {recipeId, inputDataIds, runOverrides,  │                            │
         │   enabledStages}                         │                            │
         ├─────────────────────────────────────────►                            │
         │           (require_user; validate        │                            │
@@ -55,8 +55,16 @@ Frontend (/calibrate/:recipeId)                 Engine                      Exte
         ◄─────────────────────────────────────────┤                            │
 ```
 
-- **Stage-3 fast path**: when `inputs` are library `_cal` keys and only
-  `image3` is enabled, the download and detector1/image2 stages are skipped —
+- **Inputs are library ids, never paths** (#1751): the client sends
+  `inputDataIds` and the engine resolves each to a storage key from a document
+  the caller may read — their own, public, or shared-with-them items; an Admin
+  may use any. An id that is unknown, invisible, archived, duplicated, or has
+  no file behind it fails the whole request with 422 rather than being dropped,
+  since a run on a silently shorter input list yields a wrong mosaic. Raw
+  storage keys in `inputs` are **rejected** (422): nothing authorizes a key
+  per-record, so accepting one would let any user calibrate another's file.
+- **Stage-3 fast path**: when the resolved inputs are library `_cal` files and
+  only `image3` is enabled, the download and detector1/image2 stages are skipped —
   the pipeline re-combines already-calibrated exposures into a fresh mosaic in
   minutes. This is what the library **Reprocess** action triggers.
 - **File handoff** between stages is by suffix inside the per-job workdir:

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -143,7 +143,7 @@ CE env vars: `CE_MODE`, `MONGODB_URI` (read-only credentials suffice), `MONGODB_
 - `GET /api/calibration/recipes` - List visible recipes (seeds + public + own) | `GET /api/calibration/recipes/{id}` - Get one
 - `POST /api/calibration/recipes` - Create (auth) | `PUT`/`DELETE .../{id}` - Update/delete own; seeds immutable (403)
 - `POST /api/calibration/recipes/import` - Import a JWPipeNB `.ipynb` (auth; static parse, never executes; 5MB cap)
-- `POST /api/calibration/runs` - Start a run (auth; 501 when disabled) -> `{jobId}`
+- `POST /api/calibration/runs` - Start a run (auth; 501 when disabled) -> `{jobId}`. Body takes `inputDataIds` (library ids, resolved server-side); raw `inputs` storage keys are rejected 422 (#1751)
 
 **Jobs** (#1709 — generic job store, ADR-0001 Phase 3):
 - `GET /api/jobs` - Own jobs | `GET /api/jobs/{id}` - Status/progress/logTail (poll for live updates) | `POST /api/jobs/{id}/cancel`

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -61,11 +61,9 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
         return;
       }
       const recipeId = `seed-${instrument}-imaging`;
+      // reprocessInputIds always returns at least the clicked item, so there
+      // is nothing to guard against here.
       const inputDataIds = reprocessInputIds(data, item);
-      if (inputDataIds.length === 0) {
-        toast.info('No downloaded calibrated exposures to reprocess for this observation.');
-        return;
-      }
       navigate(`/calibrate/${recipeId}`, { state: { inputDataIds, stage3Only: true } });
     },
     [data, navigate]

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom';
 import { CE_MODE } from '../config/ce';
 import { getCapabilities } from '../services/calibrationService';
+import { reprocessInputIds } from './calibration/dataGrouping';
 import { toast } from './ui/toast';
 import {
   JwstDataModel,
@@ -60,15 +61,7 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
         return;
       }
       const recipeId = `seed-${instrument}-imaging`;
-      const siblings = data.filter(
-        (d) =>
-          d.observationBaseId === item.observationBaseId &&
-          d.fileName.includes('_cal') &&
-          d.filePath
-      );
-      // Ids, not paths (#1751): the DTO has no filePath, so the old mapping
-      // was always empty and Reprocess never actually worked.
-      const inputDataIds = (siblings.length > 0 ? siblings : [item]).map((d) => d.id);
+      const inputDataIds = reprocessInputIds(data, item);
       if (inputDataIds.length === 0) {
         toast.info('No downloaded calibrated exposures to reprocess for this observation.');
         return;

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -66,14 +66,14 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
           d.fileName.includes('_cal') &&
           d.filePath
       );
-      const inputs = (siblings.length > 0 ? siblings : [item])
-        .map((d) => d.filePath)
-        .filter((p): p is string => Boolean(p));
-      if (inputs.length === 0) {
+      // Ids, not paths (#1751): the DTO has no filePath, so the old mapping
+      // was always empty and Reprocess never actually worked.
+      const inputDataIds = (siblings.length > 0 ? siblings : [item]).map((d) => d.id);
+      if (inputDataIds.length === 0) {
         toast.info('No downloaded calibrated exposures to reprocess for this observation.');
         return;
       }
-      navigate(`/calibrate/${recipeId}`, { state: { inputs, stage3Only: true } });
+      navigate(`/calibrate/${recipeId}`, { state: { inputDataIds, stage3Only: true } });
     },
     [data, navigate]
   );

--- a/frontend/jwst-frontend/src/components/calibration/dataGrouping.test.ts
+++ b/frontend/jwst-frontend/src/components/calibration/dataGrouping.test.ts
@@ -4,7 +4,14 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { fitRecipes, formatBytes, groupByTarget, instrumentOf, suffixOf } from './dataGrouping';
+import {
+  fitRecipes,
+  formatBytes,
+  groupByTarget,
+  instrumentOf,
+  reprocessInputIds,
+  suffixOf,
+} from './dataGrouping';
 import type { JwstDataModel } from '../../types/JwstDataTypes';
 import type { CalibrationRecipe } from '../../types/CalibrationTypes';
 
@@ -76,11 +83,9 @@ describe('groupByTarget', () => {
 
 describe('suffixOf / instrumentOf', () => {
   it('reads the product suffix from the path', () => {
-    expect(suffixOf(item({ id: 'a', filePath: 'mast/x/a_uncal.fits' }))).toBe('_uncal');
-    expect(suffixOf(item({ id: 'b', filePath: 'mast/x/b_i2d.fits' }))).toBe('_i2d');
-    expect(
-      suffixOf(item({ id: 'c', filePath: 'mast/x/mystery.fits', fileName: 'mystery.fits' }))
-    ).toBeNull();
+    expect(suffixOf(item({ id: 'a', fileName: 'a_uncal.fits' }))).toBe('_uncal');
+    expect(suffixOf(item({ id: 'b', fileName: 'b_i2d.fits' }))).toBe('_i2d');
+    expect(suffixOf(item({ id: 'c', fileName: 'mystery.fits' }))).toBeNull();
   });
 
   it('normalises the instrument name', () => {
@@ -114,7 +119,7 @@ describe('fitRecipes', () => {
     // _i2d data can't usefully run anything, but the recipe still matches the
     // instrument; #1736's stage rules explain what can actually run.
     const fits = fitRecipes(recipes, [
-      item({ id: 'a', filePath: 'x/a_i2d.fits', metadata: { mast_instrument_name: 'MIRI' } }),
+      item({ id: 'a', fileName: 'a_i2d.fits', metadata: { mast_instrument_name: 'MIRI' } }),
     ]);
     expect(fits[0].applicable).toBe(true);
   });
@@ -125,5 +130,33 @@ describe('formatBytes', () => {
     expect(formatBytes(0)).toBe('—');
     expect(formatBytes(5 * 1024 ** 2)).toBe('5 MB');
     expect(formatBytes(2.5 * 1024 ** 3)).toBe('2.5 GB');
+  });
+});
+
+describe('reprocessInputIds', () => {
+  const row = (id: string, fileName: string, obs?: string) =>
+    ({ id, fileName, observationBaseId: obs }) as JwstDataModel;
+
+  it('takes every calibrated exposure in the observation, not just the clicked one', () => {
+    // Regression (#1751): a `filePath` predicate here matched nothing, so a
+    // reprocess silently mosaicked a single frame.
+    const data = [
+      row('a', 'a_cal.fits', 'obs1'),
+      row('b', 'b_cal.fits', 'obs1'),
+      row('c', 'c_cal.fits', 'obs2'),
+      row('d', 'd_uncal.fits', 'obs1'),
+    ];
+    expect(reprocessInputIds(data, data[0])).toEqual(['a', 'b']);
+  });
+
+  it('falls back to the clicked item when it has no siblings', () => {
+    const only = row('a', 'a_cal.fits', 'obs1');
+    expect(reprocessInputIds([only], only)).toEqual(['a']);
+  });
+
+  it('does not group unrelated items that both lack an observation id', () => {
+    const a = row('a', 'a_cal.fits');
+    const b = row('b', 'b_cal.fits');
+    expect(reprocessInputIds([a, b], a)).toEqual(['a']);
   });
 });

--- a/frontend/jwst-frontend/src/components/calibration/dataGrouping.ts
+++ b/frontend/jwst-frontend/src/components/calibration/dataGrouping.ts
@@ -25,7 +25,8 @@ export interface DataGroup {
 }
 
 export function suffixOf(item: JwstDataModel): string | null {
-  const path = item.filePath ?? item.fileName ?? '';
+  // fileName only: the library DTO never publishes a path (#1751).
+  const path = item.fileName ?? '';
   return SUFFIXES.find((s) => path.includes(s)) ?? null;
 }
 
@@ -118,4 +119,22 @@ export function formatBytes(bytes: number): string {
   const gb = bytes / 1024 ** 3;
   if (gb >= 1) return `${gb.toFixed(1)} GB`;
   return `${Math.max(1, Math.round(bytes / 1024 ** 2))} MB`;
+}
+
+/**
+ * Library ids to reprocess when the user hits Reprocess on one exposure: the
+ * whole observation's calibrated set, so stage 3 has something to mosaic.
+ *
+ * Falls back to the clicked item alone when it has no siblings. Deliberately
+ * matches on fileName — the DTO publishes no path (#1751), and an earlier
+ * `filePath` predicate here silently reduced every reprocess to a single frame.
+ */
+export function reprocessInputIds(data: JwstDataModel[], item: JwstDataModel): string[] {
+  const siblings = data.filter(
+    (d) =>
+      d.observationBaseId !== undefined &&
+      d.observationBaseId === item.observationBaseId &&
+      d.fileName.includes('_cal')
+  );
+  return (siblings.length > 0 ? siblings : [item]).map((d) => d.id);
 }

--- a/frontend/jwst-frontend/src/components/calibration/dataGrouping.ts
+++ b/frontend/jwst-frontend/src/components/calibration/dataGrouping.ts
@@ -132,9 +132,9 @@ export function formatBytes(bytes: number): string {
 export function reprocessInputIds(data: JwstDataModel[], item: JwstDataModel): string[] {
   const siblings = data.filter(
     (d) =>
-      d.observationBaseId !== undefined &&
+      d.observationBaseId != null &&
       d.observationBaseId === item.observationBaseId &&
-      d.fileName.includes('_cal')
+      (d.fileName ?? '').includes('_cal')
   );
   return (siblings.length > 0 ? siblings : [item]).map((d) => d.id);
 }

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.ce.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.ce.test.tsx
@@ -23,7 +23,6 @@ const item: JwstDataModel = {
   dataType: 'image',
   fileSize: 5242880,
   processingStatus: 'completed',
-  filePath: '/app/data/mast/test/test_cal.fits',
   uploadDate: '2026-01-01T00:00:00Z',
   tags: [],
   description: '',

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.test.tsx
@@ -37,7 +37,6 @@ const mockItem: JwstDataModel = {
   dataType: 'image',
   fileSize: 5242880,
   processingStatus: 'completed',
-  filePath: '/app/data/mast/test/test_cal.fits',
   uploadDate: '2026-01-01T00:00:00Z',
   tags: ['nircam', 'deep-field'],
   description: 'Test description',

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.ce.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.ce.test.tsx
@@ -23,7 +23,6 @@ const item: JwstDataModel = {
   dataType: 'image',
   fileSize: 1048576,
   processingStatus: 'completed',
-  filePath: 'mast/x/test_i2d.fits',
   uploadDate: '2026-01-01T00:00:00Z',
   tags: [],
   description: '',

--- a/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageFileCard.test.tsx
@@ -37,7 +37,6 @@ const mockItem: JwstDataModel = {
   dataType: 'image',
   fileSize: 5242880,
   processingStatus: 'completed',
-  filePath: '/app/data/mast/test/test_cal.fits',
   uploadDate: '2026-01-01T00:00:00Z',
   tags: ['nircam'],
   description: 'Test description',

--- a/frontend/jwst-frontend/src/components/dashboard/LineageView.ce.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/LineageView.ce.test.tsx
@@ -20,7 +20,6 @@ const item: JwstDataModel = {
   observationBaseId: 'jw01234-o001',
   dataType: 'image',
   processingStatus: 'completed',
-  filePath: 'mast/x/test_i2d.fits',
   tags: [],
   description: '',
   isArchived: false,

--- a/frontend/jwst-frontend/src/pages/CalibrateNew.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateNew.test.tsx
@@ -17,7 +17,6 @@ import { getAll } from '../services/jwstDataService';
 const nircamFile = {
   id: 'a',
   fileName: 'jw02733_nircam_cal.fits',
-  filePath: 'mast/jw02733/a_cal.fits',
   fileSize: 1024 ** 2,
   metadata: {
     mast_target_name: 'NGC 3132',

--- a/frontend/jwst-frontend/src/pages/CalibrateNew.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateNew.test.tsx
@@ -78,9 +78,7 @@ describe('CalibrateNew', () => {
     await userEvent.click(buttons[0]);
     // The chosen files travel to the review step.
     const stub = await screen.findByTestId('config-stub');
-    expect(JSON.parse(stub.textContent || '{}')).toEqual({
-      inputs: ['mast/jw02733/a_cal.fits'],
-    });
+    expect(JSON.parse(stub.textContent || '{}')).toEqual({ inputDataIds: ['a'] });
   });
 
   it('filters the library by search', async () => {

--- a/frontend/jwst-frontend/src/pages/CalibrateNew.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateNew.tsx
@@ -47,14 +47,8 @@ export default function CalibrateNew() {
     };
   }, []);
 
-  // The library DTO does not expose filePath (see #1751), so nothing here is
-  // selectable against the real API. Distinguish "you have no data" from "your
-  // data has no usable path" rather than showing one misleading empty state.
-  const unusable = (items ?? []).length > 0 && (items ?? []).every((i) => !i.filePath);
-
   const groups = useMemo(() => {
     const filtered = (items ?? []).filter((item) => {
-      if (!item.filePath) return false;
       if (!query.trim()) return true;
       const haystack = `${item.fileName} ${item.metadata?.mast_target_name ?? ''}`.toLowerCase();
       return haystack.includes(query.trim().toLowerCase());
@@ -80,7 +74,7 @@ export default function CalibrateNew() {
     // Hand off to the existing config page as the review step, with the
     // chosen files pre-selected.
     navigate(`/calibrate/${recipe.id}`, {
-      state: { inputs: selected.map((i) => i.filePath).filter(Boolean) },
+      state: { inputDataIds: selected.map((i) => i.id) },
     });
   };
 
@@ -118,14 +112,7 @@ export default function CalibrateNew() {
           </div>
 
           {items === null && <p role="status">Loading library…</p>}
-          {items !== null && groups.length === 0 && unusable && (
-            <EmptyState
-              title="Your library items can't be used as calibration inputs yet"
-              description="The library API doesn't return a file path for these items, so they can't be passed to the pipeline. Tracked in #1751."
-            />
-          )}
-
-          {items !== null && groups.length === 0 && !unusable && (
+          {items !== null && groups.length === 0 && (
             <EmptyState
               title="Nothing to calibrate yet"
               description="Import observations from MAST first — they'll show up here grouped by target."

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -337,6 +337,42 @@ describe('CalibrateRun', () => {
     expect(vi.mocked(startRun).mock.lastCall?.[0].inputDataIds).toEqual(['c']);
   });
 
+  it('does not claim an empty library while the library is still loading', async () => {
+    // Guaranteed, not racy: the first render of the Inputs section always has
+    // an empty list with the fetch in flight, so an ungated empty state shows
+    // "No matching library files found" to every visitor, every time.
+    let resolveGetAll: (items: unknown) => void = () => {};
+    vi.mocked(getAll).mockReturnValue(
+      new Promise((resolve) => {
+        resolveGetAll = resolve;
+      }) as never
+    );
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: { inputDataIds: ['c'], stage3Only: true },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Mid-flight: no false empty state, no "left out" claim, Run held back.
+    expect(await screen.findByText('Loading your library…')).toBeInTheDocument();
+    expect(screen.queryByText(/No matching library files/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run calibration' })).toBeDisabled();
+
+    resolveGetAll([{ id: 'c', fileName: 'a_cal.fits' }]);
+    expect(await screen.findByRole('checkbox', { name: /a_cal\.fits/ })).toBeChecked();
+    expect(screen.getByRole('button', { name: 'Run calibration' })).toBeEnabled();
+  });
+
   it('a failed library load reads as a failure, not as an empty library', async () => {
     vi.mocked(getAll).mockRejectedValue(new Error('network down'));
     render(

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -222,4 +222,82 @@ describe('CalibrateRun', () => {
     expect(b).not.toBeChecked();
     expect(screen.queryByText(/No matching library files/)).not.toBeInTheDocument();
   });
+
+  it('data-first hand-off keeps the recipe _uncal filter — it is not a reprocess', async () => {
+    // Regression: the _cal override used to fire for ANY preset ids, which
+    // made the picker's _uncal selections vanish from this page while still
+    // being submitted.
+    vi.mocked(getAll).mockResolvedValue([
+      { id: 'u', fileName: 'a_uncal.fits' },
+      { id: 'c', fileName: 'a_cal.fits' },
+    ] as never);
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: { inputDataIds: ['u'] },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    const uncal = await screen.findByRole('checkbox', { name: /a_uncal\.fits/ });
+    expect(uncal).toBeChecked();
+    expect(screen.queryByRole('checkbox', { name: /a_cal\.fits/ })).not.toBeInTheDocument();
+  });
+
+  it('never submits a pre-selected file it did not show, and says so', async () => {
+    vi.mocked(getAll).mockResolvedValue([{ id: 'c', fileName: 'a_cal.fits' }] as never);
+    vi.mocked(startRun).mockResolvedValue({ jobId: 'job-9' } as never);
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            // 'ghost' matches the _cal filter in no way the list can show.
+            state: { inputDataIds: ['c', 'ghost'], stage3Only: true },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+          <Route path="/calibrate/runs/:jobId" element={<div>run detail stub</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    // Wait for the list itself first — the loading placeholder is also a
+    // status region. Text is interpolated, so assert on the region's content.
+    await screen.findByRole('checkbox', { name: /a_cal\.fits/ });
+    expect(screen.getByRole('status')).toHaveTextContent(/1 pre-selected file/i);
+    await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+    await waitFor(() => expect(startRun).toHaveBeenCalled());
+    // lastCall, not calls[0]: this file's beforeEach re-stubs the mocks but
+    // never clears their call history.
+    expect(vi.mocked(startRun).mock.lastCall?.[0].inputDataIds).toEqual(['c']);
+  });
+
+  it('a failed library load reads as a failure, not as an empty library', async () => {
+    vi.mocked(getAll).mockRejectedValue(new Error('network down'));
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: { inputDataIds: ['a'], stage3Only: true },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole('alert')).toHaveTextContent('network down');
+    expect(screen.queryByText(/No matching library files/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run calibration' })).toBeDisabled();
+  });
 });

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -223,6 +223,63 @@ describe('CalibrateRun', () => {
     expect(screen.queryByText(/No matching library files/)).not.toBeInTheDocument();
   });
 
+  it('always lists a pre-selected file, even when it does not match the recipe suffix', async () => {
+    // The filter decides what to BROWSE, never what you may run on. Hiding a
+    // preset broke _uncal picks on a reprocess and then _cal picks on a seed
+    // recipe — a dead end with no recovery on the page either way.
+    vi.mocked(getAll).mockResolvedValue([
+      { id: 'c', fileName: 'a_cal.fits' },
+      { id: 'u', fileName: 'b_uncal.fits' },
+    ] as never);
+    vi.mocked(startRun).mockResolvedValue({ jobId: 'job-8' } as never);
+    render(
+      <MemoryRouter
+        initialEntries={[
+          // Seed recipe browses _uncal; the picked file is _cal.
+          { pathname: '/calibrate/seed-nircam-imaging', state: { inputDataIds: ['c'] } },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+          <Route path="/calibrate/runs/:jobId" element={<div>run detail stub</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    const cal = await screen.findByRole('checkbox', { name: /a_cal\.fits/ });
+    expect(cal).toBeChecked();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+    await waitFor(() => expect(startRun).toHaveBeenCalled());
+    expect(vi.mocked(startRun).mock.lastCall?.[0].inputDataIds).toEqual(['c']);
+  });
+
+  it('never submits a stage the page shows as blocked', async () => {
+    // The recipe enables detector1, but _cal inputs block it; the timeline
+    // renders it off and excludes it from the estimate. Submitting it as on
+    // would fail hours into the run.
+    vi.mocked(getAll).mockResolvedValue([{ id: 'c', fileName: 'a_cal.fits' }] as never);
+    vi.mocked(startRun).mockResolvedValue({ jobId: 'job-7' } as never);
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: { inputDataIds: ['c'], stage3Only: false },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+          <Route path="/calibrate/runs/:jobId" element={<div>run detail stub</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await screen.findByRole('checkbox', { name: /a_cal\.fits/ });
+    await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+    await waitFor(() => expect(startRun).toHaveBeenCalled());
+    expect(vi.mocked(startRun).mock.lastCall?.[0].enabledStages.detector1).toBe(false);
+  });
+
   it('data-first hand-off keeps the recipe _uncal filter — it is not a reprocess', async () => {
     // Regression: the _cal override used to fire for ANY preset ids, which
     // made the picker's _uncal selections vanish from this page while still

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -117,7 +117,7 @@ describe('CalibrateRun', () => {
 
     expect(vi.mocked(startRun)).toHaveBeenCalledWith({
       recipeId: 'seed-nircam-imaging',
-      inputs: [],
+      inputDataIds: [],
       runOverrides: { jump: { maximum_cores: 'half' } },
       enabledStages: { detector1: true, image2: true, image3: true },
     });
@@ -151,7 +151,7 @@ describe('CalibrateRun', () => {
               rerun: {
                 enabledStages: { detector1: false, image2: false, image3: true },
                 runOverrides: { skymatch: { skymethod: 'global+match' } },
-                inputs: ['mast/jw1/a_cal.fits'],
+                inputDataIds: ['a'],
               },
             },
           },
@@ -178,7 +178,7 @@ describe('CalibrateRun', () => {
         initialEntries={[
           {
             pathname: '/calibrate/seed-nircam-imaging',
-            state: { inputs: ['mast/jw1/a_cal.fits'], stage3Only: true },
+            state: { inputDataIds: ['a'], stage3Only: true },
           },
         ]}
       >
@@ -195,16 +195,18 @@ describe('CalibrateRun', () => {
   });
 
   it('reprocess shows pre-selected _cal inputs as checked despite the recipe _uncal suffix', async () => {
+    // Deliberately NO filePath — matching the real DTO (#1751), which is what
+    // the old mock got wrong and why this path shipped broken.
     vi.mocked(getAll).mockResolvedValue([
-      { id: 'a', fileName: 'a_cal.fits', filePath: 'mast/jw1/a_cal.fits' },
-      { id: 'b', fileName: 'b_cal.fits', filePath: 'mast/jw1/b_cal.fits' },
+      { id: 'a', fileName: 'a_cal.fits' },
+      { id: 'b', fileName: 'b_cal.fits' },
     ] as never);
     render(
       <MemoryRouter
         initialEntries={[
           {
             pathname: '/calibrate/seed-nircam-imaging',
-            state: { inputs: ['mast/jw1/a_cal.fits'], stage3Only: true },
+            state: { inputDataIds: ['a'], stage3Only: true },
           },
         ]}
       >

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -396,9 +396,13 @@ describe('CalibrateRun', () => {
     );
     expect(await screen.findByText(/No matching library files/)).toBeInTheDocument();
     expect(screen.queryByText(/Choose at least one input file/)).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Run calibration' })).toBeDisabled();
-    // The reason given is the one the user can act on.
+    const button = screen.getByRole('button', { name: 'Run calibration' });
+    expect(button).toBeDisabled();
+    // The reason given is the one the user can act on, and it is announced.
+    expect(button).toHaveAttribute('aria-describedby', 'run-blocked-reason');
     expect(screen.getByText(/Import or calibrate some data first/)).toBeInTheDocument();
+    // With nothing listed, nothing may claim "the files checked above".
+    expect(screen.queryByText(/files checked above/)).not.toBeInTheDocument();
   });
 
   it('a failed library load reads as a failure, not as an empty library', async () => {

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -373,6 +373,34 @@ describe('CalibrateRun', () => {
     expect(screen.getByRole('button', { name: 'Run calibration' })).toBeEnabled();
   });
 
+  it('does not tell you to choose a file when there are none to choose', async () => {
+    // Regression: the disabled-Run hint fired "Choose at least one input file
+    // above." over an empty list and over a failed load — a disabled button
+    // plus an instruction you cannot follow, which is the dead end the hint
+    // was added to remove.
+    vi.mocked(getAll).mockResolvedValue([{ id: 'x', fileName: 'x_i2d.fits' }] as never);
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            // A preset that is gone, and nothing in the library matches _cal.
+            state: { inputDataIds: ['ghost'], stage3Only: true },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByText(/No matching library files/)).toBeInTheDocument();
+    expect(screen.queryByText(/Choose at least one input file/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run calibration' })).toBeDisabled();
+    // The reason given is the one the user can act on.
+    expect(screen.getByText(/Import or calibrate some data first/)).toBeInTheDocument();
+  });
+
   it('a failed library load reads as a failure, not as an empty library', async () => {
     vi.mocked(getAll).mockRejectedValue(new Error('network down'));
     render(

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -505,13 +505,20 @@ function CalibrateRunForm() {
             </ul>
           )
         ) : null}
-        {needsLibraryInputs && !libraryError && !libraryLoading && hiddenSelectedCount > 0 && (
-          <p className="calibrate-hint" role="status">
-            {hiddenSelectedCount} pre-selected {hiddenSelectedCount === 1 ? 'file' : 'files'}{' '}
-            {hiddenSelectedCount === 1 ? "isn't" : "aren't"} in your library any more (archived,
-            deleted, or no longer shared with you). Only the files checked above will be used.
-          </p>
-        )}
+        {/* Requires a non-empty list: with nothing shown, "the files checked
+            above" describes UI that isn't on the screen — the empty state and
+            the run hint already cover that case. */}
+        {needsLibraryInputs &&
+          !libraryError &&
+          !libraryLoading &&
+          libraryFiles.length > 0 &&
+          hiddenSelectedCount > 0 && (
+            <p className="calibrate-hint" role="status">
+              {hiddenSelectedCount} pre-selected {hiddenSelectedCount === 1 ? 'file' : 'files'}{' '}
+              {hiddenSelectedCount === 1 ? "isn't" : "aren't"} in your library any more (archived,
+              deleted, or no longer shared with you). Only the files checked above will be used.
+            </p>
+          )}
         {!needsLibraryInputs && (
           <p className="calibrate-hint">
             Data is fetched from MAST (proposal{' '}

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -79,7 +79,8 @@ function overridesFromRows(rows: ParamRow[]): StepOverrides {
 }
 
 interface ReprocessState {
-  inputs?: string[];
+  /** Library item ids to pre-select (#1751 — not storage keys). */
+  inputDataIds?: string[];
   stage3Only?: boolean;
   /** Settings carried back from a finished run (#1735). The engine stores a
    *  recipe snapshot per job with the run's stage toggles already applied, so
@@ -87,7 +88,7 @@ interface ReprocessState {
   rerun?: {
     enabledStages?: Record<string, boolean>;
     runOverrides?: StepOverrides;
-    inputs?: string[];
+    inputDataIds?: string[];
   };
 }
 
@@ -110,7 +111,7 @@ export default function CalibrateRun() {
 
   const [enabledStages, setEnabledStages] = useState<Record<string, boolean>>({});
   const [paramRows, setParamRows] = useState<ParamRow[]>([]);
-  const [libraryFiles, setLibraryFiles] = useState<string[]>([]);
+  const [libraryFiles, setLibraryFiles] = useState<{ id: string; fileName: string }[]>([]);
   const [selectedInputs, setSelectedInputs] = useState<string[]>([]);
 
   const [starting, setStarting] = useState(false);
@@ -142,7 +143,7 @@ export default function CalibrateRun() {
         setParamRows(
           rerun?.runOverrides ? rowsFromOverrides(rerun.runOverrides) : rowsFromRecipe(loaded)
         );
-        const presetInputs = rerun?.inputs ?? reprocess.inputs;
+        const presetInputs = rerun?.inputDataIds ?? reprocess.inputDataIds;
         if (presetInputs?.length) setSelectedInputs(presetInputs);
       })
       .catch((err: unknown) => {
@@ -154,7 +155,7 @@ export default function CalibrateRun() {
     };
   }, [recipeId]);
 
-  const reprocessInputs = reprocess.rerun?.inputs ?? reprocess.inputs;
+  const reprocessInputs = reprocess.rerun?.inputDataIds ?? reprocess.inputDataIds;
   const needsLibraryInputs =
     recipe?.input_source.type === 'library_products' || Boolean(reprocessInputs?.length);
   // Reprocess supplies calibrated (_cal) files regardless of the recipe's own
@@ -174,18 +175,16 @@ export default function CalibrateRun() {
       .getAll(false)
       .then((items) => {
         if (cancelled) return;
-        const files = items
-          .map((item) => item.filePath)
-          .filter((path): path is string =>
-            Boolean(path && inputSuffixes.some((s) => path.includes(s)))
-          );
-        // Always surface the pre-selected reprocess inputs, even if getAll
-        // doesn't return them, so the user can see and deselect them.
-        const union = Array.from(new Set([...(reprocessInputs ?? []), ...files]));
-        setLibraryFiles(union);
+        // Match on fileName: the DTO has no filePath (#1751), and the
+        // product suffix is part of the name anyway.
+        setLibraryFiles(
+          items
+            .filter((item) => inputSuffixes.some((s) => (item.fileName ?? '').includes(s)))
+            .map((item) => ({ id: item.id, fileName: item.fileName }))
+        );
       })
       .catch(() => {
-        if (!cancelled) setLibraryFiles(reprocessInputs ?? []);
+        if (!cancelled) setLibraryFiles([]);
       });
     return () => {
       cancelled = true;
@@ -195,14 +194,16 @@ export default function CalibrateRun() {
   // Suffixes actually in play: the selected library files if there are any,
   // otherwise what the recipe's own input source will fetch.
   const activeSuffixes = useMemo(() => {
-    const source = selectedInputs.length > 0 ? selectedInputs : [];
-    if (source.length > 0) {
+    const names = libraryFiles
+      .filter((f) => selectedInputs.includes(f.id))
+      .map((f) => f.fileName ?? '');
+    if (names.length > 0) {
       return Array.from(
-        new Set(source.map((path) => KNOWN_SUFFIXES.find((s) => path.includes(s)) ?? '_uncal'))
+        new Set(names.map((n) => KNOWN_SUFFIXES.find((s) => n.includes(s)) ?? '_uncal'))
       );
     }
     return recipe?.input_source.product_suffixes ?? [];
-  }, [selectedInputs, recipe]);
+  }, [selectedInputs, libraryFiles, recipe]);
 
   const enabledSpecs = useMemo(
     () =>
@@ -239,7 +240,7 @@ export default function CalibrateRun() {
     try {
       const response = await startRun({
         recipeId: recipe.id,
-        inputs: needsLibraryInputs ? selectedInputs : [],
+        inputDataIds: needsLibraryInputs ? selectedInputs : [],
         runOverrides: overridesFromRows(paramRows),
         enabledStages,
       });
@@ -384,18 +385,20 @@ export default function CalibrateRun() {
           ) : (
             <ul className="calibrate-input-list">
               {libraryFiles.map((file) => (
-                <li key={file}>
+                <li key={file.id}>
                   <label>
                     <input
                       type="checkbox"
-                      checked={selectedInputs.includes(file)}
+                      checked={selectedInputs.includes(file.id)}
                       onChange={(event) =>
                         setSelectedInputs((prev) =>
-                          event.target.checked ? [...prev, file] : prev.filter((f) => f !== file)
+                          event.target.checked
+                            ? [...prev, file.id]
+                            : prev.filter((f) => f !== file.id)
                         )
                       }
                     />
-                    <span className="calibrate-input-file">{file}</span>
+                    <span className="calibrate-input-file">{file.fileName}</span>
                   </label>
                 </li>
               ))}

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -112,6 +112,7 @@ export default function CalibrateRun() {
   const [enabledStages, setEnabledStages] = useState<Record<string, boolean>>({});
   const [paramRows, setParamRows] = useState<ParamRow[]>([]);
   const [libraryFiles, setLibraryFiles] = useState<{ id: string; fileName: string }[]>([]);
+  const [libraryError, setLibraryError] = useState<string | null>(null);
   const [selectedInputs, setSelectedInputs] = useState<string[]>([]);
 
   const [starting, setStarting] = useState(false);
@@ -160,12 +161,13 @@ export default function CalibrateRun() {
     recipe?.input_source.type === 'library_products' || Boolean(reprocessInputs?.length);
   // Reprocess supplies calibrated (_cal) files regardless of the recipe's own
   // input suffix (seed recipes are _uncal MAST queries), so the library list
-  // must match _cal here. Memoized so the library-fetch effect below fires
-  // only when the recipe or reprocess inputs change, not on every render.
+  // must match _cal for that path. Keyed off stage3Only — the actual Reprocess
+  // signal — and NOT off "there are preset ids", which would also capture the
+  // data-first picker, whose whole purpose is choosing _uncal frames.
+  const stage3Only = Boolean(reprocess.stage3Only);
   const inputSuffixes = useMemo(
-    () =>
-      reprocessInputs?.length ? ['_cal'] : (recipe?.input_source.product_suffixes ?? ['_cal']),
-    [reprocessInputs, recipe]
+    () => (stage3Only ? ['_cal'] : (recipe?.input_source.product_suffixes ?? ['_cal'])),
+    [stage3Only, recipe]
   );
 
   useEffect(() => {
@@ -175,6 +177,7 @@ export default function CalibrateRun() {
       .getAll(false)
       .then((items) => {
         if (cancelled) return;
+        setLibraryError(null);
         // Match on fileName: the DTO has no filePath (#1751), and the
         // product suffix is part of the name anyway.
         setLibraryFiles(
@@ -183,19 +186,33 @@ export default function CalibrateRun() {
             .map((item) => ({ id: item.id, fileName: item.fileName }))
         );
       })
-      .catch(() => {
-        if (!cancelled) setLibraryFiles([]);
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        // Distinguish a failed fetch from "your library has nothing matching" —
+        // the empty state used to claim the latter for both.
+        setLibraryFiles([]);
+        setLibraryError(err instanceof Error ? err.message : 'Failed to load your library');
       });
     return () => {
       cancelled = true;
     };
   }, [needsLibraryInputs, recipe, reprocessInputs, inputSuffixes]);
 
+  // What actually gets submitted. Preset ids (Reprocess, the data-first
+  // picker, a re-run) can name items the current suffix filter doesn't list —
+  // submitting those would run on a selection the user cannot see or uncheck,
+  // so the visible list is the source of truth.
+  const visibleSelected = useMemo(
+    () => selectedInputs.filter((id) => libraryFiles.some((f) => f.id === id)),
+    [selectedInputs, libraryFiles]
+  );
+  const hiddenSelectedCount = selectedInputs.length - visibleSelected.length;
+
   // Suffixes actually in play: the selected library files if there are any,
   // otherwise what the recipe's own input source will fetch.
   const activeSuffixes = useMemo(() => {
     const names = libraryFiles
-      .filter((f) => selectedInputs.includes(f.id))
+      .filter((f) => visibleSelected.includes(f.id))
       .map((f) => f.fileName ?? '');
     if (names.length > 0) {
       return Array.from(
@@ -203,7 +220,7 @@ export default function CalibrateRun() {
       );
     }
     return recipe?.input_source.product_suffixes ?? [];
-  }, [selectedInputs, libraryFiles, recipe]);
+  }, [visibleSelected, libraryFiles, recipe]);
 
   const enabledSpecs = useMemo(
     () =>
@@ -223,15 +240,15 @@ export default function CalibrateRun() {
     return { curatedRows: curated, advancedRows: advanced };
   }, [paramRows]);
 
-  const fileCount = selectedInputs.length;
+  const fileCount = visibleSelected.length;
   const fromMast = recipe?.input_source.type === 'mast_query';
   const usesDetector1 = enabledSpecs.some((s) => s.name === 'detector1');
 
   const runDisabled = useMemo(() => {
     if (!recipe || starting) return true;
-    if (needsLibraryInputs && selectedInputs.length === 0) return true;
+    if (needsLibraryInputs && visibleSelected.length === 0) return true;
     return !Object.values(enabledStages).some(Boolean);
-  }, [recipe, starting, needsLibraryInputs, selectedInputs, enabledStages]);
+  }, [recipe, starting, needsLibraryInputs, visibleSelected, enabledStages]);
 
   const handleRun = async () => {
     if (!recipe) return;
@@ -240,7 +257,7 @@ export default function CalibrateRun() {
     try {
       const response = await startRun({
         recipeId: recipe.id,
-        inputDataIds: needsLibraryInputs ? selectedInputs : [],
+        inputDataIds: needsLibraryInputs ? visibleSelected : [],
         runOverrides: overridesFromRows(paramRows),
         enabledStages,
       });
@@ -378,7 +395,11 @@ export default function CalibrateRun() {
       <section className="calibrate-section" aria-labelledby="inputs-heading">
         <h2 id="inputs-heading">Inputs</h2>
         {needsLibraryInputs ? (
-          libraryFiles.length === 0 ? (
+          libraryError ? (
+            <p className="calibrate-error" role="alert">
+              Couldn&apos;t load your library: {libraryError}
+            </p>
+          ) : libraryFiles.length === 0 ? (
             <p className="calibrate-hint">
               No matching library files found (looking for {inputSuffixes.join(', ')}).
             </p>
@@ -404,7 +425,15 @@ export default function CalibrateRun() {
               ))}
             </ul>
           )
-        ) : (
+        ) : null}
+        {needsLibraryInputs && !libraryError && hiddenSelectedCount > 0 && (
+          <p className="calibrate-hint" role="status">
+            {hiddenSelectedCount} pre-selected {hiddenSelectedCount === 1 ? 'file' : 'files'} were
+            left out because they don&apos;t match {inputSuffixes.join(', ')}. Only the files
+            checked above will be used.
+          </p>
+        )}
+        {!needsLibraryInputs && (
           <p className="calibrate-hint">
             Data is fetched from MAST (proposal{' '}
             {recipe.input_source.type === 'mast_query' ? recipe.input_source.proposal_id : ''}) when

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -103,7 +103,8 @@ function rowsFromOverrides(overrides: StepOverrides): ParamRow[] {
 }
 
 /**
- * Remounts on every recipe change. React Router reuses the component instance
+ * Remounts on every recipe change (param changes only — no in-app route can
+ * reach /calibrate/X from /calibrate/X with different state). React Router reuses the component instance
  * across a param-only navigation, which would otherwise leave the previous
  * recipe's selection, library list and loaded flag in place — long enough to
  * submit recipe A's inputs against recipe B. A key is the whole fix; resetting
@@ -294,17 +295,35 @@ function CalibrateRunForm() {
     if (!recipe || starting) return null;
     // Loading already says so where the list will appear; repeating it here
     // would just duplicate the same sentence on the page.
-    if (needsLibraryInputs && libraryLoading) return null;
+    if (libraryLoading) return null;
+    // Order matters: "choose a file" is only actionable when there ARE files.
+    // Saying it over an empty or failed list is the dead end this hint exists
+    // to remove, not an instance of it.
+    if (needsLibraryInputs && libraryError)
+      return "Your library couldn't be loaded, so there's nothing to run on yet.";
+    if (needsLibraryInputs && libraryFiles.length === 0)
+      return `No library files match this recipe (looking for ${inputSuffixes.join(', ')}). Import or calibrate some data first.`;
     if (needsLibraryInputs && visibleSelected.length === 0)
       return 'Choose at least one input file above.';
     if (enabledSpecs.length === 0)
       return 'No stage can run: every stage is either turned off or blocked by the inputs you chose.';
     return null;
-  }, [recipe, starting, needsLibraryInputs, libraryLoading, visibleSelected, enabledSpecs]);
+  }, [
+    recipe,
+    starting,
+    needsLibraryInputs,
+    libraryLoading,
+    libraryError,
+    libraryFiles,
+    inputSuffixes,
+    visibleSelected,
+    enabledSpecs,
+  ]);
 
   const runDisabled = useMemo(() => {
     if (!recipe || starting) return true;
-    if (needsLibraryInputs && (libraryLoading || visibleSelected.length === 0)) return true;
+    if (libraryLoading) return true;
+    if (needsLibraryInputs && visibleSelected.length === 0) return true;
     return enabledSpecs.length === 0;
   }, [recipe, starting, needsLibraryInputs, libraryLoading, visibleSelected, enabledSpecs]);
 
@@ -511,12 +530,16 @@ function CalibrateRunForm() {
         type="button"
         className="btn-base btn-standard calibrate-run-button"
         disabled={runDisabled}
-        title={runBlockedReason ?? undefined}
+        aria-describedby={runBlockedReason ? 'run-blocked-reason' : undefined}
         onClick={() => void handleRun()}
       >
-        Run calibration
+        {starting ? 'Starting…' : 'Run calibration'}
       </button>
-      {runBlockedReason && <p className="calibrate-hint">{runBlockedReason}</p>}
+      {runBlockedReason && (
+        <p id="run-blocked-reason" className="calibrate-hint" role="status">
+          {runBlockedReason}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -113,6 +113,9 @@ export default function CalibrateRun() {
   const [paramRows, setParamRows] = useState<ParamRow[]>([]);
   const [libraryFiles, setLibraryFiles] = useState<{ id: string; fileName: string }[]>([]);
   const [libraryError, setLibraryError] = useState<string | null>(null);
+  // Tracked as "resolved" rather than "loading" so the effect never calls a
+  // setter synchronously (cascading-render lint rule); loading is derived.
+  const [libraryLoaded, setLibraryLoaded] = useState(false);
   const [selectedInputs, setSelectedInputs] = useState<string[]>([]);
 
   const [starting, setStarting] = useState(false);
@@ -159,11 +162,16 @@ export default function CalibrateRun() {
   const reprocessInputs = reprocess.rerun?.inputDataIds ?? reprocess.inputDataIds;
   const needsLibraryInputs =
     recipe?.input_source.type === 'library_products' || Boolean(reprocessInputs?.length);
-  // Reprocess supplies calibrated (_cal) files regardless of the recipe's own
-  // input suffix (seed recipes are _uncal MAST queries), so the library list
-  // must match _cal for that path. Keyed off stage3Only — the actual Reprocess
-  // signal — and NOT off "there are preset ids", which would also capture the
-  // data-first picker, whose whole purpose is choosing _uncal frames.
+  // Which suffixes to OFFER for browsing. Reprocess supplies calibrated files
+  // regardless of the recipe's own input suffix (seed recipes are _uncal MAST
+  // queries), so that path browses _cal instead.
+  //
+  // This filter never decides what the user may RUN on: pre-selected items are
+  // always listed (below), whatever their suffix. Making the filter alone the
+  // gate is what broke both directions in turn — first _uncal picks vanished
+  // on a reprocess, then _cal picks vanished on a seed recipe. A suffix the
+  // pipeline can't start from is a stage-blocking concern, and StageTimeline
+  // already explains it; it is not a reason to hide the user's own file.
   const stage3Only = Boolean(reprocess.stage3Only);
   const inputSuffixes = useMemo(
     () => (stage3Only ? ['_cal'] : (recipe?.input_source.product_suffixes ?? ['_cal'])),
@@ -171,7 +179,9 @@ export default function CalibrateRun() {
   );
 
   useEffect(() => {
-    if (!needsLibraryInputs) return undefined;
+    // Wait for the recipe: until it loads, inputSuffixes falls back to ['_cal'],
+    // so fetching now would briefly list the wrong products (and fetch twice).
+    if (!needsLibraryInputs || !recipe) return undefined;
     let cancelled = false;
     jwstDataService
       .getAll(false)
@@ -180,11 +190,14 @@ export default function CalibrateRun() {
         setLibraryError(null);
         // Match on fileName: the DTO has no filePath (#1751), and the
         // product suffix is part of the name anyway.
-        setLibraryFiles(
-          items
-            .filter((item) => inputSuffixes.some((s) => (item.fileName ?? '').includes(s)))
-            .map((item) => ({ id: item.id, fileName: item.fileName }))
+        const preset = new Set(reprocessInputs ?? []);
+        const shown = items.filter(
+          (item) =>
+            preset.has(item.id) || inputSuffixes.some((s) => (item.fileName ?? '').includes(s))
         );
+        // Pre-selected items first: they are why the user is on this page.
+        shown.sort((a, b) => Number(preset.has(b.id)) - Number(preset.has(a.id)));
+        setLibraryFiles(shown.map((item) => ({ id: item.id, fileName: item.fileName })));
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -192,16 +205,21 @@ export default function CalibrateRun() {
         // the empty state used to claim the latter for both.
         setLibraryFiles([]);
         setLibraryError(err instanceof Error ? err.message : 'Failed to load your library');
+      })
+      .finally(() => {
+        if (!cancelled) setLibraryLoaded(true);
       });
     return () => {
       cancelled = true;
     };
   }, [needsLibraryInputs, recipe, reprocessInputs, inputSuffixes]);
 
-  // What actually gets submitted. Preset ids (Reprocess, the data-first
-  // picker, a re-run) can name items the current suffix filter doesn't list —
-  // submitting those would run on a selection the user cannot see or uncheck,
-  // so the visible list is the source of truth.
+  const libraryLoading = needsLibraryInputs && !libraryLoaded;
+
+  // What actually gets submitted: only files the page is showing, so a run can
+  // never use a selection the user cannot see or uncheck. Since pre-selected
+  // items are always listed, anything missing here is missing from the library
+  // itself — archived, deleted, or not visible to this user.
   const visibleSelected = useMemo(
     () => selectedInputs.filter((id) => libraryFiles.some((f) => f.id === id)),
     [selectedInputs, libraryFiles]
@@ -244,11 +262,25 @@ export default function CalibrateRun() {
   const fromMast = recipe?.input_source.type === 'mast_query';
   const usesDetector1 = enabledSpecs.some((s) => s.name === 'detector1');
 
+  // Blocked stages are rendered off and excluded from the estimate, so they
+  // must not be submitted as on — the engine would honour the toggle and fail
+  // hours in, which is the failure #1736 exists to prevent.
+  const effectiveStages = useMemo(
+    () =>
+      Object.fromEntries(
+        IMAGING_PIPELINE.map((s) => [
+          s.name,
+          Boolean(enabledStages[s.name]) && !blockedReason(s, activeSuffixes),
+        ])
+      ),
+    [enabledStages, activeSuffixes]
+  );
+
   const runDisabled = useMemo(() => {
     if (!recipe || starting) return true;
-    if (needsLibraryInputs && visibleSelected.length === 0) return true;
-    return !Object.values(enabledStages).some(Boolean);
-  }, [recipe, starting, needsLibraryInputs, visibleSelected, enabledStages]);
+    if (needsLibraryInputs && (libraryLoading || visibleSelected.length === 0)) return true;
+    return enabledSpecs.length === 0;
+  }, [recipe, starting, needsLibraryInputs, libraryLoading, visibleSelected, enabledSpecs]);
 
   const handleRun = async () => {
     if (!recipe) return;
@@ -259,7 +291,7 @@ export default function CalibrateRun() {
         recipeId: recipe.id,
         inputDataIds: needsLibraryInputs ? visibleSelected : [],
         runOverrides: overridesFromRows(paramRows),
-        enabledStages,
+        enabledStages: effectiveStages,
       });
       // Hand off to the run's own URL — it survives refresh and stays
       // reachable from the history once we navigate away.
@@ -426,11 +458,11 @@ export default function CalibrateRun() {
             </ul>
           )
         ) : null}
-        {needsLibraryInputs && !libraryError && hiddenSelectedCount > 0 && (
+        {needsLibraryInputs && !libraryError && !libraryLoading && hiddenSelectedCount > 0 && (
           <p className="calibrate-hint" role="status">
-            {hiddenSelectedCount} pre-selected {hiddenSelectedCount === 1 ? 'file' : 'files'} were
-            left out because they don&apos;t match {inputSuffixes.join(', ')}. Only the files
-            checked above will be used.
+            {hiddenSelectedCount} pre-selected {hiddenSelectedCount === 1 ? 'file' : 'files'}{' '}
+            {hiddenSelectedCount === 1 ? "isn't" : "aren't"} in your library any more (archived,
+            deleted, or no longer shared with you). Only the files checked above will be used.
           </p>
         )}
         {!needsLibraryInputs && (

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -102,7 +102,19 @@ function rowsFromOverrides(overrides: StepOverrides): ParamRow[] {
   return rows;
 }
 
+/**
+ * Remounts on every recipe change. React Router reuses the component instance
+ * across a param-only navigation, which would otherwise leave the previous
+ * recipe's selection, library list and loaded flag in place — long enough to
+ * submit recipe A's inputs against recipe B. A key is the whole fix; resetting
+ * five pieces of state by hand is the version that rots.
+ */
 export default function CalibrateRun() {
+  const { recipeId } = useParams<{ recipeId: string }>();
+  return <CalibrateRunForm key={recipeId} />;
+}
+
+function CalibrateRunForm() {
   const { recipeId } = useParams<{ recipeId: string }>();
   // Library "Reprocess" pre-fills inputs and narrows to the stage-3 path.
   const reprocess = (useLocation().state ?? {}) as ReprocessState;
@@ -276,6 +288,20 @@ export default function CalibrateRun() {
     [enabledStages, activeSuffixes]
   );
 
+  // Say why, on the control itself — a disabled button with no reason is the
+  // dead end this redesign keeps running into.
+  const runBlockedReason = useMemo(() => {
+    if (!recipe || starting) return null;
+    // Loading already says so where the list will appear; repeating it here
+    // would just duplicate the same sentence on the page.
+    if (needsLibraryInputs && libraryLoading) return null;
+    if (needsLibraryInputs && visibleSelected.length === 0)
+      return 'Choose at least one input file above.';
+    if (enabledSpecs.length === 0)
+      return 'No stage can run: every stage is either turned off or blocked by the inputs you chose.';
+    return null;
+  }, [recipe, starting, needsLibraryInputs, libraryLoading, visibleSelected, enabledSpecs]);
+
   const runDisabled = useMemo(() => {
     if (!recipe || starting) return true;
     if (needsLibraryInputs && (libraryLoading || visibleSelected.length === 0)) return true;
@@ -427,7 +453,9 @@ export default function CalibrateRun() {
       <section className="calibrate-section" aria-labelledby="inputs-heading">
         <h2 id="inputs-heading">Inputs</h2>
         {needsLibraryInputs ? (
-          libraryError ? (
+          libraryLoading ? (
+            <p className="calibrate-hint">Loading your library…</p>
+          ) : libraryError ? (
             <p className="calibrate-error" role="alert">
               Couldn&apos;t load your library: {libraryError}
             </p>
@@ -483,10 +511,12 @@ export default function CalibrateRun() {
         type="button"
         className="btn-base btn-standard calibrate-run-button"
         disabled={runDisabled}
+        title={runBlockedReason ?? undefined}
         onClick={() => void handleRun()}
       >
         Run calibration
       </button>
+      {runBlockedReason && <p className="calibrate-hint">{runBlockedReason}</p>}
     </div>
   );
 }

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -183,6 +183,35 @@ describe('RunDetail', () => {
       });
     });
 
+    it('a MAST run re-runs as a MAST run — no phantom library inputs', async () => {
+      const job = withRequest(succeededJob(), { detector1: true, image2: true, image3: true });
+      job.request.inputs = [];
+      job.request.input_data_ids = [];
+      vi.mocked(getJob).mockResolvedValue(job);
+      let handedOff: unknown = null;
+      function ConfigStub() {
+        handedOff = useLocation().state;
+        return <div>config stub</div>;
+      }
+      renderRun(<Route path="/calibrate/:recipeId" element={<ConfigStub />} />);
+
+      await userEvent.click(await screen.findByRole('button', { name: 'Re-run with changes' }));
+      await screen.findByText('config stub');
+      // stage3Only must stay false, or the config page would switch to the
+      // library picker for a run that fetches its own data.
+      expect(handedOff).toMatchObject({ stage3Only: false, rerun: { inputDataIds: [] } });
+    });
+
+    it('will not offer a misleading re-run for a job that predates input tracking', async () => {
+      // Only storage keys, no ids: the source items can't be re-selected, and
+      // re-running would silently become a fresh MAST download (#1751).
+      const job = withRequest(succeededJob(), { image3: true });
+      delete job.request.input_data_ids;
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+      expect(await screen.findByRole('button', { name: 'Re-run with changes' })).toBeDisabled();
+    });
+
     it('offers re-run on a failed run too — that is when you most want to tweak', async () => {
       vi.mocked(getJob).mockResolvedValue(
         withRequest({ ...runningJob(), status: 'failed', error: 'boom' }, { image3: true })

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -209,7 +209,15 @@ describe('RunDetail', () => {
       delete job.request.input_data_ids;
       vi.mocked(getJob).mockResolvedValue(job);
       renderRun();
-      expect(await screen.findByRole('button', { name: 'Re-run with changes' })).toBeDisabled();
+      const button = await screen.findByRole('button', { name: 'Re-run with changes' });
+      expect(button).toBeDisabled();
+      // The reason must be on the page, not in a title a disabled control
+      // never surfaces and assistive tech never announces.
+      expect(button).toHaveAttribute('aria-describedby', 'rerun-unavailable-reason');
+      // By id: the page has other live regions (progress).
+      expect(document.getElementById('rerun-unavailable-reason')).toHaveTextContent(
+        /predates input tracking/
+      );
     });
 
     it('offers re-run on a failed run too — that is when you most want to tweak', async () => {

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -84,6 +84,7 @@ function withRequest(job: CalibrationJob, enabled: Record<string, boolean>): Cal
       } as never,
       run_overrides: { jump: { maximum_cores: 'half' } },
       inputs: [{ path: 'mast/jw1/a_cal.fits', role: 'science' }],
+      input_data_ids: ['lib-a'],
     },
   };
 }
@@ -160,7 +161,7 @@ describe('RunDetail', () => {
       );
       let handedOff: unknown = null;
       function ConfigStub() {
-        handedOff = (useLocation().state as { rerun?: unknown } | null)?.rerun ?? null;
+        handedOff = useLocation().state;
         return <div>config stub</div>;
       }
       renderRun(<Route path="/calibrate/:recipeId" element={<ConfigStub />} />);
@@ -168,12 +169,17 @@ describe('RunDetail', () => {
       await userEvent.click(await screen.findByRole('button', { name: 'Re-run with changes' }));
 
       expect(await screen.findByText('config stub')).toBeInTheDocument();
-      // The snapshot's toggles, overrides and inputs all travel to the form.
-      // Inputs are not carried: the job records storage keys, but the form now
-      // selects library ITEMS by id (#1751), so the user re-picks them.
+      // Toggles, overrides AND the source library items travel to the form.
+      // The ids matter: a storage key can't be turned back into a library item,
+      // so without them a re-run of a library run would silently become a fresh
+      // MAST download (#1751). stage3Only is derived from the _cal inputs.
       expect(handedOff).toEqual({
-        enabledStages: { detector1: false, image2: false, image3: true },
-        runOverrides: { jump: { maximum_cores: 'half' } },
+        rerun: {
+          enabledStages: { detector1: false, image2: false, image3: true },
+          runOverrides: { jump: { maximum_cores: 'half' } },
+          inputDataIds: ['lib-a'],
+        },
+        stage3Only: true,
       });
     });
 

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -169,10 +169,11 @@ describe('RunDetail', () => {
 
       expect(await screen.findByText('config stub')).toBeInTheDocument();
       // The snapshot's toggles, overrides and inputs all travel to the form.
+      // Inputs are not carried: the job records storage keys, but the form now
+      // selects library ITEMS by id (#1751), so the user re-picks them.
       expect(handedOff).toEqual({
         enabledStages: { detector1: false, image2: false, image3: true },
         runOverrides: { jump: { maximum_cores: 'half' } },
-        inputs: ['mast/jw1/a_cal.fits'],
       });
     });
 

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -59,6 +59,14 @@ export default function RunDetail() {
   const { job, isTerminal, error: pollError } = useCalibrationJob(jobId ?? null);
   const navigate = useNavigate();
 
+  // Jobs created before #1751 stored only storage keys, which cannot be turned
+  // back into library items. Re-running one would drop to the recipe's MAST
+  // query and silently start a fresh multi-GB download, so offer it as
+  // unavailable rather than as something that quietly does the wrong thing.
+  const rerunUnavailable = Boolean(
+    (job?.request?.inputs?.length ?? 0) > 0 && !(job?.request?.input_data_ids?.length ?? 0)
+  );
+
   const [cancelling, setCancelling] = useState(false);
   const [savedIds, setSavedIds] = useState<Record<number, string>>({});
   const [savingIndex, setSavingIndex] = useState<number | null>(null);
@@ -134,6 +142,12 @@ export default function RunDetail() {
               <button
                 type="button"
                 className="btn-base btn-compact"
+                disabled={rerunUnavailable}
+                title={
+                  rerunUnavailable
+                    ? 'This run predates input tracking, so its source files cannot be re-selected automatically. Start it again from your library.'
+                    : undefined
+                }
                 onClick={() =>
                   navigate(`/calibrate/${job.request.recipe_id}`, {
                     state: {

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -145,7 +145,13 @@ export default function RunDetail() {
                           ])
                         ),
                         runOverrides: job.request.run_overrides ?? {},
+                        // Carry the source library items so a re-run of a
+                        // library run stays a library run — without these the
+                        // form falls back to the recipe's MAST query and
+                        // silently starts a fresh download instead (#1751).
+                        inputDataIds: job.request.input_data_ids ?? [],
                       },
+                      stage3Only: (job.request.inputs ?? []).some((i) => i.path.includes('_cal')),
                     },
                   })
                 }

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -143,11 +143,7 @@ export default function RunDetail() {
                 type="button"
                 className="btn-base btn-compact"
                 disabled={rerunUnavailable}
-                title={
-                  rerunUnavailable
-                    ? 'This run predates input tracking, so its source files cannot be re-selected automatically. Start it again from your library.'
-                    : undefined
-                }
+                aria-describedby={rerunUnavailable ? 'rerun-unavailable-reason' : undefined}
                 onClick={() =>
                   navigate(`/calibrate/${job.request.recipe_id}`, {
                     state: {
@@ -174,6 +170,12 @@ export default function RunDetail() {
               </button>
             )}
           </div>
+          {rerunUnavailable && TERMINAL.has(job.status) && (
+            <p id="rerun-unavailable-reason" className="calibrate-hint" role="status">
+              This run predates input tracking, so its source files can&apos;t be re-selected
+              automatically. Start it again from your library.
+            </p>
+          )}
           <p className="calibrate-hint">
             What this run was started with — kept so you can see it while the run is in flight, and
             reuse it afterwards.

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -145,7 +145,6 @@ export default function RunDetail() {
                           ])
                         ),
                         runOverrides: job.request.run_overrides ?? {},
-                        inputs: (job.request.inputs ?? []).map((i) => i.path),
                       },
                     },
                   })

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -22,7 +22,7 @@ import {
   getJobOutputPreview,
   saveJobOutputToLibrary,
 } from '../services/calibrationService';
-import type { CalibrationJob, StepOverrides } from '../types/CalibrationTypes';
+import type { StepOverrides } from '../types/CalibrationTypes';
 import './CalibrateRun.css';
 
 /** Only FITS image products can be rendered or saved as library images;
@@ -32,12 +32,6 @@ import './CalibrateRun.css';
 const PREVIEWABLE_RE = /\.(fits(\.gz)?|fit)$/i;
 const isPreviewable = (storageKey: string): boolean => PREVIEWABLE_RE.test(storageKey);
 const basename = (key: string): string => key.split('/').pop() ?? key;
-
-const TERMINAL: ReadonlySet<CalibrationJob['status']> = new Set([
-  'succeeded',
-  'failed',
-  'cancelled',
-]);
 
 /** Flatten run overrides into display rows, in the shape the config form uses. */
 function overrideRows(overrides: StepOverrides | undefined): {
@@ -138,7 +132,7 @@ export default function RunDetail() {
         <section className="calibrate-section" aria-labelledby="config-heading">
           <div className="calibrate-config-head">
             <h2 id="config-heading">Configuration</h2>
-            {TERMINAL.has(job.status) && job.request.recipe_id && (
+            {isTerminal && job.request.recipe_id && (
               <button
                 type="button"
                 className="btn-base btn-compact"
@@ -170,7 +164,7 @@ export default function RunDetail() {
               </button>
             )}
           </div>
-          {rerunUnavailable && TERMINAL.has(job.status) && (
+          {rerunUnavailable && isTerminal && job.request.recipe_id && (
             <p id="rerun-unavailable-reason" className="calibrate-hint" role="status">
               This run predates input tracking, so its source files can&apos;t be re-selected
               automatically. Start it again from your library.

--- a/frontend/jwst-frontend/src/pages/index.test.ts
+++ b/frontend/jwst-frontend/src/pages/index.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
 describe('pages barrel export', () => {
-  it('exports all page components', async () => {
+  // Pulls in every page module at once, so it is by far the heaviest import in
+  // the suite; the 5s default started timing out under full-suite parallelism
+  // once the calibration pages joined the barrel (#1733).
+  it('exports all page components', { timeout: 20000 }, async () => {
     const pages = await import('./index');
     expect(pages.LoginPage).toBeDefined();
     expect(pages.RegisterPage).toBeDefined();

--- a/frontend/jwst-frontend/src/types/CalibrationTypes.ts
+++ b/frontend/jwst-frontend/src/types/CalibrationTypes.ts
@@ -61,8 +61,13 @@ export interface CalibrationCapabilities {
 
 export interface StartRunRequest {
   recipeId: string;
-  /** Storage keys of library `_cal` files; empty for MAST-driven recipes. */
-  inputs: string[];
+  /**
+   * Library item ids to calibrate; empty for MAST-driven recipes.
+   * Ids rather than storage keys (#1751): the library DTO never publishes
+   * `filePath`, so the client cannot know a key — the engine resolves it from
+   * a document the caller is allowed to read.
+   */
+  inputDataIds: string[];
   runOverrides: StepOverrides;
   /** Per-run stage toggles, applied to the recipe snapshot server-side. */
   enabledStages: Record<string, boolean>;

--- a/frontend/jwst-frontend/src/types/CalibrationTypes.ts
+++ b/frontend/jwst-frontend/src/types/CalibrationTypes.ts
@@ -127,6 +127,12 @@ export interface CalibrationJobRequest {
   recipe_id?: string;
   recipe_snapshot?: CalibrationRecipe;
   inputs?: { path: string; role: string }[];
+  /**
+   * Library ids the run was started from (#1751). Recorded alongside `inputs`
+   * because a storage key cannot be turned back into a library item, so a
+   * re-run has nothing to re-select without these.
+   */
+  input_data_ids?: string[];
   run_overrides?: StepOverrides;
 }
 

--- a/frontend/jwst-frontend/src/types/JwstDataTypes.ts
+++ b/frontend/jwst-frontend/src/types/JwstDataTypes.ts
@@ -5,7 +5,6 @@ export interface JwstDataModel {
   uploadDate: string;
   description?: string;
   metadata: Record<string, any>;
-  filePath?: string;
   fileSize: number;
   processingStatus: string;
   tags: string[];

--- a/processing-engine/app/auth/deps.py
+++ b/processing-engine/app/auth/deps.py
@@ -76,9 +76,16 @@ def _decode(token: str) -> AuthenticatedUser:
     except jwt.InvalidTokenError as exc:
         raise _unauthorized("Invalid or expired token") from exc
 
+    # `require` only checks presence, so an empty subject decodes cleanly. It
+    # must not: user_id == "" would match any record with a missing/blank
+    # UserId in the visibility checks that compare it (#1356 on the .NET side).
+    user_id = str(claims["sub"]).strip()
+    if not user_id:
+        raise _unauthorized("Invalid or expired token")
+
     role = next((claims[name] for name in _ROLE_CLAIMS if claims.get(name)), "User")
     return AuthenticatedUser(
-        user_id=str(claims["sub"]),
+        user_id=user_id,
         username=claims.get("unique_name"),
         email=claims.get("email"),
         role=str(role),

--- a/processing-engine/app/calibration/executor.py
+++ b/processing-engine/app/calibration/executor.py
@@ -439,9 +439,11 @@ async def run_calibration_job(
         await ctx.set_progress(stages=stage_list, message="preparing inputs")
 
         if input_keys:
-            # Library inputs. NOTE trust boundary: keys are only
-            # traversal-guarded — the library is shared/public today and the
-            # engine has no per-user file ownership (#1719).
+            # Library inputs. These keys are NOT client input: the route derives
+            # each one from a library document the caller is authorized to read
+            # (app/calibration/inputs.py, #1751), and raw keys in the request
+            # body are rejected. resolve_fits_path stays as defence in depth.
+            # Do not reintroduce a path that lets a caller supply a key.
             input_paths = [resolve_fits_path(key) for key in input_keys]
         else:
             input_paths = await _download_inputs(ctx, recipe, workdir)

--- a/processing-engine/app/calibration/inputs.py
+++ b/processing-engine/app/calibration/inputs.py
@@ -1,0 +1,71 @@
+"""Resolve library data ids to storage keys for a calibration run (#1751).
+
+Why ids and not paths: the library DTO deliberately does not publish
+``FilePath`` — it is an internal storage location — so a client physically
+cannot send one, which is why every library-input path in the UI was silently
+empty. Sending ids instead fixes that AND removes the "client supplies a raw
+path" surface that #1719 is about: the key is now derived server-side from a
+document the caller is allowed to read.
+
+Visibility mirrors the .NET FilterAccessibleData rule: a caller may use their
+own items or public ones; an Admin may use any.
+"""
+
+from bson import ObjectId
+from bson.errors import InvalidId
+from fastapi import HTTPException
+
+from app.db.access import to_relative_key
+
+
+class InputResolutionError(Exception):
+    """A requested input can't be used — message is safe to show the caller."""
+
+
+async def resolve_input_data_ids(
+    collection,
+    data_ids: list[str],
+    *,
+    user_id: str,
+    is_admin: bool = False,
+) -> list[str]:
+    """Map library ids to relative storage keys, preserving the caller's order.
+
+    Raises InputResolutionError when an id is unknown, not visible to the
+    caller, or has no file behind it — never silently drops one, because a
+    calibration run that quietly used fewer inputs than requested would
+    produce a wrong mosaic with no indication why.
+    """
+    if not data_ids:
+        return []
+
+    oids: dict[str, ObjectId] = {}
+    for data_id in data_ids:
+        if not isinstance(data_id, str):
+            raise InputResolutionError("inputDataIds must be strings")
+        try:
+            oids[data_id] = ObjectId(data_id)
+        except (InvalidId, TypeError) as exc:
+            raise InputResolutionError(f"not a valid library id: {data_id}") from exc
+
+    docs = [d async for d in collection.find({"_id": {"$in": list(oids.values())}})]
+    by_id = {str(d["_id"]): d for d in docs}
+
+    keys: list[str] = []
+    for data_id in data_ids:
+        doc = by_id.get(data_id)
+        # Unknown and not-visible collapse to the same message on purpose —
+        # distinguishing them would let a caller probe for ids.
+        if doc is None:
+            raise InputResolutionError(f"library item not found: {data_id}")
+        if not (is_admin or doc.get("IsPublic") is True or doc.get("UserId") == user_id):
+            raise InputResolutionError(f"library item not found: {data_id}")
+        file_path = doc.get("FilePath")
+        if not file_path:
+            raise InputResolutionError(f"library item has no file to calibrate: {data_id}")
+        keys.append(to_relative_key(file_path))
+    return keys
+
+
+def as_http_error(exc: InputResolutionError) -> HTTPException:
+    return HTTPException(status_code=422, detail=str(exc))

--- a/processing-engine/app/calibration/inputs.py
+++ b/processing-engine/app/calibration/inputs.py
@@ -7,8 +7,12 @@ empty. Sending ids instead fixes that AND removes the "client supplies a raw
 path" surface that #1719 is about: the key is now derived server-side from a
 document the caller is allowed to read.
 
-Visibility mirrors the .NET FilterAccessibleData rule: a caller may use their
-own items or public ones; an Admin may use any.
+Visibility mirrors the .NET ``FilterAccessibleData`` rule (MongoDBService.cs):
+a caller may use their own items, public ones, or ones shared with them; an
+Admin may use any. This does NOT go through ``JwstDataReadRepository`` — that
+class deliberately enforces the *anonymous* branch of the same rule (IsPublic
+only), which is a different, stricter rule than the authenticated one needed
+here.
 """
 
 from bson import ObjectId
@@ -18,8 +22,26 @@ from fastapi import HTTPException
 from app.db.access import to_relative_key
 
 
+# Enough to authorize and locate the file. Notably excludes ThumbnailData,
+# which is a binary blob on every one of these documents.
+_PROJECTION = {
+    "_id": 1,
+    "UserId": 1,
+    "IsPublic": 1,
+    "SharedWith": 1,
+    "FilePath": 1,
+    "IsArchived": 1,
+}
+
+
 class InputResolutionError(Exception):
     """A requested input can't be used — message is safe to show the caller."""
+
+
+def _visible_to(doc: dict, *, user_id: str, is_admin: bool) -> bool:
+    if is_admin or doc.get("IsPublic") is True or doc.get("UserId") == user_id:
+        return True
+    return user_id in (doc.get("SharedWith") or [])
 
 
 async def resolve_input_data_ids(
@@ -32,23 +54,30 @@ async def resolve_input_data_ids(
     """Map library ids to relative storage keys, preserving the caller's order.
 
     Raises InputResolutionError when an id is unknown, not visible to the
-    caller, or has no file behind it — never silently drops one, because a
-    calibration run that quietly used fewer inputs than requested would
-    produce a wrong mosaic with no indication why.
+    caller, archived, duplicated, or has no file behind it — never silently
+    drops or de-duplicates one, because a calibration run that quietly used a
+    different set of inputs than requested would produce a wrong mosaic with
+    no indication why.
     """
     if not data_ids:
         return []
 
-    oids: dict[str, ObjectId] = {}
+    seen: set[str] = set()
+    oids: list[ObjectId] = []
     for data_id in data_ids:
         if not isinstance(data_id, str):
             raise InputResolutionError("inputDataIds must be strings")
+        if data_id in seen:
+            # Associating the same exposure twice would double-weight it in
+            # the mosaic, so this is a caller error rather than a no-op.
+            raise InputResolutionError(f"duplicate library item: {data_id}")
+        seen.add(data_id)
         try:
-            oids[data_id] = ObjectId(data_id)
+            oids.append(ObjectId(data_id))
         except (InvalidId, TypeError) as exc:
             raise InputResolutionError(f"not a valid library id: {data_id}") from exc
 
-    docs = [d async for d in collection.find({"_id": {"$in": list(oids.values())}})]
+    docs = [d async for d in collection.find({"_id": {"$in": oids}}, _PROJECTION)]
     by_id = {str(d["_id"]): d for d in docs}
 
     keys: list[str] = []
@@ -56,10 +85,10 @@ async def resolve_input_data_ids(
         doc = by_id.get(data_id)
         # Unknown and not-visible collapse to the same message on purpose —
         # distinguishing them would let a caller probe for ids.
-        if doc is None:
+        if doc is None or not _visible_to(doc, user_id=user_id, is_admin=is_admin):
             raise InputResolutionError(f"library item not found: {data_id}")
-        if not (is_admin or doc.get("IsPublic") is True or doc.get("UserId") == user_id):
-            raise InputResolutionError(f"library item not found: {data_id}")
+        if doc.get("IsArchived"):
+            raise InputResolutionError(f"library item is archived: {data_id}")
         file_path = doc.get("FilePath")
         if not file_path:
             raise InputResolutionError(f"library item has no file to calibrate: {data_id}")

--- a/processing-engine/app/calibration/routes.py
+++ b/processing-engine/app/calibration/routes.py
@@ -46,6 +46,14 @@ def get_recipe_store() -> RecipeStore:
     return RecipeStore(get_database()[COLLECTION_NAME])
 
 
+def get_library_collection():
+    """The .NET-era ``jwst_data`` collection, as a dependency so tests can
+    point at a throwaway one — the same reason get_library_writer exists.
+    Reaching for get_database() inline would make run tests write into the
+    real shared library."""
+    return get_database()["jwst_data"]
+
+
 def _validate(payload: dict) -> CalibrationRecipe:
     # Bodies arrive as plain dicts (server-controlled fields are injected
     # before validation), so surface pydantic errors as a proper 422.
@@ -98,6 +106,7 @@ async def start_run(
     user: AuthenticatedUser = Depends(require_user),
     store: RecipeStore = Depends(get_recipe_store),
     job_store: JobStore = Depends(get_job_store),
+    library=Depends(get_library_collection),
 ):
     """Start a calibration run (stage-3 fast path on library inputs, or the
     recipe's full MAST-driven chain). Returns {jobId}; poll /api/jobs/{id}."""
@@ -172,7 +181,7 @@ async def start_run(
     # The key is derived here, from a document the caller is allowed to read.
     try:
         input_keys = await resolve_input_data_ids(
-            get_database()["jwst_data"],
+            library,
             input_data_ids,
             user_id=user.user_id,
             is_admin=user.role == "Admin",

--- a/processing-engine/app/calibration/routes.py
+++ b/processing-engine/app/calibration/routes.py
@@ -121,12 +121,40 @@ async def start_run(
         )
 
     from app.calibration.executor import MAX_CALIBRATION_INPUTS
+    from app.calibration.inputs import (
+        InputResolutionError,
+        as_http_error,
+        resolve_input_data_ids,
+    )
 
     recipe_id = payload.get("recipeId")
     input_keys = payload.get("inputs") or []
+    input_data_ids = payload.get("inputDataIds") or []
     run_overrides = payload.get("runOverrides") or {}
     if not recipe_id or not isinstance(input_keys, list):
         raise HTTPException(status_code=422, detail="recipeId is required; inputs must be a list")
+    if not isinstance(input_data_ids, list):
+        raise HTTPException(status_code=422, detail="inputDataIds must be a list")
+
+    # Preferred path (#1751): the client sends library ids and the key is
+    # derived here, from a document the caller is allowed to read. Raw
+    # `inputs` keys remain accepted for callers that already hold one.
+    if input_data_ids:
+        if len(input_data_ids) > MAX_CALIBRATION_INPUTS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"too many inputs (max {MAX_CALIBRATION_INPUTS})",
+            )
+        try:
+            resolved = await resolve_input_data_ids(
+                get_database()["jwst_data"],
+                input_data_ids,
+                user_id=user.user_id,
+                is_admin=user.role == "Admin",
+            )
+        except InputResolutionError as exc:
+            raise as_http_error(exc) from exc
+        input_keys = [*input_keys, *resolved]
     if len(input_keys) > MAX_CALIBRATION_INPUTS:
         raise HTTPException(
             status_code=422,

--- a/processing-engine/app/calibration/routes.py
+++ b/processing-engine/app/calibration/routes.py
@@ -143,6 +143,11 @@ async def start_run(
             status_code=422,
             detail="inputs (raw storage keys) is no longer accepted — send inputDataIds",
         )
+    enabled_stages = payload.get("enabledStages") or {}
+    if not isinstance(enabled_stages, dict) or not all(
+        isinstance(v, bool) for v in enabled_stages.values()
+    ):
+        raise HTTPException(status_code=422, detail="enabledStages must map stage->bool")
     if len(input_data_ids) > MAX_CALIBRATION_INPUTS:
         raise HTTPException(
             status_code=422,
@@ -159,11 +164,6 @@ async def start_run(
 
     # Per-run stage toggles: applied to the recipe snapshot BEFORE validation
     # and execution, so the job's embedded snapshot reflects what actually ran.
-    enabled_stages = payload.get("enabledStages") or {}
-    if not isinstance(enabled_stages, dict) or not all(
-        isinstance(v, bool) for v in enabled_stages.values()
-    ):
-        raise HTTPException(status_code=422, detail="enabledStages must map stage->bool")
     if enabled_stages:
         for stage in recipe.stages:
             if stage.name in enabled_stages:

--- a/processing-engine/app/calibration/routes.py
+++ b/processing-engine/app/calibration/routes.py
@@ -128,43 +128,45 @@ async def start_run(
     )
 
     recipe_id = payload.get("recipeId")
-    input_keys = payload.get("inputs") or []
     input_data_ids = payload.get("inputDataIds") or []
     run_overrides = payload.get("runOverrides") or {}
-    if not recipe_id or not isinstance(input_keys, list):
-        raise HTTPException(status_code=422, detail="recipeId is required; inputs must be a list")
+    if not recipe_id:
+        raise HTTPException(status_code=422, detail="recipeId is required")
     if not isinstance(input_data_ids, list):
         raise HTTPException(status_code=422, detail="inputDataIds must be a list")
-
-    # Preferred path (#1751): the client sends library ids and the key is
-    # derived here, from a document the caller is allowed to read. Raw
-    # `inputs` keys remain accepted for callers that already hold one.
-    if input_data_ids:
-        if len(input_data_ids) > MAX_CALIBRATION_INPUTS:
-            raise HTTPException(
-                status_code=422,
-                detail=f"too many inputs (max {MAX_CALIBRATION_INPUTS})",
-            )
-        try:
-            resolved = await resolve_input_data_ids(
-                get_database()["jwst_data"],
-                input_data_ids,
-                user_id=user.user_id,
-                is_admin=user.role == "Admin",
-            )
-        except InputResolutionError as exc:
-            raise as_http_error(exc) from exc
-        input_keys = [*input_keys, *resolved]
-    if len(input_keys) > MAX_CALIBRATION_INPUTS:
+    # Raw storage keys are NOT accepted from a client (#1719/#1751). Nothing
+    # authorizes a key per-record, so honouring one would let any authenticated
+    # caller calibrate another user's file and download the result. Storage
+    # keys stay an internal contract between here and the executor.
+    if payload.get("inputs"):
+        raise HTTPException(
+            status_code=422,
+            detail="inputs (raw storage keys) is no longer accepted — send inputDataIds",
+        )
+    if len(input_data_ids) > MAX_CALIBRATION_INPUTS:
         raise HTTPException(
             status_code=422,
             detail=f"too many inputs (max {MAX_CALIBRATION_INPUTS})",
         )
 
+    # Recipe visibility is checked before inputs are resolved, so a caller
+    # asking about a recipe they can't see gets that answer rather than an
+    # input-shaped error.
     recipe_doc = await store.get(recipe_id)
     if recipe_doc is None or not _visible_to(recipe_doc, user):
         raise HTTPException(status_code=404, detail="Recipe not found")
     recipe = CalibrationRecipe.model_validate(recipe_doc)
+
+    # The key is derived here, from a document the caller is allowed to read.
+    try:
+        input_keys = await resolve_input_data_ids(
+            get_database()["jwst_data"],
+            input_data_ids,
+            user_id=user.user_id,
+            is_admin=user.role == "Admin",
+        )
+    except InputResolutionError as exc:
+        raise as_http_error(exc) from exc
 
     # Per-run stage toggles: applied to the recipe snapshot BEFORE validation
     # and execution, so the job's embedded snapshot reflects what actually ran.
@@ -186,12 +188,9 @@ async def start_run(
         per_stage = _assign_run_overrides(stages, run_overrides)
         for stage in stages:
             validate_step_overrides(stage.name, per_stage[stage.name])
-        for key in input_keys:
-            if not isinstance(key, str):
-                raise RecipeValidationError("inputs must be storage-key strings")
         if not input_keys and recipe.input_source.type != "mast_query":
             raise RecipeValidationError(
-                "this recipe takes library inputs — provide a non-empty inputs list"
+                "this recipe takes library inputs — provide a non-empty inputDataIds list"
             )
     except (ValidationError, RecipeValidationError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
@@ -203,6 +202,9 @@ async def start_run(
             "recipe_id": recipe.id,
             "recipe_snapshot": recipe.to_document(),
             "inputs": [{"path": key, "role": "science"} for key in input_keys],
+            # The ids as well as the keys: a re-run needs to re-select library
+            # ITEMS, and a storage key can't be turned back into one (#1751).
+            "input_data_ids": input_data_ids,
             "run_overrides": run_overrides,
         },
     )

--- a/processing-engine/app/calibration/routes.py
+++ b/processing-engine/app/calibration/routes.py
@@ -157,17 +157,6 @@ async def start_run(
         raise HTTPException(status_code=404, detail="Recipe not found")
     recipe = CalibrationRecipe.model_validate(recipe_doc)
 
-    # The key is derived here, from a document the caller is allowed to read.
-    try:
-        input_keys = await resolve_input_data_ids(
-            get_database()["jwst_data"],
-            input_data_ids,
-            user_id=user.user_id,
-            is_admin=user.role == "Admin",
-        )
-    except InputResolutionError as exc:
-        raise as_http_error(exc) from exc
-
     # Per-run stage toggles: applied to the recipe snapshot BEFORE validation
     # and execution, so the job's embedded snapshot reflects what actually ran.
     enabled_stages = payload.get("enabledStages") or {}
@@ -179,6 +168,17 @@ async def start_run(
         for stage in recipe.stages:
             if stage.name in enabled_stages:
                 stage.enabled = enabled_stages[stage.name]
+
+    # The key is derived here, from a document the caller is allowed to read.
+    try:
+        input_keys = await resolve_input_data_ids(
+            get_database()["jwst_data"],
+            input_data_ids,
+            user_id=user.user_id,
+            is_admin=user.role == "Admin",
+        )
+    except InputResolutionError as exc:
+        raise as_http_error(exc) from exc
 
     try:
         # Scalar-only shape check (schema validator), then the executor's

--- a/processing-engine/tests/test_auth_deps.py
+++ b/processing-engine/tests/test_auth_deps.py
@@ -182,6 +182,20 @@ class TestRequireUser:
         response = client.get("/protected", headers=auth_header(token))
         assert response.status_code == 401
 
+    @pytest.mark.parametrize("sub", ["", "   "])
+    def test_blank_sub_claim_is_401(self, client: TestClient, sub: str) -> None:
+        # `require` only checks presence. A blank subject would decode to
+        # user_id == "", which matches any record with a missing or blank
+        # UserId in every visibility check that compares it (#1356).
+        now = int(time.time())
+        token = jwt.encode(
+            {"sub": sub, "iss": ISSUER, "aud": AUDIENCE, "exp": now + 900, "role": "User"},
+            SECRET,
+            algorithm="HS256",
+        )
+        response = client.get("/protected", headers=auth_header(token))
+        assert response.status_code == 401
+
     def test_missing_secret_env_is_503(
         self, client: TestClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/processing-engine/tests/test_calibration_executor.py
+++ b/processing-engine/tests/test_calibration_executor.py
@@ -24,7 +24,7 @@ from app.calibration.executor import (
     validate_step_overrides,
 )
 from app.calibration.models import CalibrationRecipe
-from app.calibration.routes import get_recipe_store
+from app.calibration.routes import get_library_collection, get_recipe_store
 from app.calibration.store import RecipeStore
 from app.db.client import get_database, reset_client
 from app.jobs.models import JobRecord
@@ -579,11 +579,20 @@ async def recipe_store():
 
 
 @pytest.fixture()
-async def client(recipe_store: RecipeStore, store: JobStore):
+async def library_collection():
+    # Throwaway: run tests must never touch the real shared library.
+    collection = get_database()[f"jwst_data_test_{uuid.uuid4().hex}"]
+    yield collection
+    await collection.drop()
+
+
+@pytest.fixture()
+async def client(recipe_store: RecipeStore, store: JobStore, library_collection):
     from main import app
 
     app.dependency_overrides[get_recipe_store] = lambda: recipe_store
     app.dependency_overrides[get_job_store] = lambda: store
+    app.dependency_overrides[get_library_collection] = lambda: library_collection
     transport = httpx.ASGITransport(app=app)
     try:
         async with httpx.AsyncClient(
@@ -593,20 +602,10 @@ async def client(recipe_store: RecipeStore, store: JobStore):
     finally:
         app.dependency_overrides.pop(get_recipe_store, None)
         app.dependency_overrides.pop(get_job_store, None)
+        app.dependency_overrides.pop(get_library_collection, None)
 
 
 class TestRunsEndpoint:
-    _library_ids: list = []
-
-    @pytest.fixture(autouse=True)
-    async def _clean_library(self):
-        # These tests write into the shared `jwst_data` collection (the route
-        # reads it directly), so remove exactly what they inserted.
-        type(self)._library_ids = []
-        yield
-        if self._library_ids:
-            await get_database()["jwst_data"].delete_many({"_id": {"$in": self._library_ids}})
-
     async def _seed_recipe(self, recipe_store: RecipeStore) -> str:
         # Owned by the caller — private recipes are invisible to non-owners.
         recipe = make_recipe(created_by=USER)
@@ -663,13 +662,13 @@ class TestRunsEndpoint:
         self,
         client: httpx.AsyncClient,
         recipe_store,
+        library_collection,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         self._enable(monkeypatch)
         recipe_id = await self._seed_recipe(recipe_store)
         # Inputs are library ids now (#1751): seed the item the key comes from.
-        library = get_database()["jwst_data"]
-        inserted = await library.insert_one(
+        inserted = await library_collection.insert_one(
             {
                 "FileName": "a_cal.fits",
                 "FilePath": "mast/obs/a_cal.fits",
@@ -677,7 +676,6 @@ class TestRunsEndpoint:
                 "IsPublic": False,
             }
         )
-        self._library_ids.append(inserted.inserted_id)
         response = await client.post(
             "/api/calibration/runs",
             json={"recipeId": recipe_id, "inputDataIds": [str(inserted.inserted_id)]},

--- a/processing-engine/tests/test_calibration_executor.py
+++ b/processing-engine/tests/test_calibration_executor.py
@@ -596,6 +596,17 @@ async def client(recipe_store: RecipeStore, store: JobStore):
 
 
 class TestRunsEndpoint:
+    _library_ids: list = []
+
+    @pytest.fixture(autouse=True)
+    async def _clean_library(self):
+        # These tests write into the shared `jwst_data` collection (the route
+        # reads it directly), so remove exactly what they inserted.
+        type(self)._library_ids = []
+        yield
+        if self._library_ids:
+            await get_database()["jwst_data"].delete_many({"_id": {"$in": self._library_ids}})
+
     async def _seed_recipe(self, recipe_store: RecipeStore) -> str:
         # Owned by the caller — private recipes are invisible to non-owners.
         recipe = make_recipe(created_by=USER)
@@ -609,14 +620,14 @@ class TestRunsEndpoint:
         recipe_id = await self._seed_recipe(recipe_store)
         response = await client.post(
             "/api/calibration/runs",
-            json={"recipeId": recipe_id, "inputs": ["k"]},
+            json={"recipeId": recipe_id, "inputDataIds": []},
             headers=bearer(),
         )
         assert response.status_code == 501
 
     async def test_requires_auth(self, client: httpx.AsyncClient) -> None:
         response = await client.post(
-            "/api/calibration/runs", json={"recipeId": "x", "inputs": ["k"]}
+            "/api/calibration/runs", json={"recipeId": "x", "inputDataIds": []}
         )
         assert response.status_code == 401
 
@@ -626,7 +637,7 @@ class TestRunsEndpoint:
         self._enable(monkeypatch)
         response = await client.post(
             "/api/calibration/runs",
-            json={"recipeId": "nope", "inputs": ["k"]},
+            json={"recipeId": "nope", "inputDataIds": []},
             headers=bearer(),
         )
         assert response.status_code == 404
@@ -640,7 +651,7 @@ class TestRunsEndpoint:
             "/api/calibration/runs",
             json={
                 "recipeId": recipe_id,
-                "inputs": ["k"],
+                "inputDataIds": [],
                 "runOverrides": {"resample": {"output_file": "/etc/passwd"}},
             },
             headers=bearer(),
@@ -656,12 +667,23 @@ class TestRunsEndpoint:
     ) -> None:
         self._enable(monkeypatch)
         recipe_id = await self._seed_recipe(recipe_store)
+        # Inputs are library ids now (#1751): seed the item the key comes from.
+        library = get_database()["jwst_data"]
+        inserted = await library.insert_one(
+            {
+                "FileName": "a_cal.fits",
+                "FilePath": "mast/obs/a_cal.fits",
+                "UserId": USER,
+                "IsPublic": False,
+            }
+        )
+        self._library_ids.append(inserted.inserted_id)
         response = await client.post(
             "/api/calibration/runs",
-            json={"recipeId": recipe_id, "inputs": ["mast/obs/a_cal.fits"]},
+            json={"recipeId": recipe_id, "inputDataIds": [str(inserted.inserted_id)]},
             headers=bearer(),
         )
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         job_id = response.json()["jobId"]
 
         import asyncio
@@ -694,7 +716,7 @@ class TestRunsEndpoint:
             "/api/calibration/runs",
             json={
                 "recipeId": recipe.id,
-                "inputs": [],
+                "inputDataIds": [],
                 "enabledStages": {"detector1": False, "image2": False},
             },
             headers=bearer(),

--- a/processing-engine/tests/test_calibration_inputs.py
+++ b/processing-engine/tests/test_calibration_inputs.py
@@ -91,9 +91,30 @@ class TestResolveInputDataIds:
 
     async def test_does_not_load_thumbnail_blobs(self, library) -> None:
         # These documents carry binary ThumbnailData; pulling it for every
-        # input would move megabytes to authorize a path lookup.
+        # input would move megabytes just to authorize a path lookup. Assert
+        # the projection itself — a truthy result proves nothing here.
         data_id = await seed(library, ThumbnailData=b"x" * 32)
-        assert await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+
+        seen: dict = {}
+        original = library.find
+
+        def _spy(query, projection=None, *args, **kwargs):
+            seen["projection"] = projection
+            return original(query, projection, *args, **kwargs)
+
+        library.find = _spy
+        try:
+            assert await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+        finally:
+            library.find = original
+
+        projection = seen["projection"]
+        assert projection, "find() must be projected, not fetch whole documents"
+        # An inclusion projection: only the listed fields come back.
+        assert set(projection.values()) == {1}
+        assert "ThumbnailData" not in projection
+        # Everything the authorization decision reads must be included.
+        assert {"UserId", "IsPublic", "SharedWith", "FilePath", "IsArchived"} <= set(projection)
 
     async def test_admin_may_use_any_item(self, library) -> None:
         data_id = await seed(library, UserId=OTHER, IsPublic=False)

--- a/processing-engine/tests/test_calibration_inputs.py
+++ b/processing-engine/tests/test_calibration_inputs.py
@@ -66,6 +66,35 @@ class TestResolveInputDataIds:
         with pytest.raises(InputResolutionError, match="not found"):
             await resolve_input_data_ids(library, [data_id], user_id=OWNER)
 
+    async def test_item_shared_with_the_caller_is_usable(self, library) -> None:
+        # Mirrors the .NET FilterAccessibleData SharedWith branch: these items
+        # show up in the caller's library, so they must be selectable too.
+        data_id = await seed(library, UserId=OTHER, IsPublic=False, SharedWith=[OWNER])
+        assert await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+
+    async def test_shared_with_someone_else_is_still_refused(self, library) -> None:
+        data_id = await seed(library, UserId=OTHER, IsPublic=False, SharedWith=["user-c"])
+        with pytest.raises(InputResolutionError, match="not found"):
+            await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+
+    async def test_archived_item_is_refused(self, library) -> None:
+        data_id = await seed(library, IsArchived=True)
+        with pytest.raises(InputResolutionError, match="archived"):
+            await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+
+    async def test_duplicate_ids_are_refused(self, library) -> None:
+        # Silently de-duplicating would change the association; double-counting
+        # would over-weight one exposure. Neither is a safe guess.
+        data_id = await seed(library)
+        with pytest.raises(InputResolutionError, match="duplicate"):
+            await resolve_input_data_ids(library, [data_id, data_id], user_id=OWNER)
+
+    async def test_does_not_load_thumbnail_blobs(self, library) -> None:
+        # These documents carry binary ThumbnailData; pulling it for every
+        # input would move megabytes to authorize a path lookup.
+        data_id = await seed(library, ThumbnailData=b"x" * 32)
+        assert await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+
     async def test_admin_may_use_any_item(self, library) -> None:
         data_id = await seed(library, UserId=OTHER, IsPublic=False)
         assert await resolve_input_data_ids(library, [data_id], user_id=OWNER, is_admin=True)

--- a/processing-engine/tests/test_calibration_inputs.py
+++ b/processing-engine/tests/test_calibration_inputs.py
@@ -1,0 +1,97 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""Resolving library ids to calibration input keys (#1751).
+
+The bug this fixes: the library DTO never publishes FilePath, so a client
+literally could not send a storage key, and every library-input path in the UI
+was silently empty. Ids are resolved server-side instead.
+"""
+
+import uuid
+
+import pytest
+from bson import ObjectId
+
+from app.calibration.inputs import InputResolutionError, resolve_input_data_ids
+from app.db.client import get_database, reset_client
+
+
+OWNER = "user-a"
+OTHER = "user-b"
+
+
+@pytest.fixture()
+async def library():
+    reset_client()
+    collection = get_database()[f"jwst_data_test_{uuid.uuid4().hex}"]
+    yield collection
+    await collection.drop()
+    reset_client()
+
+
+async def seed(collection, **over) -> str:
+    doc = {
+        "FileName": "a_cal.fits",
+        "FilePath": "mast/jw1/a_cal.fits",
+        "UserId": OWNER,
+        "IsPublic": False,
+        **over,
+    }
+    result = await collection.insert_one(doc)
+    return str(result.inserted_id)
+
+
+class TestResolveInputDataIds:
+    async def test_returns_relative_keys_in_the_callers_order(self, library) -> None:
+        first = await seed(library, FilePath="mast/jw1/a_cal.fits")
+        second = await seed(library, FilePath="mast/jw1/b_cal.fits")
+
+        keys = await resolve_input_data_ids(library, [second, first], user_id=OWNER)
+
+        # Order matters: it decides how exposures are associated into a mosaic.
+        assert keys == ["mast/jw1/b_cal.fits", "mast/jw1/a_cal.fits"]
+
+    async def test_strips_the_container_data_prefix(self, library) -> None:
+        data_id = await seed(library, FilePath="/app/data/mast/jw1/a_cal.fits")
+        keys = await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+        assert keys == ["mast/jw1/a_cal.fits"]
+
+    async def test_public_items_are_usable_by_anyone(self, library) -> None:
+        data_id = await seed(library, UserId=OTHER, IsPublic=True)
+        assert await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+
+    async def test_someone_elses_private_item_is_refused(self, library) -> None:
+        data_id = await seed(library, UserId=OTHER, IsPublic=False)
+        with pytest.raises(InputResolutionError, match="not found"):
+            await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+
+    async def test_admin_may_use_any_item(self, library) -> None:
+        data_id = await seed(library, UserId=OTHER, IsPublic=False)
+        assert await resolve_input_data_ids(library, [data_id], user_id=OWNER, is_admin=True)
+
+    async def test_unknown_id_reads_the_same_as_not_visible(self, library) -> None:
+        # Same message on purpose — otherwise a caller could probe for ids.
+        missing = str(ObjectId())
+        with pytest.raises(InputResolutionError, match="not found"):
+            await resolve_input_data_ids(library, [missing], user_id=OWNER)
+
+    async def test_item_without_a_file_is_refused(self, library) -> None:
+        data_id = await seed(library, FilePath=None)
+        with pytest.raises(InputResolutionError, match="no file"):
+            await resolve_input_data_ids(library, [data_id], user_id=OWNER)
+
+    async def test_never_silently_drops_an_input(self, library) -> None:
+        # A run that quietly used fewer frames than asked would produce a wrong
+        # mosaic with no indication why, so one bad id fails the whole request.
+        good = await seed(library)
+        bad = str(ObjectId())
+        with pytest.raises(InputResolutionError):
+            await resolve_input_data_ids(library, [good, bad], user_id=OWNER)
+
+    async def test_malformed_id_is_rejected(self, library) -> None:
+        with pytest.raises(InputResolutionError, match="valid library id"):
+            await resolve_input_data_ids(library, ["not-an-objectid"], user_id=OWNER)
+
+    async def test_empty_list_is_fine(self, library) -> None:
+        assert await resolve_input_data_ids(library, [], user_id=OWNER) == []

--- a/processing-engine/tests/test_calibration_run_routes.py
+++ b/processing-engine/tests/test_calibration_run_routes.py
@@ -126,6 +126,7 @@ def body(**over) -> dict:
 
 
 class TestStartRunInputContract:
+    @pytest.mark.usefixtures("launched")
     async def test_raw_storage_keys_are_refused(self, client: httpx.AsyncClient) -> None:
         # The whole point of #1751/#1719: a raw key is authorized nowhere, so
         # honouring one would let any user calibrate another user's file.
@@ -198,6 +199,19 @@ class TestStartRunInputContract:
         # Both: keys for the executor, ids so the form can re-select the items.
         assert job.request["inputs"] == [{"path": "mast/jw1/a_cal.fits", "role": "science"}]
         assert job.request["input_data_ids"] == [data_id]
+
+    @pytest.mark.usefixtures("launched")
+    async def test_an_empty_inputs_key_is_ignored_not_rejected(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        # A client that always sends the key must not be broken by the
+        # rejection above — only a non-empty one is an attempt to supply keys.
+        response = await client.post(
+            "/api/calibration/runs",
+            json=body(inputs=[]),
+            headers=bearer(USER),
+        )
+        assert response.status_code == 202, response.text
 
     async def test_requires_auth(self, client: httpx.AsyncClient) -> None:
         response = await client.post("/api/calibration/runs", json=body())

--- a/processing-engine/tests/test_calibration_run_routes.py
+++ b/processing-engine/tests/test_calibration_run_routes.py
@@ -1,0 +1,204 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""POST /api/calibration/runs — the request contract (#1751).
+
+Covers what unit-testing `resolve_input_data_ids` alone cannot: that the route
+refuses raw storage keys, enforces the input cap before any job exists, maps
+resolution failures to 422, derives admin from the token role, and records the
+source ids on the job so a re-run can re-select them.
+"""
+
+import time
+import uuid
+
+import httpx
+import jwt as pyjwt
+import pytest
+from bson import ObjectId
+
+from app.calibration.executor import MAX_CALIBRATION_INPUTS
+from app.calibration.routes import get_recipe_store
+from app.calibration.store import RecipeStore
+from app.db.client import get_database, reset_client
+
+
+SECRET = "unit-test-secret-key-at-least-32-chars!!"
+ROLE_URI = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+USER = "user-a"
+OTHER = "user-b"
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JWT_SECRET_KEY", SECRET)
+    monkeypatch.setenv("CALIBRATION_ENABLED", "true")
+
+
+def bearer(user_id: str, role: str = "User") -> dict[str, str]:
+    now = int(time.time())
+    token = pyjwt.encode(
+        {
+            "sub": user_id,
+            ROLE_URI: role,
+            "iss": "JwstDataAnalysis",
+            "aud": "JwstDataAnalysisClient",
+            "iat": now,
+            "exp": now + 900,
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+async def store():
+    reset_client()
+    collection = get_database()[f"recipes_test_{uuid.uuid4().hex}"]
+    recipe_store = RecipeStore(collection)
+    await recipe_store.seed()
+    yield recipe_store
+    await collection.drop()
+    reset_client()
+
+
+@pytest.fixture()
+async def library():
+    """The route reads `jwst_data` directly, so seed that collection and take
+    the inserted ids away again rather than dropping a shared collection."""
+    collection = get_database()["jwst_data"]
+    inserted: list[ObjectId] = []
+
+    async def add(**over) -> str:
+        doc = {
+            "FileName": "a_cal.fits",
+            "FilePath": "mast/jw1/a_cal.fits",
+            "UserId": USER,
+            "IsPublic": False,
+            **over,
+        }
+        result = await collection.insert_one(doc)
+        inserted.append(result.inserted_id)
+        return str(result.inserted_id)
+
+    yield add
+    if inserted:
+        await collection.delete_many({"_id": {"$in": inserted}})
+
+
+@pytest.fixture()
+async def launched(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Capture jobs instead of running them — this is a request-contract test."""
+    calls: list = []
+
+    async def _fake_launch(job_store, job, work):
+        calls.append(job)
+        return "job-1"
+
+    monkeypatch.setattr("app.jobs.runner.launch", _fake_launch)
+    return calls
+
+
+@pytest.fixture()
+async def client(store: RecipeStore):
+    from main import app
+
+    app.dependency_overrides[get_recipe_store] = lambda: store
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as async_client:
+            yield async_client
+    finally:
+        app.dependency_overrides.pop(get_recipe_store, None)
+
+
+def body(**over) -> dict:
+    return {
+        "recipeId": "seed-nircam-imaging",
+        "inputDataIds": [],
+        "runOverrides": {},
+        "enabledStages": {"detector1": False, "image2": False, "image3": True},
+        **over,
+    }
+
+
+class TestStartRunInputContract:
+    async def test_raw_storage_keys_are_refused(self, client: httpx.AsyncClient) -> None:
+        # The whole point of #1751/#1719: a raw key is authorized nowhere, so
+        # honouring one would let any user calibrate another user's file.
+        response = await client.post(
+            "/api/calibration/runs",
+            json=body(inputs=["mast/someone-elses/x_cal.fits"]),
+            headers=bearer(USER),
+        )
+        assert response.status_code == 422
+        assert "inputDataIds" in response.json()["detail"]
+
+    async def test_someone_elses_private_item_is_refused(
+        self, client: httpx.AsyncClient, library
+    ) -> None:
+        data_id = await library(UserId=OTHER, IsPublic=False)
+        response = await client.post(
+            "/api/calibration/runs",
+            json=body(inputDataIds=[data_id]),
+            headers=bearer(USER),
+        )
+        assert response.status_code == 422
+        assert "not found" in response.json()["detail"]
+
+    @pytest.mark.usefixtures("launched")
+    async def test_admin_role_from_the_token_may_use_any_item(
+        self, client: httpx.AsyncClient, library
+    ) -> None:
+        data_id = await library(UserId=OTHER, IsPublic=False)
+        response = await client.post(
+            "/api/calibration/runs",
+            json=body(inputDataIds=[data_id]),
+            headers=bearer(USER, role="Admin"),
+        )
+        assert response.status_code == 202, response.text
+
+    async def test_over_the_cap_is_refused_before_a_job_exists(
+        self, client: httpx.AsyncClient, launched: list
+    ) -> None:
+        ids = [str(ObjectId()) for _ in range(MAX_CALIBRATION_INPUTS + 1)]
+        response = await client.post(
+            "/api/calibration/runs",
+            json=body(inputDataIds=ids),
+            headers=bearer(USER),
+        )
+        assert response.status_code == 422
+        assert "too many inputs" in response.json()["detail"]
+        assert launched == []
+
+    async def test_unknown_recipe_answers_about_the_recipe_not_the_inputs(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        response = await client.post(
+            "/api/calibration/runs",
+            json=body(recipeId="nope", inputDataIds=[str(ObjectId())]),
+            headers=bearer(USER),
+        )
+        assert response.status_code == 404
+
+    async def test_run_records_the_source_ids_for_a_re_run(
+        self, client: httpx.AsyncClient, library, launched: list
+    ) -> None:
+        data_id = await library()
+        response = await client.post(
+            "/api/calibration/runs",
+            json=body(inputDataIds=[data_id]),
+            headers=bearer(USER),
+        )
+        assert response.status_code == 202, response.text
+        job = launched[0]
+        # Both: keys for the executor, ids so the form can re-select the items.
+        assert job.request["inputs"] == [{"path": "mast/jw1/a_cal.fits", "role": "science"}]
+        assert job.request["input_data_ids"] == [data_id]
+
+    async def test_requires_auth(self, client: httpx.AsyncClient) -> None:
+        response = await client.post("/api/calibration/runs", json=body())
+        assert response.status_code in (401, 403)

--- a/processing-engine/tests/test_calibration_run_routes.py
+++ b/processing-engine/tests/test_calibration_run_routes.py
@@ -222,14 +222,18 @@ class TestStartRunInputContract:
         assert response.status_code == 422
         assert "enabledStages" in response.json()["detail"]
 
-    async def test_request_shape_is_checked_before_the_library_round_trip(
+    async def test_request_shape_is_checked_before_any_database_round_trip(
         self, client: httpx.AsyncClient
     ) -> None:
-        # Both are wrong; the cheap in-memory check must answer first rather
-        # than spending a Mongo query to report the input error instead.
+        # Both are wrong. Shape checks cost nothing, so a malformed body must
+        # be answered before any database round-trip — recipe or library.
         response = await client.post(
             "/api/calibration/runs",
-            json=body(enabledStages={"image3": "yes"}, inputDataIds=[str(ObjectId())]),
+            json=body(
+                recipeId="nope",
+                enabledStages={"image3": "yes"},
+                inputDataIds=[str(ObjectId())],
+            ),
             headers=bearer(USER),
         )
         assert response.status_code == 422

--- a/processing-engine/tests/test_calibration_run_routes.py
+++ b/processing-engine/tests/test_calibration_run_routes.py
@@ -18,7 +18,7 @@ import pytest
 from bson import ObjectId
 
 from app.calibration.executor import MAX_CALIBRATION_INPUTS
-from app.calibration.routes import get_recipe_store
+from app.calibration.routes import get_library_collection, get_recipe_store
 from app.calibration.store import RecipeStore
 from app.db.client import get_database, reset_client
 
@@ -31,8 +31,13 @@ OTHER = "user-b"
 
 @pytest.fixture(autouse=True)
 def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.calibration import flags
+
     monkeypatch.setenv("JWT_SECRET_KEY", SECRET)
+    # Both gates: the env var AND the build-time jwst layer, which CI's image
+    # does not install — env alone leaves every run request a 501.
     monkeypatch.setenv("CALIBRATION_ENABLED", "true")
+    monkeypatch.setattr(flags, "jwst_available", lambda: True)
 
 
 def bearer(user_id: str, role: str = "User") -> dict[str, str]:
@@ -64,12 +69,17 @@ async def store():
 
 
 @pytest.fixture()
-async def library():
-    """The route reads `jwst_data` directly, so seed that collection and take
-    the inserted ids away again rather than dropping a shared collection."""
-    collection = get_database()["jwst_data"]
-    inserted: list[ObjectId] = []
+async def library_collection():
+    """Throwaway stand-in for the shared `jwst_data` collection — run tests
+    must never read or write the real library (same rule as get_library_writer
+    in the jobs routes)."""
+    collection = get_database()[f"jwst_data_test_{uuid.uuid4().hex}"]
+    yield collection
+    await collection.drop()
 
+
+@pytest.fixture()
+def library(library_collection):
     async def add(**over) -> str:
         doc = {
             "FileName": "a_cal.fits",
@@ -78,13 +88,10 @@ async def library():
             "IsPublic": False,
             **over,
         }
-        result = await collection.insert_one(doc)
-        inserted.append(result.inserted_id)
+        result = await library_collection.insert_one(doc)
         return str(result.inserted_id)
 
-    yield add
-    if inserted:
-        await collection.delete_many({"_id": {"$in": inserted}})
+    return add
 
 
 @pytest.fixture()
@@ -101,10 +108,11 @@ async def launched(monkeypatch: pytest.MonkeyPatch) -> list:
 
 
 @pytest.fixture()
-async def client(store: RecipeStore):
+async def client(store: RecipeStore, library_collection):
     from main import app
 
     app.dependency_overrides[get_recipe_store] = lambda: store
+    app.dependency_overrides[get_library_collection] = lambda: library_collection
     transport = httpx.ASGITransport(app=app)
     try:
         async with httpx.AsyncClient(
@@ -113,6 +121,7 @@ async def client(store: RecipeStore):
             yield async_client
     finally:
         app.dependency_overrides.pop(get_recipe_store, None)
+        app.dependency_overrides.pop(get_library_collection, None)
 
 
 def body(**over) -> dict:

--- a/processing-engine/tests/test_calibration_run_routes.py
+++ b/processing-engine/tests/test_calibration_run_routes.py
@@ -213,6 +213,28 @@ class TestStartRunInputContract:
         )
         assert response.status_code == 202, response.text
 
+    async def test_malformed_enabled_stages_is_422(self, client: httpx.AsyncClient) -> None:
+        response = await client.post(
+            "/api/calibration/runs",
+            json=body(enabledStages={"image3": "yes"}),
+            headers=bearer(USER),
+        )
+        assert response.status_code == 422
+        assert "enabledStages" in response.json()["detail"]
+
+    async def test_request_shape_is_checked_before_the_library_round_trip(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        # Both are wrong; the cheap in-memory check must answer first rather
+        # than spending a Mongo query to report the input error instead.
+        response = await client.post(
+            "/api/calibration/runs",
+            json=body(enabledStages={"image3": "yes"}, inputDataIds=[str(ObjectId())]),
+            headers=bearer(USER),
+        )
+        assert response.status_code == 422
+        assert "enabledStages" in response.json()["detail"]
+
     async def test_requires_auth(self, client: httpx.AsyncClient) -> None:
         response = await client.post("/api/calibration/runs", json=body())
         assert response.status_code in (401, 403)


### PR DESCRIPTION
## Summary

Calibration runs took **storage keys** from the client. The library DTO never publishes `FilePath` — it's an internal storage location — so every `.map(item => item.filePath)` in the frontend produced an empty array. Three flows were silently broken with no error to explain why:

- **Reprocess** (library → calibrate) submitted nothing, or after a partial fix, exactly one exposure instead of the observation's whole `_cal` set.
- The **config page's input checkboxes** never matched anything.
- The **data-first picker** at `/calibrate/new` handed off empty inputs.

Tests never caught it because the fixtures mocked `getAll` *with* a `filePath` the API does not send.

The client now sends `inputDataIds` (library ids) and the engine resolves each to a storage key from a document the caller is authorized to read. That also closes the raw-path surface #1719 is about: nothing authorizes a storage key per-record, so accepting one let any authenticated user calibrate another user's file and download the result from the job.

Six self-review rounds; rounds 1–5 each found real defects, including two where a previous round's fix introduced or failed to apply a change. Round 6 came back clean.

Closes #1751
Closes #1719

## Changes Made

**Engine — authorization**
- New `app/calibration/inputs.py`: `resolve_input_data_ids` maps ids → storage keys, preserving caller order. Visibility mirrors .NET `FilterAccessibleData`: own items, public items, items shared with the caller, or any item for an Admin.
- Unknown and not-visible collapse to one message, so ids can't be probed. Archived items, duplicate ids, and items with no file are refused. A single bad id fails the whole request — a run that quietly used fewer frames would produce a wrong mosaic with nothing to indicate why.
- Projection excludes `ThumbnailData`; these documents carry binary blobs.
- `POST /api/calibration/runs` **rejects** raw `inputs` storage keys (422). An empty `inputs: []` is tolerated for clients that always send the key.
- Shape checks now run before any database round-trip; recipe visibility is answered before input errors.
- The job records `input_data_ids` alongside the keys, so a re-run can re-select the same library items.
- `app/auth/deps.py`: a blank or whitespace `sub` claim is now 401. `require` only checks presence, so `sub: ""` decoded to `user_id == ""`, which would match any record with a missing or blank `UserId` in every visibility check that compares it — including the one this PR adds. .NET guards this explicitly (#1356); the engine did not.

**Frontend — selection integrity**
- `StartRunRequest.inputs` → `inputDataIds`; `filePath` removed from `JwstDataModel` entirely (the optional field the DTO never sent is what let this bug class typecheck).
- `reprocessInputIds` extracted to `dataGrouping.ts` and unit-tested; it no longer filters on the nonexistent `filePath`, so Reprocess submits the whole observation again.
- Pre-selected files are **always listed**, whatever their suffix. The suffix filter decides what to browse, never what you may run on — making it the gate broke `_uncal` picks on a reprocess and then `_cal` picks on a seed recipe, in turn.
- Only files the page is showing are submitted, so a run can never use a selection the user cannot see or uncheck.
- Blocked stages are no longer submitted as enabled. The timeline renders them off and excludes them from the estimate, but the raw map was posted, so the engine would honour the toggle and run Detector1 on `_cal` frames — failing hours in, which is what #1736 exists to prevent.
- Real loading state: without it, every visit to a library-input page showed "No matching library files found" for the length of a full-library GET before flipping to a populated list.
- The form remounts per recipe (`key={recipeId}`), so a recipe change can't run recipe A's selection against recipe B.
- A disabled Run button says why, in order of what's actionable, and the reason is announced (`role="status"` + `aria-describedby`) rather than hidden in a `title` a disabled control never surfaces. Same treatment for RunDetail's Re-run button.
- Re-run is offered as unavailable for jobs predating input tracking — those store keys but no ids, so re-running one would silently become a fresh multi-GB MAST download.

**Docs**
- `docs/architecture/calibration-pipeline-flow.md` and `docs/quick-reference.md` updated for the new request contract and input-visibility rule.

## Test Plan

Automated (all run and passing locally):

- [x] Frontend unit: **1258 passed**, 115 files (`npx vitest run`)
- [x] Engine: **1758 passed** (`docker exec jwst-processing python -m pytest tests/`)
- [x] `tsc -b` clean; `eslint src` 0 errors (82 warnings = repo baseline)
- [x] `ruff check app tests` clean
- [x] Confirmed each new test fails if its fix is reverted (verified per-finding during review rounds)

Manual — authorization (the important part):

1. Sign in as user A. Note the id of one of A's private library `_cal` files.
2. Sign in as user B. `POST /api/calibration/runs` with `{"recipeId":"seed-nircam-imaging","inputDataIds":["<A's id>"],"enabledStages":{"image3":true}}`.
   → **422 `library item not found`** (same message as a nonexistent id — no way to tell them apart).
3. Same request but with `{"inputs":["mast/<A's path>/x_cal.fits"]}`.
   → **422 `inputs (raw storage keys) is no longer accepted — send inputDataIds`**.
4. Repeat step 2 as an Admin → **202**, run starts.
5. Have A share the item with B, retry step 2 → **202** (this is the `SharedWith` case that used to fail with "not found" despite the file being visible in B's library).

Manual — the three broken flows:

6. Library → a `_cal` card → **Reprocess**. The config page opens with **every `_cal` exposure of that observation** checked, not just the one clicked. Start it; the run succeeds and produces an `_i2d`.
7. `/calibrate/new` → select `_uncal` files → pick a seed recipe. Your files are listed and checked (they used to vanish). Now do it again with `_cal` files — those are listed too, and the stage timeline explains which stages they block.
8. On a finished library run, **Re-run with changes** → the config page reopens with the same library items selected, and does **not** start a MAST download.

Manual — the states that used to lie:

9. Open a Reprocess config page and watch the Inputs section: it reads "Loading your library…", never "No matching library files found".
10. With devtools offline, reload → "Couldn't load your library: …" and the Run hint says there's nothing to run on, **not** "Choose at least one input file above."
11. Tab to a disabled Run button with a screen reader → the reason is announced.

## Documentation Checklist

- [x] `docs/architecture/calibration-pipeline-flow.md` — request body, input-visibility rule, raw-key rejection
- [x] `docs/quick-reference.md` — `POST /api/calibration/runs` contract
- [x] Code comments record the invariant at the trust boundary (`executor.py`) so client-supplied keys aren't reintroduced
- [ ] No user-facing guide exists for calibration yet — tracked separately under the #1733 epic

## Tech Debt Impact

- [x] **Reduces** — removes the client-supplied storage-key surface (#1719) rather than documenting it
- [x] **Reduces** — deletes `filePath` from the frontend model, so this bug class no longer typechecks
- [x] **Reduces** — collapses three copies of "is this job terminal" in RunDetail to one
- [x] **Reduces** — fixtures no longer mock a field production doesn't send
- [ ] Adds no new debt

## Risk & Rollback

**Risk: medium.** Touches an authorization boundary and changes a request contract.

- **Breaking contract change**: `POST /api/calibration/runs` no longer accepts `inputs`. Only this repo's frontend calls it, and it was updated in the same PR. Any external caller holding a storage key gets a 422 naming the replacement.
- **Auth change**: rejecting a blank `sub` is auth-adjacent, and `CLAUDE.md` flags auth as fragile. Scope is narrow — `optional_user` returns before decoding when there is no header, so anonymous and CE paths are untouched; the only behavior change is that a token with an empty subject is 401 instead of authenticating as `""`. Covered by `test_blank_sub_claim_is_401`.
- **Jobs created before this PR** keep working; only their **Re-run** button is disabled, with a visible explanation.
- **Not covered**: no live end-to-end run against real JWST data was executed — the engine tests use a faked pipeline. The authorization paths and the request contract are covered by tests; the actual `jwst` invocation is unchanged by this PR.

**Rollback**: revert the six commits. No migrations, no schema changes, no data written or deleted. `input_data_ids` is additive on the job record and ignored by older code.
