### PR TITLE
feat: offer raw data when a target has no finished image (#1760)

### DIFF
--- a/docs/mast-usage.md
+++ b/docs/mast-usage.md
@@ -12,7 +12,9 @@ JWST data products come in different calibration levels:
 | 2       | Calibrated individual exposures | `*_rate.fits`, `*_cal.fits`, `*_crf.fits` |
 | 3       | Combined/mosaic images          | `*_i2d.fits`, `*_s2d.fits`                |
 
-By default, searches return **Level 3 only** (combined/mosaic images) which are typically what users want for analysis. Toggle "Show all calibration levels" to include Level 1-3 products.
+By default, searches return **Level 3 only** (combined/mosaic images) which are typically what users want for analysis. Toggle **"Include raw & part-processed data"** to include Level 1-3 products.
+
+**Raw-data fallback** (#1760): when a Level 3 search comes back with little or nothing, the app says so and offers to search again including the raw exposures — because that is exactly when downloading raw data and running the pipeline yourself is the only way to get an image. The offer describes the search that actually ran, and does not appear when there are plenty of finished images (processing hours of data to reproduce a published mosaic is bad advice) or on an Observation-ID search, which always returns every level anyway.
 
 **Import filtering**: When importing, only files matching your selected calibration level are downloaded. If you searched with Level 3 only, only Level 3 files are imported.
 
@@ -24,7 +26,7 @@ By default, searches return **Level 3 only** (combined/mosaic images) which are 
    - **Coordinates**: Enter RA/Dec in degrees with search radius
    - **Observation ID**: Enter MAST observation ID (e.g., "jw02733-o001_t001_nircam_clear-f090w")
    - **Program ID**: Enter JWST program number (e.g., "2733")
-3. (Optional) Toggle "Show all calibration levels" to include Level 1-3 products
+3. (Optional) Toggle "Include raw & part-processed data" to include Level 1-3 products — these are the exposures you can process yourself with the calibration pipeline
 4. Click "Search MAST" to query the archive
 5. Review results in the table (shows target, instrument, filter, exposure time)
 6. Click "Import" on individual observations or select multiple and use "Import Selected"

--- a/frontend/jwst-frontend/src/components/mast/MastSearch.css
+++ b/frontend/jwst-frontend/src/components/mast/MastSearch.css
@@ -182,3 +182,30 @@
     flex: 1 1 50%;
   }
 }
+
+/* Raw-data fallback (#1760): shown only when Level 3 came back sparse, so it
+   reads as an answer to what you just searched rather than a standing advert. */
+.raw-fallback {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding: 0.9rem 1rem;
+  margin: 1rem 0;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.14));
+  border-left: 3px solid var(--accent, #6ea8fe);
+  border-radius: 8px;
+  background: var(--surface-1, rgba(110, 168, 254, 0.06));
+}
+
+.raw-fallback-headline {
+  font-weight: 600;
+  margin-bottom: 0.2rem;
+}
+
+.raw-fallback-detail {
+  color: var(--text-secondary, #9aa4b2);
+  font-size: 0.9rem;
+  max-width: 70ch;
+}

--- a/frontend/jwst-frontend/src/components/mast/MastSearch.test.tsx
+++ b/frontend/jwst-frontend/src/components/mast/MastSearch.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MastSearch from './MastSearch';
+import { mastService } from '../../services';
 
 interface ResumableJob {
   jobId: string;
@@ -110,5 +111,72 @@ describe('MastSearch', () => {
     renderMastSearch();
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(screen.queryByText(/Incomplete Downloads/)).not.toBeInTheDocument();
+  });
+
+  describe('raw-data fallback (#1760)', () => {
+    beforeEach(() => {
+      vi.mocked(mastService.searchByTarget).mockResolvedValue({ results: [] } as never);
+      vi.mocked(mastService.searchByObservation).mockResolvedValue({ results: [] } as never);
+    });
+
+    const searchTarget = async (name = 'M16') => {
+      renderMastSearch();
+      fireEvent.change(screen.getByPlaceholderText(/Target name/i), {
+        target: { value: name },
+      });
+      fireEvent.click(screen.getByText('Search MAST'));
+    };
+
+    it('says nothing before a search has run', () => {
+      renderMastSearch();
+      expect(screen.queryByText(/No finished images/)).not.toBeInTheDocument();
+    });
+
+    it('offers raw data when a Level 3 search comes back empty', async () => {
+      await searchTarget();
+      expect(await screen.findByText('No finished images for this target')).toBeInTheDocument();
+    });
+
+    it('re-runs the search including every level when the offer is taken', async () => {
+      await searchTarget();
+      fireEvent.click(await screen.findByRole('button', { name: /Search including raw data/ }));
+      await waitFor(() =>
+        expect(vi.mocked(mastService.searchByTarget).mock.lastCall?.[0]).toMatchObject({
+          calibLevel: [1, 2, 3],
+        })
+      );
+      // ...and the offer goes away, because the results ARE the raw data now.
+      await waitFor(() =>
+        expect(screen.queryByText('No finished images for this target')).not.toBeInTheDocument()
+      );
+    });
+
+    it('stays quiet on an observation-ID search, which always returns every level', async () => {
+      renderMastSearch();
+      fireEvent.click(screen.getByLabelText(/Observation ID/i));
+      fireEvent.change(screen.getByPlaceholderText(/Observation ID/i), {
+        target: { value: 'jw02733-o001' },
+      });
+      fireEvent.click(screen.getByText('Search MAST'));
+      await waitFor(() => expect(mastService.searchByObservation).toHaveBeenCalled());
+      // Offering raw data here would re-run the identical query.
+      expect(screen.queryByText(/No finished images/)).not.toBeInTheDocument();
+    });
+
+    it('says nothing when the search fails — an error is not evidence', async () => {
+      vi.mocked(mastService.searchByTarget).mockRejectedValue(new Error('boom'));
+      await searchTarget();
+      await waitFor(() => expect(mastService.searchByTarget).toHaveBeenCalled());
+      expect(screen.queryByText(/No finished images/)).not.toBeInTheDocument();
+    });
+
+    it('says nothing when the search was abandoned on a blank input', async () => {
+      renderMastSearch();
+      fireEvent.click(screen.getByText('Search MAST'));
+      await waitFor(() =>
+        expect(screen.getByText(/Please enter a target name/)).toBeInTheDocument()
+      );
+      expect(screen.queryByText(/No finished images/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
@@ -14,6 +14,7 @@ import { useJobProgress, subscribeToJobProgress } from '../../hooks/useJobProgre
 import { useAuth } from '../../context/useAuth';
 import { useActiveImportsContext } from '../../context/useActiveImportsContext';
 import SearchForm from './SearchForm';
+import { rawFallbackOffer } from './rawFallback';
 import ResultsTable from './ResultsTable';
 import ImportProgress from './ImportProgress';
 import './MastSearch.css';
@@ -58,6 +59,10 @@ const MastSearch: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchResults, setSearchResults] = useState<MastObservationResult[]>([]);
+  // What the LAST search asked for, not what the toggle currently says — the
+  // offer must describe the results on screen, not a setting since changed.
+  const [lastSearchLevel3Only, setLastSearchLevel3Only] = useState(true);
+  const [hasSearched, setHasSearched] = useState(false);
   const [availability, setAvailability] = useState<Record<string, DataAvailabilityItem>>({});
   const [selectedObs, setSelectedObs] = useState<Set<string>>(() => new Set());
   const [importing, setImporting] = useState<string | null>(null);
@@ -82,6 +87,11 @@ const MastSearch: React.FC = () => {
 
   // Calculate paginated results
   const totalPages = Math.ceil(searchResults.length / itemsPerPage);
+  const rawOffer = rawFallbackOffer({
+    level3Only: lastSearchLevel3Only,
+    resultCount: searchResults.length,
+    hasSearched,
+  });
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   const paginatedResults = searchResults.slice(startIndex, endIndex);
@@ -176,7 +186,9 @@ const MastSearch: React.FC = () => {
     }
   };
 
-  const handleSearch = async () => {
+  /** `forceAllLevels` lets the raw-data offer re-run immediately: the toggle's
+   *  state update is not visible inside this call. */
+  const handleSearch = async (forceAllLevels = false) => {
     setLoading(true);
     setError(null);
     setSearchResults([]);
@@ -192,7 +204,8 @@ const MastSearch: React.FC = () => {
 
       // Determine calibration levels: show all (1,2,3) or just Level 3 (combined/mosaic)
       // Observation ID searches always show all levels (calibLevel undefined)
-      const calibLevel = showAllCalibLevels ? [1, 2, 3] : [3];
+      const includeRaw = forceAllLevels || showAllCalibLevels;
+      const calibLevel = includeRaw ? [1, 2, 3] : [3];
 
       switch (searchType) {
         case 'target':
@@ -247,7 +260,11 @@ const MastSearch: React.FC = () => {
 
       if (data) {
         setSearchResults(data.results);
-        if (data.results.length === 0) {
+        setLastSearchLevel3Only(!includeRaw);
+        setHasSearched(true);
+        if (data.results.length === 0 && includeRaw) {
+          // With raw levels included there genuinely is nothing. Restricted to
+          // Level 3, the fallback offer below explains it better than an error.
           setError('No JWST observations found matching your search criteria');
         }
       }
@@ -703,6 +720,26 @@ const MastSearch: React.FC = () => {
       />
 
       {error && <div className="error-message">{error}</div>}
+
+      {rawOffer && (
+        <div className="raw-fallback" role="status">
+          <div>
+            <p className="raw-fallback-headline">{rawOffer.headline}</p>
+            <p className="raw-fallback-detail">{rawOffer.detail}</p>
+          </div>
+          <button
+            type="button"
+            className="btn-base btn-compact"
+            onClick={() => {
+              setShowAllCalibLevels(true);
+              void handleSearch(true);
+            }}
+            disabled={loading}
+          >
+            Search including raw data
+          </button>
+        </div>
+      )}
 
       {/* Resumable (Incomplete) Downloads Section — authenticated only */}
       {isAuthenticated && resumableJobs.length > 0 && (

--- a/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
@@ -14,7 +14,7 @@ import { useJobProgress, subscribeToJobProgress } from '../../hooks/useJobProgre
 import { useAuth } from '../../context/useAuth';
 import { useActiveImportsContext } from '../../context/useActiveImportsContext';
 import SearchForm from './SearchForm';
-import { rawFallbackOffer } from './rawFallback';
+import { rawFallbackOffer, type CompletedSearch } from './rawFallback';
 import ResultsTable from './ResultsTable';
 import ImportProgress from './ImportProgress';
 import './MastSearch.css';
@@ -59,10 +59,11 @@ const MastSearch: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchResults, setSearchResults] = useState<MastObservationResult[]>([]);
-  // What the LAST search asked for, not what the toggle currently says — the
-  // offer must describe the results on screen, not a setting since changed.
-  const [lastSearchLevel3Only, setLastSearchLevel3Only] = useState(true);
-  const [hasSearched, setHasSearched] = useState(false);
+  // A snapshot of the last COMPLETED search. One value, committed only on
+  // success and cleared whenever the results stop being current, so the offer
+  // can never describe a search that is still running, was abandoned on a
+  // validation error, or failed.
+  const [lastSearch, setLastSearch] = useState<CompletedSearch | null>(null);
   const [availability, setAvailability] = useState<Record<string, DataAvailabilityItem>>({});
   const [selectedObs, setSelectedObs] = useState<Set<string>>(() => new Set());
   const [importing, setImporting] = useState<string | null>(null);
@@ -87,11 +88,18 @@ const MastSearch: React.FC = () => {
 
   // Calculate paginated results
   const totalPages = Math.ceil(searchResults.length / itemsPerPage);
-  const rawOffer = rawFallbackOffer({
-    level3Only: lastSearchLevel3Only,
-    resultCount: searchResults.length,
-    hasSearched,
-  });
+  const rawOffer = rawFallbackOffer(lastSearch);
+
+  /** Changing mode invalidates the results on screen — and therefore the
+   *  offer, whose button would otherwise run a different kind of search than
+   *  the sentence above it describes. */
+  const changeSearchType = (type: MastSearchType) => {
+    setSearchType(type);
+    setSearchResults([]);
+    setLastSearch(null);
+    setError(null);
+    setCurrentPage(1);
+  };
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   const paginatedResults = searchResults.slice(startIndex, endIndex);
@@ -192,6 +200,9 @@ const MastSearch: React.FC = () => {
     setLoading(true);
     setError(null);
     setSearchResults([]);
+    // The previous search's results are no longer on screen, so nothing may
+    // claim anything about them until this one completes.
+    setLastSearch(null);
     setSelectedObs(new Set());
     setCurrentPage(1); // Reset to first page on new search
 
@@ -260,9 +271,12 @@ const MastSearch: React.FC = () => {
 
       if (data) {
         setSearchResults(data.results);
-        setLastSearchLevel3Only(!includeRaw);
-        setHasSearched(true);
-        if (data.results.length === 0 && includeRaw) {
+        // Observation-ID searches always return every level regardless of the
+        // toggle, so restricting-to-L3 is false there — offering raw data on
+        // results that ARE raw data would re-run the identical query.
+        const level3Only = searchType !== 'observation' && !includeRaw;
+        setLastSearch({ level3Only, resultCount: data.results.length, subject: searchType });
+        if (data.results.length === 0 && !level3Only) {
           // With raw levels included there genuinely is nothing. Restricted to
           // Level 3, the fallback offer below explains it better than an error.
           setError('No JWST observations found matching your search criteria');
@@ -698,7 +712,7 @@ const MastSearch: React.FC = () => {
 
       <SearchForm
         searchType={searchType}
-        onSearchTypeChange={setSearchType}
+        onSearchTypeChange={changeSearchType}
         targetName={targetName}
         onTargetNameChange={setTargetName}
         ra={ra}
@@ -721,25 +735,31 @@ const MastSearch: React.FC = () => {
 
       {error && <div className="error-message">{error}</div>}
 
-      {rawOffer && (
-        <div className="raw-fallback" role="status">
-          <div>
-            <p className="raw-fallback-headline">{rawOffer.headline}</p>
-            <p className="raw-fallback-detail">{rawOffer.detail}</p>
+      {/* The live region is always mounted and only its contents change:
+          several screen readers announce nothing when the region itself is
+          inserted, and on the empty-L3 path this is the only signal that the
+          search succeeded but found almost nothing. */}
+      <div role="status" aria-live="polite">
+        {rawOffer && (
+          <div className="raw-fallback">
+            <div>
+              <h3 className="raw-fallback-headline">{rawOffer.headline}</h3>
+              <p className="raw-fallback-detail">{rawOffer.detail}</p>
+            </div>
+            <button
+              type="button"
+              className="btn-base btn-compact"
+              onClick={() => {
+                setShowAllCalibLevels(true);
+                void handleSearch(true);
+              }}
+              disabled={loading}
+            >
+              Search including raw data
+            </button>
           </div>
-          <button
-            type="button"
-            className="btn-base btn-compact"
-            onClick={() => {
-              setShowAllCalibLevels(true);
-              void handleSearch(true);
-            }}
-            disabled={loading}
-          >
-            Search including raw data
-          </button>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* Resumable (Incomplete) Downloads Section — authenticated only */}
       {isAuthenticated && resumableJobs.length > 0 && (

--- a/frontend/jwst-frontend/src/components/mast/SearchForm.test.tsx
+++ b/frontend/jwst-frontend/src/components/mast/SearchForm.test.tsx
@@ -53,12 +53,19 @@ describe('SearchForm', () => {
 
   it('hides the calibration-level toggle for observation ID searches', () => {
     render(<SearchForm {...baseProps} searchType="observation" />);
-    expect(screen.queryByText('Show all calibration levels')).not.toBeInTheDocument();
+    expect(screen.queryByText('Include raw & part-processed data')).not.toBeInTheDocument();
   });
 
-  it('shows the calibration-level toggle for non-observation searches', () => {
+  it('shows the raw-data toggle for non-observation searches', () => {
     render(<SearchForm {...baseProps} />);
-    expect(screen.getByText('Show all calibration levels')).toBeInTheDocument();
+    // Named for what it is FOR, not for the mechanism (#1760).
+    expect(screen.getByText('Include raw & part-processed data')).toBeInTheDocument();
+    expect(screen.getByText(/images already combined for you/)).toBeInTheDocument();
+  });
+
+  it('says what including raw data gets you once it is on', () => {
+    render(<SearchForm {...baseProps} showAllCalibLevels />);
+    expect(screen.getByText(/exposures you can process yourself/)).toBeInTheDocument();
   });
 
   it('calls onSearch when the search button is clicked', () => {
@@ -66,6 +73,9 @@ describe('SearchForm', () => {
     render(<SearchForm {...baseProps} onSearch={onSearch} />);
     fireEvent.click(screen.getByText('Search MAST'));
     expect(onSearch).toHaveBeenCalledTimes(1);
+    // With no arguments: the caller's first parameter forces raw levels on, so
+    // passing the handler directly would make the click event turn it on.
+    expect(onSearch).toHaveBeenCalledWith();
   });
 
   it('calls onSearch when Enter is pressed in the target-name input', () => {

--- a/frontend/jwst-frontend/src/components/mast/SearchForm.test.tsx
+++ b/frontend/jwst-frontend/src/components/mast/SearchForm.test.tsx
@@ -53,7 +53,8 @@ describe('SearchForm', () => {
 
   it('hides the calibration-level toggle for observation ID searches', () => {
     render(<SearchForm {...baseProps} searchType="observation" />);
-    expect(screen.queryByText('Include raw & part-processed data')).not.toBeInTheDocument();
+    // By role, so this cannot pass merely because the label was reworded.
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 
   it('shows the raw-data toggle for non-observation searches', () => {

--- a/frontend/jwst-frontend/src/components/mast/SearchForm.tsx
+++ b/frontend/jwst-frontend/src/components/mast/SearchForm.tsx
@@ -23,7 +23,8 @@ interface SearchFormProps {
   downloadSource: DownloadSource;
   onDownloadSourceChange: (value: DownloadSource) => void;
   loading: boolean;
-  onSearch: () => void;
+  /** Optional flag forces raw levels on; see the wrapped onClick below. */
+  onSearch: (forceAllLevels?: boolean) => void;
 }
 
 /**

--- a/frontend/jwst-frontend/src/components/mast/SearchForm.tsx
+++ b/frontend/jwst-frontend/src/components/mast/SearchForm.tsx
@@ -110,11 +110,14 @@ const SearchForm: React.FC<SearchFormProps> = ({
               checked={showAllCalibLevels}
               onChange={(e) => onShowAllCalibLevelsChange(e.target.checked)}
             />
-            <span className="toggle-label">Show all calibration levels</span>
+            <span className="toggle-label">Include raw &amp; part-processed data</span>
+            {/* Says what it is FOR. "Show all calibration levels" described the
+                mechanism and left the reason unstated, so nobody turned it on
+                and there was never anything to calibrate (#1760). */}
             <span className="toggle-hint">
               {showAllCalibLevels
-                ? '(Levels 1-3: includes individual exposures)'
-                : '(Level 3 only: combined/mosaic images)'}
+                ? '(Levels 1–3: the exposures you can process yourself)'
+                : '(Level 3 only: images already combined for you)'}
             </span>
           </label>
         )}
@@ -211,7 +214,10 @@ const SearchForm: React.FC<SearchFormProps> = ({
         )}
 
         <button
-          onClick={onSearch}
+          // Wrapped, not passed directly: React would hand the click event to
+          // onSearch's first parameter, which is a boolean the caller uses to
+          // force raw levels on — every manual search would include them.
+          onClick={() => onSearch()}
           disabled={loading}
           className={`btn-base btn-large search-button ${loading ? 'searching' : ''}`}
         >

--- a/frontend/jwst-frontend/src/components/mast/rawFallback.test.ts
+++ b/frontend/jwst-frontend/src/components/mast/rawFallback.test.ts
@@ -4,42 +4,52 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { SPARSE_L3_THRESHOLD, rawFallbackOffer } from './rawFallback';
+import { SPARSE_L3_MAX_RESULTS, rawFallbackOffer, type CompletedSearch } from './rawFallback';
 
-const ctx = (over: Partial<Parameters<typeof rawFallbackOffer>[0]> = {}) => ({
+const search = (over: Partial<CompletedSearch> = {}): CompletedSearch => ({
   level3Only: true,
   resultCount: 0,
-  hasSearched: true,
+  subject: 'target',
   ...over,
 });
 
 describe('rawFallbackOffer', () => {
   it('offers raw data when a target has no finished image', () => {
-    const offer = rawFallbackOffer(ctx({ resultCount: 0 }));
-    expect(offer?.headline).toMatch(/No finished images/);
+    const offer = rawFallbackOffer(search({ resultCount: 0 }));
+    expect(offer?.headline).toBe('No finished images for this target');
     // Says what you would DO with it — the missing "why" is the whole bug.
     expect(offer?.detail).toMatch(/run the official JWST pipeline/i);
   });
 
   it('offers raw data when there is barely anything published', () => {
-    expect(rawFallbackOffer(ctx({ resultCount: 1 }))?.headline).toMatch(/Only one/);
-    expect(rawFallbackOffer(ctx({ resultCount: 2 }))?.headline).toMatch(/Only 2/);
+    expect(rawFallbackOffer(search({ resultCount: 1 }))?.headline).toMatch(/^Only one/);
+    expect(rawFallbackOffer(search({ resultCount: 2 }))?.headline).toMatch(/^Only 2/);
+  });
+
+  it('names what was actually searched', () => {
+    // "for this target" is wrong for a program or a coordinate cone, and a
+    // program's L3 count says nothing about how many raw exposures exist.
+    expect(rawFallbackOffer(search({ subject: 'program' }))?.headline).toMatch(/in this program$/);
+    expect(rawFallbackOffer(search({ subject: 'coordinates' }))?.headline).toMatch(
+      /at these coordinates$/
+    );
   });
 
   it('stays quiet when there are plenty of finished images', () => {
     // Level 3 is the default because people want the best version already
     // made; pointing at hours of processing here would be bad advice.
-    expect(rawFallbackOffer(ctx({ resultCount: SPARSE_L3_THRESHOLD + 1 }))).toBeNull();
-    expect(rawFallbackOffer(ctx({ resultCount: 50 }))).toBeNull();
+    expect(rawFallbackOffer(search({ resultCount: SPARSE_L3_MAX_RESULTS + 1 }))).toBeNull();
+    expect(rawFallbackOffer(search({ resultCount: 50 }))).toBeNull();
   });
 
-  it('stays quiet when raw levels are already included', () => {
-    // The results ARE the raw data — offering it again is noise.
-    expect(rawFallbackOffer(ctx({ level3Only: false, resultCount: 0 }))).toBeNull();
+  it('stays quiet when the results already include raw data', () => {
+    // Offering it again would re-run the identical query — a visible dead end.
+    expect(rawFallbackOffer(search({ level3Only: false }))).toBeNull();
   });
 
-  it('stays quiet before the first search', () => {
-    // An empty page is not evidence that a target lacks finished images.
-    expect(rawFallbackOffer(ctx({ hasSearched: false }))).toBeNull();
+  it('stays quiet with no completed search', () => {
+    // In flight, abandoned on a validation error, or failed: none of those are
+    // evidence about what the archive holds, and the offer states a fact.
+    expect(rawFallbackOffer(null)).toBeNull();
   });
 });

--- a/frontend/jwst-frontend/src/components/mast/rawFallback.test.ts
+++ b/frontend/jwst-frontend/src/components/mast/rawFallback.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Offering raw data as a fallback (#1760) — the decision that closes the loop
+ * between Discover and the calibration pipeline.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SPARSE_L3_THRESHOLD, rawFallbackOffer } from './rawFallback';
+
+const ctx = (over: Partial<Parameters<typeof rawFallbackOffer>[0]> = {}) => ({
+  level3Only: true,
+  resultCount: 0,
+  hasSearched: true,
+  ...over,
+});
+
+describe('rawFallbackOffer', () => {
+  it('offers raw data when a target has no finished image', () => {
+    const offer = rawFallbackOffer(ctx({ resultCount: 0 }));
+    expect(offer?.headline).toMatch(/No finished images/);
+    // Says what you would DO with it — the missing "why" is the whole bug.
+    expect(offer?.detail).toMatch(/run the official JWST pipeline/i);
+  });
+
+  it('offers raw data when there is barely anything published', () => {
+    expect(rawFallbackOffer(ctx({ resultCount: 1 }))?.headline).toMatch(/Only one/);
+    expect(rawFallbackOffer(ctx({ resultCount: 2 }))?.headline).toMatch(/Only 2/);
+  });
+
+  it('stays quiet when there are plenty of finished images', () => {
+    // Level 3 is the default because people want the best version already
+    // made; pointing at hours of processing here would be bad advice.
+    expect(rawFallbackOffer(ctx({ resultCount: SPARSE_L3_THRESHOLD + 1 }))).toBeNull();
+    expect(rawFallbackOffer(ctx({ resultCount: 50 }))).toBeNull();
+  });
+
+  it('stays quiet when raw levels are already included', () => {
+    // The results ARE the raw data — offering it again is noise.
+    expect(rawFallbackOffer(ctx({ level3Only: false, resultCount: 0 }))).toBeNull();
+  });
+
+  it('stays quiet before the first search', () => {
+    // An empty page is not evidence that a target lacks finished images.
+    expect(rawFallbackOffer(ctx({ hasSearched: false }))).toBeNull();
+  });
+});

--- a/frontend/jwst-frontend/src/components/mast/rawFallback.ts
+++ b/frontend/jwst-frontend/src/components/mast/rawFallback.ts
@@ -13,16 +13,29 @@
  * A pure decision so it can be tested without driving a MAST search.
  */
 
-/** At or below this many finished images, raw data is worth offering. */
-export const SPARSE_L3_THRESHOLD = 3;
+/** At or below this many returned rows, raw data is worth offering. */
+export const SPARSE_L3_MAX_RESULTS = 3;
 
-export interface RawFallbackContext {
-  /** Whether the search that just ran was restricted to Level 3. */
+/** What a search was for, so the offer can name it correctly. */
+export type SearchSubject = 'target' | 'coordinates' | 'program' | 'observation';
+
+const SUBJECT_PHRASE: Record<SearchSubject, string> = {
+  target: 'for this target',
+  coordinates: 'at these coordinates',
+  program: 'in this program',
+  observation: 'for this observation',
+};
+
+/**
+ * A COMPLETED search. Null elsewhere — a search that is still running, was
+ * abandoned on a validation error, or failed outright is not evidence about
+ * what the archive holds, and the offer states a fact about the archive.
+ */
+export interface CompletedSearch {
+  /** Whether the results on screen are restricted to Level 3. */
   level3Only: boolean;
-  /** How many results came back. */
   resultCount: number;
-  /** Whether a search has actually run — no offer before the first one. */
-  hasSearched: boolean;
+  subject: SearchSubject;
 }
 
 export interface RawFallbackOffer {
@@ -37,14 +50,16 @@ export interface RawFallbackOffer {
  * results ARE the raw data), or when there is a healthy set of finished images
  * — in which case pointing at hours of processing would be bad advice.
  */
-export function rawFallbackOffer(context: RawFallbackContext): RawFallbackOffer | null {
-  const { level3Only, resultCount, hasSearched } = context;
-  if (!hasSearched || !level3Only) return null;
-  if (resultCount > SPARSE_L3_THRESHOLD) return null;
+export function rawFallbackOffer(search: CompletedSearch | null): RawFallbackOffer | null {
+  if (!search) return null;
+  const { level3Only, resultCount, subject } = search;
+  if (!level3Only) return null;
+  if (resultCount > SPARSE_L3_MAX_RESULTS) return null;
 
+  const where = SUBJECT_PHRASE[subject];
   if (resultCount === 0) {
     return {
-      headline: 'No finished images for this target',
+      headline: `No finished images ${where}`,
       detail:
         'Nobody has published a combined image here yet — but the raw exposures are almost certainly in the archive. You can download those and run the official JWST pipeline on them yourself to make one.',
     };
@@ -52,8 +67,8 @@ export function rawFallbackOffer(context: RawFallbackContext): RawFallbackOffer 
   return {
     headline:
       resultCount === 1
-        ? 'Only one finished image for this target'
-        : `Only ${resultCount} finished images for this target`,
+        ? `Only one finished image ${where}`
+        : `Only ${resultCount} finished images ${where}`,
     detail:
       'There may be more raw exposures than have been combined. Downloading those lets you build your own image — often deeper, or framed differently, than what is published.',
   };

--- a/frontend/jwst-frontend/src/components/mast/rawFallback.ts
+++ b/frontend/jwst-frontend/src/components/mast/rawFallback.ts
@@ -1,0 +1,60 @@
+/**
+ * When to offer raw data as a fallback (#1760).
+ *
+ * Level 3 stays the default: people want the best version already made. But a
+ * target with little or no L3 has no good answer under that default, and the
+ * app used to say nothing — you got an empty result and no hint that the raw
+ * exposures exist and can be processed yourself.
+ *
+ * That silence is why libraries end up 91% L3 with nothing the calibration
+ * pipeline can work on: not because raw data was unwanted, but because there
+ * was no reason given to want it.
+ *
+ * A pure decision so it can be tested without driving a MAST search.
+ */
+
+/** At or below this many finished images, raw data is worth offering. */
+export const SPARSE_L3_THRESHOLD = 3;
+
+export interface RawFallbackContext {
+  /** Whether the search that just ran was restricted to Level 3. */
+  level3Only: boolean;
+  /** How many results came back. */
+  resultCount: number;
+  /** Whether a search has actually run — no offer before the first one. */
+  hasSearched: boolean;
+}
+
+export interface RawFallbackOffer {
+  headline: string;
+  detail: string;
+}
+
+/**
+ * The offer to show, or null.
+ *
+ * Null when a search hasn't run, when raw levels were already included (the
+ * results ARE the raw data), or when there is a healthy set of finished images
+ * — in which case pointing at hours of processing would be bad advice.
+ */
+export function rawFallbackOffer(context: RawFallbackContext): RawFallbackOffer | null {
+  const { level3Only, resultCount, hasSearched } = context;
+  if (!hasSearched || !level3Only) return null;
+  if (resultCount > SPARSE_L3_THRESHOLD) return null;
+
+  if (resultCount === 0) {
+    return {
+      headline: 'No finished images for this target',
+      detail:
+        'Nobody has published a combined image here yet — but the raw exposures are almost certainly in the archive. You can download those and run the official JWST pipeline on them yourself to make one.',
+    };
+  }
+  return {
+    headline:
+      resultCount === 1
+        ? 'Only one finished image for this target'
+        : `Only ${resultCount} finished images for this target`,
+    detail:
+      'There may be more raw exposures than have been combined. Downloading those lets you build your own image — often deeper, or framed differently, than what is published.',
+  };
+}


### PR DESCRIPTION
## Summary

PR 4 of 4, and the one that closes the loop.

Discover defaults to **Level 3**, which is right — people want the best version already made. But the toggle for raw data read *"Show all calibration levels — (Levels 1-3: includes individual exposures)"*. That describes a mechanism and never says why you'd want it.

So nobody turns it on. So libraries fill with Level 3 only. So the calibration pipeline has nothing to work on and looks pointless. On this library that's **91% L3, with 18 usable files out of 1,523** — not because raw data was unwanted, but because there was never a reason given to want it.

Closes #1760

## Changes Made

**The toggle says what it's for**: *"Include raw & part-processed data — the exposures you can process yourself."*

**A fallback offer.** When a Level 3 search comes back with little or nothing, the app says so and offers the raw exposures *with the reason*: nobody has published a combined image here, but the raw data is in the archive and you can make one.

Deliberate calls:

- **L3 stays the default.** The offer only appears when Level 3 came back sparse (≤3 results). Recommending hours of processing over an existing published mosaic would be bad advice.
- **The offer describes the search that actually ran**, not the toggle's current state.
- **Nothing on an Observation-ID search** — those always return every level regardless of the toggle, so the results already *are* raw data.

## Test Plan

- [x] Frontend suite: **1310 passed**
- [x] `tsc -b` clean; `eslint src` 0 errors (82 warnings, repo baseline)
- [x] 6 unit tests on the decision; **6 integration tests** through `MastSearch` — the offer appears after a sparse L3 search, taking it re-runs with `calibLevel: [1,2,3]` and the offer clears, and it stays silent before any search, on an obs-ID search, after a failure, and after a blank-input bail-out

Manual:

1. Search a target with no published mosaic → *"No finished images for this target"* with the explanation and a **Search including raw data** button.
2. Click it → results now include Level 1–2 exposures, and the offer disappears.
3. Search a well-covered target (say Stephan's Quintet) → no offer.
4. Switch search type mid-flow → the stale offer clears rather than sitting above a button that would run a different search.

Not covered: no live MAST query was run; `mastService` is mocked in tests.

### What self-review caught

Four states where the offer asserted something untrue:

- **Observation-ID searches** — results already include every level, so taking the offer re-ran the identical query: a visible dead end.
- **In-flight, bailed-out, and failed searches** — "No finished images for this target" rendered under the spinner on every subsequent search, and sat directly beneath *"Search timed out"*, contradicting it.
- **"for this target" on program and coordinate searches** — where there is no target, and where an L3 count says least about how many raw exposures exist.
- **Switching search type** left a sentence about "this target" above a button that would run a program search.

Plus a bug the change itself introduced: the search button passed its handler directly to `onClick`, so React handed the **click event** to the new `forceAllLevels` parameter — every manual search would have silently included raw data. Wrapped, and pinned by a test asserting `onSearch` is called with no arguments.

## Documentation Checklist

- [x] `docs/mast-usage.md` — renamed toggle in both places, plus a paragraph on the fallback offer and when it appears
- [ ] No API change — `calibLevel` was already a supported search parameter

## Tech Debt Impact

- [x] **Reduces** — three loosely-coupled pieces of state replaced by one snapshot of the last completed search
- [ ] Adds no new debt

## Risk & Rollback

**Risk: low.** Frontend only. No API, schema or engine change; the search parameters were already supported. The default stays Level 3, so an existing search behaves exactly as before — the only new behaviour is an additional panel after a sparse result, and copy on an existing toggle.

Accessibility note for review: the live region is always mounted and only its contents change, because several screen readers announce nothing when the region itself is inserted — and on the empty-L3 path this panel is the *only* signal that the search succeeded but found almost nothing (the error message is deliberately suppressed there).

**Rollback**: revert the two commits. Nothing persisted.
