### PR TITLE
fix: make the data mount explicit so worktree runs find the real library

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,7 +46,13 @@ services:
       - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Development}
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173}
     volumes:
-      - ../data:/app/data
+      # JWST_DATA_DIR overrides where the library lives. The `../data` default
+      # is relative to THIS FILE, so starting the stack from a git worktree
+      # silently points the app at the worktree's own empty data dir while
+      # Mongo still holds records for the real one — every image 404s. Set
+      # JWST_DATA_DIR=/absolute/path/to/checkout/data when running from a
+      # worktree.
+      - ${JWST_DATA_DIR:-../data}:/app/data
     depends_on:
       mongodb:
         condition: service_started
@@ -74,7 +80,7 @@ services:
       - S3_FORCE_PATH_STYLE=${S3_FORCE_PATH_STYLE:-true}
       - S3_PUBLIC_ENDPOINT=${S3_PUBLIC_ENDPOINT:-http://localhost:8333}
     volumes:
-      - ../data:/app/data
+      - ${JWST_DATA_DIR:-../data}:/app/data
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 10s
@@ -128,7 +134,7 @@ services:
       # posture — Detector1 on deep exposures can legitimately take hours).
       - CALIBRATION_TIMEOUT_S=${CALIBRATION_TIMEOUT_S:-14400}
     volumes:
-      - ../data:/app/data
+      - ${JWST_DATA_DIR:-../data}:/app/data
     depends_on:
       - backend
     healthcheck:

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -150,6 +150,16 @@ CE env vars: `CE_MODE`, `MONGODB_URI` (read-only credentials suffice), `MONGODB_
 
 ## Troubleshooting
 
+**Every image 404s / library items have thumbnails but no file**:
+- Almost always the data mount, not lost data. `docker-compose.yml` mounts
+  `../data` *relative to itself*, so starting the stack from a git worktree
+  points the app at the worktree's own (empty) `data/` while MongoDB still
+  holds records for the real library.
+- Confirm: `docker exec jwst-processing ls /app/data` — if there's no
+  `uploads/`, it's mounted in the wrong place.
+- Fix: start the stack with an explicit path —
+  `JWST_DATA_DIR=/absolute/path/to/main-checkout/data docker compose -f docker/docker-compose.yml up -d`
+
 **MongoDB Connection Issues**:
 - Ensure MongoDB is running (Docker: `docker compose ps`)
 - Check connection string in `appsettings.json` matches your setup


### PR DESCRIPTION
## Summary

Every image in the app 404s when the stack is started from a git worktree. It looks like data loss — library items still show thumbnails (those are stored as a blob in Mongo) but no file ever loads.

Nothing is lost. `docker-compose.yml` mounts `../data`, which resolves **relative to the compose file**. Start the stack from `.claude/worktrees/<name>/docker/` and it mounts that worktree's own `data/` — a fresh, near-empty directory, because `data/` is gitignored and worktrees don't inherit it. MongoDB is a shared container, so it still holds records pointing into the main checkout's library. The result is a stack that boots healthy, passes its healthchecks, and cannot serve a single file.

Found while running the app from an epic worktree.

No linked issue

## Changes Made

- `JWST_DATA_DIR` now drives the three `/app/data` mounts (backend, processing-engine, mast-proxy), defaulting to `../data` so behaviour is unchanged for anyone running from the repo root.
- Comment on the mount explaining why the default is a trap from a worktree.
- `docs/quick-reference.md` Troubleshooting entry for the symptom, with a one-command confirmation (`docker exec jwst-processing ls /app/data` — no `uploads/` means it's mounted wrong) and the fix.

## Test Plan

Measured on this machine, before and after:

- [x] **Before**: 1523 of 1523 records with a `FilePath` pointed at a file that did not exist under the mounted path (100%).
- [x] **After** (`JWST_DATA_DIR=/Users/.../Astronomy/data`): 1 of 1523 missing (a genuinely orphaned record, unrelated to the mount).
- [x] `GET /api/jwstdata/{id}/preview` → 200, 12506 bytes
- [x] `GET /api/jwstdata/{id}/histogram` → 200, 12914 bytes
- [x] `GET /api/jwstdata/{id}/file` → 200, 46080 bytes — matches the file's size on disk exactly
- [x] `GET /api/jwstdata/{id}/thumbnail` → 200 (served before the fix too, since it comes from Mongo — this is what makes the failure look like partial data loss)

To reproduce the bug and verify the fix:

1. From a worktree: `docker compose -f docker/docker-compose.yml up -d`
2. `docker exec jwst-processing ls /app/data` → no `uploads/` directory.
3. Open any library item in the UI → thumbnail renders, image 404s.
4. Restart with `JWST_DATA_DIR=/absolute/path/to/main-checkout/data docker compose -f docker/docker-compose.yml up -d`
5. `docker exec jwst-processing ls /app/data` → `uploads/`, `mosaic/`, `mast/` present.
6. Same library item now loads.

No automated test: this is a compose-level path resolution behaviour with no test harness in the repo, and asserting on it would mean asserting on Docker's variable interpolation rather than our code.

## Documentation Checklist

- [x] `docs/quick-reference.md` — Troubleshooting entry for the 404 symptom
- [x] Inline comment on the compose mount explaining the worktree trap
- [ ] No architecture doc change needed — the mount target is unchanged, only where it is sourced from

## Tech Debt Impact

- [x] **Reduces** — replaces an implicit, position-dependent path with an explicit one
- [ ] Adds no new debt (the default preserves existing behaviour exactly)

## Risk & Rollback

**Risk: low.** One variable with a default identical to the previous hardcoded value, so a run from the repo root resolves to exactly the same path as before. Nothing reads or writes data differently; only the bind-mount source can now be overridden.

Worth noting: this changes nothing about *where* data should live, and moves no files. The 199 GB library stays exactly where it is.

**Rollback**: revert the commit. No migrations, no data touched.

