### PR TITLE
feat: calibration outputs record their level, parents and settings (#1754)

### DIFF
--- a/docs/key-files.md
+++ b/docs/key-files.md
@@ -218,6 +218,9 @@ Quick reference for finding important files in the codebase.
 - `processing-engine/app/mast/api_routes.py` - CE /api/mast search facade (5 routes, alias resolve)
 - `processing-engine/app/composite/api_routes.py` - CE /api/composite sync render facade (dataId resolution, input caps)
 - `processing-engine/app/library/routes.py` - CE read endpoints: /api/jwstdata list, thumbnail, check-availability
+- `processing-engine/app/library/writer.py` - the engine's only write path into `jwst_data` (calibration outputs)
+- `processing-engine/app/library/levels.py` - suffix -> processing level (L1/L2a/L2b/L3), mirrors the .NET table
+- `processing-engine/app/library/lineage.py` - ObservationBaseId/ExposureId/parent derivation for saved outputs
 - `processing-engine/app/discovery/api_routes.py` - CE /api/discovery facade: featured targets, camelCase suggest-recipes
 - `processing-engine/app/discovery/featured_targets.json` - Featured targets config (engine copy; .NET Configuration copy is canonical until gateway retires)
 - `processing-engine/Dockerfile` - Main processing engine Docker image

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -20,6 +20,8 @@ from app.auth.deps import AuthenticatedUser, require_user
 from app.db.casing import snake_to_camel_keys
 from app.db.client import get_database
 from app.jobs.store import COLLECTION_NAME, JobStore
+from app.library.levels import UNKNOWN, level_for_filename, level_for_suffix
+from app.library.lineage import derived_from_for_output, observation_base_id_for_output
 from app.library.writer import JwstDataWriteRepository
 from app.render.routes import generate_preview as engine_preview
 from app.storage.helpers import resolve_fits_path
@@ -205,9 +207,6 @@ async def save_output_to_library(
     if existing is not None:
         return {"dataId": str(existing["_id"]), "created": False}
 
-    from app.library.levels import UNKNOWN, level_for_filename, level_for_suffix
-    from app.library.lineage import observation_base_id_from
-
     result = job.get("result") or {}
     request = job.get("request") or {}
     snapshot = request.get("recipe_snapshot") or {}
@@ -237,6 +236,11 @@ async def save_output_to_library(
     if level == UNKNOWN:
         level = level_for_filename(file_name)
 
+    # Lineage comes from the inputs, not the output's name: an image3 output is
+    # named after the recipe ({product_name}_i2d.fits), so it encodes no
+    # observation at all. The parents already carry a correctly-shaped id.
+    parents = await writer.parents_for(list(request.get("input_data_ids") or []))
+
     data_id = await writer.create_from_calibration_output(
         file_path=storage_key,
         file_name=file_name,
@@ -244,12 +248,32 @@ async def save_output_to_library(
         user_id=owner_id,
         metadata=metadata,
         thumbnail=await _render_thumbnail(job_id, storage_key),
+        description=_variant_description(request, level),
         processing_level=None if level == UNKNOWN else level,
-        # The library items this run consumed — the output's parents.
-        derived_from=list(request.get("input_data_ids") or []),
-        observation_base_id=observation_base_id_from(file_name),
+        derived_from=derived_from_for_output(parents, file_name),
+        observation_base_id=observation_base_id_for_output(parents, file_name),
     )
     return {"dataId": data_id, "created": True}
+
+
+def _variant_description(request: dict, level: str) -> str:
+    """A one-line description that tells two variants apart in the library.
+
+    Runs of the same recipe produce identically-named files, so without this
+    the library shows N indistinguishable rows — which defeats the point of
+    trying several settings and keeping the best.
+    """
+    recipe_id = request.get("recipe_id") or "calibration"
+    overrides = request.get("run_overrides") or {}
+    tweaks = sorted(
+        f"{step}.{param}={value}"
+        for step, params in overrides.items()
+        if isinstance(params, dict)
+        for param, value in params.items()
+    )
+    suffix = f" ({', '.join(tweaks)})" if tweaks else " (recipe defaults)"
+    label = level if level != UNKNOWN else "output"
+    return f"{label} from {recipe_id}{suffix}"
 
 
 @router.post("/{job_id}/cancel")

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -21,7 +21,11 @@ from app.db.casing import snake_to_camel_keys
 from app.db.client import get_database
 from app.jobs.store import COLLECTION_NAME, JobStore
 from app.library.levels import UNKNOWN, level_for_filename, level_for_suffix
-from app.library.lineage import derived_from_for_output, observation_base_id_for_output
+from app.library.lineage import (
+    derived_from_for_output,
+    exposure_id_from,
+    observation_base_id_for_output,
+)
 from app.library.writer import JwstDataWriteRepository
 from app.render.routes import generate_preview as engine_preview
 from app.storage.helpers import resolve_fits_path
@@ -239,7 +243,9 @@ async def save_output_to_library(
     # Lineage comes from the inputs, not the output's name: an image3 output is
     # named after the recipe ({product_name}_i2d.fits), so it encodes no
     # observation at all. The parents already carry a correctly-shaped id.
-    parents = await writer.parents_for(list(request.get("input_data_ids") or []))
+    input_ids = list(request.get("input_data_ids") or [])
+    parents = await writer.parents_for(input_ids)
+    derived_from = derived_from_for_output(parents, file_name)
 
     data_id = await writer.create_from_calibration_output(
         file_path=storage_key,
@@ -250,10 +256,22 @@ async def save_output_to_library(
         thumbnail=await _render_thumbnail(job_id, storage_key),
         description=_variant_description(request, level),
         processing_level=None if level == UNKNOWN else level,
-        derived_from=derived_from_for_output(parents, file_name),
+        derived_from=derived_from,
         observation_base_id=observation_base_id_for_output(parents, file_name),
+        # The lineage view draws its edges from ParentId, not DerivedFrom, so
+        # without this a saved output appears in the tree as a disconnected
+        # root — the very view this provenance work exists to feed.
+        parent_id=derived_from[0] if len(derived_from) == 1 else None,
+        exposure_id=exposure_id_from(file_name),
     )
     return {"dataId": data_id, "created": True}
+
+
+#: JwstDataModel.Description is [StringLength(1000)]; stay well inside it so a
+#: client round-tripping the record through PUT /api/jwstdata is never rejected
+#: by model validation on data the engine wrote. Override names and values are
+#: unbounded (the validators check shape, not size).
+_DESCRIPTION_MAX = 200
 
 
 def _variant_description(request: dict, level: str) -> str:
@@ -271,9 +289,22 @@ def _variant_description(request: dict, level: str) -> str:
         if isinstance(params, dict)
         for param, value in params.items()
     )
-    suffix = f" ({', '.join(tweaks)})" if tweaks else " (recipe defaults)"
     label = level if level != UNKNOWN else "output"
-    return f"{label} from {recipe_id}{suffix}"
+    head = f"{label} from {recipe_id}"
+    if not tweaks:
+        return f"{head} (recipe defaults)"
+
+    # Drop whole tweaks until it fits, and say how many went — never truncate
+    # inside a value, which would read as a real (wrong) setting.
+    for keep in range(len(tweaks), 0, -1):
+        body = ", ".join(tweaks[:keep])
+        if keep < len(tweaks):
+            body += f", +{len(tweaks) - keep} more"
+        candidate = f"{head} ({body})"
+        if len(candidate) <= _DESCRIPTION_MAX:
+            return candidate
+    # Even one tweak is too long to show; summarise rather than mangle it.
+    return f"{head} ({len(tweaks)} custom settings)"[:_DESCRIPTION_MAX]
 
 
 @router.post("/{job_id}/cancel")

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -205,8 +205,14 @@ async def save_output_to_library(
     if existing is not None:
         return {"dataId": str(existing["_id"]), "created": False}
 
+    from app.library.levels import UNKNOWN, level_for_filename, level_for_suffix
+    from app.library.lineage import observation_base_id_from
+
     result = job.get("result") or {}
     request = job.get("request") or {}
+    snapshot = request.get("recipe_snapshot") or {}
+    file_name = storage_key.rsplit("/", 1)[-1]
+
     metadata = {
         "source": "calibration",
         "job_id": job_id,
@@ -216,15 +222,32 @@ async def save_output_to_library(
         # which pipeline and reference files produced this image.
         "jwst_version": result.get("jwst_version"),
         "crds_context": result.get("crds_context"),
+        # The settings that made THIS file. Two outputs of the same input at
+        # the same level are only distinguishable by these, which is what makes
+        # "run it three ways and keep the best" a workable loop.
+        "run_overrides": request.get("run_overrides") or {},
+        "stages_run": [
+            stage.get("name") for stage in (snapshot.get("stages") or []) if stage.get("enabled")
+        ],
     }
+
+    # Prefer the declared suffix; fall back to the filename so an output the
+    # engine didn't label still lands with a level rather than none.
+    level = level_for_suffix(output.get("suffix"))
+    if level == UNKNOWN:
+        level = level_for_filename(file_name)
 
     data_id = await writer.create_from_calibration_output(
         file_path=storage_key,
-        file_name=storage_key.rsplit("/", 1)[-1],
+        file_name=file_name,
         size_bytes=int(output.get("size_bytes") or 0),
         user_id=owner_id,
         metadata=metadata,
         thumbnail=await _render_thumbnail(job_id, storage_key),
+        processing_level=None if level == UNKNOWN else level,
+        # The library items this run consumed — the output's parents.
+        derived_from=list(request.get("input_data_ids") or []),
+        observation_base_id=observation_base_id_from(file_name),
     )
     return {"dataId": data_id, "created": True}
 

--- a/processing-engine/app/library/levels.py
+++ b/processing-engine/app/library/levels.py
@@ -9,11 +9,22 @@ from one level to the next. A calibration output that carries no level cannot
 be told apart from its siblings, cannot be fed to the next stage, and cannot be
 compared against a variant produced with different settings.
 
-Kept in lockstep with ``JwstDataModel.cs`` ``ProcessingLevels.SuffixToLevel``.
+Mirrors the .NET classification. That classification lives in two places on the
+C# side — the ``ProcessingLevels.SuffixToLevel`` dictionary (8 entries) and the
+longer if/else chain in ``DataScanService.ParseFileInfo`` — and this table is
+the union of both, so a calibration output gets the same level the scanner
+would give the identical file. The four entries beyond ``SuffixToLevel``
+(``_calints``, ``_x1dints``, ``_cat``, and ``_asn`` deliberately omitted) come
+from ``ParseFileInfo``; without them a saved catalog would be levelless while
+the same file imported from MAST is L3 — two labels for identical data.
+
 Duplicating the table is deliberate: the alternative is the engine reaching into
 the .NET tier at write time, and the mapping is a stable property of the JWST
 data products, not of either service.
 """
+
+from pathlib import Path
+
 
 LEVEL_1 = "L1"
 LEVEL_2A = "L2a"
@@ -21,17 +32,18 @@ LEVEL_2B = "L2b"
 LEVEL_3 = "L3"
 UNKNOWN = "unknown"
 
-#: Longest suffixes first so ``_rateints`` is not matched as ``_rate``.
 SUFFIX_TO_LEVEL: dict[str, str] = {
-    "_rateints": LEVEL_2A,
     "_uncal": LEVEL_1,
     "_rate": LEVEL_2A,
-    "_calints": LEVEL_2B,
+    "_rateints": LEVEL_2A,
     "_cal": LEVEL_2B,
+    "_calints": LEVEL_2B,
     "_crf": LEVEL_2B,
     "_i2d": LEVEL_3,
     "_s2d": LEVEL_3,
     "_x1d": LEVEL_3,
+    "_x1dints": LEVEL_3,
+    "_cat": LEVEL_3,
 }
 
 #: Ascending, for "can this be advanced?" questions. Excludes UNKNOWN.
@@ -49,15 +61,17 @@ def level_for_suffix(suffix: str | None) -> str:
 def level_for_filename(file_name: str | None) -> str:
     """Level implied by a product filename, or ``unknown``.
 
-    Matches the longest suffix present, so ``jw01_rateints.fits`` is L2a rather
-    than being mistaken for a plain ``_rate`` product (same level here, but the
-    same trap applies to ``_cal``/``_calints``).
+    Matches the END of the stem, the way the executor identifies its own
+    outputs (``path.stem.endswith(s)``). Searching anywhere in the name would
+    misread a recipe-named product: an image3 output is
+    ``{product_name}_i2d.fits``, and a product name may itself contain ``_``,
+    so ``ngc_calibration_i2d.fits`` would match ``_cal`` and be labelled L2b —
+    a finished mosaic filed as a half-processed exposure.
     """
     if not file_name:
         return UNKNOWN
-    lowered = file_name.lower()
-    best: tuple[int, str] | None = None
+    stem = Path(file_name.lower()).stem
     for suffix, level in SUFFIX_TO_LEVEL.items():
-        if suffix in lowered and (best is None or len(suffix) > best[0]):
-            best = (len(suffix), level)
-    return best[1] if best else UNKNOWN
+        if stem.endswith(suffix):
+            return level
+    return UNKNOWN

--- a/processing-engine/app/library/levels.py
+++ b/processing-engine/app/library/levels.py
@@ -1,0 +1,63 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""JWST processing levels, mirrored from the .NET ``ProcessingLevels`` class.
+
+The library labels every file L1/L2a/L2b/L3, and that label is what makes the
+calibration pipeline legible: a run does not "enable image2", it raises a file
+from one level to the next. A calibration output that carries no level cannot
+be told apart from its siblings, cannot be fed to the next stage, and cannot be
+compared against a variant produced with different settings.
+
+Kept in lockstep with ``JwstDataModel.cs`` ``ProcessingLevels.SuffixToLevel``.
+Duplicating the table is deliberate: the alternative is the engine reaching into
+the .NET tier at write time, and the mapping is a stable property of the JWST
+data products, not of either service.
+"""
+
+LEVEL_1 = "L1"
+LEVEL_2A = "L2a"
+LEVEL_2B = "L2b"
+LEVEL_3 = "L3"
+UNKNOWN = "unknown"
+
+#: Longest suffixes first so ``_rateints`` is not matched as ``_rate``.
+SUFFIX_TO_LEVEL: dict[str, str] = {
+    "_rateints": LEVEL_2A,
+    "_uncal": LEVEL_1,
+    "_rate": LEVEL_2A,
+    "_calints": LEVEL_2B,
+    "_cal": LEVEL_2B,
+    "_crf": LEVEL_2B,
+    "_i2d": LEVEL_3,
+    "_s2d": LEVEL_3,
+    "_x1d": LEVEL_3,
+}
+
+#: Ascending, for "can this be advanced?" questions. Excludes UNKNOWN.
+LEVEL_ORDER: list[str] = [LEVEL_1, LEVEL_2A, LEVEL_2B, LEVEL_3]
+
+
+def level_for_suffix(suffix: str | None) -> str:
+    """Level for a product suffix (``_cal`` → ``L2b``), or ``unknown``."""
+    if not suffix:
+        return UNKNOWN
+    key = suffix if suffix.startswith("_") else f"_{suffix}"
+    return SUFFIX_TO_LEVEL.get(key.lower(), UNKNOWN)
+
+
+def level_for_filename(file_name: str | None) -> str:
+    """Level implied by a product filename, or ``unknown``.
+
+    Matches the longest suffix present, so ``jw01_rateints.fits`` is L2a rather
+    than being mistaken for a plain ``_rate`` product (same level here, but the
+    same trap applies to ``_cal``/``_calints``).
+    """
+    if not file_name:
+        return UNKNOWN
+    lowered = file_name.lower()
+    best: tuple[int, str] | None = None
+    for suffix, level in SUFFIX_TO_LEVEL.items():
+        if suffix in lowered and (best is None or len(suffix) > best[0]):
+            best = (len(suffix), level)
+    return best[1] if best else UNKNOWN

--- a/processing-engine/app/library/lineage.py
+++ b/processing-engine/app/library/lineage.py
@@ -33,8 +33,13 @@ _EXPOSURE = re.compile(r"^(jw\d{5}\d{3}\d{3})_\d{5}_\d{5}_[a-z0-9]+", re.IGNOREC
 #: jw02733-o001_t001_nircam_f200w_i2d.fits -> jw02733-o001_t001_nircam
 _STAGE3 = re.compile(r"^(jw\d{5}-o\d+_t\d+_[a-z]+)", re.IGNORECASE)
 
-#: The exposure a per-exposure product came from: jw02733001001_02101_00001
-_EXPOSURE_ROOT = re.compile(r"^(jw\d{11}_\d{5}_\d{5})", re.IGNORECASE)
+#: The exposure AND detector a per-exposure product came from. The detector is
+#: part of the identity: one JWST exposure emits one file per detector (NIRCam
+#: short-wave has eight), and they all share the exposure root — so matching on
+#: the root alone would make every detector a parent of every other detector's
+#: output, which is the mesh this function exists to prevent. Segment is
+#: included for the same reason.
+_EXPOSURE_ROOT = re.compile(r"^(jw\d{11}_\d{5}_\d{5}(?:-seg\d+)?)(?:_([a-z0-9]+))?", re.IGNORECASE)
 
 
 def observation_base_id_from(file_name: str | None) -> str | None:
@@ -59,6 +64,13 @@ def observation_base_id_for_output(parents: list[dict], file_name: str | None = 
     Inherited from the parents when they agree. Disagreement means the run
     combined several observations, which has no single base id — returning one
     of them would file the output with the wrong half of its own inputs.
+
+    A parent with no id at all is not disagreement: one known id among several
+    unknowns still groups the output correctly, and grouping beats invisibility.
+
+    Inheriting also carries through the .NET fallback where ObservationBaseId
+    holds a raw MAST ``obs_id`` rather than a ``jw...`` value
+    (DataScanService.cs) — a shape no filename parser here would produce.
     """
     ids = {str(p.get("ObservationBaseId")).lower() for p in parents if p.get("ObservationBaseId")}
     if len(ids) == 1:
@@ -68,11 +80,31 @@ def observation_base_id_for_output(parents: list[dict], file_name: str | None = 
     return observation_base_id_from(file_name)
 
 
-def _exposure_root(file_name: str | None) -> str | None:
+def _exposure_key(file_name: str | None) -> tuple[str, str | None] | None:
+    """(exposure+segment, detector) for a per-exposure product, else None."""
     if not file_name:
         return None
     match = _EXPOSURE_ROOT.match(file_name.strip())
-    return match.group(1).lower() if match else None
+    if not match:
+        return None
+    detector = match.group(2)
+    return match.group(1).lower(), detector.lower() if detector else None
+
+
+def exposure_id_from(file_name: str | None) -> str | None:
+    """``jw{program}{obs}{visit}_{exposure}`` for a per-exposure product.
+
+    Mirrors DataScanService.cs, which groups sibling detectors of one exposure
+    by this value. Writing it here means a saved output joins that grouping
+    immediately instead of waiting on the backfill endpoint to re-parse names.
+    """
+    key = _exposure_key(file_name)
+    if not key:
+        return None
+    root = key[0]
+    # The .NET form stops at the exposure number: jw02733001001_02101.
+    parts = root.split("_")
+    return "_".join(parts[:2]) if len(parts) >= 2 else None
 
 
 def derived_from_for_output(parents: list[dict], file_name: str) -> list[str]:
@@ -82,9 +114,16 @@ def derived_from_for_output(parents: list[dict], file_name: str) -> list[str]:
     so a chained run over six exposures must record six 1→1 links, not a 6×6
     mesh. A combined product (image3) genuinely consumes every input.
     """
-    root = _exposure_root(file_name)
-    if root:
-        matched = [str(p["_id"]) for p in parents if _exposure_root(p.get("FileName")) == root]
-        if matched:
-            return matched
+    key = _exposure_key(file_name)
+    if key:
+        keyed = [(p, _exposure_key(p.get("FileName"))) for p in parents]
+        # Exposure AND detector: the precise parent.
+        exact = [str(p["_id"]) for p, k in keyed if k == key]
+        if exact:
+            return exact
+        # Same exposure, detector unknown on one side — still far better than
+        # falling back to every input.
+        same_exposure = [str(p["_id"]) for p, k in keyed if k and k[0] == key[0]]
+        if same_exposure:
+            return same_exposure
     return [str(p["_id"]) for p in parents]

--- a/processing-engine/app/library/lineage.py
+++ b/processing-engine/app/library/lineage.py
@@ -1,0 +1,39 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""Deriving an ObservationBaseId from a JWST product filename.
+
+The library groups files by ``ObservationBaseId`` — that grouping is what the
+lineage view, the mosaic substitution and the "siblings of this exposure" logic
+all key on. A calibration output written without one is invisible to every one
+of them, so it appears in the library detached from the data it came from.
+
+JWST stage-3 products are named ``jw<proposal>-o<observation>_t<target>_
+<instrument>_<optical elements>_<suffix>.fits``; the base id is everything
+before the suffix. Stage-2 products use the exposure form
+``jw<proposal><obs><visit>_<...>_<suffix>.fits`` and have no ``-oNNN`` token,
+so they get no base id here rather than a wrong one.
+"""
+
+import re
+
+
+#: Stage-3 association products: jw02733-o001_t001_nircam_f200w_i2d.fits
+_STAGE3 = re.compile(
+    r"^(jw\d{5}-[oc]\d{3}_t\d+_[a-z0-9]+(?:_[a-z0-9\-]+)*?)_"
+    r"(?:i2d|s2d|x1d|cat|segm|crf|c1d|s3d)\b",
+    re.IGNORECASE,
+)
+
+
+def observation_base_id_from(file_name: str | None) -> str | None:
+    """The observation base id encoded in a product filename, or None.
+
+    Returns None rather than guessing: a wrong base id would silently group an
+    output with unrelated exposures, which is worse for the lineage view than
+    having no grouping at all.
+    """
+    if not file_name:
+        return None
+    match = _STAGE3.match(file_name.strip())
+    return match.group(1) if match else None

--- a/processing-engine/app/library/lineage.py
+++ b/processing-engine/app/library/lineage.py
@@ -1,39 +1,90 @@
 # Copyright (c) JWST Data Analysis. All rights reserved.
 # Licensed under the MIT License.
 
-"""Deriving an ObservationBaseId from a JWST product filename.
+"""Lineage for a calibration output: which library items produced it, and which
+observation it belongs to.
 
-The library groups files by ``ObservationBaseId`` — that grouping is what the
-lineage view, the mosaic substitution and the "siblings of this exposure" logic
-all key on. A calibration output written without one is invisible to every one
-of them, so it appears in the library detached from the data it came from.
+``ObservationBaseId`` is what the lineage view, the mosaic substitution and the
+"siblings of this exposure" logic all key on. An output written without one is
+invisible to every one of them.
 
-JWST stage-3 products are named ``jw<proposal>-o<observation>_t<target>_
-<instrument>_<optical elements>_<suffix>.fits``; the base id is everything
-before the suffix. Stage-2 products use the exposure form
-``jw<proposal><obs><visit>_<...>_<suffix>.fits`` and have no ``-oNNN`` token,
-so they get no base id here rather than a wrong one.
+It is taken from the run's INPUTS, not from the output's filename. Calibration
+outputs are not named like MAST products: an image3 run writes
+``{association.product_name}_i2d.fits`` (e.g. ``nircam-imaging_i2d.fits``), so
+there is no observation encoded in the name at all. The parents already carry a
+correctly-shaped id, so inheriting it is both accurate and immune to the three
+different id shapes that exist in the .NET tier.
+
+The filename parsers below are a fallback for the case where an output has no
+library parents (a MAST-sourced run). They mirror the two .NET conventions
+exactly:
+
+- exposure form (``DataScanService.cs``): ``jw{program}{obs}{visit}``
+- stage-3 form (``JwstDataController.cs``): ``jw\\d{5}-o\\d+_t\\d+_{instrument}``
+  — instrument only, deliberately without the optical elements.
 """
 
 import re
 
 
-#: Stage-3 association products: jw02733-o001_t001_nircam_f200w_i2d.fits
-_STAGE3 = re.compile(
-    r"^(jw\d{5}-[oc]\d{3}_t\d+_[a-z0-9]+(?:_[a-z0-9\-]+)*?)_"
-    r"(?:i2d|s2d|x1d|cat|segm|crf|c1d|s3d)\b",
-    re.IGNORECASE,
-)
+#: jw02733001001_02101_00001_nrca1_cal.fits -> jw02733001001
+_EXPOSURE = re.compile(r"^(jw\d{5}\d{3}\d{3})_\d{5}_\d{5}_[a-z0-9]+", re.IGNORECASE)
+
+#: jw02733-o001_t001_nircam_f200w_i2d.fits -> jw02733-o001_t001_nircam
+_STAGE3 = re.compile(r"^(jw\d{5}-o\d+_t\d+_[a-z]+)", re.IGNORECASE)
+
+#: The exposure a per-exposure product came from: jw02733001001_02101_00001
+_EXPOSURE_ROOT = re.compile(r"^(jw\d{11}_\d{5}_\d{5})", re.IGNORECASE)
 
 
 def observation_base_id_from(file_name: str | None) -> str | None:
-    """The observation base id encoded in a product filename, or None.
+    """Base id encoded in a product filename, or None.
 
-    Returns None rather than guessing: a wrong base id would silently group an
-    output with unrelated exposures, which is worse for the lineage view than
-    having no grouping at all.
+    Lowercased to match the .NET write path, which stores it lowercased —
+    Mongo string equality would otherwise never match a mixed-case name.
     """
     if not file_name:
         return None
-    match = _STAGE3.match(file_name.strip())
-    return match.group(1) if match else None
+    name = file_name.strip()
+    for pattern in (_EXPOSURE, _STAGE3):
+        match = pattern.match(name)
+        if match:
+            return match.group(1).lower()
+    return None
+
+
+def observation_base_id_for_output(parents: list[dict], file_name: str | None = None) -> str | None:
+    """The observation an output belongs to.
+
+    Inherited from the parents when they agree. Disagreement means the run
+    combined several observations, which has no single base id — returning one
+    of them would file the output with the wrong half of its own inputs.
+    """
+    ids = {str(p.get("ObservationBaseId")).lower() for p in parents if p.get("ObservationBaseId")}
+    if len(ids) == 1:
+        return ids.pop()
+    if ids:
+        return None  # genuinely spans observations — no single grouping
+    return observation_base_id_from(file_name)
+
+
+def _exposure_root(file_name: str | None) -> str | None:
+    if not file_name:
+        return None
+    match = _EXPOSURE_ROOT.match(file_name.strip())
+    return match.group(1).lower() if match else None
+
+
+def derived_from_for_output(parents: list[dict], file_name: str) -> list[str]:
+    """The parent ids to record for one output file.
+
+    A per-exposure product (a stage-1/2 output) comes from exactly one input,
+    so a chained run over six exposures must record six 1→1 links, not a 6×6
+    mesh. A combined product (image3) genuinely consumes every input.
+    """
+    root = _exposure_root(file_name)
+    if root:
+        matched = [str(p["_id"]) for p in parents if _exposure_root(p.get("FileName")) == root]
+        if matched:
+            return matched
+    return [str(p["_id"]) for p in parents]

--- a/processing-engine/app/library/writer.py
+++ b/processing-engine/app/library/writer.py
@@ -46,7 +46,12 @@ class JwstDataWriteRepository:
         if not oids:
             return []
         projection = {"_id": 1, "FileName": 1, "ObservationBaseId": 1}
-        return [d async for d in self._col.find({"_id": {"$in": oids}}, projection)]
+        docs = [d async for d in self._col.find({"_id": {"$in": oids}}, projection)]
+        # Preserve the caller's order — DerivedFrom is built from this, and
+        # Mongo's $in returns natural order, so two identical saves would
+        # otherwise record the same parents in different orders.
+        rank = {data_id: i for i, data_id in enumerate(data_ids)}
+        return sorted(docs, key=lambda d: rank.get(str(d["_id"]), len(rank)))
 
     async def create_from_calibration_output(
         self,
@@ -61,6 +66,8 @@ class JwstDataWriteRepository:
         processing_level: str | None = None,
         derived_from: list[str] | None = None,
         observation_base_id: str | None = None,
+        parent_id: str | None = None,
+        exposure_id: str | None = None,
     ) -> str:
         """Insert a calibration output as a library record; returns its id.
 
@@ -102,6 +109,10 @@ class JwstDataWriteRepository:
             doc["ProcessingLevel"] = processing_level
         if observation_base_id:
             doc["ObservationBaseId"] = observation_base_id
+        if parent_id:
+            doc["ParentId"] = parent_id
+        if exposure_id:
+            doc["ExposureId"] = exposure_id
         if thumbnail is not None:
             doc["ThumbnailData"] = thumbnail
             doc["ThumbnailGeneratedAt"] = now

--- a/processing-engine/app/library/writer.py
+++ b/processing-engine/app/library/writer.py
@@ -38,6 +38,9 @@ class JwstDataWriteRepository:
         user_id: str,
         metadata: dict[str, Any],
         thumbnail: bytes | None = None,
+        processing_level: str | None = None,
+        derived_from: list[str] | None = None,
+        observation_base_id: str | None = None,
     ) -> str:
         """Insert a calibration output as a library record; returns its id.
 
@@ -45,6 +48,13 @@ class JwstDataWriteRepository:
         owner-or-public, so the owner sees it in ``/library`` and the full
         ImageViewer while nobody else does — calibration outputs are personal
         working products, not published data.
+
+        ``processing_level``, ``derived_from`` and ``observation_base_id`` are
+        what make an output usable rather than merely stored: the level says
+        what the file now IS (and therefore what can be run on it next), and
+        the lineage says which file and settings produced it. Without them a
+        run's output lands as an anonymous record that cannot be told apart
+        from a variant produced with different settings.
         """
         now = datetime.now(UTC)
         doc: dict[str, Any] = {
@@ -64,9 +74,15 @@ class JwstDataWriteRepository:
             "SharedWith": [],
             "IsArchived": False,
             "Version": 1,
-            "DerivedFrom": [],
+            "DerivedFrom": list(derived_from or []),
             "IsViewable": True,
         }
+        # Only set when known: a null level is honest, whereas defaulting to
+        # "unknown" would be indistinguishable from a real classification.
+        if processing_level:
+            doc["ProcessingLevel"] = processing_level
+        if observation_base_id:
+            doc["ObservationBaseId"] = observation_base_id
         if thumbnail is not None:
             doc["ThumbnailData"] = thumbnail
             doc["ThumbnailGeneratedAt"] = now

--- a/processing-engine/app/library/writer.py
+++ b/processing-engine/app/library/writer.py
@@ -13,7 +13,8 @@ BSON Int64 because the C# model types it as ``long``.
 from datetime import UTC, datetime
 from typing import Any
 
-from bson import Int64
+from bson import Int64, ObjectId
+from bson.errors import InvalidId
 
 
 class JwstDataWriteRepository:
@@ -29,6 +30,24 @@ class JwstDataWriteRepository:
         """
         return await self._col.find_one({"FilePath": file_path, "UserId": user_id})
 
+    async def parents_for(self, data_ids: list[str]) -> list[dict]:
+        """Minimal records for the library items a run consumed.
+
+        Only what lineage needs: the observation an output should be filed
+        under, and the exposure a per-exposure product came from. Deliberately
+        projected — these documents carry ThumbnailData blobs.
+        """
+        oids: list[ObjectId] = []
+        for data_id in data_ids:
+            try:
+                oids.append(ObjectId(data_id))
+            except (InvalidId, TypeError):
+                continue  # unreadable id contributes no lineage, never raises
+        if not oids:
+            return []
+        projection = {"_id": 1, "FileName": 1, "ObservationBaseId": 1}
+        return [d async for d in self._col.find({"_id": {"$in": oids}}, projection)]
+
     async def create_from_calibration_output(
         self,
         *,
@@ -38,6 +57,7 @@ class JwstDataWriteRepository:
         user_id: str,
         metadata: dict[str, Any],
         thumbnail: bytes | None = None,
+        description: str | None = None,
         processing_level: str | None = None,
         derived_from: list[str] | None = None,
         observation_base_id: str | None = None,
@@ -52,16 +72,15 @@ class JwstDataWriteRepository:
         ``processing_level``, ``derived_from`` and ``observation_base_id`` are
         what make an output usable rather than merely stored: the level says
         what the file now IS (and therefore what can be run on it next), and
-        the lineage says which file and settings produced it. Without them a
-        run's output lands as an anonymous record that cannot be told apart
-        from a variant produced with different settings.
+        the lineage says which library items produced it. Without them a run's
+        output lands as an anonymous record, detached from its own inputs.
         """
         now = datetime.now(UTC)
         doc: dict[str, Any] = {
             "FileName": file_name,
             "DataType": "image",
             "UploadDate": now,
-            "Description": "Calibration pipeline output",
+            "Description": description or "Calibration pipeline output",
             "Metadata": metadata,
             "FilePath": file_path,
             "FileSize": Int64(size_bytes),

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -17,6 +17,7 @@ import uuid
 import httpx
 import jwt as pyjwt
 import pytest
+from bson import ObjectId
 from fastapi import Response
 
 from app.db.client import get_database, reset_client
@@ -212,8 +213,9 @@ async def seed_succeeded_job(
     *,
     user_id: str = USER,
     outputs: list[JobOutput] | None = None,
+    request: dict | None = None,
 ) -> str:
-    job = JobRecord(type="calibration", user_id=user_id, request={"recipe_id": "r1"})
+    job = JobRecord(type="calibration", user_id=user_id, request=request or {"recipe_id": "r1"})
     await store.create(job)
     await store.mark_succeeded(job.job_id, JobResult(outputs=outputs or []))
     return job.job_id
@@ -377,6 +379,98 @@ class TestSaveOutputToLibrary:
         assert doc["Metadata"]["job_id"] == job_id
         assert doc["Metadata"]["source"] == "calibration"
         assert doc["ThumbnailData"] is not None
+
+    async def test_records_the_level_and_lineage_that_make_it_reusable(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Without these a saved output is an anonymous file: no level, so
+        # nothing knows what can run on it next; no parents, so it is detached
+        # from the data it came from; no settings, so two runs of the same
+        # input are indistinguishable (#1754).
+        self._stub_render(monkeypatch)
+        job_id = await seed_succeeded_job(
+            store,
+            outputs=[
+                JobOutput(
+                    storage_key="calibration/job-1/jw02733-o001_t001_nircam_f200w_i2d.fits",
+                    suffix="_i2d",
+                    size_bytes=2048,
+                )
+            ],
+            request={
+                "recipe_id": "seed-nircam-imaging",
+                "input_data_ids": ["lib-a", "lib-b"],
+                "run_overrides": {"tweakreg": {"snr_threshold": 5.0}},
+                "recipe_snapshot": {
+                    "stages": [
+                        {"name": "detector1", "enabled": False},
+                        {"name": "image3", "enabled": True},
+                    ]
+                },
+            },
+        )
+
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        assert response.status_code == 201
+
+        doc = await library.find_one({"_id": ObjectId(response.json()["dataId"])})
+        # An _i2d output IS a level-3 product — that is what makes it show as
+        # finished rather than as something still to be processed.
+        assert doc["ProcessingLevel"] == "L3"
+        # The library items this run consumed.
+        assert doc["DerivedFrom"] == ["lib-a", "lib-b"]
+        # Groups with the observation it was made from, so the lineage view
+        # and mosaic substitution can see it.
+        assert doc["ObservationBaseId"] == "jw02733-o001_t001_nircam_f200w"
+        # The settings that produced THIS variant.
+        assert doc["Metadata"]["run_overrides"] == {"tweakreg": {"snr_threshold": 5.0}}
+        assert doc["Metadata"]["stages_run"] == ["image3"]
+
+    async def test_level_falls_back_to_the_filename(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # An output the engine didn't label must still land with a level
+        # rather than none, or it drops out of the pipeline flow entirely.
+        self._stub_render(monkeypatch)
+        job_id = await seed_succeeded_job(
+            store,
+            outputs=[
+                JobOutput(storage_key="calibration/job-1/jw001_rate.fits", suffix="", size_bytes=64)
+            ],
+        )
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        assert response.status_code == 201
+        doc = await library.find_one({"_id": ObjectId(response.json()["dataId"])})
+        assert doc["ProcessingLevel"] == "L2a"
+
+    async def test_unrecognised_product_gets_no_level_rather_than_a_wrong_one(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_render(monkeypatch)
+        job_id = await seed_succeeded_job(
+            store,
+            outputs=[
+                JobOutput(storage_key="calibration/job-1/mystery.fits", suffix="", size_bytes=64)
+            ],
+        )
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        doc = await library.find_one({"_id": ObjectId(response.json()["dataId"])})
+        assert "ProcessingLevel" not in doc
+        # Exposure-level names carry no observation token; no grouping beats a
+        # wrong one that files this with unrelated exposures.
+        assert "ObservationBaseId" not in doc
 
     async def test_saving_twice_is_idempotent(
         self,

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -392,18 +392,29 @@ class TestSaveOutputToLibrary:
         # from the data it came from; no settings, so two runs of the same
         # input are indistinguishable (#1754).
         self._stub_render(monkeypatch)
+        # The name the engine ACTUALLY writes for an image3 run: the recipe's
+        # association product_name, which encodes no observation at all. A
+        # MAST-shaped filename here would have made this test pass while
+        # production recorded nothing.
+        parent = await library.insert_one(
+            {
+                "FileName": "jw02733001001_02101_00001_nrca1_cal.fits",
+                "ObservationBaseId": "jw02733001001",
+                "UserId": USER,
+            }
+        )
         job_id = await seed_succeeded_job(
             store,
             outputs=[
                 JobOutput(
-                    storage_key="calibration/job-1/jw02733-o001_t001_nircam_f200w_i2d.fits",
+                    storage_key="calibration/job-1/nircam-imaging_i2d.fits",
                     suffix="_i2d",
                     size_bytes=2048,
                 )
             ],
             request={
                 "recipe_id": "seed-nircam-imaging",
-                "input_data_ids": ["lib-a", "lib-b"],
+                "input_data_ids": [str(parent.inserted_id)],
                 "run_overrides": {"tweakreg": {"snr_threshold": 5.0}},
                 "recipe_snapshot": {
                     "stages": [
@@ -422,10 +433,12 @@ class TestSaveOutputToLibrary:
         # finished rather than as something still to be processed.
         assert doc["ProcessingLevel"] == "L3"
         # The library items this run consumed.
-        assert doc["DerivedFrom"] == ["lib-a", "lib-b"]
-        # Groups with the observation it was made from, so the lineage view
-        # and mosaic substitution can see it.
-        assert doc["ObservationBaseId"] == "jw02733-o001_t001_nircam_f200w"
+        assert doc["DerivedFrom"] == [str(parent.inserted_id)]
+        # Inherited from the parent, since the output's own name carries no
+        # observation. This is what puts it back with the data it came from.
+        assert doc["ObservationBaseId"] == "jw02733001001"
+        # Tells two runs of the same recipe apart in the library listing.
+        assert doc["Description"] == "L3 from seed-nircam-imaging (tweakreg.snr_threshold=5.0)"
         # The settings that produced THIS variant.
         assert doc["Metadata"]["run_overrides"] == {"tweakreg": {"snr_threshold": 5.0}}
         assert doc["Metadata"]["stages_run"] == ["image3"]

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -439,9 +439,99 @@ class TestSaveOutputToLibrary:
         assert doc["ObservationBaseId"] == "jw02733001001"
         # Tells two runs of the same recipe apart in the library listing.
         assert doc["Description"] == "L3 from seed-nircam-imaging (tweakreg.snr_threshold=5.0)"
+        # The lineage view draws edges from ParentId, so a single-parent output
+        # must set it or it renders as a disconnected root.
+        assert doc["ParentId"] == str(parent.inserted_id)
         # The settings that produced THIS variant.
         assert doc["Metadata"]["run_overrides"] == {"tweakreg": {"snr_threshold": 5.0}}
         assert doc["Metadata"]["stages_run"] == ["image3"]
+
+    async def test_a_per_exposure_output_records_only_its_own_parent(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Two inputs, one output: recording both would claim the run's other
+        # exposure produced this file too.
+        self._stub_render(monkeypatch)
+        first = await library.insert_one(
+            {"FileName": "jw02733001001_02101_00001_nrca1_uncal.fits", "UserId": USER}
+        )
+        second = await library.insert_one(
+            {"FileName": "jw02733001001_02101_00002_nrca1_uncal.fits", "UserId": USER}
+        )
+        job_id = await seed_succeeded_job(
+            store,
+            outputs=[
+                JobOutput(
+                    storage_key="calibration/job-1/jw02733001001_02101_00002_nrca1_rate.fits",
+                    suffix="_rate",
+                    size_bytes=64,
+                )
+            ],
+            request={
+                "recipe_id": "r1",
+                "input_data_ids": [str(first.inserted_id), str(second.inserted_id)],
+            },
+        )
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        doc = await library.find_one({"_id": ObjectId(response.json()["dataId"])})
+        assert doc["DerivedFrom"] == [str(second.inserted_id)]
+        assert doc["ProcessingLevel"] == "L2a"
+        assert doc["ExposureId"] == "jw02733001001_02101"
+
+    async def test_description_stays_within_the_dotnet_length_limit(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Override names and values are unbounded (the validators check shape,
+        # not size), and Description is [StringLength(1000)] on the C# model —
+        # so an oversized one would 400 any client that round-trips the record.
+        self._stub_render(monkeypatch)
+        job_id = await seed_succeeded_job(
+            store,
+            outputs=[_fits_output()],
+            request={
+                "recipe_id": "r1",
+                "run_overrides": {"tweakreg": {f"p{i}": "x" * 200 for i in range(40)}},
+            },
+        )
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        doc = await library.find_one({"_id": ObjectId(response.json()["dataId"])})
+        # Never truncated mid-value into something that reads like a real
+        # setting: it summarises instead.
+        assert len(doc["Description"]) <= 200
+        assert doc["Description"] == "L2b from r1 (40 custom settings)"
+
+    async def test_description_drops_whole_settings_when_it_must(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_render(monkeypatch)
+        job_id = await seed_succeeded_job(
+            store,
+            outputs=[_fits_output()],
+            request={
+                "recipe_id": "r1",
+                "run_overrides": {"tweakreg": {f"param_number_{i}": i for i in range(20)}},
+            },
+        )
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        description = (await library.find_one({"_id": ObjectId(response.json()["dataId"])}))[
+            "Description"
+        ]
+        assert len(description) <= 200
+        assert description.endswith("more)")
+        # Whole settings only — no dangling half-written parameter.
+        assert "tweakreg.param_number_0=0" in description
 
     async def test_level_falls_back_to_the_filename(
         self,

--- a/processing-engine/tests/test_library_levels.py
+++ b/processing-engine/tests/test_library_levels.py
@@ -23,6 +23,7 @@ from app.library.levels import (
 )
 from app.library.lineage import (
     derived_from_for_output,
+    exposure_id_from,
     observation_base_id_for_output,
     observation_base_id_from,
 )
@@ -67,9 +68,16 @@ class TestLevelForFilename:
         assert level_for_filename("ngc_calibration_i2d.fits") == LEVEL_3
         assert level_for_filename("my_rate_limited_uncal.fits") == LEVEL_1
 
-    def test_ints_variants_are_not_read_as_their_shorter_form(self) -> None:
+    def test_ints_variants_keep_their_own_level(self) -> None:
+        # Note: endswith makes these order-independent — "..._rateints" does
+        # not end with "_rate" — so this documents the mapping rather than
+        # guarding the matching strategy (that is the test above).
         assert level_for_filename("jw01_rateints.fits") == LEVEL_2A
         assert level_for_filename("jw01_calints.fits") == LEVEL_2B
+
+    def test_association_files_are_not_a_data_level(self) -> None:
+        # DataScanService maps _asn explicitly to Unknown.
+        assert level_for_filename("jw02733-o001_asn.json") == UNKNOWN
 
     def test_no_recognisable_suffix_is_unknown(self) -> None:
         assert level_for_filename("my-export.fits") == UNKNOWN
@@ -150,12 +158,30 @@ class TestObservationBaseIdForOutput:
         ]
         assert observation_base_id_for_output(parents, "nircam-imaging_i2d.fits") is None
 
+    def test_a_parent_without_an_id_is_not_disagreement(self) -> None:
+        # One known id among unknowns still groups the output correctly;
+        # grouping beats invisibility.
+        parents = [
+            _parent("a", "x_cal.fits", "jw02733001001"),
+            _parent("b", "y_cal.fits", None),
+        ]
+        assert observation_base_id_for_output(parents, "nircam-imaging_i2d.fits") == "jw02733001001"
+
     def test_falls_back_to_the_filename_with_no_parents(self) -> None:
         # A MAST-sourced run has no library inputs.
         assert (
             observation_base_id_for_output([], "jw02733-o001_t001_nircam_f200w_i2d.fits")
             == "jw02733-o001_t001_nircam"
         )
+
+
+class TestExposureId:
+    def test_matches_the_dotnet_grouping_key(self) -> None:
+        # DataScanService.cs: jw{program}{obs}{visit}_{exposure}
+        assert exposure_id_from("jw02733001001_02101_00001_nrca1_cal.fits") == "jw02733001001_02101"
+
+    def test_none_for_a_combined_product(self) -> None:
+        assert exposure_id_from("nircam-imaging_i2d.fits") is None
 
 
 class TestDerivedFromForOutput:
@@ -177,10 +203,34 @@ class TestDerivedFromForOutput:
         ]
         assert derived_from_for_output(parents, "nircam-imaging_i2d.fits") == ["a", "b"]
 
+    def test_sibling_detectors_of_one_exposure_are_not_all_parents(self) -> None:
+        # One exposure emits a file PER DETECTOR (NIRCam SW has eight), all
+        # sharing the exposure root. Matching on the root alone would make
+        # every detector a parent of every other detector's output — the mesh
+        # this function exists to prevent.
+        parents = [
+            _parent("a", "jw02733001001_02101_00001_nrca1_rate.fits", None),
+            _parent("b", "jw02733001001_02101_00001_nrca2_rate.fits", None),
+        ]
+        got = derived_from_for_output(parents, "jw02733001001_02101_00001_nrca2_cal.fits")
+        assert got == ["b"]
+
+    def test_segments_of_one_exposure_are_kept_apart(self) -> None:
+        parents = [
+            _parent("a", "jw02733001001_02101_00001-seg001_nrca1_uncal.fits", None),
+            _parent("b", "jw02733001001_02101_00001-seg002_nrca1_uncal.fits", None),
+        ]
+        got = derived_from_for_output(parents, "jw02733001001_02101_00001-seg002_nrca1_rate.fits")
+        assert got == ["b"]
+
     def test_unmatched_exposure_falls_back_to_all_parents(self) -> None:
-        parents = [_parent("a", "jw02733001001_02101_00001_nrca1_cal.fits", None)]
+        # Two parents, so the fallback is distinguishable from a match.
+        parents = [
+            _parent("a", "jw02733001001_02101_00001_nrca1_cal.fits", None),
+            _parent("b", "jw02733001001_02101_00002_nrca1_cal.fits", None),
+        ]
         got = derived_from_for_output(parents, "jw09999009009_02101_00007_nrca1_cal.fits")
-        assert got == ["a"]
+        assert got == ["a", "b"]
 
     def test_no_parents_is_empty_not_an_error(self) -> None:
         assert derived_from_for_output([], "nircam-imaging_i2d.fits") == []

--- a/processing-engine/tests/test_library_levels.py
+++ b/processing-engine/tests/test_library_levels.py
@@ -1,0 +1,115 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""Processing levels and lineage derivation for calibration outputs (#1754).
+
+These two facts are what turn a saved output from a stored file into something
+usable: the level says what it now IS (and so what may be run on it next), and
+the base id puts it back with the data it came from.
+"""
+
+import pytest
+
+from app.library.levels import (
+    LEVEL_1,
+    LEVEL_2A,
+    LEVEL_2B,
+    LEVEL_3,
+    LEVEL_ORDER,
+    SUFFIX_TO_LEVEL,
+    UNKNOWN,
+    level_for_filename,
+    level_for_suffix,
+)
+from app.library.lineage import observation_base_id_from
+
+
+class TestLevelForSuffix:
+    @pytest.mark.parametrize(
+        ("suffix", "expected"),
+        [
+            ("_uncal", LEVEL_1),
+            ("_rate", LEVEL_2A),
+            ("_rateints", LEVEL_2A),
+            ("_cal", LEVEL_2B),
+            ("_crf", LEVEL_2B),
+            ("_i2d", LEVEL_3),
+            ("_s2d", LEVEL_3),
+            ("_x1d", LEVEL_3),
+        ],
+    )
+    def test_matches_the_dotnet_table(self, suffix: str, expected: str) -> None:
+        assert level_for_suffix(suffix) == expected
+
+    def test_accepts_a_bare_suffix(self) -> None:
+        # The engine records outputs as "_i2d"; be tolerant of "i2d" too.
+        assert level_for_suffix("i2d") == LEVEL_3
+
+    @pytest.mark.parametrize("value", [None, "", "_nonsense"])
+    def test_unknown_rather_than_a_guess(self, value) -> None:
+        assert level_for_suffix(value) == UNKNOWN
+
+
+class TestLevelForFilename:
+    def test_reads_the_level_off_a_real_product_name(self) -> None:
+        assert level_for_filename("jw02733-o001_t001_nircam_f200w_i2d.fits") == LEVEL_3
+        assert level_for_filename("jw02733001001_02101_00001_nrca1_uncal.fits") == LEVEL_1
+
+    def test_longest_suffix_wins(self) -> None:
+        # "_rateints" contains "_rate"; matching the shorter one first would
+        # still be L2a here, but the same trap misclassifies _calints.
+        assert level_for_filename("jw01_rateints.fits") == LEVEL_2A
+        assert level_for_filename("jw01_calints.fits") == LEVEL_2B
+
+    def test_no_recognisable_suffix_is_unknown(self) -> None:
+        assert level_for_filename("my-export.fits") == UNKNOWN
+
+
+class TestLevelTable:
+    def test_order_is_ascending_and_excludes_unknown(self) -> None:
+        assert LEVEL_ORDER == [LEVEL_1, LEVEL_2A, LEVEL_2B, LEVEL_3]
+        assert UNKNOWN not in LEVEL_ORDER
+
+    def test_every_mapped_level_is_orderable(self) -> None:
+        # A level that isn't in LEVEL_ORDER can't be compared, so "what can run
+        # on this next?" would have no answer for it.
+        assert set(SUFFIX_TO_LEVEL.values()) <= set(LEVEL_ORDER)
+
+
+class TestObservationBaseId:
+    @pytest.mark.parametrize(
+        ("file_name", "expected"),
+        [
+            (
+                "jw02733-o001_t001_nircam_f200w_i2d.fits",
+                "jw02733-o001_t001_nircam_f200w",
+            ),
+            (
+                "jw06675-o007_t008_nircam_clear-f444w_i2d.fits",
+                "jw06675-o007_t008_nircam_clear-f444w",
+            ),
+            (
+                "jw02736-o003_t001_niriss_f200w-gr150c_x1d.fits",
+                "jw02736-o003_t001_niriss_f200w-gr150c",
+            ),
+        ],
+    )
+    def test_strips_the_product_suffix(self, file_name: str, expected: str) -> None:
+        assert observation_base_id_from(file_name) == expected
+
+    def test_matches_the_ids_already_in_the_library(self) -> None:
+        # Exactly the shape of ObservationBaseId values on existing records, so
+        # a calibration output groups with the data it was made from.
+        assert (
+            observation_base_id_from("jw02733-o002_t001_miri_f1130w_i2d.fits")
+            == "jw02733-o002_t001_miri_f1130w"
+        )
+
+    def test_exposure_level_products_get_none_not_a_guess(self) -> None:
+        # Stage-2 names carry no -oNNN token; inventing a grouping would file
+        # the output with unrelated exposures.
+        assert observation_base_id_from("jw02733001001_02101_00001_nrca1_cal.fits") is None
+
+    @pytest.mark.parametrize("value", [None, "", "not-a-jwst-name.fits"])
+    def test_none_for_anything_unrecognised(self, value) -> None:
+        assert observation_base_id_from(value) is None

--- a/processing-engine/tests/test_library_levels.py
+++ b/processing-engine/tests/test_library_levels.py
@@ -21,7 +21,11 @@ from app.library.levels import (
     level_for_filename,
     level_for_suffix,
 )
-from app.library.lineage import observation_base_id_from
+from app.library.lineage import (
+    derived_from_for_output,
+    observation_base_id_for_output,
+    observation_base_id_from,
+)
 
 
 class TestLevelForSuffix:
@@ -55,9 +59,15 @@ class TestLevelForFilename:
         assert level_for_filename("jw02733-o001_t001_nircam_f200w_i2d.fits") == LEVEL_3
         assert level_for_filename("jw02733001001_02101_00001_nrca1_uncal.fits") == LEVEL_1
 
-    def test_longest_suffix_wins(self) -> None:
-        # "_rateints" contains "_rate"; matching the shorter one first would
-        # still be L2a here, but the same trap misclassifies _calints.
+    def test_matches_the_end_of_the_stem_not_anywhere_in_it(self) -> None:
+        # An image3 output is named {product_name}_i2d.fits and a product name
+        # may contain "_". Searching anywhere would find "_cal" here and file a
+        # finished mosaic as a half-processed exposure. This is the case a
+        # containment match gets wrong.
+        assert level_for_filename("ngc_calibration_i2d.fits") == LEVEL_3
+        assert level_for_filename("my_rate_limited_uncal.fits") == LEVEL_1
+
+    def test_ints_variants_are_not_read_as_their_shorter_form(self) -> None:
         assert level_for_filename("jw01_rateints.fits") == LEVEL_2A
         assert level_for_filename("jw01_calints.fits") == LEVEL_2B
 
@@ -76,40 +86,101 @@ class TestLevelTable:
         assert set(SUFFIX_TO_LEVEL.values()) <= set(LEVEL_ORDER)
 
 
-class TestObservationBaseId:
+class TestLevelTableMatchesTheScanner:
     @pytest.mark.parametrize(
-        ("file_name", "expected"),
-        [
-            (
-                "jw02733-o001_t001_nircam_f200w_i2d.fits",
-                "jw02733-o001_t001_nircam_f200w",
-            ),
-            (
-                "jw06675-o007_t008_nircam_clear-f444w_i2d.fits",
-                "jw06675-o007_t008_nircam_clear-f444w",
-            ),
-            (
-                "jw02736-o003_t001_niriss_f200w-gr150c_x1d.fits",
-                "jw02736-o003_t001_niriss_f200w-gr150c",
-            ),
-        ],
+        ("suffix", "expected"),
+        [("_x1dints", LEVEL_3), ("_cat", LEVEL_3), ("_calints", LEVEL_2B)],
     )
-    def test_strips_the_product_suffix(self, file_name: str, expected: str) -> None:
-        assert observation_base_id_from(file_name) == expected
+    def test_covers_what_datascanservice_classifies(self, suffix, expected) -> None:
+        # Present in ParseFileInfo but not in the C# SuffixToLevel dict. Without
+        # them a saved catalog is levelless while the same file imported from
+        # MAST is L3 — two labels for identical data in one library.
+        assert level_for_suffix(suffix) == expected
 
-    def test_matches_the_ids_already_in_the_library(self) -> None:
-        # Exactly the shape of ObservationBaseId values on existing records, so
-        # a calibration output groups with the data it was made from.
+
+class TestObservationBaseId:
+    def test_stage3_form_matches_the_dotnet_regex(self) -> None:
+        # JwstDataController.cs: (jw\d{5}-o\d+_t\d+_[a-z]+) — instrument
+        # only. Including the optical elements would produce an id that never
+        # equals a stored one.
         assert (
-            observation_base_id_from("jw02733-o002_t001_miri_f1130w_i2d.fits")
-            == "jw02733-o002_t001_miri_f1130w"
+            observation_base_id_from("jw02733-o001_t001_nircam_f200w_i2d.fits")
+            == "jw02733-o001_t001_nircam"
         )
 
-    def test_exposure_level_products_get_none_not_a_guess(self) -> None:
-        # Stage-2 names carry no -oNNN token; inventing a grouping would file
-        # the output with unrelated exposures.
-        assert observation_base_id_from("jw02733001001_02101_00001_nrca1_cal.fits") is None
+    def test_exposure_form_matches_datascanservice(self) -> None:
+        # DataScanService.cs: jw{program}{obs}{visit}. This is the shape on
+        # every MAST-imported file, so stage-2 outputs must use it too.
+        assert (
+            observation_base_id_from("jw02733001001_02101_00001_nrca1_cal.fits") == "jw02733001001"
+        )
+
+    def test_lowercased_to_match_the_stored_values(self) -> None:
+        # The .NET write path lowercases; Mongo string equality would never
+        # match otherwise.
+        assert (
+            observation_base_id_from("JW02733-O001_T001_NIRCAM_f200w_i2d.fits")
+            == "jw02733-o001_t001_nircam"
+        )
 
     @pytest.mark.parametrize("value", [None, "", "not-a-jwst-name.fits"])
     def test_none_for_anything_unrecognised(self, value) -> None:
         assert observation_base_id_from(value) is None
+
+
+def _parent(oid: str, file_name: str, base_id: str | None):
+    return {"_id": oid, "FileName": file_name, "ObservationBaseId": base_id}
+
+
+class TestObservationBaseIdForOutput:
+    def test_inherits_from_the_parents(self) -> None:
+        # The real case: an image3 output is named after the RECIPE
+        # ("nircam-imaging_i2d.fits") and encodes no observation at all, so
+        # the parents are the only source of truth.
+        parents = [
+            _parent("a", "jw02733001001_02101_00001_nrca1_cal.fits", "jw02733001001"),
+            _parent("b", "jw02733001001_02101_00002_nrca1_cal.fits", "jw02733001001"),
+        ]
+        assert observation_base_id_for_output(parents, "nircam-imaging_i2d.fits") == "jw02733001001"
+
+    def test_no_grouping_when_a_run_spans_observations(self) -> None:
+        parents = [
+            _parent("a", "x_cal.fits", "jw02733001001"),
+            _parent("b", "y_cal.fits", "jw02739001001"),
+        ]
+        assert observation_base_id_for_output(parents, "nircam-imaging_i2d.fits") is None
+
+    def test_falls_back_to_the_filename_with_no_parents(self) -> None:
+        # A MAST-sourced run has no library inputs.
+        assert (
+            observation_base_id_for_output([], "jw02733-o001_t001_nircam_f200w_i2d.fits")
+            == "jw02733-o001_t001_nircam"
+        )
+
+
+class TestDerivedFromForOutput:
+    def test_per_exposure_output_records_only_its_own_parent(self) -> None:
+        # A chained run over 6 exposures emits 6 _cal files. Recording all 6
+        # parents on each would draw a 6x6 mesh instead of six 1-to-1 links.
+        parents = [
+            _parent("a", "jw02733001001_02101_00001_nrca1_uncal.fits", None),
+            _parent("b", "jw02733001001_02101_00002_nrca1_uncal.fits", None),
+        ]
+        got = derived_from_for_output(parents, "jw02733001001_02101_00002_nrca1_cal.fits")
+        assert got == ["b"]
+
+    def test_combined_output_records_every_input(self) -> None:
+        # image3 genuinely consumes all of them.
+        parents = [
+            _parent("a", "jw02733001001_02101_00001_nrca1_cal.fits", None),
+            _parent("b", "jw02733001001_02101_00002_nrca1_cal.fits", None),
+        ]
+        assert derived_from_for_output(parents, "nircam-imaging_i2d.fits") == ["a", "b"]
+
+    def test_unmatched_exposure_falls_back_to_all_parents(self) -> None:
+        parents = [_parent("a", "jw02733001001_02101_00001_nrca1_cal.fits", None)]
+        got = derived_from_for_output(parents, "jw09999009009_02101_00007_nrca1_cal.fits")
+        assert got == ["a"]
+
+    def test_no_parents_is_empty_not_an_error(self) -> None:
+        assert derived_from_for_output([], "nircam-imaging_i2d.fits") == []


### PR DESCRIPTION
## Summary

PR 1 of 4 reframing calibration as **"raise a file's processing level"** (L1 raw → L2a → L2b → L3 mosaic). This one is invisible in the UI; it makes the rest possible.

The goal is to run a stage several ways with different settings, compare the results, keep the best, and feed it into the next step. That was impossible, because a saved calibration output recorded none of what you'd need to tell one attempt from another:

- **`ProcessingLevel`** was never set — nothing knew what the file had become, so nothing could offer the next step.
- **`DerivedFrom`** was written as `[]` — the output was detached from the data it came from.
- **The settings weren't recorded** — running one input three ways produced three library items you could not tell apart.

Both fields already exist across the C# model, the Mongo service, the DTO and the frontend types, and the app already has a lineage view. The calibration save path simply never populated them.

Closes #1754

## Changes Made

**`app/library/levels.py` (new)** — suffix → level. Mirrors the .NET classification, which lives in two places on the C# side (`ProcessingLevels.SuffixToLevel` and the longer chain in `DataScanService.ParseFileInfo`); this table is the union, so a saved output gets the same level the scanner gives an identical file. Matches the **end of the stem**, not anywhere in the name — an image3 output is `{product_name}_i2d.fits` and a product name may contain `_`, so `ngc_calibration_i2d.fits` would otherwise match `_cal` and file a finished mosaic as a half-processed exposure.

**`app/library/lineage.py` (new)** — derives `ObservationBaseId`, `ExposureId` and parentage. Taken from the run's **inputs**, not the output's filename: an image3 run writes `nircam-imaging_i2d.fits`, which encodes no observation at all. The parents already carry a correctly-shaped id, which also sidesteps the three different id shapes in the .NET tier. Filename parsers remain as a fallback for MAST-sourced runs and mirror the two C# conventions exactly.

**`app/library/writer.py`** — records level, parents, `ParentId`, `ExposureId`, and a description. `parents_for()` reads the input records through a projection that excludes `ThumbnailData`, and returns them in the caller's order so `DerivedFrom` is stable.

**`app/jobs/routes.py`** — the save endpoint derives all of the above, plus a description naming the level, recipe and overrides so repeated runs are distinguishable in the library rather than N identical rows.

### What self-review caught (2 rounds, both found real defects)

- **Round 1**: the lineage regex could never match a real output. It expected a MAST-style name, but image3 writes `{association.product_name}_i2d.fits` — so `ObservationBaseId` would have been `None` for **100% of outputs**, leaving them exactly as detached as before. The test passed only because it seeded a filename the engine cannot produce. Fixed by inheriting from the inputs.
- **Round 2**: the exposure match still produced the mesh it was written to prevent. One JWST exposure emits a file **per detector** (NIRCam SW has eight) and they share the exposure root, so every detector became a parent of every other detector's output. The test passed only because its two parents differed by exposure number — the easier case.
- **Round 2**: the description was unbounded while `Description` is `[StringLength(1000)]`, so a large override set would 400 any client round-tripping the record.
- **Round 2**: `ParentId` was unset — and the lineage view draws its edges from `ParentId`, not `DerivedFrom`, so outputs would have rendered as disconnected roots.

## Test Plan

- [x] Engine suite: **1804 passed** (`docker exec jwst-processing python -m pytest tests/`)
- [x] `ruff check app tests` and `ruff format --check` clean
- [x] 40 tests in `test_library_levels.py` covering the level table, both C# filename conventions, parent inheritance, detector/segment separation, and the mixed/disagreeing-parent cases
- [x] Route-level tests assert the saved record's `ProcessingLevel`, `DerivedFrom`, `ObservationBaseId`, `ParentId`, `ExposureId` and `Description`
- [x] Verified the round-1 regression is caught: the route test seeds the realistic `nircam-imaging_i2d.fits` and asserts the inherited base id, which the filename-derived implementation cannot produce

Manual check (needs a calibration run):

1. From the library, reprocess an observation's `_cal` exposures to L3.
2. On the run page, save the `_i2d` output to your library.
3. The new library item shows processing level **L3**, and its description reads e.g. `L3 from seed-nircam-imaging (recipe defaults)`.
4. Open the lineage view for that observation — the new output appears connected to its parent, not as a separate root.
5. Run the same recipe again with a changed setting and save. The two items are distinguishable by description.

Not covered: no live end-to-end pipeline run was executed here — the engine tests use a faked pipeline, and steps 1–5 above are the manual verification that remains.

## Documentation Checklist

- [x] `docs/key-files.md` — the three new/changed engine modules
- [ ] No API doc change: no endpoint or request/response shape changed; this is what the save endpoint *stores*
- [ ] User-facing docs deferred to PR 2, where the behaviour becomes visible

## Tech Debt Impact

- [x] **Reduces** — calibration outputs stop being second-class records that the lineage view, mosaic substitution and sibling logic all ignore
- [x] **Reduces** — one Python mirror of a classification the C# side already duplicated internally, with the divergences stated rather than implicit
- [ ] Adds no new debt

## Risk & Rollback

**Risk: low.** Write-path only, and purely additive: fields that were previously absent are now populated. No endpoint, schema or existing field changed. Records saved before this PR are unaffected and keep working — they simply lack the new fields, which the C# model already treats as nullable.

Worth noting for review: `ProcessingLevel` is deliberately **omitted** rather than written as `"unknown"`. `MigrateProcessingLevels` only backfills when the field is empty, so a literal `"unknown"` would permanently block that backfill while `null` lets it run.

**Rollback**: revert the three commits. No migration, no data rewritten — new saves simply stop recording the extra fields.
