### PR TITLE
fix: reach the processing engine from the browser, including over LAN

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -43,8 +43,13 @@ ASPNETCORE_ENVIRONMENT=Development
 JWT_SECRET_KEY=CHANGE_THIS_IN_PRODUCTION_MIN_32_CHARS_SECURE_KEY_HERE
 
 # CORS allowed origins (comma-separated)
+# Shared by the .NET backend AND the processing engine — narrowing this list
+# narrows both. To reach the app from a phone/another machine, append that
+# origin and keep the four defaults so local development keeps working.
 # For local development: localhost + 127.0.0.1 (browsers treat these as different origins)
 # For production: https://your-frontend-domain.com
+# Must NOT be "*": the engine allows credentialed requests, so a wildcard would
+# echo back any origin. It rejects "*" at startup and refuses to boot.
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173
 
 # Seed user credentials (only used when Seeding:Enabled=true AND environment=Development)
@@ -61,6 +66,18 @@ SEED_DEMO_PASSWORD=Changeme_Demo1!
 # For local development: http://localhost:5001
 # For production: https://your-api-domain.com
 VITE_API_URL=http://localhost:5001
+
+# How the browser reaches the Python processing engine (calibration + jobs).
+# Leave EMPTY (the default) to call the engine on the page's own origin and let
+# the Vite dev server proxy the request — this is what makes the app work both
+# at http://localhost:3000 and at http://<your-lan-ip>:3000 from a phone.
+# Set an absolute URL only to bypass the proxy; then the engine's
+# CORS_ALLOWED_ORIGINS must list the origin the browser is on.
+VITE_ENGINE_URL=
+# Where the Vite dev server forwards those proxied requests. Inside Docker this
+# is the compose service name; use http://localhost:8000 when running
+# `npm run dev` on the host against a published engine port.
+ENGINE_PROXY_TARGET=http://processing-engine:8000
 
 # =============================================================================
 # Processing Engine Configuration

--- a/docker/docker-compose.agent.yml
+++ b/docker/docker-compose.agent.yml
@@ -81,6 +81,10 @@ services:
       - "127.0.0.1:${FRONTEND_PORT:?FRONTEND_PORT required}:3000"
     environment:
       - VITE_API_URL=http://localhost:${BACKEND_PORT}
+      # Same-origin engine calls via the Vite proxy — agent stacks never
+      # publish the engine port, so an absolute URL would be unreachable.
+      - VITE_ENGINE_URL=
+      - ENGINE_PROXY_TARGET=http://processing-engine:8000
     volumes:
       - ${SOURCE_ROOT}/frontend/jwst-frontend:/app
       - frontend_node_modules:/app/node_modules

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -18,9 +18,11 @@ services:
 
   processing-engine:
     image: docker-mock-processing-engine
-    # The calibration UI calls the engine directly from the browser
-    # (VITE_ENGINE_URL defaults to localhost:8000); the base compose does not
-    # publish this port — only the dev override does — so E2E must.
+    # Needed only for the host-Vite E2E path: playwright.config.ts can start
+    # its own dev server, where VITE_ENGINE_URL is unset so the bundle calls
+    # http://localhost:8000 directly. The dockerised frontend instead reaches
+    # this mock same-origin through the Vite proxy, and the base compose does
+    # not publish the port — only the dev override does — so E2E must.
     ports:
       - "127.0.0.1:8000:8000"
     build:

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -9,7 +9,7 @@ services:
   backend:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173}
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173}
       - Seeding__Users__0__Password=${SEED_ADMIN_PASSWORD:?Set SEED_ADMIN_PASSWORD in .env}
       - Seeding__Users__1__Password=${SEED_DEMO_PASSWORD:?Set SEED_DEMO_PASSWORD in .env}
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-CHANGE_THIS_IN_PRODUCTION_MIN_32_CHARS_SECURE_KEY_HERE}
       # Frontend origins allowed to call the engine directly (/api/jobs,
       # /api/calibration) — same list the .NET backend uses.
-      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173}
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173}
       # Calibration Recipes (#1709): runtime gate for pipeline runs; CRDS
       # reference-file cache (grows to GBs, lives on the data volume — never
       # delete it casually) and the STScI CRDS server for lazy downloads.
@@ -156,6 +156,13 @@ services:
       - "127.0.0.1:3000:3000"
     environment:
       - VITE_API_URL=${VITE_API_URL:-http://localhost:5001}
+      # Empty = call the engine same-origin and let the Vite dev-server proxy
+      # forward /api/calibration and /api/jobs (see vite.config.ts). Without
+      # this the bundle falls back to http://localhost:8000, which a phone on
+      # the LAN cannot resolve. Set VITE_ENGINE_URL to an absolute URL only if
+      # you deliberately want the browser to hit the engine directly.
+      - VITE_ENGINE_URL=${VITE_ENGINE_URL:-}
+      - ENGINE_PROXY_TARGET=${ENGINE_PROXY_TARGET:-http://processing-engine:8000}
     depends_on:
       backend:
         condition: service_started

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -234,8 +234,9 @@ See [`docs/mast-usage.md`](mast-usage.md) for detailed API examples, metadata fi
 | `CRDS_PATH` | `/app/data/crds` | CRDS reference-file cache (grows to GBs; never delete casually) |
 | `CRDS_SERVER_URL` | `https://jwst-crds.stsci.edu` | CRDS server for lazy reference-file downloads |
 | `JWT_SECRET_KEY` | (shared with .NET) | Engine validates .NET-issued tokens; must match `Jwt__SecretKey` |
-| `CORS_ALLOWED_ORIGINS` | `http://localhost:3000,http://localhost:5173` | Origins allowed to call the engine directly |
-| `VITE_ENGINE_URL` (frontend) | `http://localhost:8000` | Engine base URL for direct calibration calls |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173` | Origins allowed to call the engine directly (shared with the .NET backend — narrowing it narrows both). `*` is rejected at startup (credentialed CORS) |
+| `VITE_ENGINE_URL` (frontend) | empty in Docker; `http://localhost:8000` when unset | Engine base URL. Empty = same-origin calls forwarded by the Vite proxy, which is what makes LAN/phone testing work |
+| `ENGINE_PROXY_TARGET` (frontend) | `http://processing-engine:8000` in Docker; `http://localhost:8000` otherwise | Where the Vite dev server forwards `/api/calibration` and `/api/jobs` |
 
 Build arg `INSTALL_CALIBRATION` (default `true`; CE builds pass `false`) gates the ~2GB `jwst` layer.
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -123,8 +123,72 @@ The engine can run the official STScI `jwst` calibration pipeline. The ~2GB
   delete the CRDS volume casually.
 - **Runs are heavy**: `MAX_CONCURRENT_CALIBRATIONS` (default 1) bounds memory;
   full raw-data reductions download real MAST data and can take hours.
-- The frontend calls the engine directly for calibration — set `VITE_ENGINE_URL`
-  (default `http://localhost:8000`).
+- The frontend calls the engine directly for calibration. In Docker,
+  `VITE_ENGINE_URL` is empty so the browser requests `/api/calibration` and
+  `/api/jobs` on the page's own origin and the Vite dev server forwards them to
+  `ENGINE_PROXY_TARGET` (`http://processing-engine:8000`). Leave it empty unless
+  you specifically want the browser to reach the engine directly, in which case
+  the engine's `CORS_ALLOWED_ORIGINS` must list the browser's origin.
+- **Running Vite on the host** (`npm run dev` instead of Docker): `VITE_ENGINE_URL`
+  is unset there, so the bundle falls back to `http://localhost:8000` and the
+  proxy is never used. That is fine on your own machine, but to use the proxy
+  path — and it is required for LAN testing — export `VITE_ENGINE_URL=` (empty)
+  and `ENGINE_PROXY_TARGET=http://localhost:8000` before starting Vite.
+- **Production**: production and staging images have no engine proxy —
+  `nginx-ssl.conf` sends all of `/api` to the .NET gateway — and
+  `VITE_ENGINE_URL` is not a build arg, so deployed bundles still point at
+  `http://localhost:8000` and calibration is effectively unavailable there.
+  Do **not** "fix" this by setting `VITE_ENGINE_URL=""` in a production build:
+  `/api/calibration/*` would 404 and `/api/jobs/*` would hit the .NET job store
+  instead of the engine's. Wiring calibration for production is tracked
+  separately.
+
+##### Testing from a phone or another machine
+
+The engine leg needs no changes — it is reached same-origin through the proxy,
+so no LAN IP is baked into the bundle. The **backend** leg does, because
+`VITE_API_URL` is an absolute URL compiled into the bundle. All four steps are
+required.
+
+1. Publish the frontend and backend on `0.0.0.0` instead of `127.0.0.1`. Add a
+   `docker/docker-compose.lan.yml` — `!override` (Compose v2.24+) replaces the
+   base port list rather than appending to it, which would leave the original
+   `127.0.0.1` bind in place and fail with "address already in use". Note the
+   backend's *container* port is 8080, not 5001:
+
+    ```yaml
+    services:
+      frontend:
+        ports: !override
+          - "0.0.0.0:3000:3000"
+      backend:
+        ports: !override
+          - "0.0.0.0:5001:8080"
+    ```
+
+2. In `docker/.env`, set `VITE_API_URL=http://<your-lan-ip>:5001`.
+3. In `docker/.env`, append your LAN origin to `CORS_ALLOWED_ORIGINS` —
+   **keep the existing four entries**, since this one variable is shared by
+   both the .NET backend and the engine, and replacing it wholesale breaks
+   local development for both:
+   `http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173,http://<your-lan-ip>:3000`
+4. Leave `VITE_ENGINE_URL` empty. If your existing `docker/.env` sets it to an
+   absolute URL such as `http://localhost:8000`, blank it — it overrides the
+   compose default and reintroduces the bug: the phone resolves `localhost` to
+   itself, `getCapabilities()` fails, and calibration silently disables itself
+   with no visible error beyond a console warning.
+
+Then start the stack, naming **all three** files. Compose only auto-loads
+`docker-compose.override.yml` when no `-f` flag is given, so omitting it here
+would silently drop the frontend bind mount (no hot reload), the published
+engine port and the dev-only backend settings:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml \
+  -f docker-compose.lan.yml up -d
+```
+
+Then browse to `http://<your-lan-ip>:3000`.
 
 ### Documentation (MkDocs)
 
@@ -142,7 +206,9 @@ MONGO_DATABASE=jwst_data_analysis
 
 # Backend
 ASPNETCORE_ENVIRONMENT=Development
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+# Shared by the .NET backend and the engine. Must not contain "*" — the engine
+# allows credentialed requests and rejects a wildcard at startup.
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173
 JWT_SECRET_KEY=CHANGE_THIS_IN_PRODUCTION_MIN_32_CHARS_SECURE_KEY_HERE  # REQUIRED for production
 
 # Frontend
@@ -157,7 +223,9 @@ CALIBRATION_ENABLED=true
 MAX_CONCURRENT_CALIBRATIONS=1
 CALIBRATION_TIMEOUT_S=14400
 CRDS_SERVER_URL=https://jwst-crds.stsci.edu
-VITE_ENGINE_URL=http://localhost:8000
+# Empty = same-origin engine calls via the Vite proxy (works over LAN too)
+VITE_ENGINE_URL=
+ENGINE_PROXY_TARGET=http://processing-engine:8000
 ```
 
 The `.env` file is gitignored and should never be committed. Default values in `docker-compose.yml` work for local development if `.env` is missing.

--- a/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
+++ b/frontend/jwst-frontend/src/components/JwstDataDashboard.tsx
@@ -45,7 +45,12 @@ const JwstDataDashboard: React.FC<JwstDataDashboardProps> = ({ data, onDataUpdat
       .then((caps) => {
         if (!cancelled) setCalibrationEnabled(caps.calibrationEnabled);
       })
-      .catch(() => {
+      .catch((err) => {
+        // Leave a breadcrumb: an unreachable engine and "the engine says
+        // calibration is off" both end up here and both just hide the
+        // button, which is exactly why the engine being unpublished went
+        // unnoticed for so long.
+        console.warn('Calibration capabilities unavailable — hiding calibration UI', err);
         if (!cancelled) setCalibrationEnabled(false);
       });
     return () => {

--- a/frontend/jwst-frontend/src/config/engine.test.ts
+++ b/frontend/jwst-frontend/src/config/engine.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+/**
+ * ENGINE_BASE_URL is read from import.meta.env at module evaluation, so each
+ * case stubs the env and re-imports the module fresh.
+ *
+ * The empty-string case is load-bearing: the dockerised dev frontend sets
+ * VITE_ENGINE_URL= so calibration/jobs calls go to the page's own origin and
+ * are forwarded by the Vite dev-server proxy. That is what lets the same
+ * bundle work at localhost:3000 and at http://<lan-ip>:3000 from a phone. If
+ * an empty value ever fell back to the localhost default, the phone would
+ * silently lose calibration again.
+ */
+describe('ENGINE_BASE_URL', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('falls back to the local engine when VITE_ENGINE_URL is unset', async () => {
+    vi.stubEnv('VITE_ENGINE_URL', undefined);
+    vi.resetModules();
+    expect((await import('./engine')).ENGINE_BASE_URL).toBe('http://localhost:8000');
+  });
+
+  it('stays same-origin for an explicit empty string rather than falling back', async () => {
+    vi.stubEnv('VITE_ENGINE_URL', '');
+    vi.resetModules();
+    expect((await import('./engine')).ENGINE_BASE_URL).toBe('');
+  });
+
+  it('uses an explicit absolute URL as-is', async () => {
+    vi.stubEnv('VITE_ENGINE_URL', 'http://192.168.86.31:8000');
+    vi.resetModules();
+    expect((await import('./engine')).ENGINE_BASE_URL).toBe('http://192.168.86.31:8000');
+  });
+});

--- a/frontend/jwst-frontend/src/config/viteGuards.test.ts
+++ b/frontend/jwst-frontend/src/config/viteGuards.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { jobsRouteCollisionError } from './viteGuards';
+
+/**
+ * The dev server proxies /api/jobs to the Python engine while the .NET gateway
+ * serves /api/jobs on identical paths. The guard must fire only for the one
+ * combination that actually misroutes, because a false positive refuses to
+ * start the dev server.
+ */
+describe('jobsRouteCollisionError', () => {
+  it('flags an empty engine URL combined with an empty (same-origin) API URL', () => {
+    expect(jobsRouteCollisionError({ VITE_ENGINE_URL: '', VITE_API_URL: '' })).toMatch(/misrouted/);
+  });
+
+  it('allows an unset API URL — api.ts falls back to an absolute localhost URL', () => {
+    expect(jobsRouteCollisionError({ VITE_ENGINE_URL: '' })).toBeNull();
+  });
+
+  it('allows the normal docker dev combination', () => {
+    expect(
+      jobsRouteCollisionError({ VITE_ENGINE_URL: '', VITE_API_URL: 'http://localhost:5001' })
+    ).toBeNull();
+  });
+
+  it('allows a same-origin API URL when the engine proxy is not in use', () => {
+    // Production/CE shape: nginx serves the API same-origin and there is no proxy.
+    expect(jobsRouteCollisionError({ VITE_API_URL: '' })).toBeNull();
+  });
+
+  it('allows an absolute engine URL with a same-origin API URL', () => {
+    expect(
+      jobsRouteCollisionError({ VITE_ENGINE_URL: 'http://localhost:8000', VITE_API_URL: '' })
+    ).toBeNull();
+  });
+});

--- a/frontend/jwst-frontend/src/config/viteGuards.ts
+++ b/frontend/jwst-frontend/src/config/viteGuards.ts
@@ -1,0 +1,37 @@
+/**
+ * Dev-server config guards, kept in their own module so they are pure and
+ * unit-testable (vite.config.ts itself is awkward to import from a test).
+ */
+
+/**
+ * The dev server proxies /api/jobs to the Python engine, but the .NET gateway
+ * serves /api/jobs on *exactly* the same paths (JobsController) for
+ * composite/mosaic jobs. There is no path-level way to tell them apart.
+ *
+ * That is only safe because the frontend addresses the .NET backend with an
+ * absolute URL, so those calls leave the page origin and never reach the dev
+ * server. Note that an *unset* VITE_API_URL is still safe: src/config/api.ts
+ * falls back to the absolute http://localhost:5001. The single dangerous value
+ * is the empty string — the same-origin shape staging/CE builds use — which
+ * would silently retarget job polling at the engine and 404.
+ *
+ * Returns an error message, or null when the combination is safe.
+ */
+export function jobsRouteCollisionError(env: {
+  VITE_ENGINE_URL?: string;
+  VITE_API_URL?: string;
+}): string | null {
+  const engineProxyActive = env.VITE_ENGINE_URL === '';
+  const backendSameOrigin = env.VITE_API_URL === '';
+  if (engineProxyActive && backendSameOrigin) {
+    return (
+      'VITE_ENGINE_URL is empty (engine proxy active) but VITE_API_URL is also empty ' +
+      '(same-origin). The dev server proxies /api/jobs to the Python engine, and the ' +
+      '.NET gateway serves /api/jobs on identical paths, so the backend must be ' +
+      'addressed by an absolute URL or its job polling would be misrouted to the ' +
+      'engine. Set VITE_API_URL (e.g. http://localhost:5001) or unset it to use the ' +
+      'default.'
+    );
+  }
+  return null;
+}

--- a/frontend/jwst-frontend/vite.config.ts
+++ b/frontend/jwst-frontend/vite.config.ts
@@ -1,38 +1,77 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+// Lives under src/ so it is covered by eslint, prettier and coverage globs.
+// Node-only: nothing in the app's module graph imports it, so it is never
+// bundled into the client.
+import { jobsRouteCollisionError } from './src/config/viteGuards';
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      // react-plotly.js internally requires 'plotly.js/dist/plotly' but we use
-      // the basic (scatter/bar/pie only) minified dist — ~75% smaller than the
-      // full bundle. Rolldown (Vite 8) needs the explicit alias for CJS resolution.
-      'plotly.js/dist/plotly': 'plotly.js-basic-dist-min',
-    },
-  },
-  server: {
-    port: 3000,
-    strictPort: true,  // Fail fast if port 3000 is unavailable
-    host: true,  // Required for Docker
-    watch: {
-      ignored: ['**/coverage/**', '**/node_modules/**']
-    }
-  },
-  build: {
-    outDir: 'dist'
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './src/setupTests.ts',
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      include: ['src/**/*.{ts,tsx}'],
-      exclude: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}', 'src/vite-env.d.ts']
-    }
+export default defineConfig(({ command, isPreview, mode }) => {
+  // Empty prefix: read the same .env files the bundle will see, plus
+  // process.env — checking process.env alone would miss a .env-provided value
+  // and misjudge one supplied only by the shell. Also covers the unprefixed
+  // ENGINE_PROXY_TARGET, which is consumed here in Node rather than in the app.
+  // process.cwd() is what Vite itself uses because neither `root` nor `envDir`
+  // is configured here — keep them in step if either is ever introduced.
+  const env = loadEnv(mode, process.cwd(), '');
+
+  // Where the dev server forwards engine-owned paths. Inside Docker the engine
+  // is only reachable on the compose network (`processing-engine:8000`); when
+  // Vite runs on the host it is the published port. Override per environment.
+  const engineProxyTarget = env.ENGINE_PROXY_TARGET || 'http://localhost:8000';
+
+  // Dev server only. `vite preview` also reports command === 'serve' but
+  // serves a built bundle through preview.proxy, and vitest loads this config
+  // without ever serving the app — neither can hit the collision, and failing
+  // them would block legitimate workflows.
+  if (command === 'serve' && !isPreview && !process.env.VITEST) {
+    const collision = jobsRouteCollisionError(env);
+    if (collision) throw new Error(collision);
   }
-})
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        // react-plotly.js internally requires 'plotly.js/dist/plotly' but we use
+        // the basic (scatter/bar/pie only) minified dist — ~75% smaller than the
+        // full bundle. Rolldown (Vite 8) needs the explicit alias for CJS resolution.
+        'plotly.js/dist/plotly': 'plotly.js-basic-dist-min',
+      },
+    },
+    server: {
+      port: 3000,
+      strictPort: true, // Fail fast if port 3000 is unavailable
+      host: true, // Required for Docker
+      // Engine-owned routes (ADR-0001: the frontend calls the Python engine
+      // directly, not through the .NET gateway). Proxying them keeps the
+      // browser on the origin it loaded from, so the same bundle works at
+      // localhost:3000 and at http://<lan-ip>:3000 for phone testing — no LAN
+      // IP baked into the bundle and no cross-origin request to CORS-approve.
+      // The rules are always registered but only exercised when the bundle emits
+      // relative URLs, i.e. when VITE_ENGINE_URL is empty (src/config/engine.ts).
+      proxy: {
+        '/api/calibration': { target: engineProxyTarget, changeOrigin: true },
+        '/api/jobs': { target: engineProxyTarget, changeOrigin: true },
+      },
+      watch: {
+        ignored: ['**/coverage/**', '**/node_modules/**'],
+      },
+    },
+    build: {
+      outDir: 'dist',
+    },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: './src/setupTests.ts',
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'json', 'html'],
+        include: ['src/**/*.{ts,tsx}'],
+        exclude: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}', 'src/vite-env.d.ts'],
+      },
+    },
+  };
+});

--- a/processing-engine/app/config.py
+++ b/processing-engine/app/config.py
@@ -63,3 +63,38 @@ def positive_int_env(name: str, default: int) -> int:
     if value <= 0:
         raise EnvVarError(f"Environment variable {name}={value} must be a positive integer.")
     return value
+
+
+# Browser origins allowed to call the engine directly. Kept in sync with the
+# .NET gateway's default (docker/.env.example): 127.0.0.1 and localhost are
+# distinct origins to a browser, so both spellings must be listed.
+DEFAULT_CORS_ORIGINS = (
+    "http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173"
+)
+
+
+def cors_origins_env(
+    name: str = "CORS_ALLOWED_ORIGINS", default: str = DEFAULT_CORS_ORIGINS
+) -> list[str]:
+    """Read ``name`` as a comma-separated CORS allow-list.
+
+    Whitespace is stripped and empty entries dropped. ``*`` is rejected
+    outright: the engine sends ``allow_credentials=True``, and Starlette
+    responds to a wildcard by echoing back whatever ``Origin`` the request
+    carried — credentialed CORS open to every site on the internet. A comment
+    saying "never set this to *" is not a control, so this raises instead.
+
+    Prefer the Vite dev-server proxy (same-origin, no CORS) for LAN/phone
+    testing over widening this list.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        raw = default
+    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
+    if "*" in origins:
+        raise EnvVarError(
+            f"Environment variable {name} must not contain '*'. The engine allows "
+            "credentialed requests, so a wildcard would echo back any origin and "
+            "expose authenticated endpoints to every site. List explicit origins."
+        )
+    return origins

--- a/processing-engine/main.py
+++ b/processing-engine/main.py
@@ -10,6 +10,7 @@ from app.auth.routes import router as auth_router
 from app.calibration.routes import router as calibration_router
 from app.composite.api_routes import router as composite_api_router
 from app.composite.routes import router as composite_router
+from app.config import cors_origins_env
 from app.db.client import MongoNotConfiguredError, get_database
 from app.discovery.api_routes import router as discovery_api_router
 from app.discovery.routes import router as discovery_router
@@ -107,15 +108,10 @@ else:
     # gateway proxies everything else, hence full-mode-only.
     from fastapi.middleware.cors import CORSMiddleware as _CORSMiddleware
 
-    _cors_origins = [
-        origin.strip()
-        for origin in os.environ.get(
-            "CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173"
-        ).split(",")
-        if origin.strip()
-    ]
-    # Never set CORS_ALLOWED_ORIGINS to "*": with allow_credentials=True,
-    # Starlette would echo any origin back — credentialed wildcard CORS.
+    # Parsing (and the "never *" rule) lives in app.config so it is unit
+    # testable. For LAN/phone testing prefer the Vite dev-server proxy —
+    # same-origin, so no entry needs adding here at all.
+    _cors_origins = cors_origins_env()
     app.add_middleware(
         _CORSMiddleware,
         allow_origins=_cors_origins,

--- a/processing-engine/tests/test_config_env_helpers.py
+++ b/processing-engine/tests/test_config_env_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from app.config import EnvVarError, float_env, int_env, positive_int_env
+from app.config import EnvVarError, cors_origins_env, float_env, int_env, positive_int_env
 
 
 @pytest.fixture
@@ -74,3 +74,45 @@ class TestPositiveIntEnv:
     def test_accepts_positive(self, clean_env):
         clean_env.setenv("TEST_POS_VAR", "50")
         assert positive_int_env("TEST_POS_VAR", 100) == 50
+
+
+class TestCorsOriginsEnv:
+    @pytest.fixture
+    def cors_env(self, monkeypatch):
+        monkeypatch.delenv("TEST_CORS_VAR", raising=False)
+        return monkeypatch
+
+    @pytest.mark.usefixtures("cors_env")
+    def test_default_covers_both_loopback_spellings(self):
+        origins = cors_origins_env("TEST_CORS_VAR")
+        # 127.0.0.1 and localhost are distinct browser origins; the .NET
+        # gateway allows both, so the engine must not be stricter.
+        assert origins == [
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "http://127.0.0.1:3000",
+            "http://127.0.0.1:5173",
+        ]
+
+    @pytest.mark.usefixtures("cors_env")
+    def test_falls_back_to_default_when_unset(self):
+        assert cors_origins_env("TEST_CORS_VAR", "http://a.test") == ["http://a.test"]
+
+    def test_falls_back_to_default_when_blank(self, cors_env):
+        cors_env.setenv("TEST_CORS_VAR", "   ")
+        assert cors_origins_env("TEST_CORS_VAR", "http://a.test") == ["http://a.test"]
+
+    def test_strips_whitespace_and_drops_empty_entries(self, cors_env):
+        cors_env.setenv("TEST_CORS_VAR", " http://a.test , ,http://b.test, ")
+        assert cors_origins_env("TEST_CORS_VAR") == ["http://a.test", "http://b.test"]
+
+    def test_rejects_wildcard(self, cors_env):
+        # allow_credentials=True + "*" would make Starlette echo any origin.
+        cors_env.setenv("TEST_CORS_VAR", "*")
+        with pytest.raises(EnvVarError, match="must not contain"):
+            cors_origins_env("TEST_CORS_VAR")
+
+    def test_rejects_wildcard_hidden_in_a_list(self, cors_env):
+        cors_env.setenv("TEST_CORS_VAR", "http://a.test, * ")
+        with pytest.raises(EnvVarError, match="must not contain"):
+            cors_origins_env("TEST_CORS_VAR")


### PR DESCRIPTION
No linked issue (bug found live while testing from a phone). Follow-up filed as #1768.

## Summary

The frontend could not reach the Python processing engine from a browser, so the calibration feature silently disabled itself.

`src/config/engine.ts` defaults `ENGINE_BASE_URL` to `http://localhost:8000`. That only works when the browser runs on the Docker host *and* the engine port is published — the base compose never publishes it (only `docker-compose.override.yml` does, on `127.0.0.1`). Browsing from a phone at `http://192.168.86.31:3000`, `localhost` resolves to the phone itself, so `getCapabilities()` fails, `calibrationEnabled` stays `false`, `JwstDataDashboard` passes `onReprocess={undefined}`, and the calibrate button never renders. The `.catch()` swallowed the error, so there was no visible symptom at all.

### Why it "worked before"

It did work in ordinary local dev, and no port mapping was ever removed — `git log -S` shows `127.0.0.1:8000:8000` has been in `docker-compose.override.yml` since Task #59, and `docker compose up -d` from `docker/` auto-loads that override. It broke in a session where the stack was started with explicit `-f` files (base compose + an ad-hoc LAN override), which suppresses the auto-loaded dev override. Tests never caught it because Playwright mocks the engine with host-agnostic `page.route('**/api/...')` globs and unit tests stub `fetch`.

Even with the override, the phone case could never have worked: `127.0.0.1:8000` is not LAN-reachable and the engine URL was hardcoded to `localhost` in the bundle.

### Approach

Considered (a) publishing the engine port and (b) a Vite dev-server proxy. Chose **(b)**: publishing the port on `0.0.0.0` would still require baking the LAN IP into the bundle via `VITE_ENGINE_URL` and adding that origin to the engine's CORS list — a per-machine, per-network config that breaks the moment the IP changes. The proxy keeps the browser on the origin it loaded from, so **the same bundle works at `localhost:3000` and at `http://<lan-ip>:3000` with zero CORS involvement**. `engine.ts` already documented an empty-string same-origin opt-in; this makes it real. The existing `127.0.0.1:8000` publish is kept for curl/debugging.

## Changes Made

- **`vite.config.ts`**: added `server.proxy` for `/api/calibration` and `/api/jobs` → `ENGINE_PROXY_TARGET` (default `http://localhost:8000`, `http://processing-engine:8000` in Docker). Switched to the function form and resolve env with `loadEnv` so `.env` files and the shell are both honoured.
- **`docker-compose.yml` / `docker-compose.agent.yml`**: frontend now gets `VITE_ENGINE_URL=` (empty → same-origin) and `ENGINE_PROXY_TARGET`, following the `JWST_DATA_DIR` env-overridable precedent.
- **`src/config/viteGuards.ts` (new)**: `jobsRouteCollisionError()`. The .NET gateway serves `/api/jobs` on *exactly* the same paths as the engine (composite/mosaic jobs vs calibration jobs). That is only safe because backend calls use an absolute `VITE_API_URL`. The dev server now refuses to start if both `VITE_ENGINE_URL` and `VITE_API_URL` are empty, instead of silently misrouting job polling. Scoped to the real dev server — `vite build`, `vite preview` and vitest are excluded.
- **`processing-engine/app/config.py`**: new `cors_origins_env()` — parses the allow-list and **rejects `*` at startup**. With `allow_credentials=True`, Starlette echoes back any origin on a wildcard; a code comment was the only thing preventing that. Default now matches the .NET gateway's four origins (the `127.0.0.1` spellings were previously rejected by the engine but accepted by the backend).
- **`main.py`**: uses the helper.
- **`docker-compose.yml` / `docker-compose.override.yml`**: aligned the `CORS_ALLOWED_ORIGINS` defaults across backend and engine.
- **`JwstDataDashboard.tsx`**: `console.warn` before hiding the calibration UI — this bug was invisible precisely because the failure was silent.
- **`docker-compose.e2e.yml`**: corrected a comment that no longer matched reality.
- **Tests**: `src/config/engine.test.ts` (3), `src/config/viteGuards.test.ts` (5), 6 new cases in `processing-engine/tests/test_config_env_helpers.py`.
- **Docs**: `setup-guide.md` (complete LAN/phone recipe, host-Vite instructions, production caveat), `quick-reference.md` (env table), `.env.example`.

## Empirical Verification

Stack rebuilt and restarted, then measured from a real headless browser at the LAN origin:

```
page origin        : http://192.168.86.31:3000/
ENGINE_BASE_URL    : ""
capabilities status: 200
capabilities body  : {"calibrationEnabled":true,"jwstVersion":"2.0.1"}
engine requests    : [ 'http://192.168.86.31:3000/api/calibration/capabilities' ]
```

Identical result at `http://localhost:3000/`. Before the change, `curl http://localhost:8000/api/calibration/capabilities` returned `000` (connection refused).

Guard behaviour, verified by actually starting Vite:

- `VITE_API_URL=""` → dev server refuses to start with the explanatory error.
- `VITE_API_URL` unset → starts normally (`api.ts` falls back to an absolute URL, so there is no collision).

CORS: `curl -H "Origin: http://127.0.0.1:3000"` → `access-control-allow-origin: http://127.0.0.1:3000`. `CORS_ALLOWED_ORIGINS=*` → `EnvVarError` at startup.

## Test Plan

- [x] `docker compose ... up -d --build processing-engine frontend`, then `curl http://localhost:8000/api/calibration/capabilities` → `{"calibrationEnabled":true,...}` HTTP 200
- [x] `curl http://localhost:3000/api/calibration/capabilities` (through the Vite proxy) → HTTP 200
- [x] `curl http://192.168.86.31:3000/api/calibration/capabilities` (LAN origin) → HTTP 200
- [x] Headless browser at the LAN origin reports `ENGINE_BASE_URL === ""` and a successful same-origin capabilities fetch
- [x] `npx vitest run` — 1341 passed, 122 files (full suite, on the host via the pre-commit hook)
- [x] `npx tsc -b` — clean
- [x] `npx eslint src` and `npx prettier --check` — clean
- [x] `pytest tests/test_config_env_helpers.py` — 18 passed (6 new)
- [x] `pytest tests/test_calibration_flags.py tests/test_jobs_routes.py` — 68 passed with the config tests
- [x] Dev server refuses to start when `VITE_ENGINE_URL` and `VITE_API_URL` are both empty; starts when `VITE_API_URL` is unset
- [x] Engine rejects `CORS_ALLOWED_ORIGINS=*` at startup

**Reviewer steps to reproduce:**

1. `cd docker && docker compose up -d --build` (auto-loads `docker-compose.override.yml`).
2. `curl -s http://localhost:3000/api/calibration/capabilities` → expect `{"calibrationEnabled":true,"jwstVersion":"..."}`. This goes through the Vite proxy, not a published engine port.
3. Find your LAN IP (`ipconfig getifaddr en0`). Add a `docker/docker-compose.lan.yml` per the new setup-guide section, restart with all three `-f` files, then browse to `http://<lan-ip>:3000` from a phone, log in, open a target and confirm the **Calibrate** button renders.
4. In the phone's browser (or desktop at the LAN IP), confirm DevTools shows the capabilities request going to `http://<lan-ip>:3000/api/calibration/...`, not `localhost:8000`.
5. Negative test: `docker compose exec -e VITE_API_URL= frontend npx vite --port 3112` → expect a startup error naming the `/api/jobs` collision.

## Documentation Checklist

- [x] `docs/setup-guide.md` — proxy behaviour, complete phone/LAN recipe, host-Vite instructions, production caveat, updated CORS sample
- [x] `docs/quick-reference.md` — `VITE_ENGINE_URL` semantics corrected, `ENGINE_PROXY_TARGET` row added, CORS default updated
- [x] `docker/.env.example` — new vars documented; CORS documented as shared by backend+engine with the no-wildcard warning
- [x] No API endpoint or model changes, so no ADR/API-docs update needed
- [x] Code comments explain the `/api/jobs` collision and the credentialed-CORS reasoning

## Tech Debt Impact

- [x] Reduces tech debt — removes a hardcoded `localhost` from the browser bundle and replaces a "never set this to `*`" *comment* with an enforced, tested check
- [x] Adds test coverage where there was none (`engine.ts` had zero tests despite subtle empty-string semantics that this fix depends on)
- [x] No new tech debt introduced
- [x] Documents a pre-existing latent hazard (`/api/jobs` served by both backends) and adds a fail-fast guard
- [x] Follow-up filed: #1768 (wire calibration for production; resolve the `/api/jobs` namespace collision)

Known pre-existing issue, unchanged by this PR: `src/config/api.test.ts` fails when run *inside* the dev container because `VITE_API_URL` is set in the container environment and `api.ts` uses `!== undefined`. It passes on the host and in CI where the var is unset. Not fixed here to keep this PR scoped.

## Risk & Rollback

**Risk: low-to-moderate.** Dev-environment configuration plus one engine startup path.

- Production, staging and CE are **unaffected**: `VITE_ENGINE_URL` is not a build `ARG` in the production `Dockerfile`, so those builds still see `undefined` and behave exactly as before. Verified by inspection of `Dockerfile`, `docker-compose.prod.yml`, `docker-compose.staging.yml`, `docker-compose.ce.yml`. CE additionally never mounts CORS middleware and gates all `/calibrate*` routes behind `!CE_MODE`.
- The riskiest change is the engine now raising on `CORS_ALLOWED_ORIGINS=*`. If any deployment sets that, the engine will refuse to boot — intentional (it is a credentialed-CORS bypass), and `scripts/server-setup*.sh` write explicit origins, not `*`.
- The `/api/jobs` guard could in principle block a dev server, but only for a combination that was already broken; `vite build`, `vite preview` and vitest are excluded and this was verified by running each.

**Rollback**: revert the commit. Nothing is persisted, no schema or data changes, no migration. Reverting restores the previous (broken-from-LAN) behaviour with no cleanup required.
