### PR TITLE
feat: offer calibration on any file that can be advanced (#1756)

### DIFF
--- a/docs/architecture/calibration-pipeline-flow.md
+++ b/docs/architecture/calibration-pipeline-flow.md
@@ -63,10 +63,17 @@ Frontend (/calibrate/:recipeId)                 Engine                      Exte
   since a run on a silently shorter input list yields a wrong mosaic. Raw
   storage keys in `inputs` are **rejected** (422): nothing authorizes a key
   per-record, so accepting one would let any user calibrate another's file.
+- **Runs are level transitions** (#1756): the library labels every file
+  L1 (`_uncal`) / L2a (`_rate`) / L2b (`_cal`) / L3 (`_i2d`), and a run raises a
+  file from one level to the next — Detector1 L1→L2a, Image2 L2a→L2b, Image3
+  L2b→L3. The library action is named for that outcome ("Process to L3",
+  "Combine to L3"), and the stages to enable are derived from the start and
+  target levels rather than chosen by hand. Files already at L3 are finished
+  and offer no action.
 - **Stage-3 fast path**: when the resolved inputs are library `_cal` files and
   only `image3` is enabled, the download and detector1/image2 stages are skipped —
   the pipeline re-combines already-calibrated exposures into a fresh mosaic in
-  minutes. This is what the library **Reprocess** action triggers.
+  minutes. This is the L2b -> L3 path, reached from the library's "Combine to L3" action.
 - **File handoff** between stages is by suffix inside the per-job workdir:
   `_uncal` → `_rate` → `_cal` → `_i2d`.
 - **Cancellation** is cooperative at stage boundaries (the monolithic

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { CE_MODE } from '../config/ce';
 import { getCapabilities } from '../services/calibrationService';
 import { reprocessInputIds } from './calibration/dataGrouping';
+import { advanceActionFor, noActionReason } from './calibration/processingLevels';
 import { toast } from './ui/toast';
 import {
   JwstDataModel,
@@ -60,11 +61,24 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
         toast.info('Calibration recipes currently support imaging data only.');
         return;
       }
+      const action = advanceActionFor(item);
+      if (!action) {
+        toast.info(noActionReason(item) ?? 'This file cannot be processed further.');
+        return;
+      }
       const recipeId = `seed-${instrument}-imaging`;
-      // reprocessInputIds always returns at least the clicked item, so there
-      // is nothing to guard against here.
-      const inputDataIds = reprocessInputIds(data, item);
-      navigate(`/calibrate/${recipeId}`, { state: { inputDataIds, stage3Only: true } });
+      // Combining needs the observation's whole calibrated set; processing a
+      // single exposure forward does not — it runs on the file you clicked.
+      const inputDataIds = action.fromLevel === 'L2b' ? reprocessInputIds(data, item) : [item.id];
+      navigate(`/calibrate/${recipeId}`, {
+        state: {
+          inputDataIds,
+          startLevel: action.fromLevel,
+          targetLevel: action.targetLevel,
+          // Kept for the stage-3 fast path the run page already understands.
+          stage3Only: action.fromLevel === 'L2b',
+        },
+      });
     },
     [data, navigate]
   );

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom';
 import { CE_MODE } from '../config/ce';
 import { getCapabilities } from '../services/calibrationService';
-import { reprocessInputIds } from './calibration/dataGrouping';
+import { instrumentOf, reprocessInputIds } from './calibration/dataGrouping';
 import { advanceActionFor, noActionReason } from './calibration/processingLevels';
 import { toast } from './ui/toast';
 import {
@@ -55,30 +55,30 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
 
   const handleReprocess = useCallback(
     (item: JwstDataModel) => {
-      const instrument = (item.imageInfo?.instrument ?? '').toLowerCase().split('/')[0];
-      // v1 curated recipes are imaging-only.
-      if (!['nircam', 'niriss', 'miri'].includes(instrument)) {
-        toast.info('Calibration recipes currently support imaging data only.');
-        return;
-      }
       const action = advanceActionFor(item);
       if (!action) {
         toast.info(noActionReason(item) ?? 'This file cannot be processed further.');
         return;
       }
-      const recipeId = `seed-${instrument}-imaging`;
-      // Combining needs the observation's whole calibrated set; processing a
-      // single exposure forward does not — it runs on the file you clicked.
-      const inputDataIds = action.fromLevel === 'L2b' ? reprocessInputIds(data, item) : [item.id];
-      navigate(`/calibrate/${recipeId}`, {
-        state: {
-          inputDataIds,
-          startLevel: action.fromLevel,
-          targetLevel: action.targetLevel,
-          // Kept for the stage-3 fast path the run page already understands.
-          stage3Only: action.fromLevel === 'L2b',
-        },
-      });
+      // Every route to L3 ends in Image3, and a mosaic needs the observation's
+      // other exposures — one member alone is a single-frame drizzle. So
+      // gather siblings at this file's level, whatever that level is.
+      const inputDataIds = reprocessInputIds(data, item);
+      const handoff = {
+        inputDataIds,
+        startLevel: action.fromLevel,
+        targetLevel: action.targetLevel,
+      };
+      const instrument = (instrumentOf(item) ?? '').toLowerCase();
+      // v1 curated recipes are imaging-only. When the instrument is genuinely
+      // unknown — uploads, engine-written outputs and MAST records without
+      // obsMeta all carry none — send them to the picker to choose, rather
+      // than asserting the file isn't imaging.
+      if (!['nircam', 'niriss', 'miri'].includes(instrument)) {
+        navigate('/calibrate/new', { state: handoff });
+        return;
+      }
+      navigate(`/calibrate/seed-${instrument}-imaging`, { state: handoff });
     },
     [data, navigate]
   );

--- a/frontend/jwst-frontend/src/components/calibration/dataGrouping.ts
+++ b/frontend/jwst-frontend/src/components/calibration/dataGrouping.ts
@@ -9,6 +9,7 @@
  * Pure functions so the grouping and matching rules are testable without a DOM.
  */
 
+import { levelOf } from './processingLevels';
 import type { JwstDataModel } from '../../types/JwstDataTypes';
 import type { CalibrationRecipe } from '../../types/CalibrationTypes';
 
@@ -45,10 +46,31 @@ function filtersOf(item: JwstDataModel): string[] {
     .filter(Boolean);
 }
 
+const KNOWN_INSTRUMENTS = ['NIRCAM', 'NIRISS', 'MIRI', 'NIRSPEC'];
+
 export function instrumentOf(item: JwstDataModel): string | null {
-  // e.g. "MIRI/IMAGE" -> "MIRI"
-  const raw = metaString(item, 'mast_instrument_name');
-  return raw ? raw.split('/')[0].trim().toUpperCase() : null;
+  // Several sources, because plenty of records carry none of the others:
+  // uploads have an ImageInfo with only a format, engine-written outputs have
+  // no ImageInfo at all, and MAST records without obsMeta get none either.
+  // Reading one field made the action dead-end on all of them.
+  const candidates = [
+    metaString(item, 'mast_instrument_name'),
+    item.imageInfo?.instrument,
+    item.sensorInfo?.instrument,
+  ];
+  for (const raw of candidates) {
+    // e.g. "MIRI/IMAGE" -> "MIRI"
+    const value = raw?.split('/')[0].trim().toUpperCase();
+    if (value && KNOWN_INSTRUMENTS.includes(value)) return value;
+  }
+  // Last resort: the filename encodes it (jw..._t001_nircam_...), as do tags.
+  const fromName = KNOWN_INSTRUMENTS.find((i) =>
+    (item.fileName ?? '').toUpperCase().includes(`_${i}_`)
+  );
+  if (fromName) return fromName;
+  return (
+    KNOWN_INSTRUMENTS.find((i) => (item.tags ?? []).some((t) => t.toUpperCase() === i)) ?? null
+  );
 }
 
 /**
@@ -130,11 +152,16 @@ export function formatBytes(bytes: number): string {
  * `filePath` predicate here silently reduced every reprocess to a single frame.
  */
 export function reprocessInputIds(data: JwstDataModel[], item: JwstDataModel): string[] {
+  // Siblings at the SAME level as the clicked file. Level rather than a "_cal"
+  // substring so this works for a raw or rate exposure too — an Image3 run on
+  // one member of an observation is a single-frame mosaic, which is not what
+  // "combine this observation" promises (#1756).
+  const level = levelOf(item);
   const siblings = data.filter(
     (d) =>
       d.observationBaseId != null &&
       d.observationBaseId === item.observationBaseId &&
-      (d.fileName ?? '').includes('_cal')
+      levelOf(d) === level
   );
   return (siblings.length > 0 ? siblings : [item]).map((d) => d.id);
 }

--- a/frontend/jwst-frontend/src/components/calibration/processingLevels.test.ts
+++ b/frontend/jwst-frontend/src/components/calibration/processingLevels.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Level-based calibration offers (#1756). These decide what every library card
+ * says, so they carry the feature's whole vocabulary: a run raises a file from
+ * one level to the next, and the card names the outcome, not the stage.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  advanceActionFor,
+  levelFromFileName,
+  levelOf,
+  noActionReason,
+  reachableLevels,
+  stagesBetween,
+} from './processingLevels';
+import type { JwstDataModel } from '../../types/JwstDataTypes';
+
+const file = (over: Partial<JwstDataModel>) => over as JwstDataModel;
+
+describe('levelFromFileName', () => {
+  it('reads the level off real product names', () => {
+    expect(levelFromFileName('jw02733001001_02101_00001_nrca1_uncal.fits')).toBe('L1');
+    expect(levelFromFileName('jw02733001001_02101_00001_nrca1_rate.fits')).toBe('L2a');
+    expect(levelFromFileName('jw02733-o001_t001_nircam_f200w_i2d.fits')).toBe('L3');
+  });
+
+  it('matches the end of the stem, not anywhere in the name', () => {
+    // A calibration output is named {product_name}_i2d.fits and a product name
+    // may contain "_" — searching anywhere would call this mosaic L2b.
+    expect(levelFromFileName('ngc_calibration_i2d.fits')).toBe('L3');
+  });
+
+  it('does not read _rateints as _rate', () => {
+    expect(levelFromFileName('jw01_rateints.fits')).toBe('L2a');
+    expect(levelFromFileName('jw01_calints.fits')).toBe('L2b');
+  });
+
+  it('returns null when there is no recognisable suffix', () => {
+    expect(levelFromFileName('my-export.fits')).toBeNull();
+    expect(levelFromFileName(undefined)).toBeNull();
+  });
+});
+
+describe('levelOf', () => {
+  it('prefers the stored label', () => {
+    expect(levelOf(file({ fileName: 'x_uncal.fits', processingLevel: 'L2b' }))).toBe('L2b');
+  });
+
+  it('falls back to the filename when the label is missing or unusable', () => {
+    // Records predating the backfill, and every calibration output saved
+    // before #1754, have no level — falling back keeps them usable.
+    expect(levelOf(file({ fileName: 'x_cal.fits' }))).toBe('L2b');
+    expect(levelOf(file({ fileName: 'x_cal.fits', processingLevel: 'unknown' }))).toBe('L2b');
+  });
+
+  it('is null when neither source knows', () => {
+    expect(levelOf(file({ fileName: 'mystery.fits', processingLevel: 'unknown' }))).toBeNull();
+  });
+});
+
+describe('stagesBetween', () => {
+  it('takes a raw file all the way to a mosaic', () => {
+    expect(stagesBetween('L1', 'L3')).toEqual(['detector1', 'image2', 'image3']);
+  });
+
+  it('runs only what is left when the file is part-way there', () => {
+    expect(stagesBetween('L2a', 'L3')).toEqual(['image2', 'image3']);
+    expect(stagesBetween('L2b', 'L3')).toEqual(['image3']);
+  });
+
+  it('supports stopping short of L3', () => {
+    expect(stagesBetween('L1', 'L2a')).toEqual(['detector1']);
+    expect(stagesBetween('L1', 'L2b')).toEqual(['detector1', 'image2']);
+  });
+
+  it('is empty when there is nothing to do or the direction is backwards', () => {
+    expect(stagesBetween('L3', 'L3')).toEqual([]);
+    // Calibration cannot un-process a file.
+    expect(stagesBetween('L3', 'L1')).toEqual([]);
+  });
+});
+
+describe('reachableLevels', () => {
+  it('lists what a file could become, nearest first', () => {
+    expect(reachableLevels('L1')).toEqual(['L2a', 'L2b', 'L3']);
+    expect(reachableLevels('L2b')).toEqual(['L3']);
+  });
+
+  it('is empty for a finished product', () => {
+    expect(reachableLevels('L3')).toEqual([]);
+  });
+});
+
+describe('advanceActionFor', () => {
+  it('offers a raw file the whole pipeline', () => {
+    const action = advanceActionFor(file({ fileName: 'x_uncal.fits' }));
+    expect(action).toEqual({
+      label: 'Process to L3',
+      fromLevel: 'L1',
+      targetLevel: 'L3',
+      stages: ['detector1', 'image2', 'image3'],
+    });
+  });
+
+  it('calls the last hop combining, because that is what it does', () => {
+    // Image3 mosaics several exposures into one image — a different promise
+    // from calibrating a single file.
+    const action = advanceActionFor(file({ fileName: 'x_cal.fits' }));
+    expect(action?.label).toBe('Combine to L3');
+    expect(action?.stages).toEqual(['image3']);
+  });
+
+  it('offers nothing on a finished mosaic', () => {
+    expect(advanceActionFor(file({ fileName: 'x_i2d.fits' }))).toBeNull();
+  });
+
+  it('offers nothing when the level is unknown', () => {
+    expect(advanceActionFor(file({ fileName: 'mystery.fits' }))).toBeNull();
+  });
+
+  it('is offered on the levels that make up most of a real library', () => {
+    // The old entry point appeared only on _cal files — 6 of 1523 items here.
+    for (const name of ['a_uncal.fits', 'a_rate.fits', 'a_cal.fits']) {
+      expect(advanceActionFor(file({ fileName: name }))).not.toBeNull();
+    }
+  });
+});
+
+describe('noActionReason', () => {
+  it('says a finished file is finished rather than hiding the control', () => {
+    expect(noActionReason(file({ fileName: 'x_i2d.fits' }))).toMatch(/Already fully processed/);
+  });
+
+  it('explains an unknown level', () => {
+    expect(noActionReason(file({ fileName: 'mystery.fits' }))).toMatch(/unknown/i);
+  });
+
+  it('is null when there IS an action, so nothing contradicts the button', () => {
+    expect(noActionReason(file({ fileName: 'x_cal.fits' }))).toBeNull();
+  });
+});

--- a/frontend/jwst-frontend/src/components/calibration/processingLevels.test.ts
+++ b/frontend/jwst-frontend/src/components/calibration/processingLevels.test.ts
@@ -6,7 +6,11 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  CANONICAL_SUFFIX,
+  LEVEL_ORDER,
+  SUFFIXES_FOR_LEVEL,
   advanceActionFor,
+  isOrderedLevel,
   levelFromFileName,
   levelOf,
   noActionReason,
@@ -30,7 +34,10 @@ describe('levelFromFileName', () => {
     expect(levelFromFileName('ngc_calibration_i2d.fits')).toBe('L3');
   });
 
-  it('does not read _rateints as _rate', () => {
+  it('classifies the ints variants', () => {
+    // Note: endsWith makes these order-independent (a name ending "_rateints"
+    // does not end with "_rate"), so this documents the mapping rather than
+    // guarding the ordering.
     expect(levelFromFileName('jw01_rateints.fits')).toBe('L2a');
     expect(levelFromFileName('jw01_calints.fits')).toBe('L2b');
   });
@@ -38,6 +45,38 @@ describe('levelFromFileName', () => {
   it('returns null when there is no recognisable suffix', () => {
     expect(levelFromFileName('my-export.fits')).toBeNull();
     expect(levelFromFileName(undefined)).toBeNull();
+  });
+});
+
+describe('the two suffix tables agree', () => {
+  it('every classified suffix is browsable at its own level', () => {
+    // SUFFIXES_FOR_LEVEL is derived from SUFFIX_TO_LEVEL precisely so a level
+    // cannot end up browsable but unclassifiable (or vice versa).
+    for (const level of LEVEL_ORDER) {
+      for (const suffix of SUFFIXES_FOR_LEVEL[level]) {
+        expect(levelFromFileName(`file${suffix}.fits`)).toBe(level);
+      }
+    }
+  });
+
+  it('every level has a canonical suffix the stage rules understand', () => {
+    // blockedReason only knows these four; anything else falls through to
+    // "assume raw" and reports Detector1 as runnable on calibrated data.
+    for (const level of LEVEL_ORDER) {
+      expect(levelFromFileName(`file${CANONICAL_SUFFIX[level]}.fits`)).toBe(level);
+    }
+    expect(Object.values(CANONICAL_SUFFIX)).toEqual(['_uncal', '_rate', '_cal', '_i2d']);
+  });
+});
+
+describe('isOrderedLevel', () => {
+  it('rejects anything that is not a level we can order by', () => {
+    // location.state survives reload and back/forward, so a stale entry must
+    // not index the suffix table with a missing key.
+    expect(isOrderedLevel('L2a')).toBe(true);
+    expect(isOrderedLevel('unknown')).toBe(false);
+    expect(isOrderedLevel(undefined)).toBe(false);
+    expect(isOrderedLevel('L4')).toBe(false);
   });
 });
 

--- a/frontend/jwst-frontend/src/components/calibration/processingLevels.ts
+++ b/frontend/jwst-frontend/src/components/calibration/processingLevels.ts
@@ -36,8 +36,14 @@ const STAGE_OUT_OF: Record<OrderedLevel, string | null> = {
 };
 
 /**
- * Longest suffix first, so `_rateints` is not read as `_rate`. Mirrors the
- * engine's `app/library/levels.py`, which mirrors the .NET table.
+ * Suffix -> level. The authority is the .NET pair
+ * `ProcessingLevels.SuffixToLevel` (JwstDataModel.cs) and the longer chain in
+ * `DataScanService.ParseFileInfo`; this is their union, so a file gets the
+ * same level here that the scanner gave it on import.
+ *
+ * Longest first only matters for a tie under `endsWith`; today every long/short
+ * pair maps to the same level, so ordering has no behavioural effect. It is
+ * kept so adding a pair that DOES differ cannot silently take the short one.
  */
 const SUFFIX_TO_LEVEL: [string, OrderedLevel][] = [
   ['_rateints', 'L2a'],
@@ -53,15 +59,38 @@ const SUFFIX_TO_LEVEL: [string, OrderedLevel][] = [
   ['_cat', 'L3'],
 ];
 
-/** The product suffixes that ARE each level — what to browse for that level. */
-export const SUFFIXES_FOR_LEVEL: Record<OrderedLevel, string[]> = {
-  L1: ['_uncal'],
-  L2a: ['_rate', '_rateints'],
-  L2b: ['_cal', '_calints', '_crf'],
-  L3: ['_i2d', '_s2d', '_x1d'],
+/**
+ * The product suffixes that ARE each level — what to browse for that level.
+ * Derived from SUFFIX_TO_LEVEL rather than hand-maintained: two tables that
+ * must agree and don't is how a level ends up browsable but unclassifiable.
+ */
+export const SUFFIXES_FOR_LEVEL: Record<OrderedLevel, string[]> = LEVEL_ORDER.reduce(
+  (acc, level) => {
+    acc[level] = SUFFIX_TO_LEVEL.filter(([, l]) => l === level).map(([suffix]) => suffix);
+    return acc;
+  },
+  {} as Record<OrderedLevel, string[]>
+);
+
+/**
+ * The one suffix that REPRESENTS each level. Used wherever a level has to be
+ * expressed as a suffix for `stagePipeline.blockedReason`, which understands
+ * only these four — handing it `_calints` would fall through to "assume raw"
+ * and report Detector1 as runnable on calibrated data.
+ */
+export const CANONICAL_SUFFIX: Record<OrderedLevel, string> = {
+  L1: '_uncal',
+  L2a: '_rate',
+  L2b: '_cal',
+  L3: '_i2d',
 };
 
-/** Level from the filename, matching the END of the stem (see levels.py). */
+/** Whether a value from router state is a level we can actually order by. */
+export function isOrderedLevel(value: unknown): value is OrderedLevel {
+  return typeof value === 'string' && (LEVEL_ORDER as readonly string[]).includes(value);
+}
+
+/** Level from the filename, matching the END of the stem (mirrors the engine). */
 export function levelFromFileName(fileName: string | undefined): OrderedLevel | null {
   if (!fileName) return null;
   const stem = fileName.toLowerCase().replace(/\.[^.]+$/, '');

--- a/frontend/jwst-frontend/src/components/calibration/processingLevels.ts
+++ b/frontend/jwst-frontend/src/components/calibration/processingLevels.ts
@@ -1,0 +1,142 @@
+/**
+ * What a library file can be advanced to, and what that costs (#1756).
+ *
+ * The library already labels every file L1/L2a/L2b/L3, but nothing connected
+ * those labels to the calibration pipeline — which is the whole story of the
+ * feature. A run does not "enable image2"; it raises a file from one level to
+ * the next:
+ *
+ *   L1 (_uncal, raw) --Detector1--> L2a (_rate)
+ *   L2a             --Image2----->  L2b (_cal)
+ *   L2b             --Image3----->  L3  (_i2d, a combined mosaic)
+ *
+ * Pure functions over a level so they can be tested directly rather than
+ * through the DOM, and so the card, the run page and the library agree on what
+ * is possible for a given file.
+ */
+
+import { ProcessingLevels, type JwstDataModel } from '../../types/JwstDataTypes';
+
+/** Ascending. `unknown` is deliberately absent: it has no position. */
+export const LEVEL_ORDER = [
+  ProcessingLevels.L1,
+  ProcessingLevels.L2a,
+  ProcessingLevels.L2b,
+  ProcessingLevels.L3,
+] as const;
+
+export type OrderedLevel = (typeof LEVEL_ORDER)[number];
+
+/** Which stage raises a file OUT of each level. Mirrors stagePipeline.ts. */
+const STAGE_OUT_OF: Record<OrderedLevel, string | null> = {
+  L1: 'detector1',
+  L2a: 'image2',
+  L2b: 'image3',
+  L3: null,
+};
+
+/**
+ * Longest suffix first, so `_rateints` is not read as `_rate`. Mirrors the
+ * engine's `app/library/levels.py`, which mirrors the .NET table.
+ */
+const SUFFIX_TO_LEVEL: [string, OrderedLevel][] = [
+  ['_rateints', 'L2a'],
+  ['_calints', 'L2b'],
+  ['_x1dints', 'L3'],
+  ['_uncal', 'L1'],
+  ['_rate', 'L2a'],
+  ['_cal', 'L2b'],
+  ['_crf', 'L2b'],
+  ['_i2d', 'L3'],
+  ['_s2d', 'L3'],
+  ['_x1d', 'L3'],
+  ['_cat', 'L3'],
+];
+
+/** The product suffixes that ARE each level — what to browse for that level. */
+export const SUFFIXES_FOR_LEVEL: Record<OrderedLevel, string[]> = {
+  L1: ['_uncal'],
+  L2a: ['_rate', '_rateints'],
+  L2b: ['_cal', '_calints', '_crf'],
+  L3: ['_i2d', '_s2d', '_x1d'],
+};
+
+/** Level from the filename, matching the END of the stem (see levels.py). */
+export function levelFromFileName(fileName: string | undefined): OrderedLevel | null {
+  if (!fileName) return null;
+  const stem = fileName.toLowerCase().replace(/\.[^.]+$/, '');
+  const hit = SUFFIX_TO_LEVEL.find(([suffix]) => stem.endsWith(suffix));
+  return hit ? hit[1] : null;
+}
+
+/**
+ * The file's level: the stored label when it is one we can order by,
+ * otherwise read off the filename. Records predating the level backfill have
+ * no `processingLevel`, and every calibration output saved before #1754 has
+ * none either — falling back keeps those usable instead of stranded.
+ */
+export function levelOf(
+  item: Pick<JwstDataModel, 'fileName' | 'processingLevel'>
+): OrderedLevel | null {
+  const stored = item.processingLevel as OrderedLevel | undefined;
+  if (stored && (LEVEL_ORDER as readonly string[]).includes(stored)) return stored;
+  return levelFromFileName(item.fileName);
+}
+
+/** The stages needed to get from `from` up to `to`, in pipeline order. */
+export function stagesBetween(from: OrderedLevel, to: OrderedLevel): string[] {
+  const start = LEVEL_ORDER.indexOf(from);
+  const end = LEVEL_ORDER.indexOf(to);
+  if (start < 0 || end < 0 || end <= start) return [];
+  return LEVEL_ORDER.slice(start, end)
+    .map((level) => STAGE_OUT_OF[level])
+    .filter((stage): stage is string => stage !== null);
+}
+
+/** Every level a file could be advanced to, nearest first. */
+export function reachableLevels(from: OrderedLevel): OrderedLevel[] {
+  return LEVEL_ORDER.slice(LEVEL_ORDER.indexOf(from) + 1);
+}
+
+export interface AdvanceAction {
+  /** Button text, naming the outcome rather than the pipeline stage. */
+  label: string;
+  fromLevel: OrderedLevel;
+  /** Where it goes by default — always the top, per "take a raw 1 to level 3". */
+  targetLevel: OrderedLevel;
+  stages: string[];
+}
+
+/**
+ * What to offer on a library file, or null when there is nothing to offer.
+ *
+ * Null means genuinely nothing to do — an L3 mosaic is finished, and a file
+ * whose level we cannot determine has no known next step. Both cases deserve
+ * an explanation rather than a hidden button, which is the caller's job.
+ */
+export function advanceActionFor(
+  item: Pick<JwstDataModel, 'fileName' | 'processingLevel'>
+): AdvanceAction | null {
+  const fromLevel = levelOf(item);
+  if (!fromLevel || fromLevel === ProcessingLevels.L3) return null;
+  const targetLevel = ProcessingLevels.L3 as OrderedLevel;
+  return {
+    // "Combine" for the last hop because that is what Image3 does — it
+    // mosaics several exposures into one image, which is a different promise
+    // from calibrating one file.
+    label: fromLevel === ProcessingLevels.L2b ? 'Combine to L3' : 'Process to L3',
+    fromLevel,
+    targetLevel,
+    stages: stagesBetween(fromLevel, targetLevel),
+  };
+}
+
+/** Why there is no action, for the cases where that needs saying. */
+export function noActionReason(
+  item: Pick<JwstDataModel, 'fileName' | 'processingLevel'>
+): string | null {
+  const level = levelOf(item);
+  if (level === ProcessingLevels.L3) return 'Already fully processed (Level 3)';
+  if (!level) return "This file's processing level is unknown, so there is no next step";
+  return null;
+}

--- a/frontend/jwst-frontend/src/components/calibration/reprocessHandoff.test.ts
+++ b/frontend/jwst-frontend/src/components/calibration/reprocessHandoff.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The join between a library card and the run page (#1756).
+ *
+ * The dashboard decides three things when you click the action: which files go
+ * in, which recipe, and which levels to travel between. Each was previously
+ * wrong in a way that only showed up at run time — a single-frame mosaic, a
+ * "not imaging" toast on a file that is imaging, or an Image3-only run on raw
+ * data — so they are exercised here rather than through the dashboard's DOM.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { instrumentOf, reprocessInputIds } from './dataGrouping';
+import { advanceActionFor } from './processingLevels';
+import type { JwstDataModel } from '../../types/JwstDataTypes';
+
+const item = (over: Partial<JwstDataModel>): JwstDataModel =>
+  ({ id: 'x', fileName: 'a_cal.fits', metadata: {}, tags: [], ...over }) as JwstDataModel;
+
+describe('instrumentOf', () => {
+  it('reads the MAST metadata first', () => {
+    expect(instrumentOf(item({ metadata: { mast_instrument_name: 'MIRI/IMAGE' } }))).toBe('MIRI');
+  });
+
+  it('falls back to imageInfo, which uploads and scans carry instead', () => {
+    expect(instrumentOf(item({ imageInfo: { instrument: 'NIRCam' } as never }))).toBe('NIRCAM');
+  });
+
+  it('falls back to the filename, which encodes it for stage-3 products', () => {
+    // Engine-written outputs carry no ImageInfo at all, so without this the
+    // action dead-ends on every file the pipeline itself produced.
+    expect(instrumentOf(item({ fileName: 'jw02733-o001_t001_niriss_f200w_i2d.fits' }))).toBe(
+      'NIRISS'
+    );
+  });
+
+  it('falls back to tags', () => {
+    expect(instrumentOf(item({ fileName: 'x.fits', tags: ['nircam', 'deep'] }))).toBe('NIRCAM');
+  });
+
+  it('is null when nothing knows, rather than guessing an instrument', () => {
+    expect(instrumentOf(item({ fileName: 'my-upload.fits' }))).toBeNull();
+  });
+});
+
+describe('reprocessInputIds', () => {
+  const obs = 'jw02733001001';
+
+  it('gathers the observation siblings at the same level as the clicked file', () => {
+    const data = [
+      item({ id: 'a', fileName: 'a_cal.fits', observationBaseId: obs }),
+      item({ id: 'b', fileName: 'b_cal.fits', observationBaseId: obs }),
+      item({ id: 'c', fileName: 'c_uncal.fits', observationBaseId: obs }),
+    ];
+    expect(reprocessInputIds(data, data[0])).toEqual(['a', 'b']);
+  });
+
+  it('gathers raw siblings too, not just calibrated ones', () => {
+    // Every route to L3 ends in Image3, and a mosaic needs the observation's
+    // other exposures — one member alone is a single-frame drizzle.
+    const data = [
+      item({ id: 'a', fileName: 'a_uncal.fits', observationBaseId: obs }),
+      item({ id: 'b', fileName: 'b_uncal.fits', observationBaseId: obs }),
+      item({ id: 'c', fileName: 'c_cal.fits', observationBaseId: obs }),
+    ];
+    expect(reprocessInputIds(data, data[0])).toEqual(['a', 'b']);
+  });
+
+  it('does not mix levels — a rate file does not pull in calibrated ones', () => {
+    const data = [
+      item({ id: 'a', fileName: 'a_rate.fits', observationBaseId: obs }),
+      item({ id: 'b', fileName: 'b_cal.fits', observationBaseId: obs }),
+    ];
+    expect(reprocessInputIds(data, data[0])).toEqual(['a']);
+  });
+
+  it('falls back to the clicked file when it has no siblings', () => {
+    const only = item({ id: 'a', fileName: 'a_cal.fits' });
+    expect(reprocessInputIds([only], only)).toEqual(['a']);
+  });
+});
+
+describe('the hand-off as a whole', () => {
+  it('sends a raw file the whole way, with its siblings', () => {
+    const data = [
+      item({
+        id: 'a',
+        fileName: 'jw02733001001_02101_00001_nrca1_uncal.fits',
+        observationBaseId: 'jw02733001001',
+        metadata: { mast_instrument_name: 'NIRCAM/IMAGE' },
+      }),
+      item({
+        id: 'b',
+        fileName: 'jw02733001001_02101_00002_nrca1_uncal.fits',
+        observationBaseId: 'jw02733001001',
+      }),
+    ];
+    const action = advanceActionFor(data[0]);
+    expect(action).toMatchObject({ fromLevel: 'L1', targetLevel: 'L3' });
+    expect(instrumentOf(data[0])).toBe('NIRCAM');
+    expect(reprocessInputIds(data, data[0])).toEqual(['a', 'b']);
+  });
+});

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.test.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.test.tsx
@@ -222,23 +222,36 @@ describe('DataCard', () => {
     expect(screen.getByText('Unarchiving...')).toBeInTheDocument();
   });
 
-  it('shows Reprocess only when onReprocess is provided and file is _cal', () => {
+  it('offers combining on a calibrated file, named for the outcome', () => {
     const onReprocess = vi.fn<(item: JwstDataModel) => void>();
     renderCard({}, { onReprocess });
-    const button = screen.getByRole('button', { name: 'Reprocess' });
-    expect(button).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Combine to L3' });
     fireEvent.click(button);
     expect(onReprocess).toHaveBeenCalledTimes(1);
   });
 
-  it('hides Reprocess when onReprocess is not provided', () => {
-    renderCard();
-    expect(screen.queryByRole('button', { name: 'Reprocess' })).not.toBeInTheDocument();
+  it('offers processing on a raw file — the old rule hid this entirely', () => {
+    // The _cal-only rule meant the action appeared on a handful of files, so
+    // the feature read as absent for most of a real library (#1756).
+    const onReprocess = vi.fn<(item: JwstDataModel) => void>();
+    renderCard({ fileName: 'test_uncal.fits' }, { onReprocess });
+    expect(screen.getByRole('button', { name: 'Process to L3' })).toBeInTheDocument();
   });
 
-  it('hides Reprocess for non-_cal files', () => {
+  it('offers processing on a rate file', () => {
+    const onReprocess = vi.fn<(item: JwstDataModel) => void>();
+    renderCard({ fileName: 'test_rate.fits' }, { onReprocess });
+    expect(screen.getByRole('button', { name: 'Process to L3' })).toBeInTheDocument();
+  });
+
+  it('hides the action when calibration is unavailable', () => {
+    renderCard();
+    expect(screen.queryByRole('button', { name: /to L3/ })).not.toBeInTheDocument();
+  });
+
+  it('offers nothing on a finished mosaic — there is no next level', () => {
     const onReprocess = vi.fn<(item: JwstDataModel) => void>();
     renderCard({ fileName: 'test_i2d.fits' }, { onReprocess });
-    expect(screen.queryByRole('button', { name: 'Reprocess' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /to L3/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
+++ b/frontend/jwst-frontend/src/components/dashboard/DataCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { JwstDataModel } from '../../types/JwstDataTypes';
 import { getFitsFileInfo, isSpectralFile } from '../../utils/fitsUtils';
+import { advanceActionFor } from '../calibration/processingLevels';
 import { getStatusColor } from '../../utils/statusUtils';
 import { API_BASE_URL } from '../../config/api';
 import { CE_MODE } from '../../config/ce';
@@ -31,6 +32,7 @@ const DataCard: React.FC<DataCardProps> = ({
   onTagClick,
   onReprocess,
 }) => {
+  const advanceAction = advanceActionFor(item);
   const fitsInfo = getFitsFileInfo(item.fileName);
   const hasFile = item.isViewable !== false || isSpectralFile(item.fileName);
   const canSelect = fitsInfo.viewable;
@@ -155,13 +157,17 @@ const DataCard: React.FC<DataCardProps> = ({
         >
           {isSpectralFile(item.fileName) ? 'Spectrum' : fitsInfo.viewable ? 'View' : 'Table'}
         </button>
-        {!CE_MODE && onReprocess && item.fileName.includes('_cal') && (
+        {/* Offered on anything that can actually be advanced, not just _cal.
+            The old _cal-only rule hid this on all but a handful of files, so
+            the feature looked absent. The label names the OUTCOME for this
+            file rather than a pipeline stage nobody has to know about. */}
+        {!CE_MODE && onReprocess && advanceAction && (
           <button
             className="btn-base btn-compact reprocess-btn"
             onClick={() => onReprocess(item)}
-            title="Re-combine this observation's calibrated exposures with the official JWST pipeline"
+            title={`Run the official JWST pipeline to raise this file from ${advanceAction.fromLevel} to ${advanceAction.targetLevel}`}
           >
-            Reprocess
+            {advanceAction.label}
           </button>
         )}
         {!CE_MODE && (

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -280,11 +280,48 @@ describe('CalibrateRun', () => {
     expect(vi.mocked(startRun).mock.lastCall?.[0].enabledStages.detector1).toBe(false);
   });
 
+  it('a rate file targeted at L3 runs exactly the two remaining stages', async () => {
+    // The discriminating case: neither the recipe defaults (all three on) nor
+    // the stage-3 fast path (image3 only) produce this — only the level
+    // derivation does.
+    vi.mocked(getAll).mockResolvedValue([{ id: 'r', fileName: 'a_rate.fits' }] as never);
+    vi.mocked(startRun).mockResolvedValue({ jobId: 'job-4' } as never);
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: { inputDataIds: ['r'], startLevel: 'L2a', targetLevel: 'L3' },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+          <Route path="/calibrate/runs/:jobId" element={<div>run detail stub</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole('checkbox', { name: /a_rate\.fits/ })).toBeChecked();
+    await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+    await waitFor(() => expect(startRun).toHaveBeenCalled());
+    expect(vi.mocked(startRun).mock.lastCall?.[0].enabledStages).toEqual({
+      detector1: false,
+      image2: true,
+      image3: true,
+    });
+  });
+
   it('a raw file targeted at L3 enables the whole pipeline', async () => {
     // "take a raw 1 to level 3": the caller names levels, never stages, and
     // all three must be on — the old hand-off could only ever do image3.
     vi.mocked(getAll).mockResolvedValue([{ id: 'u', fileName: 'a_uncal.fits' }] as never);
     vi.mocked(startRun).mockResolvedValue({ jobId: 'job-5' } as never);
+    // Recipe defaults say detector1 is OFF, so passing this can only come from
+    // the level derivation, never from falling through to s.enabled.
+    vi.mocked(getRecipe).mockResolvedValue({
+      ...recipe,
+      stages: recipe.stages.map((s) => (s.name === 'detector1' ? { ...s, enabled: false } : s)),
+    });
     render(
       <MemoryRouter
         initialEntries={[
@@ -318,12 +355,9 @@ describe('CalibrateRun', () => {
         initialEntries={[
           {
             pathname: '/calibrate/seed-nircam-imaging',
-            state: {
-              inputDataIds: ['c'],
-              startLevel: 'L2b',
-              targetLevel: 'L3',
-              stage3Only: true,
-            },
+            // No stage3Only: the level pair alone must produce this, or the
+            // older fast-path branch would be doing the work.
+            state: { inputDataIds: ['c'], startLevel: 'L2b', targetLevel: 'L3' },
           },
         ]}
       >

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.test.tsx
@@ -280,6 +280,69 @@ describe('CalibrateRun', () => {
     expect(vi.mocked(startRun).mock.lastCall?.[0].enabledStages.detector1).toBe(false);
   });
 
+  it('a raw file targeted at L3 enables the whole pipeline', async () => {
+    // "take a raw 1 to level 3": the caller names levels, never stages, and
+    // all three must be on — the old hand-off could only ever do image3.
+    vi.mocked(getAll).mockResolvedValue([{ id: 'u', fileName: 'a_uncal.fits' }] as never);
+    vi.mocked(startRun).mockResolvedValue({ jobId: 'job-5' } as never);
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: { inputDataIds: ['u'], startLevel: 'L1', targetLevel: 'L3' },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+          <Route path="/calibrate/runs/:jobId" element={<div>run detail stub</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole('checkbox', { name: /a_uncal\.fits/ })).toBeChecked();
+    await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+    await waitFor(() => expect(startRun).toHaveBeenCalled());
+    expect(vi.mocked(startRun).mock.lastCall?.[0].enabledStages).toEqual({
+      detector1: true,
+      image2: true,
+      image3: true,
+    });
+  });
+
+  it('a calibrated file targeted at L3 runs only the combine step', async () => {
+    vi.mocked(getAll).mockResolvedValue([{ id: 'c', fileName: 'a_cal.fits' }] as never);
+    vi.mocked(startRun).mockResolvedValue({ jobId: 'job-6' } as never);
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/calibrate/seed-nircam-imaging',
+            state: {
+              inputDataIds: ['c'],
+              startLevel: 'L2b',
+              targetLevel: 'L3',
+              stage3Only: true,
+            },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path="/calibrate/:recipeId" element={<CalibrateRun />} />
+          <Route path="/calibrate/runs/:jobId" element={<div>run detail stub</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole('checkbox', { name: /a_cal\.fits/ })).toBeChecked();
+    await userEvent.click(screen.getByRole('button', { name: 'Run calibration' }));
+    await waitFor(() => expect(startRun).toHaveBeenCalled());
+    expect(vi.mocked(startRun).mock.lastCall?.[0].enabledStages).toEqual({
+      detector1: false,
+      image2: false,
+      image3: true,
+    });
+  });
+
   it('data-first hand-off keeps the recipe _uncal filter — it is not a reprocess', async () => {
     // Regression: the _cal override used to fire for ANY preset ids, which
     // made the picker's _uncal selections vanish from this page while still

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -19,6 +19,11 @@ import {
   estimateMinutes,
   formatEstimate,
 } from '../components/calibration/stagePipeline';
+import {
+  SUFFIXES_FOR_LEVEL,
+  stagesBetween,
+  type OrderedLevel,
+} from '../components/calibration/processingLevels';
 import { getRecipe, startRun } from '../services/calibrationService';
 import * as jwstDataService from '../services/jwstDataService';
 import type { CalibrationRecipe, ScalarOverride, StepOverrides } from '../types/CalibrationTypes';
@@ -82,6 +87,10 @@ interface ReprocessState {
   /** Library item ids to pre-select (#1751 — not storage keys). */
   inputDataIds?: string[];
   stage3Only?: boolean;
+  /** The level the chosen files are AT, and where they should end up (#1756).
+   *  The stages follow from the pair, so the caller never names a stage. */
+  startLevel?: OrderedLevel;
+  targetLevel?: OrderedLevel;
   /** Settings carried back from a finished run (#1735). The engine stores a
    *  recipe snapshot per job with the run's stage toggles already applied, so
    *  a re-run can rebuild this form exactly as it was submitted. */
@@ -143,17 +152,26 @@ function CalibrateRunForm() {
         if (cancelled) return;
         setRecipe(loaded);
         const rerun = reprocess.rerun;
+        // Stages needed to get from where the files ARE to where they should
+        // end up — so "process this raw file to L3" enables all three without
+        // the caller naming any of them.
+        const byLevel =
+          reprocess.startLevel && reprocess.targetLevel
+            ? stagesBetween(reprocess.startLevel, reprocess.targetLevel)
+            : null;
         setEnabledStages(
           Object.fromEntries(
             loaded.stages.map((s) => [
               s.name,
-              // Precedence: a re-run's own toggles, then the Reprocess
-              // stage-3 fast path, then the recipe's defaults.
+              // Precedence: a re-run's own toggles, then a level target, then
+              // the Reprocess stage-3 fast path, then the recipe's defaults.
               rerun?.enabledStages
                 ? (rerun.enabledStages[s.name] ?? false)
-                : reprocess.stage3Only
-                  ? s.name === 'image3'
-                  : s.enabled,
+                : byLevel
+                  ? byLevel.includes(s.name)
+                  : reprocess.stage3Only
+                    ? s.name === 'image3'
+                    : s.enabled,
             ])
           )
         );
@@ -186,10 +204,14 @@ function CalibrateRunForm() {
   // pipeline can't start from is a stage-blocking concern, and StageTimeline
   // already explains it; it is not a reason to hide the user's own file.
   const stage3Only = Boolean(reprocess.stage3Only);
-  const inputSuffixes = useMemo(
-    () => (stage3Only ? ['_cal'] : (recipe?.input_source.product_suffixes ?? ['_cal'])),
-    [stage3Only, recipe]
-  );
+  const startLevel = reprocess.startLevel;
+  const inputSuffixes = useMemo(() => {
+    // Browse the products that ARE the chosen level, so the list matches what
+    // the user just clicked rather than the recipe's own starting point.
+    if (startLevel) return SUFFIXES_FOR_LEVEL[startLevel];
+    if (stage3Only) return ['_cal'];
+    return recipe?.input_source.product_suffixes ?? ['_cal'];
+  }, [startLevel, stage3Only, recipe]);
 
   useEffect(() => {
     // Wait for the recipe: until it loads, inputSuffixes falls back to ['_cal'],

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.tsx
@@ -20,7 +20,10 @@ import {
   formatEstimate,
 } from '../components/calibration/stagePipeline';
 import {
+  CANONICAL_SUFFIX,
   SUFFIXES_FOR_LEVEL,
+  isOrderedLevel,
+  levelFromFileName,
   stagesBetween,
   type OrderedLevel,
 } from '../components/calibration/processingLevels';
@@ -28,10 +31,6 @@ import { getRecipe, startRun } from '../services/calibrationService';
 import * as jwstDataService from '../services/jwstDataService';
 import type { CalibrationRecipe, ScalarOverride, StepOverrides } from '../types/CalibrationTypes';
 import './CalibrateRun.css';
-
-/** Product suffixes we can recognise in a storage key, most-processed last so
- *  `find` picks the earliest match deterministically. */
-const KNOWN_SUFFIXES = ['_uncal', '_rate', '_cal', '_i2d'];
 
 interface ParamRow {
   step: string;
@@ -204,7 +203,9 @@ function CalibrateRunForm() {
   // pipeline can't start from is a stage-blocking concern, and StageTimeline
   // already explains it; it is not a reason to hide the user's own file.
   const stage3Only = Boolean(reprocess.stage3Only);
-  const startLevel = reprocess.startLevel;
+  // Validated: location.state survives reload and back/forward, so a stale or
+  // hand-edited entry must not index SUFFIXES_FOR_LEVEL with a missing key.
+  const startLevel = isOrderedLevel(reprocess.startLevel) ? reprocess.startLevel : undefined;
   const inputSuffixes = useMemo(() => {
     // Browse the products that ARE the chosen level, so the list matches what
     // the user just clicked rather than the recipe's own starting point.
@@ -226,9 +227,15 @@ function CalibrateRunForm() {
         // Match on fileName: the DTO has no filePath (#1751), and the
         // product suffix is part of the name anyway.
         const preset = new Set(reprocessInputs ?? []);
+        // Classify by level rather than substring: a filename containing
+        // "_cal" may well be an L3 mosaic (product names may contain "_"), and
+        // listing it here would let it be submitted as a calibration input.
         const shown = items.filter(
           (item) =>
-            preset.has(item.id) || inputSuffixes.some((s) => (item.fileName ?? '').includes(s))
+            preset.has(item.id) ||
+            (startLevel
+              ? levelFromFileName(item.fileName) === startLevel
+              : inputSuffixes.some((s) => (item.fileName ?? '').endsWith(`${s}.fits`)))
         );
         // Pre-selected items first: they are why the user is on this page.
         shown.sort((a, b) => Number(preset.has(b.id)) - Number(preset.has(a.id)));
@@ -247,7 +254,7 @@ function CalibrateRunForm() {
     return () => {
       cancelled = true;
     };
-  }, [needsLibraryInputs, recipe, reprocessInputs, inputSuffixes]);
+  }, [needsLibraryInputs, recipe, reprocessInputs, inputSuffixes, startLevel]);
 
   const libraryLoading = needsLibraryInputs && !libraryLoaded;
 
@@ -268,8 +275,16 @@ function CalibrateRunForm() {
       .filter((f) => visibleSelected.includes(f.id))
       .map((f) => f.fileName ?? '');
     if (names.length > 0) {
+      // Via the level, so `_crf` is known to be calibrated rather than falling
+      // through to "assume raw" — which told the timeline that Detector1 could
+      // run on already-calibrated data, the failure #1736 exists to prevent.
       return Array.from(
-        new Set(names.map((n) => KNOWN_SUFFIXES.find((s) => n.includes(s)) ?? '_uncal'))
+        new Set(
+          names.map((n) => {
+            const level = levelFromFileName(n);
+            return level ? CANONICAL_SUFFIX[level] : '_uncal';
+          })
+        )
       );
     }
     return recipe?.input_source.product_suffixes ?? [];
@@ -294,7 +309,10 @@ function CalibrateRunForm() {
   }, [paramRows]);
 
   const fileCount = visibleSelected.length;
-  const fromMast = recipe?.input_source.type === 'mast_query';
+  // Only when the run will actually download: the executor skips the MAST
+  // fetch entirely once library inputs are supplied, so warning about it on a
+  // library run describes something that will not happen.
+  const fromMast = recipe?.input_source.type === 'mast_query' && !needsLibraryInputs;
   const usesDetector1 = enabledSpecs.some((s) => s.name === 'detector1');
 
   // Blocked stages are rendered off and excluded from the estimate, so they


### PR DESCRIPTION
## Summary

PR 2 of 4 reframing calibration as **"raise a file's processing level."**

The library's Reprocess action rendered only on filenames containing `_cal`. On a real library that is a handful of files — **6 of 1,523 here, 0.4%** — so the feature read as missing for almost everything.

It also spoke the wrong language. The app already labels every file L1/L2a/L2b/L3, and raising a file from one level to the next is *exactly* what the pipeline does:

```
L1 (_uncal, raw) --Detector1-->  L2a (_rate)
L2a              --Image2----->  L2b (_cal)
L2b              --Image3----->  L3  (_i2d, a combined mosaic)
```

Nothing in the UI connected those labels to calibration, so there was no way to see that you can take a raw file all the way to a finished image.

Closes #1756. Builds on #1754 (PR #1755), but does not depend on it merging first — `levelOf` falls back to the filename when a record has no stored level.

## Changes Made

**`components/calibration/processingLevels.ts` (new)** — the level vocabulary as pure functions: `levelOf`, `stagesBetween`, `advanceActionFor`, `noActionReason`. One classification table (the union of the two on the C# side), with `SUFFIXES_FOR_LEVEL` *derived* from it rather than maintained alongside it.

**The card** offers what is actually possible for that file, named for the outcome: **"Process to L3"** on a raw or rate file, **"Combine to L3"** on a calibrated one (Image3 mosaics several exposures — a different promise from calibrating one file), and nothing on an L3 mosaic because there is no next level.

**The levels drive the run.** The dashboard hands off `startLevel`/`targetLevel`; the run page derives both the stages to enable and the products to browse from that pair. So "take a raw file to L3" turns on all three stages without the caller naming any of them — previously the hand-off could only ever request the stage-3 fast path.

**Instrument resolution** now tries MAST metadata, `imageInfo`, `sensorInfo`, the filename and tags, and opens the picker when it genuinely can't tell.

### What self-review caught

- **The new button dead-ended on any file without `imageInfo.instrument`** — uploads, engine-written outputs and MAST records without `obsMeta` all lack it, so the newly-visible action answered *"calibration supports imaging data only"* on files that are imaging. That converts "no button" into "button that lies".
- **`_crf` was unclassifiable** by the old local suffix list, so it fell through to "assume raw" — telling the stage timeline Detector1 could run on already-calibrated data, the failure #1736 exists to prevent.
- **`ngc_calibration_i2d.fits` matched `_cal`**, so a finished mosaic was listed and selectable as a calibration input.
- **A raw file was sent alone into Image3** — a single-frame drizzle, after paying ~8 min/file of Detector1 to get there.
- **Both level tests passed with the feature reverted** (the mock recipe enables every stage; the L2b case also passed `stage3Only`).

## Test Plan

- [x] Frontend suite: **1297 passed** (`npx vitest run`)
- [x] `tsc -b` clean; `eslint src` 0 errors, 82 warnings (repo baseline)
- [x] 24 tests on the level rules, including that the two suffix tables agree and that every level has a canonical suffix `blockedReason` understands
- [x] 10 tests on the hand-off itself (instrument fallbacks, sibling gathering by level), which had no coverage before
- [x] Level tests now use a recipe whose defaults **contradict** the expected result, so they fail on revert; added the L2a → `['image2','image3']` case that only the level derivation can produce

Manual:

1. Open the library. Cards now show **"Process to L3"** on raw/rate files and **"Combine to L3"** on calibrated ones. An `_i2d` mosaic shows no action.
2. Click **Process to L3** on a raw file → the run page opens with all three stages on and the observation's raw exposures selected.
3. Click **Combine to L3** on a calibrated file → only Image3 is on, with that observation's `_cal` set selected.
4. Confirm no "downloads from MAST" warning appears on either — those runs use your library files.
5. On a file with no instrument metadata, the action opens `/calibrate/new` with the files preselected rather than claiming the file isn't imaging.

Not covered: no live pipeline run was executed. The hand-off, stage derivation and input selection are asserted; what the JWST pipeline then does with them is unchanged by this PR.

## Documentation Checklist

- [x] `docs/architecture/calibration-pipeline-flow.md` — runs described as level transitions; the stage-3 note no longer calls the action "Reprocess"
- [ ] No API change — this is entirely frontend routing and presentation

## Tech Debt Impact

- [x] **Reduces** — removes a third copy of the product-suffix table (`KNOWN_SUFFIXES` in `CalibrateRun.tsx`) and routes both remaining callers through one rule
- [x] **Reduces** — `SUFFIXES_FOR_LEVEL` derived rather than hand-maintained, with a test that the tables agree
- [ ] Adds no new debt

## Risk & Rollback

**Risk: low-medium.** Frontend only; no API, schema or engine change. The medium part is reach: an action that appeared on 0.4% of files now appears on most of them, so a mistake in level classification is far more visible than before. That is why the classification is one tested table rather than several `includes` checks, and why the "which files go in" decision now has direct coverage.

Behaviour deliberately changed: the action's **label and visibility**, and the fact that a raw file now gathers its siblings. Existing hand-offs from RunDetail (`stage3Only`) still work — the level pair simply takes precedence when present.

**Rollback**: revert the two commits. No data written, no migration, nothing persisted by this PR.
