### PR TITLE
fix: broken doc link breaking the docs deploy on main

### DIFF
--- a/docs/plans/features/650-production-environment-configuration.md
+++ b/docs/plans/features/650-production-environment-configuration.md
@@ -138,7 +138,7 @@ Add a new top-level "## Production Deployment" section after the existing "Stagi
 - **Restore procedure** — `restore-mongo.sh` usage; warning about active-connections check; example: stop backend → restore → start backend
 - **Operations** — log locations, common ops (rebuild after code update, log tail, manual cert renew)
 
-Add cross-link at top: "For architecture diagrams and design rationale (single-node MongoDB, EBS sizing), see [`architecture/deployment-architecture.md`](architecture/deployment-architecture.md)."
+Add cross-link at top: "For architecture diagrams and design rationale (single-node MongoDB, EBS sizing), see [`architecture/deployment-architecture.md`](../../architecture/deployment-architecture.md)."
 
 Remove (or move to "Decision Log") the now-obsolete bullets in "Future Improvements": Custom domain + SSL, Backups (these are the work this PR is doing).
 


### PR DESCRIPTION
## Summary

`Deploy Docs` is failing on main. `mkdocs build --strict` aborts on a broken link:

    WARNING - Doc file 'plans/features/650-production-environment-configuration.md' contains a link
              'architecture/deployment-architecture.md', but the target
              'plans/features/architecture/deployment-architecture.md' is not found
    Aborted with 1 warnings in strict mode!

The link is relative to the doc's own directory, so it resolved inside `plans/features/` instead of the docs root.

Pre-existing (from #1412) — found while verifying an unrelated merge, fixed rather than left.

No linked issue

## Changes Made

- One link: `architecture/deployment-architecture.md` -> `../../architecture/deployment-architecture.md`

## Test Plan

- [x] Path arithmetic checked: the doc lives at `docs/plans/features/`, so `../../architecture/` resolves to `docs/architecture/deployment-architecture.md`, which exists
- [ ] `mkdocs build --strict` in CI is the real verification — mkdocs is not installed locally and the docs container's bundled config is a stale mount, so I could not run it myself

## Documentation Checklist

- [x] This IS the documentation fix

## Tech Debt Impact

- [x] Reduces — unblocks the docs deploy

## Risk & Rollback

**Risk: minimal.** One relative path in a plan document. No code, no build config.

**Rollback**: revert the commit.
