### PR TITLE
feat: make a silent calibration run legible on the run page

### DIFF
--- a/frontend/jwst-frontend/src/components/calibration/StageTimeline.css
+++ b/frontend/jwst-frontend/src/components/calibration/StageTimeline.css
@@ -89,6 +89,14 @@
   color: var(--text-muted);
 }
 
+/* What the running stage is doing right now (#1770) — sub-step and file
+   counter. Sits under the io line so the node keeps its shape when absent. */
+.stage-node-detail {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.65rem;
+  color: var(--text-secondary);
+}
+
 .stage-node-reason {
   font-size: 0.7rem;
   color: var(--text-muted);

--- a/frontend/jwst-frontend/src/components/calibration/StageTimeline.test.tsx
+++ b/frontend/jwst-frontend/src/components/calibration/StageTimeline.test.tsx
@@ -46,4 +46,62 @@ describe('StageTimeline', () => {
     expect(screen.getByText('✓')).toBeInTheDocument();
     expect(screen.getByText('…')).toBeInTheDocument();
   });
+
+  describe('running-stage detail (#1770)', () => {
+    const twoRunning = [
+      { name: 'detector1', status: 'running' as const },
+      { name: 'image2', status: 'running' as const },
+    ];
+
+    it('attaches the step and file counter to the named stage only', () => {
+      render(
+        <StageTimeline
+          mode="progress"
+          progress={twoRunning}
+          currentStageName="detector1"
+          currentStep="jump"
+          fileCounter="file 2 of 4"
+        />
+      );
+
+      const details = document.querySelectorAll('.stage-node-detail');
+      expect(details).toHaveLength(1);
+      expect(details[0]).toHaveTextContent('jump · file 2 of 4');
+      // …and it hangs off Detector1, not off the other running stage.
+      expect(details[0].closest('.stage-node')).toHaveTextContent('Detector1');
+    });
+
+    it('shows nothing when the engine has not said which stage is current', () => {
+      // Painting a counter onto every running stage is worse than omitting it;
+      // the run page still shows it unattributed in the status line.
+      render(<StageTimeline mode="progress" progress={twoRunning} fileCounter="file 2 of 4" />);
+      expect(document.querySelectorAll('.stage-node-detail')).toHaveLength(0);
+    });
+
+    it('never decorates a stage that is not running', () => {
+      render(
+        <StageTimeline
+          mode="progress"
+          progress={[{ name: 'detector1', status: 'done' }]}
+          currentStageName="detector1"
+          currentStep="jump"
+          fileCounter="file 4 of 4"
+        />
+      );
+      expect(document.querySelectorAll('.stage-node-detail')).toHaveLength(0);
+    });
+
+    it('ignores the progress-only props in config mode', () => {
+      render(
+        <StageTimeline
+          mode="config"
+          enabled={{ detector1: true }}
+          currentStageName="detector1"
+          currentStep="jump"
+          fileCounter="file 2 of 4"
+        />
+      );
+      expect(document.querySelectorAll('.stage-node-detail')).toHaveLength(0);
+    });
+  });
 });

--- a/frontend/jwst-frontend/src/components/calibration/StageTimeline.tsx
+++ b/frontend/jwst-frontend/src/components/calibration/StageTimeline.tsx
@@ -24,6 +24,20 @@ interface StageTimelineProps {
   progress?: CalibrationJobStage[];
   /** Suffixes of the selected inputs, e.g. ['_cal'] — drives validity. */
   inputSuffixes?: string[];
+  /**
+   * Progress mode: what the running stage is doing right now (#1770) — the
+   * sub-step ("jump") and the file counter ("file 2 of 4"). A stage sits at
+   * "running" for many minutes, so this line is the part that actually moves.
+   *
+   * `currentStageName` is the stage half of `progress.currentStage`. It has to
+   * travel with the step, because the stage list and the current-stage string
+   * are written by separate engine updates: without it a stale `jump` (a
+   * detector1 step) could be painted onto whichever stage happens to read
+   * "running", which is worse than showing nothing.
+   */
+  currentStageName?: string | null;
+  currentStep?: string | null;
+  fileCounter?: string | null;
   onToggle?: (stageName: string, next: boolean) => void;
 }
 
@@ -40,6 +54,9 @@ export function StageTimeline({
   enabled = {},
   progress = [],
   inputSuffixes = [],
+  currentStageName = null,
+  currentStep = null,
+  fileCounter = null,
   onToggle,
 }: StageTimelineProps) {
   const byName = new Map(progress.map((p) => [p.name, p]));
@@ -51,6 +68,17 @@ export function StageTimeline({
         const live = byName.get(spec.name);
         const on = mode === 'config' ? Boolean(enabled[spec.name]) && !blocked : Boolean(live);
         const status = live?.status;
+        // Only the stage the engine says is current gets the detail line — a
+        // done, pending, or merely also-running stage showing "jump · file 2
+        // of 4" would be describing someone else's work.
+        // No fallback when the stage is unknown: attributing a file counter to
+        // every stage that reads "running" is the misattribution this prop
+        // exists to prevent. The status line still shows it, unattributed.
+        const isCurrent = status === 'running' && currentStageName === spec.name;
+        const detail =
+          mode === 'progress' && isCurrent
+            ? [currentStep, fileCounter].filter(Boolean).join(' · ')
+            : '';
 
         return (
           <div className="stage-timeline-cell" key={spec.name}>
@@ -89,6 +117,7 @@ export function StageTimeline({
               <span className="stage-node-io">
                 {spec.consumes} → {spec.produces}
               </span>
+              {detail && <span className="stage-node-detail">{detail}</span>}
             </div>
             {blocked && (
               <span className="stage-node-reason" role="note">

--- a/frontend/jwst-frontend/src/components/calibration/runTiming.test.ts
+++ b/frontend/jwst-frontend/src/components/calibration/runTiming.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The run page renders these strings straight into the DOM, so every branch
+ * that could produce "NaN", "null", or a negative duration is pinned here
+ * rather than through the component — this is where the contract lives.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  formatAgo,
+  formatDuration,
+  formatFileCounter,
+  isInterrupted,
+  parseCurrentStage,
+  toMillis,
+  wasInterrupted,
+} from './runTiming';
+
+describe('toMillis', () => {
+  it('parses an ISO timestamp', () => {
+    expect(toMillis('2026-07-24T00:00:00Z')).toBe(Date.parse('2026-07-24T00:00:00Z'));
+  });
+
+  it.each([null, undefined, '', 'not a date'])('returns null for %o', (input) => {
+    expect(toMillis(input)).toBeNull();
+  });
+});
+
+describe('formatDuration', () => {
+  it.each([
+    [0, 'less than a minute'],
+    [59_000, 'less than a minute'],
+    [60_000, '1 min'],
+    [7 * 60_000, '7 min'],
+    [59 * 60_000, '59 min'],
+    [60 * 60_000, '1h'],
+    [72 * 60_000, '1h 12m'],
+    [26 * 60 * 60_000, '26h'],
+  ])('%d ms → %s', (ms, expected) => {
+    expect(formatDuration(ms)).toBe(expected);
+  });
+
+  it('clamps a negative span rather than printing "-3 min"', () => {
+    // Engine and browser clocks can disagree; a run cannot have started later
+    // than now from the user's point of view.
+    expect(formatDuration(-180_000)).toBe('less than a minute');
+  });
+
+  it('returns nothing for a non-finite span', () => {
+    expect(formatDuration(NaN)).toBe('');
+    expect(formatDuration(Infinity)).toBe('');
+  });
+});
+
+describe('formatAgo', () => {
+  it.each([
+    [0, 'just now'],
+    [59_999, 'just now'],
+    [60_000, '1 min ago'],
+    [4 * 60_000, '4 min ago'],
+    [72 * 60_000, '1h 12m ago'],
+  ])('%d ms → %s', (ms, expected) => {
+    expect(formatAgo(ms)).toBe(expected);
+  });
+
+  it('returns nothing for a non-finite span', () => {
+    expect(formatAgo(NaN)).toBe('');
+  });
+});
+
+describe('parseCurrentStage', () => {
+  it('splits "stage:step"', () => {
+    expect(parseCurrentStage('detector1:jump')).toEqual({ stage: 'detector1', step: 'jump' });
+  });
+
+  it('keeps a bare stage name usable', () => {
+    expect(parseCurrentStage('image2')).toEqual({ stage: 'image2', step: null });
+  });
+
+  it('tolerates extra colons by keeping the remainder as the step', () => {
+    expect(parseCurrentStage('image3:outlier:detection')).toEqual({
+      stage: 'image3',
+      step: 'outlier:detection',
+    });
+  });
+
+  it.each([
+    [null, { stage: null, step: null }],
+    [undefined, { stage: null, step: null }],
+    ['', { stage: null, step: null }],
+    ['   ', { stage: null, step: null }],
+    [':', { stage: null, step: null }],
+    ['detector1:', { stage: 'detector1', step: null }],
+    [':jump', { stage: null, step: 'jump' }],
+    ['  detector1 : jump ', { stage: 'detector1', step: 'jump' }],
+  ])('degrades on %o', (input, expected) => {
+    expect(parseCurrentStage(input)).toEqual(expected);
+  });
+});
+
+describe('formatFileCounter', () => {
+  it('renders a sane counter', () => {
+    expect(formatFileCounter(2, 4)).toBe('file 2 of 4');
+    expect(formatFileCounter(1, 1)).toBe('file 1 of 1');
+  });
+
+  it.each([
+    [null, null],
+    [null, 4],
+    [2, null],
+    [undefined, undefined],
+    [0, 4],
+    [5, 4],
+    [-1, 4],
+    [2, 0],
+    [NaN, 4],
+    [2, Infinity],
+  ])('shows nothing rather than nonsense for (%o, %o)', (current, total) => {
+    expect(formatFileCounter(current, total)).toBeNull();
+  });
+});
+
+describe('isInterrupted', () => {
+  it.each([
+    'interrupted by service restart',
+    'Engine restarted mid-run',
+    'worker shutdown',
+    'engine exited unexpectedly',
+  ])('recognises %o', (error) => {
+    expect(isInterrupted(error)).toBe(true);
+  });
+
+  it.each([null, undefined, '', 'Step jump failed: not enough groups', 'CRDS lookup failed'])(
+    'does not over-claim on %o',
+    (error) => {
+      expect(isInterrupted(error)).toBe(false);
+    }
+  );
+});
+
+describe('wasInterrupted', () => {
+  it('covers the shape the engine actually records — failed + restart text', () => {
+    expect(
+      wasInterrupted({
+        status: 'failed',
+        cancelRequested: false,
+        error: 'interrupted by service restart',
+      })
+    ).toBe(true);
+  });
+
+  it('covers a cancel-shaped interruption too', () => {
+    expect(
+      wasInterrupted({ status: 'cancelled', cancelRequested: false, error: 'engine restarted' })
+    ).toBe(true);
+  });
+
+  it('never tells a user "nothing you did caused it" when they pressed Cancel', () => {
+    // cancelRequested is structured and only the user's route sets it, so it
+    // outranks any wording that happens to appear in the error text.
+    expect(
+      wasInterrupted({ status: 'cancelled', cancelRequested: true, error: 'engine restarted' })
+    ).toBe(false);
+  });
+
+  it('leaves a genuine pipeline failure alone', () => {
+    expect(
+      wasInterrupted({ status: 'failed', cancelRequested: false, error: 'jump step diverged' })
+    ).toBe(false);
+  });
+
+  it('is never true for a successful run', () => {
+    expect(wasInterrupted({ status: 'succeeded', cancelRequested: false, error: 'restart' })).toBe(
+      false
+    );
+  });
+});

--- a/frontend/jwst-frontend/src/components/calibration/runTiming.ts
+++ b/frontend/jwst-frontend/src/components/calibration/runTiming.ts
@@ -1,0 +1,115 @@
+/**
+ * Making a silent run legible (#1770).
+ *
+ * A real four-file run emitted 67 log lines in 23.6 minutes, so the run page
+ * can go visually dead for eight minutes at a stretch. The engine genuinely
+ * has little to say during a stage, so the fix is not to invent motion — it is
+ * to render the *waiting* honestly: how long it has been going, how long since
+ * anything last changed, which sub-step and which file are in flight.
+ *
+ * Pure functions over primitives, so they can be tested without the DOM and
+ * without a clock. Every one of them takes null/absent input, because runs
+ * recorded before the engine started reporting these fields will not have them
+ * and must degrade to "not shown" rather than to "NaN".
+ */
+
+/** Milliseconds for an ISO-8601 timestamp, or null if absent/unparseable. */
+export function toMillis(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * A span as a person would say it: "less than a minute", "7 min", "1h 12m".
+ * Negative spans (clock skew between engine and browser) clamp to zero rather
+ * than rendering "-3 min".
+ */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms)) return '';
+  const totalMinutes = Math.floor(Math.max(ms, 0) / 60_000);
+  if (totalMinutes < 1) return 'less than a minute';
+  if (totalMinutes < 60) return `${totalMinutes} min`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+}
+
+/** How long ago something happened: "just now", "4 min ago", "1h 12m ago". */
+export function formatAgo(ms: number): string {
+  if (!Number.isFinite(ms)) return '';
+  // Under a minute is "just now" — the same boundary formatDuration uses, so
+  // the two never disagree ("less than a minute ago" reads as a bug).
+  if (ms < 60_000) return 'just now';
+  return `${formatDuration(ms)} ago`;
+}
+
+export interface StageAndStep {
+  stage: string | null;
+  step: string | null;
+}
+
+/**
+ * `progress.currentStage` is "stage:step" (e.g. "detector1:jump") — the UI used
+ * to show only the stage, which is the part that does not change for minutes at
+ * a time. Plain stage names (no colon) stay valid input.
+ */
+export function parseCurrentStage(currentStage: string | null | undefined): StageAndStep {
+  if (!currentStage) return { stage: null, step: null };
+  const trimmed = currentStage.trim();
+  if (!trimmed) return { stage: null, step: null };
+  const colon = trimmed.indexOf(':');
+  if (colon === -1) return { stage: trimmed, step: null };
+  const stage = trimmed.slice(0, colon).trim();
+  const step = trimmed.slice(colon + 1).trim();
+  return { stage: stage || null, step: step || null };
+}
+
+/** "file 2 of 4", or null unless both numbers are present and sane. */
+export function formatFileCounter(
+  currentFile: number | null | undefined,
+  totalFiles: number | null | undefined
+): string | null {
+  if (typeof currentFile !== 'number' || typeof totalFiles !== 'number') return null;
+  if (!Number.isFinite(currentFile) || !Number.isFinite(totalFiles)) return null;
+  if (currentFile < 1 || totalFiles < 1 || currentFile > totalFiles) return null;
+  return `file ${currentFile} of ${totalFiles}`;
+}
+
+/**
+ * A run killed by an engine restart ends in a terminal state with no
+ * explanation the user can act on — the same words for "you did this" and "the
+ * machine did this to you". Today the engine's reconciler records it as
+ * `failed` with "interrupted by service restart"; a cancel-shaped record is
+ * also possible. Both are covered.
+ */
+// Deliberately not a bare /interrupt/: a jwst traceback containing
+// "KeyboardInterrupt" is a failure, and telling that user "nothing you did
+// caused this" would be worse than saying nothing.
+const INTERRUPTED_RE = /restart(ed|ing)?\b|interrupted by|shut\s*down|engine (stopped|exited)/i;
+
+export function isInterrupted(error: string | null | undefined): boolean {
+  return Boolean(error && INTERRUPTED_RE.test(error));
+}
+
+export interface InterruptionInput {
+  status: string;
+  /** True only when the user pressed Cancel — the engine sets it on that route. */
+  cancelRequested: boolean;
+  error: string | null;
+}
+
+/**
+ * Did the machine stop this run, rather than the user?
+ *
+ * `cancelRequested` is the primary signal because it is structured and can only
+ * be set by the user-initiated cancel route; the error text only narrows the
+ * remaining cases, so a pipeline traceback that happens to contain the word
+ * "interrupt" cannot get us to tell someone "nothing you did caused this" when
+ * they pressed the button themselves.
+ */
+export function wasInterrupted(job: InterruptionInput): boolean {
+  if (job.status === 'succeeded' || job.status === 'queued') return false;
+  if (job.cancelRequested) return false;
+  return isInterrupted(job.error);
+}

--- a/frontend/jwst-frontend/src/hooks/useCalibrationJob.test.ts
+++ b/frontend/jwst-frontend/src/hooks/useCalibrationJob.test.ts
@@ -69,8 +69,63 @@ describe('useCalibrationJob', () => {
       await vi.advanceTimersByTimeAsync(1600);
       await vi.waitFor(() => expect(result.current.job?.status).toBe('succeeded'));
       expect(result.current.error).toBeNull();
+      expect(result.current.stopped).toBe(false);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  /**
+   * The run page (#1770) proves it is alive with a ticking clock, so it has to
+   * be told when the hook has stopped watching — a clock still moving over a
+   * page that gave up is a worse lie than the silence it explains.
+   */
+  describe('giving up', () => {
+    it('keeps trying below the failure threshold, then reports stopped', async () => {
+      vi.mocked(getJob).mockRejectedValue(new Error('network down'));
+      vi.useFakeTimers();
+      try {
+        const { result } = renderHook(() => useCalibrationJob('j1'));
+        await vi.waitFor(() => expect(result.current.error).toBe('network down'));
+
+        // Attempts 2..4: still retrying, still claiming to be watching.
+        await vi.advanceTimersByTimeAsync(1600 * 3);
+        expect(vi.mocked(getJob).mock.calls.length).toBe(4);
+        expect(result.current.stopped).toBe(false);
+
+        // The fifth failure is the one that gives up.
+        await vi.advanceTimersByTimeAsync(1600);
+        await vi.waitFor(() => expect(result.current.stopped).toBe(true));
+
+        // And polling really has ceased, not merely been relabelled.
+        const callsAtGiveUp = vi.mocked(getJob).mock.calls.length;
+        expect(callsAtGiveUp).toBe(5);
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(vi.mocked(getJob).mock.calls.length).toBe(callsAtGiveUp);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('starts watching again when the job id changes', async () => {
+      vi.mocked(getJob).mockRejectedValue(new Error('network down'));
+      vi.useFakeTimers();
+      try {
+        const { result, rerender } = renderHook(({ id }) => useCalibrationJob(id), {
+          initialProps: { id: 'j1' },
+        });
+        await vi.advanceTimersByTimeAsync(1600 * 5);
+        await vi.waitFor(() => expect(result.current.stopped).toBe(true));
+
+        vi.mocked(getJob).mockResolvedValue(makeJob('running'));
+        rerender({ id: 'j2' });
+
+        await vi.waitFor(() => expect(result.current.job?.status).toBe('running'));
+        expect(result.current.stopped).toBe(false);
+        expect(result.current.error).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/frontend/jwst-frontend/src/hooks/useCalibrationJob.ts
+++ b/frontend/jwst-frontend/src/hooks/useCalibrationJob.ts
@@ -19,12 +19,21 @@ export interface UseCalibrationJobResult {
   job: CalibrationJob | null;
   isTerminal: boolean;
   error: string | null;
+  /**
+   * True once polling has given up on a non-terminal job (#1770). The run page
+   * shows a ticking clock as proof that it is still watching, so it has to
+   * know when it has stopped watching — otherwise the clock keeps moving over
+   * a page that is no longer talking to the engine, which is a worse lie than
+   * the silence it was built to explain.
+   */
+  stopped: boolean;
 }
 
 interface Snapshot {
   key: string | null;
   job: CalibrationJob | null;
   error: string | null;
+  stopped: boolean;
 }
 
 export function useCalibrationJob(jobId: string | null): UseCalibrationJobResult {
@@ -32,13 +41,14 @@ export function useCalibrationJob(jobId: string | null): UseCalibrationJobResult
     key: jobId,
     job: null,
     error: null,
+    stopped: false,
   });
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Reset during render when the job id changes (React's documented
   // derived-state pattern) — avoids a synchronous setState inside the effect.
   if (snapshot.key !== jobId) {
-    setSnapshot({ key: jobId, job: null, error: null });
+    setSnapshot({ key: jobId, job: null, error: null, stopped: false });
   }
 
   useEffect(() => {
@@ -52,7 +62,7 @@ export function useCalibrationJob(jobId: string | null): UseCalibrationJobResult
         const next = await getJob<CalibrationJob>(jobId);
         if (cancelled) return;
         consecutiveFailures = 0;
-        setSnapshot({ key: jobId, job: next, error: null });
+        setSnapshot({ key: jobId, job: next, error: null, stopped: false });
         if ((TERMINAL_JOB_STATUSES as readonly string[]).includes(next.status)) {
           return; // done — stop polling
         }
@@ -62,8 +72,11 @@ export function useCalibrationJob(jobId: string | null): UseCalibrationJobResult
         // job (e.g. an evicted/invalid id) instead of polling forever.
         consecutiveFailures += 1;
         const message = err instanceof Error ? err.message : 'Failed to fetch job';
-        setSnapshot((prev) => (prev.key === jobId ? { ...prev, error: message } : prev));
-        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) return;
+        const givingUp = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
+        setSnapshot((prev) =>
+          prev.key === jobId ? { ...prev, error: message, stopped: givingUp } : prev
+        );
+        if (givingUp) return;
       }
       timerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
     };
@@ -77,7 +90,8 @@ export function useCalibrationJob(jobId: string | null): UseCalibrationJobResult
 
   const job = snapshot.key === jobId ? snapshot.job : null;
   const error = snapshot.key === jobId ? snapshot.error : null;
+  const stopped = snapshot.key === jobId && snapshot.stopped;
   const isTerminal =
     job !== null && (TERMINAL_JOB_STATUSES as readonly string[]).includes(job.status);
-  return { job, isTerminal, error };
+  return { job, isTerminal, error, stopped };
 }

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.css
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.css
@@ -85,6 +85,14 @@
   margin: 0.5rem 0;
 }
 
+/* The heartbeat (#1770): elapsed, last update, rough remaining. Quieter than
+   the status line — it is reassurance, not news. */
+.calibrate-heartbeat {
+  margin: 0.25rem 0 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
 .calibrate-stage-checklist {
   list-style: none;
   padding: 0;

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -156,8 +156,11 @@ describe('RunDetail', () => {
     /** Freeze the wall clock at `startedMs + offsetMs`. */
     function clockAt(offsetMs: number, opts?: { fake?: boolean }) {
       if (opts?.fake) {
-        // shouldAdvanceTime keeps promises/microtasks resolving, so the poll
-        // hook still works while the heartbeat interval is under our control.
+        // shouldAdvanceTime is required: Testing Library's findBy*/waitFor
+        // poll on timers, so a fully frozen clock stalls them forever. The
+        // cost is that the fake clock also drifts with real time, so
+        // assertions here must not depend on an exact elapsed value.
+        vi.useRealTimers();
         vi.useFakeTimers({ shouldAdvanceTime: true });
       }
       vi.setSystemTime(new Date(startedMs + offsetMs));
@@ -204,11 +207,22 @@ describe('RunDetail', () => {
       const timer = await screen.findByRole('timer');
       expect(timer).toHaveTextContent(/Running for\s+1 min/);
 
+      // Async advance: the heartbeat's interval is registered in an effect and
+      // the poll resolves through the microtask queue, so a bare synchronous
+      // advance races the mount on a loaded machine (it did, in CI).
       await act(async () => {
-        vi.advanceTimersByTime(5 * 60_000);
+        await vi.advanceTimersByTimeAsync(5 * 60_000);
       });
 
-      expect(await screen.findByRole('timer')).toHaveTextContent(/Running for\s+6 min/);
+      // Asserts the clock MOVED, not an exact reading: with shouldAdvanceTime
+      // the fake clock also drifts with real time, so pinning "6 min" made
+      // this pass alone and fail under full-suite load.
+      await waitFor(() => {
+        const minutes = Number(
+          /Running for\s+(\d+)\s*min/.exec(screen.getByRole('timer').textContent ?? '')?.[1]
+        );
+        expect(minutes).toBeGreaterThanOrEqual(6);
+      });
     });
 
     it('stops the clock once the run is terminal', async () => {
@@ -261,24 +275,20 @@ describe('RunDetail', () => {
     });
 
     it('tears the clock down on unmount', async () => {
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-      const setInterval = vi.spyOn(globalThis, 'setInterval');
-      const clearInterval = vi.spyOn(globalThis, 'clearInterval');
+      clockAt(60_000, { fake: true });
       vi.mocked(getJob).mockResolvedValue(runningJob());
       const { unmount } = renderRun();
 
       await screen.findByRole('timer');
-      const tick = setInterval.mock.results.find(
-        (_, i) => setInterval.mock.calls[i][1] === TICK_MS
-      );
-      expect(tick).toBeDefined();
+      // A live clock while the page is mounted...
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
 
       unmount();
 
-      // The heartbeat's own timer, by id — not just "some interval was freed".
-      expect(clearInterval).toHaveBeenCalledWith(tick?.value);
-      setInterval.mockRestore();
-      clearInterval.mockRestore();
+      // ...and nothing left running after it goes. Asserted behaviourally:
+      // spying on globalThis.setInterval after fake timers have replaced it
+      // pins an implementation detail and finds nothing under some orderings.
+      expect(vi.getTimerCount()).toBe(0);
     });
 
     it('stops the clock and says so when polling gives up', async () => {

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -3,12 +3,12 @@
  * with the progress/outputs UI — the run now has its own page and URL.
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { ReactNode } from 'react';
-import RunDetail from './RunDetail';
+import RunDetail, { TICK_MS } from './RunDetail';
 import type { CalibrationJob } from '../types/CalibrationTypes';
 
 vi.mock('../services/calibrationService', () => ({
@@ -43,7 +43,10 @@ function runningJob(): CalibrationJob {
       currentStage: 'image2',
       message: 'running image2',
       downloadPct: null,
+      currentFile: null,
+      totalFiles: null,
     },
+    updatedAt: null,
     logTail: ['Step flat_field running'],
     result: null,
     error: null,
@@ -134,6 +137,420 @@ describe('RunDetail', () => {
     renderRun();
     await waitFor(() => expect(screen.getByText(/Run failed: boom/)).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument();
+  });
+
+  /**
+   * A run goes visually dead for minutes at a time (#1770) — a measured 4-file
+   * run emitted 67 log lines in 23.6 minutes. These cases pin the parts of the
+   * page whose whole job is to make that silence legible, and the graceful
+   * degradation for runs recorded before the engine reported any of it.
+   */
+  describe('heartbeat and progress detail', () => {
+    const STARTED_AT = '2026-07-24T00:00:01Z';
+    const startedMs = Date.parse(STARTED_AT);
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /** Freeze the wall clock at `startedMs + offsetMs`. */
+    function clockAt(offsetMs: number, opts?: { fake?: boolean }) {
+      if (opts?.fake) {
+        // shouldAdvanceTime keeps promises/microtasks resolving, so the poll
+        // hook still works while the heartbeat interval is under our control.
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+      }
+      vi.setSystemTime(new Date(startedMs + offsetMs));
+    }
+
+    it('shows how long the run has been going', async () => {
+      clockAt(7 * 60_000);
+      vi.mocked(getJob).mockResolvedValue(runningJob());
+      renderRun();
+
+      const timer = await screen.findByRole('timer');
+      expect(timer).toHaveTextContent(/Running for\s+7 min/);
+    });
+
+    it('shows how long since the engine last said anything', async () => {
+      clockAt(10 * 60_000);
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        updatedAt: new Date(startedMs + 6 * 60_000).toISOString(),
+      });
+      renderRun();
+
+      expect(await screen.findByRole('timer')).toHaveTextContent(/last update 4 min ago/);
+    });
+
+    it('says "just now" for a fresh update rather than "0 min ago"', async () => {
+      clockAt(60_000);
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        updatedAt: new Date(startedMs + 59_000).toISOString(),
+      });
+      renderRun();
+
+      expect(await screen.findByRole('timer')).toHaveTextContent(/last update just now/);
+    });
+
+    it('keeps ticking when no new data arrives — that motion is the signal', async () => {
+      clockAt(60_000, { fake: true });
+      // The same job object on every poll: nothing about the run changes.
+      const frozen = runningJob();
+      vi.mocked(getJob).mockResolvedValue(frozen);
+      renderRun();
+
+      const timer = await screen.findByRole('timer');
+      expect(timer).toHaveTextContent(/Running for\s+1 min/);
+
+      await act(async () => {
+        vi.advanceTimersByTime(5 * 60_000);
+      });
+
+      expect(await screen.findByRole('timer')).toHaveTextContent(/Running for\s+6 min/);
+    });
+
+    it('stops the clock once the run is terminal', async () => {
+      clockAt(60 * 60_000, { fake: true });
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        status: 'succeeded' as const,
+        finishedAt: new Date(startedMs + 12 * 60_000).toISOString(),
+        result: null,
+      });
+      renderRun();
+
+      const timer = await screen.findByRole('timer');
+      // Frozen at the run's own end, not at "now" an hour later.
+      expect(timer).toHaveTextContent(/Took\s+12 min/);
+
+      await act(async () => {
+        vi.advanceTimersByTime(10 * 60_000);
+      });
+      expect(await screen.findByRole('timer')).toHaveTextContent(/Took\s+12 min/);
+    });
+
+    it('says a queued run is queued, not running, and quotes no remaining time', async () => {
+      clockAt(4 * 60_000);
+      const job = withRequest(runningJob(), { detector1: true });
+      job.status = 'queued';
+      job.startedAt = null;
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      const timer = await screen.findByRole('timer');
+      expect(timer).toHaveTextContent(/Queued for\s+4 min/);
+      expect(timer).not.toHaveTextContent(/left/);
+    });
+
+    it('never starts a clock for a run that is already over', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const setInterval = vi.spyOn(globalThis, 'setInterval');
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        status: 'succeeded' as const,
+        finishedAt: '2026-07-24T00:12:00Z',
+        result: null,
+      });
+      renderRun();
+
+      await screen.findByRole('timer');
+      expect(setInterval.mock.calls.some(([, ms]) => ms === TICK_MS)).toBe(false);
+      setInterval.mockRestore();
+    });
+
+    it('tears the clock down on unmount', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const setInterval = vi.spyOn(globalThis, 'setInterval');
+      const clearInterval = vi.spyOn(globalThis, 'clearInterval');
+      vi.mocked(getJob).mockResolvedValue(runningJob());
+      const { unmount } = renderRun();
+
+      await screen.findByRole('timer');
+      const tick = setInterval.mock.results.find(
+        (_, i) => setInterval.mock.calls[i][1] === TICK_MS
+      );
+      expect(tick).toBeDefined();
+
+      unmount();
+
+      // The heartbeat's own timer, by id — not just "some interval was freed".
+      expect(clearInterval).toHaveBeenCalledWith(tick?.value);
+      setInterval.mockRestore();
+      clearInterval.mockRestore();
+    });
+
+    it('stops the clock and says so when polling gives up', async () => {
+      // A ticking clock over a page that is no longer talking to the engine is
+      // a worse lie than the silence the heartbeat exists to explain.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.mocked(getJob).mockRejectedValue(new Error('network down'));
+      renderRun();
+
+      // Async advance: each retry is scheduled from a rejected promise, so the
+      // microtask queue has to drain between timer firings.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+
+      expect(await screen.findByText(/Lost contact with the engine/)).toBeInTheDocument();
+      expect(screen.queryByText(/retrying/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('timer')).not.toBeInTheDocument();
+    });
+
+    it('switches the clock to the past tense once contact is lost mid-run', async () => {
+      clockAt(6 * 60_000, { fake: true });
+      // One good poll, then the engine goes away for good.
+      vi.mocked(getJob)
+        .mockResolvedValueOnce(runningJob())
+        .mockRejectedValue(new Error('network down'));
+      renderRun();
+
+      await screen.findByRole('timer');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+
+      // The last known duration is still worth showing — but not as a claim
+      // about right now.
+      const timer = screen.getByRole('timer');
+      expect(timer).toHaveTextContent(/Was running for\s+6 min/);
+      expect(timer).not.toHaveTextContent(/last update/);
+      expect(screen.getByText(/Lost contact with the engine/)).toBeInTheDocument();
+    });
+
+    it('keeps the engine error visible when it calls a run interrupted', async () => {
+      // The detection is a heuristic; a false positive must not swallow the
+      // only diagnostic the page had.
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        status: 'failed' as const,
+        finishedAt: '2026-07-24T00:10:00Z',
+        error: 'Connection aborted, remote end shut down',
+      });
+      renderRun();
+
+      expect(await screen.findByText(/Interrupted — the engine restarted/)).toBeInTheDocument();
+      expect(screen.getByText(/Connection aborted, remote end shut down/)).toBeInTheDocument();
+    });
+
+    it('hides the duration of a terminal run with no finish time', async () => {
+      // Rather than measure to "now" and claim a five-minute run took a week.
+      clockAt(7 * 24 * 60 * 60_000);
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        status: 'cancelled' as const,
+        finishedAt: null,
+      });
+      renderRun();
+
+      await screen.findByText('Run cancelled.');
+      expect(screen.queryByRole('timer')).not.toBeInTheDocument();
+    });
+
+    it('attributes the sub-step to the stage it came from, not to any running stage', async () => {
+      const job = runningJob();
+      job.progress.currentStage = 'detector1:jump';
+      job.progress.currentFile = 2;
+      job.progress.totalFiles = 4;
+      // A stale stage list where image2 also reads running: "jump" is a
+      // detector1 step and must not be painted onto image2.
+      job.progress.stages = [
+        { name: 'detector1', status: 'running' },
+        { name: 'image2', status: 'running' },
+      ];
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      await waitFor(() => expect(document.querySelectorAll('.stage-node-detail')).toHaveLength(1));
+      expect(document.querySelector('.stage-node-detail')).toHaveTextContent('jump · file 2 of 4');
+    });
+
+    it('shows the file counter when the engine reports it', async () => {
+      const job = runningJob();
+      job.progress.currentFile = 2;
+      job.progress.totalFiles = 4;
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      // Both in the status line and on the running stage row — the counter is
+      // the answer to "which of my four files is this?" wherever you look.
+      await waitFor(() => expect(screen.getAllByText(/file 2 of 4/)).toHaveLength(2));
+    });
+
+    it('hides the file counter when the engine does not report it', async () => {
+      vi.mocked(getJob).mockResolvedValue(runningJob());
+      renderRun();
+
+      await screen.findByRole('timer');
+      expect(screen.queryByText(/file .* of/)).not.toBeInTheDocument();
+      expect(document.body.textContent).not.toMatch(/null|NaN|undefined/);
+    });
+
+    it('surfaces the sub-step from a "stage:step" currentStage', async () => {
+      const job = runningJob();
+      job.progress.currentStage = 'detector1:jump';
+      job.progress.stages = [{ name: 'detector1', status: 'running' }];
+      job.progress.currentFile = 2;
+      job.progress.totalFiles = 4;
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      const status = await screen.findByText(/Status:/);
+      expect(status).toHaveTextContent('detector1');
+      expect(status).toHaveTextContent('jump');
+      expect(status).toHaveTextContent('file 2 of 4');
+    });
+
+    it('handles a currentStage with no colon', async () => {
+      const job = runningJob();
+      job.progress.currentStage = 'image2';
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      const status = await screen.findByText(/Status:/);
+      expect(status).toHaveTextContent('image2');
+      // No step to show, and no stray separator left behind.
+      expect(status.textContent).not.toMatch(/·/);
+    });
+
+    it('quotes a rough remaining estimate for the stages that are running', async () => {
+      const job = withRequest(runningJob(), { detector1: true, image2: false, image3: false });
+      job.progress.totalFiles = 4;
+      clockAt(2 * 60_000);
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      // Detector1 is ~8 min/file × 4 files = ~32 min total, ~30 left after 2.
+      expect(await screen.findByRole('timer')).toHaveTextContent(/rough estimate: ~30 min left/);
+    });
+
+    it('quotes no estimate at all when the file count is unknown', async () => {
+      // A MAST run has no `inputs` until the engine reports totalFiles, and
+      // estimateMinutes would silently cost it as a single file — a 20-file
+      // run "past its ~10 min estimate" while it has hours to go.
+      const job = withRequest(runningJob(), { detector1: true });
+      job.request.inputs = [];
+      job.progress.totalFiles = null;
+      clockAt(2 * 60_000);
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      const timer = await screen.findByRole('timer');
+      expect(timer).toHaveTextContent(/Running for/);
+      expect(timer).not.toHaveTextContent(/estimate/);
+    });
+
+    it('treats a reported file count of zero as unknown, not as one file', async () => {
+      const job = withRequest(runningJob(), { detector1: true });
+      job.request.inputs = [];
+      job.progress.totalFiles = 0;
+      clockAt(2 * 60_000);
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      expect(await screen.findByRole('timer')).not.toHaveTextContent(/estimate/);
+    });
+
+    it('is honest when a run outlives its estimate', async () => {
+      const job = withRequest(runningJob(), { detector1: false, image2: true, image3: false });
+      job.progress.totalFiles = 1;
+      clockAt(90 * 60_000);
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      expect(await screen.findByRole('timer')).toHaveTextContent(/already past the rough/);
+    });
+
+    it('explains an interrupted run instead of calling it cancelled', async () => {
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        status: 'cancelled' as const,
+        finishedAt: '2026-07-24T00:10:00Z',
+        error: 'engine restarted while the job was running',
+      });
+      renderRun();
+
+      expect(await screen.findByText(/Interrupted — the engine restarted/)).toBeInTheDocument();
+      expect(screen.queryByText('Run cancelled.')).not.toBeInTheDocument();
+    });
+
+    it('explains an interrupted run recorded as failed, without the red alert', async () => {
+      // The engine's restart reconciler writes exactly this: status failed,
+      // error "interrupted by service restart". Shouting "Run failed" at
+      // someone whose run the engine killed is the bug.
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        status: 'failed' as const,
+        finishedAt: '2026-07-24T00:10:00Z',
+        error: 'interrupted by service restart',
+      });
+      renderRun();
+
+      expect(await screen.findByText(/Interrupted — the engine restarted/)).toBeInTheDocument();
+      expect(screen.queryByText(/Run failed/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('does not blame the engine when the user pressed Cancel', async () => {
+      // cancelRequested outranks the error text: only the cancel route sets it.
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        status: 'cancelled' as const,
+        cancelRequested: true,
+        finishedAt: '2026-07-24T00:10:00Z',
+        // Even with text that would otherwise read as an interruption.
+        error: 'interrupted by service restart',
+      });
+      renderRun();
+
+      expect(await screen.findByText('Run cancelled.')).toBeInTheDocument();
+      expect(screen.queryByText(/Interrupted/)).not.toBeInTheDocument();
+    });
+
+    it('keeps a real pipeline failure loud', async () => {
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        status: 'failed' as const,
+        finishedAt: '2026-07-24T00:10:00Z',
+        error: 'jump step diverged',
+      });
+      renderRun();
+
+      expect(await screen.findByText(/Run failed: jump step diverged/)).toBeInTheDocument();
+    });
+
+    it('still says "cancelled" when the user pressed Cancel', async () => {
+      vi.mocked(getJob).mockResolvedValue({
+        ...runningJob(),
+        status: 'cancelled' as const,
+        finishedAt: '2026-07-24T00:10:00Z',
+        error: null,
+      });
+      renderRun();
+
+      expect(await screen.findByText('Run cancelled.')).toBeInTheDocument();
+      expect(screen.queryByText(/Interrupted/)).not.toBeInTheDocument();
+    });
+
+    it('degrades gracefully when every new field is null', async () => {
+      const job = runningJob();
+      job.progress.currentStage = null;
+      job.progress.message = null;
+      job.updatedAt = null;
+      job.startedAt = null;
+      job.progress.currentFile = null;
+      job.progress.totalFiles = null;
+      vi.mocked(getJob).mockResolvedValue(job);
+      renderRun();
+
+      // Falls back to createdAt for elapsed; everything else simply absent.
+      await waitFor(() => expect(screen.getByText(/Status:/)).toBeInTheDocument());
+      expect(screen.queryByText(/last update/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/file .* of/)).not.toBeInTheDocument();
+      expect(document.body.textContent).not.toMatch(/NaN|null|undefined/);
+    });
   });
 
   describe('configuration summary and re-run', () => {

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -8,12 +8,21 @@
  * with no way back to it.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { LogPanel } from '../components/wizard/LogPanel';
 import { EmptyState } from '../components/ui/EmptyState';
 import { ImagePreviewLightbox } from '../components/ui/ImagePreviewLightbox';
 import { StageTimeline } from '../components/calibration/StageTimeline';
+import { estimateMinutes, formatEstimate, specFor } from '../components/calibration/stagePipeline';
+import {
+  formatAgo,
+  formatDuration,
+  formatFileCounter,
+  parseCurrentStage,
+  toMillis,
+  wasInterrupted,
+} from '../components/calibration/runTiming';
 import { toast } from '../components/ui/toast';
 import { useCalibrationJob } from '../hooks/useCalibrationJob';
 import {
@@ -24,6 +33,14 @@ import {
 } from '../services/calibrationService';
 import type { StepOverrides } from '../types/CalibrationTypes';
 import './CalibrateRun.css';
+
+/**
+ * How often the heartbeat re-renders (#1770). The engine can be silent for
+ * eight minutes at a time, so the ticking clock — not new data — is what tells
+ * the user the page is alive. One second is fine: it is a text swap on a
+ * handful of nodes, and it stops entirely once the job is terminal.
+ */
+export const TICK_MS = 1000;
 
 /** Only FITS image products can be rendered or saved as library images;
  *  catalogs (.ecsv) and ASDF outputs are download-only. */
@@ -50,7 +67,12 @@ function overrideRows(overrides: StepOverrides | undefined): {
 
 export default function RunDetail() {
   const { jobId } = useParams<{ jobId: string }>();
-  const { job, isTerminal, error: pollError } = useCalibrationJob(jobId ?? null);
+  const {
+    job,
+    isTerminal,
+    error: pollError,
+    stopped: pollStopped,
+  } = useCalibrationJob(jobId ?? null);
   const navigate = useNavigate();
 
   // Jobs created before #1751 stored only storage keys, which cannot be turned
@@ -65,6 +87,19 @@ export default function RunDetail() {
   const [savedIds, setSavedIds] = useState<Record<number, string>>({});
   const [savingIndex, setSavingIndex] = useState<number | null>(null);
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+
+  // The heartbeat clock. Depends on a boolean rather than on `job` itself, so
+  // the 1.5s poll doesn't tear down and rebuild the interval on every tick.
+  const [now, setNow] = useState(() => Date.now());
+  // Not just "the job is unfinished": once polling has given up, the page is
+  // no longer watching anything, and a clock that kept moving would be
+  // claiming otherwise.
+  const isLive = job !== null && !isTerminal && !pollStopped;
+  useEffect(() => {
+    if (!isLive) return undefined;
+    const id = setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => clearInterval(id);
+  }, [isLive]);
 
   const loadPreview = useCallback(
     () => getJobOutputPreview(jobId ?? '', previewIndex ?? 0),
@@ -109,6 +144,79 @@ export default function RunDetail() {
       });
     }
   };
+
+  // Computed once rather than twice inline: this render now repeats on a
+  // one-second tick, so the JSX should not do the same work twice per tick.
+  const paramRows = overrideRows(job?.request?.run_overrides);
+
+  // --- Heartbeat / progress detail (#1770) -------------------------------
+  // Every value below is null-tolerant: runs recorded before the engine
+  // reported these fields must simply not show them, never "file null of null".
+  // `??` per-parse, not on the raw strings: a present-but-unparseable
+  // startedAt should still fall back to createdAt rather than lose the clock.
+  const runStartMs = toMillis(job?.startedAt);
+  const startMs = runStartMs ?? toMillis(job?.createdAt);
+  const finishedMs = toMillis(job?.finishedAt);
+  const endMs = isTerminal ? finishedMs : now;
+  // A finished run's clock stops at its end, not at the last render. Without a
+  // finishedAt there is no honest duration to show — `now` would be whenever
+  // the page happened to mount, so a run opened a week later would claim to
+  // have taken a week. Hide it instead of inventing it.
+  const elapsedMs = startMs === null || endMs === null ? null : Math.max(endMs - startMs, 0);
+  const updatedMs = toMillis(job?.updatedAt);
+  const sinceUpdateMs = updatedMs === null ? null : Math.max(now - updatedMs, 0);
+
+  const { stage: currentStageName, step: currentStep } = parseCurrentStage(
+    job?.progress.currentStage
+  );
+  const fileCounter = formatFileCounter(job?.progress.currentFile, job?.progress.totalFiles);
+
+  // Same rough model the config page quotes before the run starts, so the
+  // number the user was given up front is the one they keep seeing.
+  const enabledSpecs = (job?.request?.recipe_snapshot?.stages ?? []).flatMap((s) => {
+    const spec = specFor(s.name);
+    return s.enabled && spec ? [spec] : [];
+  });
+  // Only when the file count is actually known. estimateMinutes clamps an
+  // unknown count to one file, so a 20-file MAST run (inputs is empty until
+  // the engine reports totalFiles) would be quoted as a single file and go
+  // "past the estimate" within minutes of a job that legitimately runs for
+  // hours. A missing estimate is honest; a confidently wrong one is not.
+  const reportedFiles = job?.progress.totalFiles;
+  const knownFileCount =
+    (reportedFiles && reportedFiles > 0 ? reportedFiles : null) ??
+    (job?.request?.inputs?.length || null);
+  const totalEstimateMinutes =
+    enabledSpecs.length > 0 && knownFileCount !== null
+      ? estimateMinutes(enabledSpecs, knownFileCount)
+      : 0;
+  const remainingMinutes =
+    totalEstimateMinutes > 0 && elapsedMs !== null
+      ? totalEstimateMinutes - elapsedMs / 60_000
+      : null;
+
+  // Reachable from `failed` as well as `cancelled`: the engine's restart
+  // reconciler records an interrupted run as failed with
+  // "interrupted by service restart", which is the very case this explains.
+  const interrupted = job !== null && isTerminal && wasInterrupted(job);
+  // A queued run is waiting and a downloading one is fetching — neither is
+  // "running", and saying so would mislabel minutes the pipeline never saw.
+  // Without a startedAt the clock is measuring from submission, which includes
+  // the queue wait, so it says "in flight" rather than naming a phase it
+  // cannot actually vouch for.
+  const isQueued = job?.status === 'queued';
+  const elapsedLabel = (() => {
+    if (isTerminal) return 'Took';
+    // The phase comes first, then the tense: once polling has given up the
+    // clock is frozen at the last successful poll, so the present tense would
+    // be the page's one remaining moving-target claim — but a run that was
+    // queued when contact was lost was never "running" either.
+    if (isQueued) return pollStopped ? 'Was queued for' : 'Queued for';
+    if (runStartMs === null) return pollStopped ? 'Was in flight for' : 'In flight for';
+    if (job?.status === 'downloading')
+      return pollStopped ? 'Was downloading for' : 'Downloading for';
+    return pollStopped ? 'Was running for' : 'Running for';
+  })();
 
   if (!jobId) {
     return (
@@ -184,11 +292,9 @@ export default function RunDetail() {
             </li>
             <li>
               <strong>Parameters:</strong>{' '}
-              {overrideRows(job.request.run_overrides).length === 0
+              {paramRows.length === 0
                 ? 'pipeline defaults'
-                : overrideRows(job.request.run_overrides)
-                    .map((r) => `${r.step}.${r.param}=${r.value}`)
-                    .join(', ')}
+                : paramRows.map((r) => `${r.step}.${r.param}=${r.value}`).join(', ')}
             </li>
             <li>
               <strong>Inputs:</strong>{' '}
@@ -203,8 +309,10 @@ export default function RunDetail() {
       <section className="calibrate-section" aria-labelledby="progress-heading">
         <h2 id="progress-heading">Run progress</h2>
         {pollError && (
-          <p className="calibrate-hint" role="alert">
-            {pollError} (retrying…)
+          <p className={pollStopped ? 'calibrate-error' : 'calibrate-hint'} role="alert">
+            {pollStopped
+              ? `Lost contact with the engine (${pollError}). This page has stopped watching — reload to reconnect. The run itself may still be going.`
+              : `${pollError} (retrying…)`}
           </p>
         )}
         {!job && !pollError && <p role="status">Loading run…</p>}
@@ -212,18 +320,63 @@ export default function RunDetail() {
           <>
             <p className="calibrate-status" role="status">
               Status: <strong>{job.status}</strong>
+              {currentStageName ? ` — ${currentStageName}` : ''}
+              {currentStep ? ` · ${currentStep}` : ''}
+              {fileCounter ? ` — ${fileCounter}` : ''}
               {job.progress.message ? ` — ${job.progress.message}` : ''}
               {job.status === 'downloading' && job.progress.downloadPct !== null
                 ? ` (${job.progress.downloadPct}%)`
                 : ''}
             </p>
+            {/* role="timer" rather than role="status": this text changes every
+                second, and a second polite live region next to the status line
+                would talk over it once a second. A timer is a live region with
+                aria-live="off" by default — visible motion, no announcements. */}
+            {/* Same condition the children use, so this never renders as an
+                empty named live region with nothing inside it. */}
+            {(elapsedMs !== null || (!isTerminal && sinceUpdateMs !== null)) && (
+              <p className="calibrate-heartbeat" role="timer" aria-label="Run timing">
+                {elapsedMs !== null && (
+                  <span>
+                    {elapsedLabel} <strong>{formatDuration(elapsedMs)}</strong>
+                  </span>
+                )}
+                {!isTerminal && sinceUpdateMs !== null && (
+                  <span> · last update {formatAgo(sinceUpdateMs)}</span>
+                )}
+                {/* A queued run has not started, so nothing of the estimate has
+                    been consumed yet — quoting "left" there would be a lie. */}
+                {!isTerminal && !isQueued && remainingMinutes !== null && (
+                  <span>
+                    {' · '}
+                    {/* Floored at a minute: formatEstimate renders anything
+                        under 30s as "~0 min", which reads as broken. */}
+                    {remainingMinutes > 0
+                      ? `rough estimate: ${formatEstimate(Math.max(remainingMinutes, 1))} left`
+                      : `already past the rough ${formatEstimate(totalEstimateMinutes)} estimate`}
+                  </span>
+                )}
+              </p>
+            )}
+            {!isTerminal && !isQueued && (
+              <p className="calibrate-hint">
+                Long stages are normal — the engine can be quiet for several minutes at a time. The
+                clock above keeps moving even when there is nothing new to report.
+              </p>
+            )}
             {job.status === 'queued' && (
               <p className="calibrate-hint">
                 Waiting to start — the engine runs one calibration at a time.
               </p>
             )}
             {job.progress.stages.length > 0 && (
-              <StageTimeline mode="progress" progress={job.progress.stages} />
+              <StageTimeline
+                mode="progress"
+                progress={job.progress.stages}
+                currentStageName={currentStageName}
+                currentStep={currentStep}
+                fileCounter={fileCounter}
+              />
             )}
             <LogPanel messages={job.logTail} defaultOpen={true} />
             {!isTerminal && (
@@ -308,12 +461,27 @@ export default function RunDetail() {
                 )}
               </div>
             )}
-            {job.status === 'failed' && (
+            {/* An interruption is not a failure of the run and not something
+                the user did, so it gets neither the red "Run failed: …" alert
+                nor the bare "Run cancelled." — both of which read as blame. */}
+            {interrupted && (
+              <>
+                <p className="calibrate-hint" role="status">
+                  Interrupted — the engine restarted, so this run stopped. Nothing you did caused
+                  it; re-run it when you are ready.
+                </p>
+                {/* The detection is a heuristic over the error text, so keep
+                    the text: if it guesses wrong, the user still has the only
+                    diagnostic string the page ever had. */}
+                {job.error && <p className="calibrate-hint">Engine said: {job.error}</p>}
+              </>
+            )}
+            {!interrupted && job.status === 'failed' && (
               <p className="calibrate-error" role="alert">
                 Run failed: {job.error ?? 'unknown error'}
               </p>
             )}
-            {job.status === 'cancelled' && (
+            {!interrupted && job.status === 'cancelled' && (
               <p className="calibrate-hint" role="status">
                 Run cancelled.
               </p>

--- a/frontend/jwst-frontend/src/types/CalibrationTypes.ts
+++ b/frontend/jwst-frontend/src/types/CalibrationTypes.ts
@@ -97,11 +97,23 @@ export interface CalibrationJob {
   createdAt: string;
   startedAt: string | null;
   finishedAt: string | null;
+  /**
+   * When the engine last touched this job (#1770). The run page renders it as
+   * "last update N min ago" — during a long stage this is the only honest
+   * answer to "is it stuck?". Null for jobs recorded before the engine
+   * started stamping it.
+   */
+  updatedAt?: string | null;
   progress: {
     stages: CalibrationJobStage[];
+    /** "stage:step" (e.g. "detector1:jump"), or a bare stage name. */
     currentStage: string | null;
     message: string | null;
     downloadPct: number | null;
+    /** 1-based index of the file being processed; null when unreported. */
+    currentFile?: number | null;
+    /** How many files this run will process; null when unreported. */
+    totalFiles?: number | null;
   };
   logTail: string[];
   result: {


### PR DESCRIPTION
Closes #1770

## Summary

The calibration run page went visually dead for minutes at a time: a measured 4-file run emitted **67 log lines in 23.6 minutes**, and the page showed only `Status: running — jump running`, a stage checklist, a log panel and Cancel. There was no way to tell a working run from a hung one.

The engine genuinely has little to say while a stage runs, so this PR does not invent motion — it makes the *waiting* legible, and removes the places where the page was quietly making claims it could not back.

Frontend only. The new job fields (`updatedAt`, `progress.currentFile`, `progress.totalFiles`) are being added engine-side separately; every element here degrades to "not shown" when they are absent, so this is safe to merge before that lands and safe for runs already in the database.

## Changes Made

- **Heartbeat** (`RunDetail.tsx`): elapsed time and "last update N min ago", re-rendered on a 1s interval so the ticking itself is the signal that the page is alive. Rendered in a `role="timer"` region — a live region with `aria-live="off"` by default — rather than a second `role="status"` that would talk over the existing one once a second. The interval never starts for a terminal job, stops when polling gives up, and is cleared on unmount.
- **Phase-accurate labels**: "Running for" / "Downloading for" / "Queued for" / "In flight for" (no `startedAt`, so the clock includes queue time) / "Took" (terminal) / "Was … for" (contact lost). A terminal run with no `finishedAt` shows no duration at all rather than measuring to "now".
- **File counter**: "file 2 of 4" in the status line and on the running stage row, when the engine reports it.
- **Sub-step**: `progress.currentStage` is `"stage:step"`; the step is now surfaced ("detector1 · jump"). Bare stage names, empty halves, extra colons and whitespace all handled.
- **Stage attribution** (`StageTimeline.tsx`): new optional `currentStageName` / `currentStep` / `fileCounter` props. The detail line attaches only to the stage the engine named, so a stale `jump` (a detector1 step) can never be painted onto whichever stage happens to read `running`.
- **Rough remaining estimate**: reuses `stagePipeline.estimateMinutes`/`formatEstimate` (the same numbers the config page quotes before the run starts). Quoted **only when the file count is actually known** — `estimateMinutes` clamps an unknown count to one file, which would cost a 20-file MAST run as a single file. Copy is explicit that it is rough, and says "already past the rough ~N min estimate" when a run outlives it.
- **Interrupted vs cancelled**: an engine restart is recorded as terminal with an error the user cannot act on and, today, as `failed` with "interrupted by service restart". It now renders "Interrupted — the engine restarted, so this run stopped. Nothing you did caused it…" instead of a red "Run failed" or a bare "Run cancelled." Detection is primarily the structured `cancelRequested` flag (only the user's cancel route sets it), narrowed by the error text; the engine's error string is kept visible underneath because the text match is a heuristic.
- **Honest polling state** (`useCalibrationJob.ts`): the hook already gave up after 5 consecutive failures but the page still said "(retrying…)" and would have kept ticking. It now exposes `stopped`; the page halts the clock and says "Lost contact with the engine … reload to reconnect. The run itself may still be going."
- **New module** `components/calibration/runTiming.ts`: pure, total-over-null helpers (`toMillis`, `formatDuration`, `formatAgo`, `parseCurrentStage`, `formatFileCounter`, `isInterrupted`, `wasInterrupted`).
- **Types** (`CalibrationTypes.ts`): `updatedAt`, `progress.currentFile`, `progress.totalFiles` added as optional/nullable, documented as absent on older records.

## Test Plan

Automated (all run locally on this branch):

- [x] `npx tsc -b` — clean
- [x] `npx eslint src` — **0 errors**, 70 warnings (all pre-existing; none in the changed files)
- [x] `npx vitest run` — **1436 passed / 121 files** (full suite, not just the changed file — the two heartbeat timer tests were initially load-dependent and are now asserted behaviourally: the ticking case advances timers asynchronously and asserts the clock *moved* rather than pinning an exact reading, and the teardown case uses `vi.getTimerCount()` instead of spying on a `setInterval` that fake timers have already replaced). Was 1333 before this branch; +103 cases, including four self-review rounds' worth of regressions.
- [x] `runTiming.test.ts` — table-driven cases per helper: hour/minute/negative/non-finite durations, the "just now" boundary, `parseCurrentStage` on `null`/`''`/`':'`/`'a:'`/`':b'`/`'a:b:c'`/whitespace, `formatFileCounter` on `0 of 4`, `5 of 4`, `NaN`, `Infinity`, nulls, and every `wasInterrupted` branch
- [x] `RunDetail.test.tsx` — elapsed, last-update, "just now", ticking with no new data (fake timers), clock frozen on terminal, no interval registered for a terminal job, nothing left pending after unmount, poll give-up, past-tense label after contact loss, file counter shown/hidden, sub-step with and without a colon, estimate shown / suppressed when the count is unknown / suppressed at `totalFiles: 0` / "past the estimate", interrupted-as-failed, interrupted-as-cancelled, user-cancel not blamed on the engine, genuine failure still loud, engine error preserved under the interrupted banner, and all-fields-null degradation asserting the DOM contains no `null`/`NaN`/`undefined`
- [x] `StageTimeline.test.tsx` — detail attaches to the named stage only (with two stages reading `running`), nothing when the stage is unknown, nothing on a non-running stage, ignored in config mode
- [x] `useCalibrationJob.test.ts` — `stopped` stays false below the 5-failure threshold and flips at it, polling really ceases afterwards, and `stopped` resets when the job id changes

Manual (needs a running stack; **not yet performed** — the engine fields land separately):

1. `docker compose up -d --build`, start a calibration run from a recipe with Detector1 enabled and 2+ input files.
2. Open `/calibrate/runs/:jobId`. Confirm "Running for N min" increments once a second **without** any new log lines arriving, and that the log panel stays still — the clock is the only thing moving.
3. Leave the page open through a full Detector1 stage (several minutes of silence). Confirm the elapsed clock and the "rough estimate: ~N min left" both keep updating and that the estimate decreases.
4. Once the engine reports them, confirm "detector1 · jump — file 2 of 4" appears in the status line and the same detail appears under the Detector1 node only — not under any other stage.
5. Let the run finish. Confirm the clock switches to "Took N min" and stops moving, and that no interval remains (React DevTools / no re-renders).
6. Press Cancel on a fresh run. Confirm it reads exactly "Run cancelled." with no interruption copy.
7. `docker compose restart processing-engine` mid-run. Reopen the run. Confirm it reads "Interrupted — the engine restarted…" with the engine's error text beneath, and **not** a red "Run failed".
8. Stop the engine entirely while a run page is open. After ~8 seconds confirm the clock stops, the label becomes "Was running for", and the banner reads "Lost contact with the engine … reload to reconnect".
9. Open an old run recorded before this change. Confirm no "file null of null", no "NaN min ago", and no empty timer region.

## Documentation Checklist

- [x] No API endpoints added or changed — frontend-only rendering over the existing `GET /api/jobs/{id}`
- [x] No new models or migrations
- [x] New optional wire fields documented inline in `CalibrationTypes.ts` with why they may be absent
- [x] Rationale for each decision captured in code comments (why `role="timer"`, why the estimate is suppressed, why the error text is kept)
- [ ] No user-facing docs page covers the run detail screen yet — nothing to update

## Tech Debt Impact

- [x] Reduces debt — `useCalibrationJob` no longer silently gives up while the UI claims to be retrying, a bug that predates this work
- [x] Reduces debt — the interrupted-run case was previously indistinguishable from a user cancel
- [x] No new debt introduced
- [ ] Adds debt
- **Follow-up worth filing**: the engine's `current_stage` defaults to the placeholder `"run"`, so a step logged before any stage is entered surfaces as "running — run · jump". Cosmetic, engine-side, and out of scope here.

## Risk & Rollback

**Risk: low.** One page, one shared component (with new props defaulting to `null`, so the config-mode consumer is unchanged), one hook (additive return field, single consumer), and one new pure module. No API, storage, auth or data-model surface. The heartbeat is a 1s text swap on a handful of nodes that only runs while a job is live and this page is mounted.

Sharpest edge: the `wasInterrupted` heuristic could mislabel a genuine failure whose error text mentions a restart or shutdown. Mitigated by gating on the structured `cancelRequested` flag first and by keeping the engine's error text on screen either way, so no diagnostic is ever lost.

**Rollback:** `git revert` the single commit. Nothing persists, nothing migrates, and no other code depends on the new module.

https://claude.ai/code/session_011MwLzBH8Zm3mnCf6SBxzJh
