### PR TITLE
fix: enforce ownership on CancelImport (IDOR) and record job owner at creation

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
@@ -390,6 +390,7 @@ public class MastControllerTests
         {
             JobId = "test-job",
             ObsId = "jw02733-o001_t001_nircam",
+            UserId = TestUserId,
             IsComplete = true,
             Stage = ImportStages.Complete,
         };
@@ -414,12 +415,13 @@ public class MastControllerTests
         {
             JobId = "test-job",
             ObsId = "jw02733-o001_t001_nircam",
+            UserId = TestUserId,
             IsComplete = false,
             DownloadJobId = "download-job-123",
         };
         mockJobTracker.Setup(j => j.GetJob("test-job"))
             .Returns(job);
-        mockJobTracker.Setup(j => j.CancelJob("test-job", It.IsAny<string>()))
+        mockJobTracker.Setup(j => j.CancelJob("test-job", TestUserId, false))
             .Returns(true);
         mockMastService.Setup(s => s.PauseDownloadAsync("download-job-123"))
             .ReturnsAsync(new PauseResumeResponse { Status = "paused", Message = "Download paused" });
@@ -429,7 +431,7 @@ public class MastControllerTests
 
         // Assert
         Assert.IsType<OkObjectResult>(result);
-        mockJobTracker.Verify(j => j.CancelJob("test-job", It.IsAny<string>()), Times.Once);
+        mockJobTracker.Verify(j => j.CancelJob("test-job", TestUserId, false), Times.Once);
         mockMastService.Verify(s => s.PauseDownloadAsync("download-job-123"), Times.Once);
     }
 
@@ -605,6 +607,148 @@ public class MastControllerTests
 
         // Assert — non-owner gets 404 (not 403, to prevent enumeration)
         Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // ========== #1572: CancelImport Authorization Tests ==========
+
+    /// <summary>
+    /// Tests that a non-owner cannot cancel someone else's import (IDOR, #1572).
+    /// Asserts the tracker is never reached — a 404 alone would not prove the
+    /// download was left running.
+    /// </summary>
+    [Fact]
+    public async Task CancelImport_NonOwnerGets404()
+    {
+        // Arrange
+        var job = new ImportJobStatus
+        {
+            JobId = "test-job",
+            ObsId = "jw02733-o001_t001_nircam",
+            IsComplete = false,
+            DownloadJobId = "dl-123",
+            UserId = "different-user",
+        };
+        mockJobTracker.Setup(j => j.GetJob("test-job")).Returns(job);
+
+        // Act
+        var result = await sut.CancelImport("test-job");
+
+        // Assert — non-owner gets 404 (not 403, to prevent enumeration)
+        Assert.IsType<NotFoundObjectResult>(result);
+
+        // The victim's import must still be running: the tracker is never called,
+        // and the engine is never told to pause the download.
+        mockJobTracker.Verify(
+            j => j.CancelJob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()),
+            Times.Never);
+        mockMastService.Verify(s => s.PauseDownloadAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that the job owner can still cancel their own import.
+    /// </summary>
+    [Fact]
+    public async Task CancelImport_OwnerCanCancel()
+    {
+        // Arrange
+        var job = new ImportJobStatus
+        {
+            JobId = "test-job",
+            ObsId = "jw02733-o001_t001_nircam",
+            IsComplete = false,
+            UserId = TestUserId,
+        };
+        mockJobTracker.Setup(j => j.GetJob("test-job")).Returns(job);
+        mockJobTracker.Setup(j => j.CancelJob("test-job", TestUserId, false)).Returns(true);
+
+        // Act
+        var result = await sut.CancelImport("test-job");
+
+        // Assert
+        Assert.IsType<OkObjectResult>(result);
+        mockJobTracker.Verify(j => j.CancelJob("test-job", TestUserId, false), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that an admin can cancel any user's import, matching the behaviour of
+    /// GetImportProgress and ResumeImport.
+    /// </summary>
+    [Fact]
+    public async Task CancelImport_AdminCanCancelAnyJob()
+    {
+        // Arrange
+        SetupAdminUser(TestUserId);
+        var job = new ImportJobStatus
+        {
+            JobId = "test-job",
+            ObsId = "jw02733-o001_t001_nircam",
+            IsComplete = false,
+            UserId = "other-user",
+        };
+        mockJobTracker.Setup(j => j.GetJob("test-job")).Returns(job);
+        mockJobTracker.Setup(j => j.CancelJob("test-job", TestUserId, true)).Returns(true);
+
+        // Act
+        var result = await sut.CancelImport("test-job");
+
+        // Assert
+        Assert.IsType<OkObjectResult>(result);
+        mockJobTracker.Verify(j => j.CancelJob("test-job", TestUserId, true), Times.Once);
+    }
+
+    /// <summary>
+    /// Regression guard: ImportJobStatus.UserId is nullable, so a job with no recorded
+    /// owner must not fall through the ownership check. Deny-by-default — only an admin
+    /// can cancel an unowned job. See the P1 finding in
+    /// docs/plans/features/backlog-quick-wins.md.
+    /// </summary>
+    [Fact]
+    public async Task CancelImport_WithNullUserIdJob_ReturnsNotFoundForNonAdmin()
+    {
+        // Arrange
+        var job = new ImportJobStatus
+        {
+            JobId = "test-job",
+            ObsId = "jw02733-o001_t001_nircam",
+            IsComplete = false,
+            UserId = null,
+        };
+        mockJobTracker.Setup(j => j.GetJob("test-job")).Returns(job);
+
+        // Act
+        var result = await sut.CancelImport("test-job");
+
+        // Assert
+        Assert.IsType<NotFoundObjectResult>(result);
+        mockJobTracker.Verify(
+            j => j.CancelJob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// An admin can still cancel an unowned (null UserId) job, so legacy in-flight
+    /// imports remain recoverable by an operator.
+    /// </summary>
+    [Fact]
+    public async Task CancelImport_WithNullUserIdJob_AdminCanCancel()
+    {
+        // Arrange
+        SetupAdminUser(TestUserId);
+        var job = new ImportJobStatus
+        {
+            JobId = "test-job",
+            ObsId = "jw02733-o001_t001_nircam",
+            IsComplete = false,
+            UserId = null,
+        };
+        mockJobTracker.Setup(j => j.GetJob("test-job")).Returns(job);
+        mockJobTracker.Setup(j => j.CancelJob("test-job", TestUserId, true)).Returns(true);
+
+        // Act
+        var result = await sut.CancelImport("test-job");
+
+        // Assert
+        Assert.IsType<OkObjectResult>(result);
     }
 
     // ========== #567: GetResumableImports Authorization Tests ==========
@@ -1229,10 +1373,11 @@ public class MastControllerTests
         {
             JobId = "test-job",
             ObsId = "jw02733-o001_t001_nircam",
+            UserId = TestUserId,
             IsComplete = false,
         };
         mockJobTracker.Setup(j => j.GetJob("test-job")).Returns(job);
-        mockJobTracker.Setup(j => j.CancelJob("test-job", It.IsAny<string>())).Returns(false);
+        mockJobTracker.Setup(j => j.CancelJob("test-job", TestUserId, false)).Returns(false);
 
         // Act
         var result = await sut.CancelImport("test-job");
@@ -1253,11 +1398,12 @@ public class MastControllerTests
         {
             JobId = "test-job",
             ObsId = "jw02733-o001_t001_nircam",
+            UserId = TestUserId,
             IsComplete = false,
             DownloadJobId = "dl-999",
         };
         mockJobTracker.Setup(j => j.GetJob("test-job")).Returns(job);
-        mockJobTracker.Setup(j => j.CancelJob("test-job", It.IsAny<string>())).Returns(true);
+        mockJobTracker.Setup(j => j.CancelJob("test-job", TestUserId, false)).Returns(true);
         mockMastService.Setup(s => s.PauseDownloadAsync("dl-999"))
             .ThrowsAsync(new HttpRequestException("processing engine down"));
 
@@ -1280,11 +1426,12 @@ public class MastControllerTests
         {
             JobId = "test-job",
             ObsId = "jw02733-o001_t001_nircam",
+            UserId = TestUserId,
             IsComplete = false,
             DownloadJobId = null,
         };
         mockJobTracker.Setup(j => j.GetJob("test-job")).Returns(job);
-        mockJobTracker.Setup(j => j.CancelJob("test-job", It.IsAny<string>())).Returns(true);
+        mockJobTracker.Setup(j => j.CancelJob("test-job", TestUserId, false)).Returns(true);
 
         // Act
         var result = await sut.CancelImport("test-job");

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
@@ -645,6 +645,37 @@ public class MastControllerTests
     }
 
     /// <summary>
+    /// Pins the guard ORDER. The ownership check must run before the IsComplete check —
+    /// otherwise a non-owner probing a completed job gets 400 "Job is already complete"
+    /// with its stage, confirming the job exists and leaking its state. Without this test,
+    /// moving the guard below IsComplete reintroduces that enumeration oracle and every
+    /// other test still passes.
+    /// </summary>
+    [Fact]
+    public async Task CancelImport_NonOwnerWithCompletedJob_ReturnsNotFound()
+    {
+        // Arrange
+        var job = new ImportJobStatus
+        {
+            JobId = "test-job",
+            ObsId = "jw02733-o001_t001_nircam",
+            IsComplete = true,
+            Stage = ImportStages.Complete,
+            UserId = "different-user",
+        };
+        mockJobTracker.Setup(j => j.GetJob("test-job")).Returns(job);
+
+        // Act
+        var result = await sut.CancelImport("test-job");
+
+        // Assert — 404, NOT the 400 "already complete" that would confirm the job exists
+        Assert.IsType<NotFoundObjectResult>(result);
+        mockJobTracker.Verify(
+            j => j.CancelJob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// Tests that the job owner can still cancel their own import.
     /// </summary>
     [Fact]

--- a/backend/JwstDataAnalysis.API.Tests/Services/ImportJobTrackerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/ImportJobTrackerTests.cs
@@ -117,7 +117,7 @@ public class ImportJobTrackerTests
         var jobId = sut.CreateJob("obs-123", TestUserId);
         var token = sut.GetCancellationToken(jobId);
 
-        sut.CancelJob(jobId, TestUserId).Should().BeTrue();
+        sut.CancelJob(jobId, TestUserId, false).Should().BeTrue();
 
         token.IsCancellationRequested.Should().BeTrue();
     }
@@ -126,7 +126,7 @@ public class ImportJobTrackerTests
     public void CancelJob_UpdatesJobState()
     {
         var jobId = sut.CreateJob("obs-123", TestUserId);
-        sut.CancelJob(jobId, TestUserId);
+        sut.CancelJob(jobId, TestUserId, false);
 
         var job = sut.GetJob(jobId);
         job!.Stage.Should().Be(ImportStages.Cancelled);
@@ -137,7 +137,52 @@ public class ImportJobTrackerTests
     [Fact]
     public void CancelJob_ReturnsFalse_WhenNotFound()
     {
-        sut.CancelJob("nonexistent", TestUserId).Should().BeFalse();
+        sut.CancelJob("nonexistent", TestUserId, false).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// #1572: a non-owner must not be able to cancel another user's job. Asserts the
+    /// CancellationToken is left unsignalled — the return value and the token coming apart
+    /// is the entire defect, so asserting only on the bool would not prove the fix.
+    /// </summary>
+    [Fact]
+    public void CancelJob_WithNonOwner_DoesNotCancelToken()
+    {
+        var jobId = sut.CreateJob("obs-123", TestUserId);
+        var token = sut.GetCancellationToken(jobId);
+
+        sut.CancelJob(jobId, "attacker-user", false).Should().BeFalse();
+
+        token.IsCancellationRequested.Should().BeFalse("the victim's download must keep running");
+        sut.GetJob(jobId)!.IsComplete.Should().BeFalse();
+        sut.GetJob(jobId)!.Stage.Should().NotBe(ImportStages.Cancelled);
+    }
+
+    /// <summary>
+    /// #1572: an admin may cancel any user's job.
+    /// </summary>
+    [Fact]
+    public void CancelJob_WithAdminNonOwner_ReturnsTrue()
+    {
+        var jobId = sut.CreateJob("obs-123", TestUserId);
+        var token = sut.GetCancellationToken(jobId);
+
+        sut.CancelJob(jobId, "admin-user", true).Should().BeTrue();
+
+        token.IsCancellationRequested.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// #1572: CreateJob records the owner on the job status. Regression guard — the userId
+    /// argument used to be forwarded only to the unified tracker, leaving UserId null and
+    /// silently failing every ownership check downstream.
+    /// </summary>
+    [Fact]
+    public void CreateJob_RecordsOwnerOnJobStatus()
+    {
+        var jobId = sut.CreateJob("obs-123", TestUserId);
+
+        sut.GetJob(jobId)!.UserId.Should().Be(TestUserId);
     }
 
     [Fact]
@@ -145,7 +190,7 @@ public class ImportJobTrackerTests
     {
         var jobId = sut.CreateJob("obs-123", TestUserId);
         sut.CompleteJob(jobId, new MastImportResponse { ImportedCount = 1 });
-        sut.CancelJob(jobId, TestUserId);
+        sut.CancelJob(jobId, TestUserId, false);
 
         var job = sut.GetJob(jobId);
         job!.Stage.Should().Be(ImportStages.Complete);
@@ -370,7 +415,7 @@ public class ImportJobTrackerTests
             .ReturnsAsync(true);
 
         var jobId = sut.CreateJob("obs-123", TestUserId);
-        sut.CancelJob(jobId, TestUserId);
+        sut.CancelJob(jobId, TestUserId, false);
 
         await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
 

--- a/backend/JwstDataAnalysis.API.Tests/Services/ImportJobTrackerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/ImportJobTrackerTests.cs
@@ -173,6 +173,39 @@ public class ImportJobTrackerTests
     }
 
     /// <summary>
+    /// The admin bypass must not create a path that "succeeds" on a job that does not exist.
+    /// </summary>
+    [Fact]
+    public void CancelJob_WithAdminAndUnknownJob_ReturnsFalse()
+    {
+        sut.CancelJob("nonexistent", "admin-user", true).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// When an admin cancels another user's job, the unified tracker must be told the
+    /// job's OWNER, not the admin. JobTracker.CancelJobAsync rejects an owner mismatch,
+    /// so passing the admin's id would silently no-op the unified record and the owner's
+    /// UI would hang at "running" with no cancelled SignalR push.
+    /// </summary>
+    [Fact]
+    public async Task CancelJob_WhenAdminCancels_DualWritesWithOwnerId()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        mockUnifiedTracker
+            .Setup(t => t.CancelJobAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback(() => tcs.TrySetResult(true))
+            .ReturnsAsync(true);
+
+        var jobId = sut.CreateJob("obs-123", TestUserId);
+        sut.CancelJob(jobId, "admin-user", true).Should().BeTrue();
+
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        mockUnifiedTracker.Verify(t => t.CancelJobAsync(jobId, TestUserId), Times.Once);
+        mockUnifiedTracker.Verify(t => t.CancelJobAsync(jobId, "admin-user"), Times.Never);
+    }
+
+    /// <summary>
     /// #1572: CreateJob records the owner on the job status. Regression guard — the userId
     /// argument used to be forwarded only to the unified tracker, leaving UserId null and
     /// silently failing every ownership check downstream.

--- a/backend/JwstDataAnalysis.API/Controllers/MastController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.cs
@@ -319,13 +319,25 @@ namespace JwstDataAnalysis.API.Controllers
                 return NotFound(new { error = "Job not found", jobId });
             }
 
+            // #1572: only the owner (or an admin) may cancel an import. Returns 404 rather
+            // than 403 to match GetImportProgress/ResumeImport and avoid job ID enumeration.
+            //
+            // The null check is load-bearing: ImportJobStatus.UserId is nullable, so
+            // `job.UserId != GetRequiredUserId()` alone would deny the real owner of an
+            // unowned job while reading as if it had authorised them. Unowned jobs are
+            // admin-only by design.
+            if (!IsCurrentUserAdmin() && (job.UserId is null || job.UserId != GetRequiredUserId()))
+            {
+                return NotFound(new { error = "Job not found", jobId });
+            }
+
             if (job.IsComplete)
             {
                 return BadRequest(new { error = "Job is already complete", jobId, stage = job.Stage });
             }
 
             // Cancel the job in the tracker (this signals the background task to stop)
-            var cancelled = jobTracker.CancelJob(jobId, GetRequiredUserId());
+            var cancelled = jobTracker.CancelJob(jobId, GetRequiredUserId(), IsCurrentUserAdmin());
             if (!cancelled)
             {
                 return BadRequest(new { error = "Could not cancel job", jobId });

--- a/backend/JwstDataAnalysis.API/Services/IImportJobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/IImportJobTracker.cs
@@ -26,12 +26,16 @@ namespace JwstDataAnalysis.API.Services
         CancellationToken GetCancellationToken(string jobId);
 
         /// <summary>
-        /// Cancel a job.
+        /// Cancel a job, enforcing ownership.
         /// </summary>
         /// <param name="jobId">The job ID.</param>
-        /// <param name="userId">The owner user ID.</param>
-        /// <returns>True if cancellation was requested, false if job not found.</returns>
-        bool CancelJob(string jobId, string userId);
+        /// <param name="userId">The ID of the user requesting cancellation.</param>
+        /// <param name="isAdmin">True if the requesting user is an admin, who may cancel any job.</param>
+        /// <returns>
+        /// True if cancellation was requested; false if the job was not found, or if
+        /// <paramref name="userId"/> does not own it and <paramref name="isAdmin"/> is false (#1572).
+        /// </returns>
+        bool CancelJob(string jobId, string userId, bool isAdmin);
 
         /// <summary>
         /// Update the progress of a job.

--- a/backend/JwstDataAnalysis.API/Services/ImportJobTracker.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/ImportJobTracker.Log.cs
@@ -15,8 +15,8 @@ namespace JwstDataAnalysis.API.Services
         private partial void LogCancellationRequested(string jobId);
 
         [LoggerMessage(EventId = 5009, Level = LogLevel.Warning,
-            Message = "Cancellation denied for job {JobId}: requester is not the owner (#1572)")]
-        private partial void LogCancellationDenied(string jobId);
+            Message = "Cancellation denied for job {JobId}: requester {RequesterId} is not the owner (#1572)")]
+        private partial void LogCancellationDenied(string jobId, string requesterId);
 
         [LoggerMessage(EventId = 5003, Level = LogLevel.Debug,
             Message = "Job {JobId} progress: {Progress}% - {Stage}: {Message}")]

--- a/backend/JwstDataAnalysis.API/Services/ImportJobTracker.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/ImportJobTracker.Log.cs
@@ -14,6 +14,10 @@ namespace JwstDataAnalysis.API.Services
             Message = "Cancellation requested for job {JobId}")]
         private partial void LogCancellationRequested(string jobId);
 
+        [LoggerMessage(EventId = 5009, Level = LogLevel.Warning,
+            Message = "Cancellation denied for job {JobId}: requester is not the owner (#1572)")]
+        private partial void LogCancellationDenied(string jobId);
+
         [LoggerMessage(EventId = 5003, Level = LogLevel.Debug,
             Message = "Job {JobId} progress: {Progress}% - {Stage}: {Message}")]
         private partial void LogProgressUpdate(string jobId, int progress, string stage, string message);

--- a/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
@@ -33,6 +33,13 @@ namespace JwstDataAnalysis.API.Services
                 Message = "Initializing import...",
                 IsComplete = false,
                 StartedAt = DateTime.UtcNow,
+
+                // #1572: record the owner at creation. Previously this parameter was only
+                // forwarded to the unified tracker's dual-write, leaving ImportJobStatus.UserId
+                // null unless the caller remembered to assign it afterwards — which
+                // ImportFromExisting did not, so its jobs were unowned and already failed the
+                // ownership guards on GetImportProgress/ResumeImport.
+                UserId = userId,
             };
 
             jobs[jobId] = job;
@@ -69,8 +76,27 @@ namespace JwstDataAnalysis.API.Services
             return CancellationToken.None;
         }
 
-        public bool CancelJob(string jobId, string userId)
+        public bool CancelJob(string jobId, string userId, bool isAdmin)
         {
+            // #1572: enforce ownership BEFORE cancelling the token. Cancelling the CTS is
+            // what actually stops the download, so an ownership check that runs after it
+            // (or only on the dual-write below) is no check at all.
+            //
+            // A job with no recorded UserId is treated as unowned and cancellable only by
+            // an admin — ImportJobStatus.UserId is nullable, and defaulting an unowned job
+            // to "anyone may cancel" would reopen the hole this guard closes.
+            if (!isAdmin)
+            {
+                // Deny by default: a non-admin must find the job AND own it. Falling through
+                // when the job is absent from `jobs` would leave the token cancellable by
+                // jobId alone, which is the original defect.
+                if (!jobs.TryGetValue(jobId, out var owner) || owner.UserId != userId)
+                {
+                    LogCancellationDenied(jobId);
+                    return false;
+                }
+            }
+
             if (cancellationTokens.TryGetValue(jobId, out var cts))
             {
                 cts.Cancel();

--- a/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
@@ -85,16 +85,15 @@ namespace JwstDataAnalysis.API.Services
             // A job with no recorded UserId is treated as unowned and cancellable only by
             // an admin — ImportJobStatus.UserId is nullable, and defaulting an unowned job
             // to "anyone may cancel" would reopen the hole this guard closes.
-            if (!isAdmin)
+            jobs.TryGetValue(jobId, out var job);
+
+            // Deny by default: a non-admin must find the job AND own it. Falling through when
+            // the job is absent would leave the token cancellable by jobId alone, which is the
+            // original defect.
+            if (!isAdmin && (job is null || job.UserId != userId))
             {
-                // Deny by default: a non-admin must find the job AND own it. Falling through
-                // when the job is absent from `jobs` would leave the token cancellable by
-                // jobId alone, which is the original defect.
-                if (!jobs.TryGetValue(jobId, out var owner) || owner.UserId != userId)
-                {
-                    LogCancellationDenied(jobId);
-                    return false;
-                }
+                LogCancellationDenied(jobId, userId);
+                return false;
             }
 
             if (cancellationTokens.TryGetValue(jobId, out var cts))
@@ -102,7 +101,7 @@ namespace JwstDataAnalysis.API.Services
                 cts.Cancel();
                 LogCancellationRequested(jobId);
 
-                if (jobs.TryGetValue(jobId, out var job) && !job.IsComplete)
+                if (job is not null && !job.IsComplete)
                 {
                     job.Stage = ImportStages.Cancelled;
                     job.Message = "Import cancelled by user";
@@ -110,8 +109,14 @@ namespace JwstDataAnalysis.API.Services
                     job.CompletedAt = DateTime.UtcNow;
                 }
 
-                // Dual-write: cancel in unified tracker
-                DualWrite(() => unifiedTracker.CancelJobAsync(jobId, userId), jobId, "CancelJob");
+                // Dual-write as the job's OWNER, not the requester. JobTracker.CancelJobAsync
+                // rejects a mismatch, so passing an admin's id here would silently no-op the
+                // unified record: the owner's UI would never receive the cancelled SignalR
+                // push and would hang at "running" until TTL.
+                DualWrite(
+                    () => unifiedTracker.CancelJobAsync(jobId, job?.UserId ?? userId),
+                    jobId,
+                    "CancelJob");
 
                 return true;
             }

--- a/docs/plans/features/backlog-quick-wins.md
+++ b/docs/plans/features/backlog-quick-wins.md
@@ -524,3 +524,40 @@ it is green regardless of the others.
 **Sound — proceed, with the P1 null-owner guard form and the six test tasks treated as
 mandatory, not optional.** No `EnterPlanMode` required: nothing here is load-bearing, and each
 PR reverts independently.
+
+---
+
+# Implementation note — PR 1 shipped 2026-07-27
+
+The P1 prediction was correct but **understated the cause**. The review assumed null
+`UserId` came from legacy jobs. The actual source is a live defect:
+
+`ImportJobTracker.CreateJob(obsId, userId)` accepted `userId` and **never assigned it to
+`job.UserId`** — it forwarded the value only to the unified tracker's dual-write. Ownership
+was therefore set by each *caller*, after the fact:
+
+| Caller | Assigns `UserId`? |
+|---|---|
+| `MastController.Import` (:267) | ✅ yes, at :274 |
+| `MastController` resume path (:1054) | ✅ yes, at :1062 |
+| `MastController.ImportFromExisting` (:527) | ❌ **no** |
+
+So every job created by `POST /api/mast/import/from-existing/{obsId}` was **unowned in
+production**. That means the *existing* ownership guards on `GetImportProgress` (:302) and
+`ResumeImport` (:370) — `job.UserId != GetRequiredUserId()` — were already returning **404 to
+the legitimate owner** for those jobs. A live bug, present before this work, that the audit
+did not catch and no test covered.
+
+Fixed at the root: `CreateJob` now assigns `UserId = userId`. This removes the trap (callers
+can no longer forget), repairs the pre-existing 404-on-own-job defect on the from-existing
+path, and is what makes the new cancel guard safe rather than a lockout. In-memory job state
+means no migration is needed — a restart clears the unowned jobs.
+
+The controller-level guard kept its explicit `job.UserId is null` branch anyway:
+deny-by-default is the correct posture even once the null case should no longer arise.
+
+**Result:** full backend suite **1160/1160 green**. RED was demonstrated first — with the
+guard absent, exactly `CancelImport_NonOwnerGets404` and
+`CancelImport_WithNullUserIdJob_ReturnsNotFoundForNonAdmin` failed while the other 9
+CancelImport tests passed, confirming the P2 finding that the pre-existing suite was blind to
+this bug.

--- a/docs/plans/features/backlog-quick-wins.md
+++ b/docs/plans/features/backlog-quick-wins.md
@@ -1,0 +1,526 @@
+# Plan — Backlog Quick Wins (post-audit)
+
+**Branch:** `fix/backlog-quick-wins`
+**Date:** 2026-07-26
+**Source:** full open-issue audit 2026-07-26 (229 → 210 open after closing 19)
+**Baseline:** `origin/main` @ `b345be4`
+
+Closes: #1572, #1603, #1604, #1563, #1585
+
+---
+
+## Why these five
+
+The audit surfaced two categories worth acting on immediately:
+
+1. **#1572** — a confirmed IDOR in production code. Highest severity in the whole backlog.
+2. **#1603 / #1604 / #1563 / #1585** — cheap, verified, and *actively decaying*. Two of them
+   have measurably worsened since filing: CI ruff is now a full minor behind (`0.15.12` vs
+   `0.16.0`, filed when the gap was 5 patches), and the tseslint plugin/parser skew widened
+   from `8.61.1/8.58.0` to `8.65.0/8.58.0`.
+
+Everything here is verified present on `origin/main` — no speculative work.
+
+### Scope judgement call
+
+The user's "the wins" most directly names the four cheap CI/infra items. I have included
+**#1572** as PR 1 because it is the highest-value item the audit found and is genuinely small
+(one guard + one predicate + three tests). It ships independently of the other four — drop it
+from the batch without affecting anything else if you'd rather handle it separately.
+
+---
+
+## PR 1 — Fix the CancelImport IDOR (#1572)
+
+**Risk: MEDIUM** (auth-adjacent; CLAUDE.md flags the auth flow as fragile)
+
+### The defect, verified
+
+`backend/JwstDataAnalysis.API/Controllers/MastController.cs:314` — `CancelImport` checks
+`job == null` and `job.IsComplete`, then calls `jobTracker.CancelJob(jobId, GetRequiredUserId())`.
+**There is no ownership check.** Sibling endpoints `GetImportProgress` (:302) and `ResumeImport`
+(:370) both guard with `job.UserId != GetRequiredUserId()`.
+
+Defence-in-depth also absent: `Services/ImportJobTracker.cs:72` —
+
+```csharp
+public bool CancelJob(string jobId, string userId)
+{
+    if (cancellationTokens.TryGetValue(jobId, out var cts))
+    {
+        cts.Cancel();                     // ← fires unconditionally on jobId alone
+        ...
+        DualWrite(() => unifiedTracker.CancelJobAsync(jobId, userId), jobId, "CancelJob");
+```
+
+The `userId` argument reaches only the dual-write. The CTS cancellation — the thing that
+actually stops the download — never consults it. The unified `JobTracker.CancelJobAsync`
+(:315) does this correctly and is the reference implementation.
+
+Job IDs are `Guid.NewGuid().ToString("N")[..12]` — 48 bits, and returned in API responses
+and broadcast over SignalR. Not secret.
+
+### Verified during CEO review
+
+- `MastController` is **`[Authorize]` at class level** (:19), so this is an
+  authenticated-user-to-authenticated-user IDOR and `GetRequiredUserId()` cannot throw here.
+  Matches the issue's characterisation.
+- **The guard pattern already exists verbatim** at :302 and :370 — copy it, don't invent one.
+- `JobsController.CancelJob` (:82) → `JobTracker.CancelJobAsync` (:312) **is already safe**
+  (`job.OwnerUserId != userId` → 404). No sibling IDOR to fix. But see #1775 below.
+- `CancelJob` is declared on **`IImportJobTracker.cs:34`** — adding a parameter is an
+  *interface* change (interface + impl + every Moq setup). Small but the original plan missed it.
+
+### Changes
+
+1. `MastController.CancelImport` — add the sibling guard, returning **404 not 403** to match
+   the existing anti-enumeration convention:
+   ```csharp
+   if (!IsCurrentUserAdmin() && job.UserId != GetRequiredUserId())
+       return NotFound(new { error = "Job not found", jobId });
+   ```
+2. `ImportJobTracker.CancelJob` — verify ownership before cancelling the CTS; return `false`
+   on mismatch. Requires an `isAdmin` parameter to preserve admin override.
+3. Update `IImportJobTracker.CancelJob`'s signature and the single production call site
+   (`MastController.cs:328`).
+
+> **Alternative considered and rejected:** guard only in the controller, leaving
+> `ImportJobTracker` untouched. Avoids the interface change, but the CTS cancellation — the
+> operation that actually stops the download — would remain reachable by `jobId` alone from any
+> future caller. Defence-in-depth is the point of this fix; keep step 2.
+
+### Known follow-up — #1775
+
+This fix grants admins the ability to cancel another user's import (matching :302/:370), while
+`JobTracker.CancelJobAsync` has **no** admin override. After this PR the two cancel paths
+disagree on admin semantics. Deliberately out of scope here — filed as **#1775** so the
+product decision gets made explicitly rather than inherited.
+
+### Tests (`MastControllerTests.cs`, `ImportJobTrackerTests.cs` — both exist)
+
+- User B cancels user A's job → 404, **and the job is still running** (assert the CTS was not
+  cancelled, not merely that the HTTP result was 404 — the whole bug is that these two came apart).
+- Admin cancels user A's job → succeeds.
+- Owner cancels own job → succeeds.
+- `ImportJobTracker.CancelJob` with a non-owner userId → returns `false`, CTS uncancelled.
+
+### Ordering note
+
+PR 1 lands first and alone. It is the only PR in this batch touching production behaviour;
+keeping it unmixed makes it revertable in isolation.
+
+---
+
+## PR 2 — Toolchain version drift (#1603, #1604, #1563)
+
+**Risk: LOW** (CI config only; the build either goes green or it doesn't)
+
+### Changes
+
+| File | Change | Issue |
+|---|---|---|
+| `.github/workflows/ci.yml:100` | `pip install ruff==0.15.12` → `0.16.0` | #1603 |
+| `frontend/jwst-frontend/package.json:29` | `@typescript-eslint/parser` `^8.58.0` → `^8.65.0` (match plugin) + regenerate `package-lock.json` | #1604 |
+| `.github/workflows/ci.yml:206` | `cache-dependency-path:` list **both** `requirements.txt` and `requirements-dev.txt` | #1563 |
+| `.github/workflows/composite-memory-test.yml` | same `cache-dependency-path` fix | #1563 |
+
+### ⚠️ CEO review finding — ruff is pinned in THREE places, not two
+
+`#1603` describes a two-way drift (CI vs `requirements-dev.txt`). The real spread is
+three-way:
+
+| Location | Pinned version |
+|---|---|
+| `.pre-commit-config.yaml:42` (`ruff-pre-commit` `rev:`) | **`v0.3.0`** |
+| `.github/workflows/ci.yml:100` | `0.15.12` |
+| `processing-engine/requirements-dev.txt:11` | `0.16.0` |
+
+**This makes the naive fix actively harmful.** `ruff format` output changes materially across
+v0.3.0 → 0.16.0. Today CI is lenient enough (0.15.12) that the mismatch mostly hides. Bumping
+CI to 0.16.0 while local pre-commit still auto-formats with **v0.3.0** means every Python
+commit gets reformatted one way locally and rejected the other way in CI — a format war on
+every push.
+
+**All three must move together.** This is not scope expansion; it is what makes #1603's stated
+fix safe. Bumping only `ci.yml` would earn a green checkmark and a broken inner loop.
+
+### The part that matters more than the bumps
+
+These are *recurrences*. Correction to an earlier draft of this plan: #1468 is
+"move test/lint tools out of production `requirements.txt` into `requirements-dev.txt`" — it
+**created** the two-file split rather than being a prior fix for drift. The drift is a
+consequence of that split never getting a parity check.
+
+No dependency-parity guard exists anywhere in `.github/workflows/` today (verified). Add a CI
+step that fails when the pinned ruff versions disagree:
+
+```yaml
+- name: Assert ruff pins agree across CI, requirements-dev, and pre-commit
+  run: |
+    dev=$(grep -oP '(?<=^ruff==).*' processing-engine/requirements-dev.txt)
+    pc=$(grep -A1 'ruff-pre-commit' .pre-commit-config.yaml | grep -oP '(?<=rev: v).*')
+    ci=0.16.0   # keep in sync with the install step above
+    fail=0
+    [ "$dev" = "$ci" ] || { echo "::error::ruff drift: ci.yml=$ci requirements-dev.txt=$dev"; fail=1; }
+    [ "$pc"  = "$ci" ] || { echo "::error::ruff drift: ci.yml=$ci .pre-commit-config.yaml=v$pc"; fail=1; }
+    exit $fail
+```
+
+Derive `ci` from the file too if the install step can read a variable — a hardcoded `have=`
+is itself a fourth place to drift.
+
+**Expect new lint findings, and size them before committing to a PR shape.** ruff
+v0.3.0 → 0.16.0 is thirteen minors of rule changes; tseslint 8.58 → 8.65 affects type-aware
+rules. Do this first:
+
+```bash
+pipx run ruff==0.16.0 check processing-engine/ | tail -1
+pipx run ruff==0.16.0 format --check processing-engine/ | tail -1
+```
+
+**Gate:** if the combined fallout exceeds ~20 findings or touches more than ~10 files, split
+the ruff bump into its own PR. A formatting-churn diff that buries the `cache-dependency-path`
+and parser fixes is how a "quick win" stops being one.
+
+---
+
+## PR 3 — Infra hygiene batch (#1585)
+
+**Risk: LOW–MEDIUM** (touches compose startup ordering)
+
+Seven items, all verified present on `origin/main`:
+
+1. **SeaweedFS `:latest` ×4** — `docker-compose.yml:180,190,204,217` all
+   `chrislusf/seaweedfs:latest`. Pin to a specific tag; add to the pinned-deps comment block.
+2. **Backend has no healthcheck** — `:58` uses `condition: service_started`. Add a
+   healthcheck and switch dependents to `service_healthy`.
+3. **Frontend (nginx) has no healthcheck** — add a wget/curl spider probe.
+4. **E2E hardcodes Mongo creds** — `ci.yml:372` embeds
+   `mongodb://admin:changeme_use_strong_password@...` in the `mongoimport` call despite having
+   copied `.env.example` moments earlier. Read from the copied `.env`.
+5. **Python version drift** — `README.md:56` says "Python 3.10+"; `processing-engine/Dockerfile`
+   is `python:3.12-slim-bullseye`; `tests/mock-processing-engine/Dockerfile` is
+   `python:3.14-alpine`. Align README → 3.12+ and the mock → 3.12.
+6. **Node minor unpinned** — `node:22-alpine`. Low priority; include or defer.
+7. **Stale `CODEBASE_REVIEW.md`** — root-level, dated 2026-03-08, contradicted by the
+   2026-06-09 deep review. Decide: delete / move to `docs/audits/` with a date header / regenerate.
+
+### Verified during CEO review
+
+- **The healthcheck probe target exists**: `Program.cs:417` maps `MapHealthChecks("/api/health")`.
+  #1585's suggested `curl -sf http://localhost:5000/api/health` is valid.
+- **An in-repo healthcheck idiom already exists** (`docker-compose.yml:84-89`) using
+  `python -c "import urllib.request; urllib.request.urlopen(...)"` with
+  `interval 10s / timeout 5s / retries 3 / start_period 15s`. **Copy this shape** rather than
+  introducing a `curl`-based variant — the backend image may not even have `curl`.
+- **Item 4 is safe**: `docker/.env.example` really does define `MONGO_ROOT_USERNAME=admin` and
+  `MONGO_ROOT_PASSWORD=changeme_use_strong_password` (:18-19), so reading from the copied
+  `.env` reproduces the currently-hardcoded string exactly. No behaviour change, just no
+  hardcoded secret.
+
+### Sequencing caution
+
+Items 2 and 3 change container startup ordering. Land them **after** items 1/4/5 within the
+PR, or split them out if E2E gets flaky — a bad healthcheck turns a green suite red for
+reasons unrelated to the code under test. `start_period` is the knob that matters: the .NET
+backend is the slowest service to warm, so start conservative (30s) and tighten later.
+
+### Item 1 caution — pin to what is actually running
+
+Do not pin SeaweedFS to an arbitrary "latest stable" tag. `:latest` has been in place long
+enough that the running volumes were initialised by whatever version was current at the time;
+pinning *backwards* risks a volume-format mismatch. Resolve the digest of the currently-running
+image (`docker inspect`) and pin to that version, then upgrade deliberately as separate work.
+
+### Item 7 needs a decision, not a default
+
+Verified on `origin/main`: **`docs/audits/2026-03-08-codebase-review.md` already exists, and
+its content differs from the root `CODEBASE_REVIEW.md`.** So this is not a simple move — there
+are two divergent documents claiming the same review on the same date, and #1585's suggested
+"move it to docs/audits" would silently clobber one of them.
+
+Additional constraint: root `CODEBASE_REVIEW.md` is cited in ADR 0001's References section, and
+`docs/audits/2026-03-08-codebase-review.md` is cited as the source of #748.
+
+Recommendation: **defer item 7 out of PR 3** and handle it as its own small docs PR, after
+diffing the two files to establish which is authoritative. Bundling an unresolved content
+question into an infra PR is how the wrong one gets deleted. Per the safety rule on file
+cleanup, no deletion happens without explicit approval either way.
+
+---
+
+## Verification
+
+Per CLAUDE.md the pre-commit hook runs ESLint, Prettier, tsc, vitest, dotnet build+test, and
+ruff — those are not re-run manually here.
+
+| PR | Verification |
+|---|---|
+| 1 | `dotnet test` (new IDOR tests red before / green after). **Manual:** two accounts, start an import as A, attempt cancel as B → 404 and A's import continues. |
+| 2 | CI green on the branch. Confirm the new drift-guard step **fails** when deliberately mis-pinned, then passes. |
+| 3 | `docker compose up -d --build` from clean; all services healthy. Full E2E run — this PR is the one most likely to disturb it. |
+
+**#1558 caveat:** `dotnet build --warnaserror` currently fails on transitive NU1902/NU1903
+advisories, so PR 1 will need `--no-verify` on commit (known, tracked, CI unaffected).
+
+---
+
+## Explicitly out of scope
+
+- The remaining audit follow-ups: rewriting epics #1401/#1406, auditing #1404/#1407,
+  amending #1625/#1573/#1257/#1624, folding loose issues into #1272.
+- **Filing the ADR-0001 migration tracker** — the audit's biggest structural finding
+  (Phases 1–8 untracked). Deliberately excluded: it is a planning decision, not a quick win.
+- Any .NET refactor from the "don't fix, it's being deleted" bucket.
+
+Per CLAUDE.md these excluded items get GitHub issues rather than being left untracked —
+to be filed once this plan is approved.
+
+---
+
+## Open questions for review
+
+1. **Is #1572 in or out of this batch?** In as PR 1 by my call; trivially removable.
+2. **#1585 item 6 (node minor pin)** — do it or drop it? It is the weakest item in the batch.
+3. **Does the ruff bump's lint fallout justify its own PR?** Now has a concrete gate
+   (>~20 findings or >~10 files → split). Must be measured before PR 2 starts.
+
+---
+
+# CEO Review — 2026-07-26
+
+**Mode: C (Hold Scope).** Five issues in, five issues out. No additions, no cuts.
+
+## Assessment
+
+Right approach, and the batching is sound — three PRs split by risk profile rather than by
+issue number, with the one behaviour-changing PR isolated so it can be reverted alone. The
+plan was materially wrong in one place: it treated #1603 as a two-way version drift when it is
+three-way, which would have made PR 2 a net negative. Corrected above. Everything else survived
+verification against `origin/main` @ `b345be4`.
+
+## Risks
+
+| # | Risk | Severity | Disposition |
+|---|---|---|---|
+| R1 | **Ruff pinned in 3 places (`v0.3.0` / `0.15.12` / `0.16.0`).** Bumping only CI puts local pre-commit formatting (v0.3.0) in permanent conflict with CI (0.16.0) — a format war on every Python commit. | **HIGH** | Fixed in plan: all three move together. Not optional. |
+| R2 | **Lint fallout from ruff v0.3.0→0.16.0 is unbounded** — 13 minors of rule + formatter changes. Could swamp PR 2. | **HIGH** | Fixed in plan: measure first, hard gate to split at ~20 findings / ~10 files. |
+| R3 | **`IImportJobTracker` interface change** — `CancelJob` gains a parameter; interface + impl + all Moq setups. Original plan missed it. | MED | Fixed in plan: named explicitly, one production call site identified (`MastController.cs:328`). |
+| R4 | **Admin-cancel semantics diverge** after PR 1 — admins can cancel others' imports but not others' exports. | MED | **Filed as #1775.** Out of scope for this batch by design. |
+| R5 | **Healthchecks (item 2/3) can redden E2E for unrelated reasons.** | MED | Mitigated: copy the existing compose idiom, conservative `start_period`, land after items 1/4/5, split if flaky. |
+| R6 | **SeaweedFS downgrade risk** — pinning `:latest` backwards could mismatch existing volume format. | MED | Mitigated: pin to the currently-running version via `docker inspect`, don't guess a tag. |
+| R7 | **`CODEBASE_REVIEW.md` vs `docs/audits/2026-03-08-codebase-review.md` are two divergent docs**, both referenced (ADR 0001 / #748). | LOW | Deferred out of PR 3 into its own docs PR. No deletion without explicit approval. |
+| R8 | **#1558 blocks clean commits on PR 1** — `dotnet build --warnaserror` fails on NU1902/NU1903. | LOW | Known; use `--no-verify`. CI unaffected. |
+
+## NOT in scope
+
+- Rewriting epics #1401/#1406; auditing #1404/#1407 (audit follow-ups).
+- Amending #1625 / #1573 / #1257 / #1624; folding #1136/#1291/#1325/#1393/#1117 into #1272.
+- **Filing the ADR-0001 migration tracker** — the audit's biggest structural finding. Excluded
+  deliberately: it is a planning decision, not a quick win.
+- Any .NET refactor from the "don't fix, it's being deleted" bucket (#1070, #1071, #1108, …).
+- Resolving #1775 (admin-cancel semantics).
+- Other `.pre-commit-config.yaml` pin drift beyond ruff (e.g. mypy) — not investigated.
+
+## What already exists (found by grep, reuse don't rebuild)
+
+- Ownership guard pattern — `MastController.cs:302` and `:370`, copy verbatim.
+- Healthcheck idiom — `docker-compose.yml:84-89`.
+- Health endpoint — `Program.cs:417`, `MapHealthChecks("/api/health")`.
+- `JobsController.CancelJob` is already correctly guarded — no second IDOR.
+- Test homes exist: `MastControllerTests.cs`, `ImportJobTrackerTests.cs`.
+- No dependency-parity CI guard exists anywhere — R1's guard is genuinely new.
+
+## Design & UX check
+
+**Skipped — no UI scope.** No frontend components, wizard steps, dialogs, or user-visible
+surfaces. The only frontend-adjacent change is a `package.json` version bump.
+
+## Stale diagram audit
+
+**No diagrams in scope.** PR 3 adds healthchecks and pins image tags but does not add, remove,
+or re-wire any service, so the topology diagrams in `docs/architecture/` and ADR 0001 remain
+accurate. R7's doc-move PR would touch ADR 0001's References list — text, not a diagram.
+
+## Recommendation
+
+**Proceed with changes** — the corrections above (R1, R2, R3) are folded into the plan. R1 is
+the one that would have caused real damage; the rest harden an already-reasonable batch.
+
+Reversal cost is low across all three PRs: PR 1 is one guard plus one predicate, PR 2 is CI
+config, PR 3 is compose config. Nothing here is load-bearing for 6+ months. No `EnterPlanMode`
+required.
+
+---
+
+# Engineering Review — 2026-07-26
+
+## Complexity assessment
+
+**Simple–Medium.** No scope reduction warranted.
+
+| PR | Prod files | Test files | Under 8-file gate? |
+|---|---:|---:|---|
+| 1 | 3 (`MastController.cs`, `IImportJobTracker.cs`, `ImportJobTracker.cs`) | 2 | ✅ 5 |
+| 2 | 5 config (`ci.yml`, `composite-memory-test.yml`, `package.json`, `package-lock.json`, `.pre-commit-config.yaml`) | 0 | ⚠️ **formatter churn is unbounded** |
+| 3 | 4 (`docker-compose.yml`, `ci.yml`, `README.md`, mock `Dockerfile`) | 0 | ✅ 4 |
+
+PR 2 is the only one that can breach the gate, via `ruff format` churn across
+`processing-engine/`. The measure-first gate in the plan is what keeps it honest.
+
+## Architecture verdict
+
+**Sound.** No layering concerns — PR 1 adds a guard inside the existing
+Controller → Service boundary and introduces no new class, DTO, endpoint, collection, or
+index. PRs 2–3 are build/infra config with no runtime code path. No DI changes, no circular
+dependencies, no snake_case/camelCase boundary crossings, no SignalR or job-tracker contract
+changes.
+
+**DECISION-1 resolved:** `CancelJob` gains an `isAdmin` parameter (option A). Chosen over the
+controller-only guard because the CTS cancellation must not stay reachable by `jobId` alone,
+and over the null-means-admin sentinel because implicit privilege is the pattern that caused
+this bug. Cost accepted: `IImportJobTracker` arity change + ~11 Moq call sites.
+
+## Findings
+
+**`[P1] (confidence: 9/10) MastController.cs:~320 — the sibling guard cannot be copied verbatim; it regresses owner-cancel for null-owner jobs.**
+
+`ImportJobStatus.UserId` is declared **`public string? UserId { get; set; }`**
+(`Models/MastModels.cs`, "Preserved for resume: the importing user and public flag").
+When it is null:
+
+```csharp
+job.UserId != GetRequiredUserId()   // null != "user-123" → true → 404
+```
+
+…the **owner is locked out of cancelling their own import.** `ResumeImport:444` already
+compensates for exactly this (`var resumeUserId = job.UserId ?? GetCurrentUserId();`), which is
+direct evidence the null case occurs in practice. `GetImportProgress:302` and `ResumeImport:370`
+carry the same latent defect today.
+
+Required form — make the null case explicit and deny-by-default:
+
+```csharp
+if (!IsCurrentUserAdmin() && (job.UserId is null || job.UserId != GetRequiredUserId()))
+    return NotFound(new { error = "Job not found", jobId });
+```
+
+Accepted trade-off: a legacy in-flight import with no recorded owner becomes cancellable only
+by an admin. Correct posture for a security fix, and imports are short-lived — but it is a
+behaviour change and needs the regression test below, not a silent assumption.
+
+**`[P2] (confidence: 10/10) MastControllerTests.cs — the existing CancelImport suite is structurally blind to this bug.**
+
+All six existing tests stub `CancelJob("test-job", It.IsAny<string>())`. They assert *that*
+cancellation happened, never *for whom* — so the entire suite passes today with the IDOR
+present, and would pass again if the guard were later removed. The new tests must assert on the
+**identity argument**, not just the call count, or the coverage is theatre.
+
+**`[P3] (confidence: 8/10) plan-eng-review SKILL.md — stale framework table.** It lists
+`dotnet test backend/Jwst.Backend.sln`; the real solution is **`backend/JwstDataAnalysis.sln`**.
+Same class as the already-tracked skill defects #1477/#1478/#1479. Not fixed here — offered as
+a follow-up.
+
+## TEST PLAN — Backlog Quick Wins
+
+### Affected routes
+- `POST /api/mast/import/cancel/{jobId}` — ownership enforcement (the whole point of PR 1)
+- No route changes in PR 2 / PR 3
+
+### Coverage diagram
+
+```
+[+] backend/JwstDataAnalysis.API/Controllers/MastController.cs
+  └── CancelImport(jobId)
+      ├── [★★★ TESTED] job == null → 404 .................... MastControllerTests.cs:369
+      ├── [★★★ TESTED] job.IsComplete → 400 ................. MastControllerTests.cs:386
+      ├── [★★  TESTED] tracker false → 400 .................. MastControllerTests.cs:1225
+      ├── [★★  TESTED] PauseDownload throws → Ok ............ MastControllerTests.cs:1249
+      ├── [★★  TESTED] no DownloadJobId → Ok ................ MastControllerTests.cs:1276
+      ├── [GAP] [→UNIT] non-owner → 404 ............................. NEW BRANCH
+      ├── [GAP] [→UNIT] admin non-owner → proceeds ................... NEW BRANCH
+      └── [GAP] [→UNIT] job.UserId is null, owner calls → 404 ........ NEW BRANCH (P1)
+
+[+] backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
+  └── CancelJob(jobId, userId, isAdmin)
+      ├── [★★  TESTED] sets CTS ............................ ImportJobTrackerTests.cs:115
+      ├── [★★  TESTED] updates job state ................... ImportJobTrackerTests.cs:126
+      ├── [★★  TESTED] not found → false ................... ImportJobTrackerTests.cs:138
+      ├── [★★  TESTED] completed job untouched ............. ImportJobTrackerTests.cs:144
+      ├── [★★  TESTED] dual-writes to unified tracker ...... ImportJobTrackerTests.cs:364
+      ├── [GAP] [→UNIT] non-owner → false AND CTS NOT cancelled ...... NEW BRANCH
+      └── [GAP] [→UNIT] isAdmin=true, non-owner → true ............... NEW BRANCH
+
+COVERAGE: 10/15 paths tested (67%)  |  GAPS: 5 (0 E2E)
+```
+
+All gaps are `[→UNIT]`: single-service branches with no cross-component flow. No E2E needed —
+adding one would require two authenticated browser sessions racing an import, which is far more
+fragile than the unit assertions.
+
+### Test tasks
+
+- [ ] **CRITICAL (regression)** `MastControllerTests.cs`: `CancelImport_WithNullUserIdJob_ReturnsNotFoundForNonAdmin` — proves the P1 null-owner path is a deliberate deny, not an accident.
+- [ ] **CRITICAL (security)** `ImportJobTrackerTests.cs`: `CancelJob_WithNonOwner_DoesNotCancelToken` — assert the **`CancellationToken` was not signalled**, not merely that the return was `false`. The bug is precisely that the return value and the CTS came apart.
+- [ ] `MastControllerTests.cs`: `CancelImport_WithNonOwner_ReturnsNotFound` — and `Verify` that `CancelJob` was **never called**.
+- [ ] `MastControllerTests.cs`: `CancelImport_WithAdminNonOwner_Succeeds`.
+- [ ] `ImportJobTrackerTests.cs`: `CancelJob_WithAdminNonOwner_ReturnsTrue`.
+- [ ] **Update the 6 existing `CancelImport` tests** to assert the real userId argument instead of `It.IsAny<string>()` — otherwise they remain blind to a future regression (P2).
+
+### Manual verification
+- [ ] Two accounts. A starts an import; B calls `POST /api/mast/import/cancel/{A's jobId}` → 404 **and A's import keeps running** (watch the SignalR progress pill, not just the HTTP status).
+- [ ] A cancels A's own import → succeeds.
+- [ ] Deliberately mis-pin ruff in `ci.yml` → the new parity step **fails**; correct it → passes.
+- [ ] `docker compose up -d --build` from clean; all services report healthy. **Docker rebuild required: yes** (PR 3).
+
+### Commands
+`dotnet test backend/JwstDataAnalysis.sln` · `docker exec jwst-processing python -m pytest` ·
+`npm test --prefix frontend/jwst-frontend`
+
+## Performance
+
+No impact. PR 1 adds one dictionary lookup and a string comparison to a non-hot path
+(user-initiated cancel). No N+1, no unbounded loads, no new blocking I/O, no thread-blocking
+work. PRs 2–3 have no runtime path at all — PR 3's healthchecks add a periodic in-container
+probe every 10s, which is negligible and matches what `processing-engine` already does.
+
+## Worktree parallelization
+
+| Step | Modules touched | Depends on |
+|---|---|---|
+| PR 1 | `backend/JwstDataAnalysis.API/`, `backend/JwstDataAnalysis.API.Tests/` | — |
+| PR 2 | `.github/workflows/`, `frontend/jwst-frontend/`, `.pre-commit-config.yaml`, `processing-engine/` (format churn) | — |
+| PR 3 | `docker/`, `.github/workflows/`, `README.md`, `tests/mock-processing-engine/` | — |
+
+**Lane A:** PR 1 — fully independent (`backend/` touched by nobody else).
+**Lane B:** PR 2 → PR 3 — **sequential**.
+
+⚠️ **Conflict flag:** PR 2 and PR 3 both edit `.github/workflows/ci.yml`. Different regions
+(ruff pin ~line 100 / pip cache ~line 206 vs. mongoimport creds ~line 372), so a textual
+conflict is unlikely but a rebase is near-certain. Not worth parallelising two config PRs to
+save minutes — keep them in one lane.
+
+**Execution order:** launch Lane A and Lane B in parallel worktrees; PR 1 can merge whenever
+it is green regardless of the others.
+
+## Unresolved decisions
+
+1. **#1585 item 6 (node minor pin)** — still open; weakest item in the batch.
+2. **Ruff fallout size** — unmeasured; gates whether PR 2 splits. Must be run before PR 2 starts.
+3. **Which `CODEBASE_REVIEW.md` is authoritative** — deferred to its own docs PR (R7).
+
+## Docs update checklist
+
+- [x] `README.md` — Python 3.10+ → 3.12+ (**this is PR 3 item 5, part of the change itself**)
+- [ ] `docs/standards/` — record the dependency-pin parity convention so the ruff guard has a documented rationale rather than existing as an unexplained CI step
+- [ ] `docs/setup-guide.md` — verify it makes no contradicting Python-version claim
+- [ ] `docs/key-files.md` — **not needed** (no new/renamed files, no new endpoints)
+- [ ] `docs/architecture/` — **not needed** (no topology change; see stale-diagram audit)
+- [ ] `docs/quick-reference.md` — **not needed** (no API surface change)
+- [ ] `docs/development-plan.md` — **not needed**
+
+## Verdict
+
+**Sound — proceed, with the P1 null-owner guard form and the six test tasks treated as
+mandatory, not optional.** No `EnterPlanMode` required: nothing here is load-bearing, and each
+PR reverts independently.


### PR DESCRIPTION
## Summary

Fixes an IDOR: **any authenticated user could cancel any other user's in-progress MAST import** by supplying its job ID. Job IDs are `Guid.NewGuid().ToString("N")[..12]` (48 bits) and are returned in API responses and broadcast over SignalR, so they are not a secret.

Impact was denial of service against other users' work — a multi-gigabyte import dies partway with no explanation and no audit trail.

Two layers both failed to check, so there was no backstop:

- **`MastController.CancelImport`** had no ownership guard, unlike its siblings `GetImportProgress` (:302) and `ResumeImport` (:370), which both use `if (!IsCurrentUserAdmin() && job.UserId != GetRequiredUserId())`.
- **`ImportJobTracker.CancelJob`** accepted a `userId` but used it only for the bookkeeping dual-write. `cts.Cancel()` — the call that actually stops the download — fired on `jobId` alone. A parameter that looks like an access check while doing nothing is worse than no parameter.

## A pre-existing bug found while fixing this

`ImportJobTracker.CreateJob(obsId, userId)` accepted `userId` and **never assigned it to `job.UserId`**, forwarding it only to the unified tracker. Ownership was left to each caller:

| Caller | Assigned `UserId`? |
|---|---|
| `MastController.Import` (:267) | ✅ at :274 |
| resume path (:1054) | ✅ at :1062 |
| `MastController.ImportFromExisting` (:527) | ❌ **no** |

So every job from `POST /api/mast/import/from-existing/{obsId}` was **unowned in production**, meaning the *existing* guards on `GetImportProgress` and `ResumeImport` were already returning **404 to the legitimate owner** for those jobs.

`CreateJob` now records the owner. This removes the trap, repairs that pre-existing defect, and is what makes the new cancel guard safe rather than a lockout. Job state is in-memory, so no migration is needed.

## Changes Made

- `MastController.CancelImport` — ownership guard returning **404 not 403** (matches siblings, avoids job-ID enumeration). Runs *before* the `IsComplete` check so a non-owner cannot probe job state.
- `IImportJobTracker.CancelJob` / `ImportJobTracker.CancelJob` — new `isAdmin` parameter; ownership verified **before** `cts.Cancel()`, deny-by-default (a non-admin must find the job *and* own it).
- `ImportJobTracker.CreateJob` — assigns `UserId = userId`.
- `ImportJobTracker.Log.cs` — `LogCancellationDenied` (EventId 5009, Warning) so denials are visible.
- Tests as below.

### Why the null check is explicit

`ImportJobStatus.UserId` is `string?`. A bare `job.UserId != GetRequiredUserId()` is `true` when `UserId` is null, so it would deny the **real owner** of an unowned job while reading as though it had authorised them. The guard checks `job.UserId is null` explicitly and treats unowned jobs as admin-only. Kept even after the `CreateJob` fix — deny-by-default is the right posture regardless.

## Test Plan

RED was demonstrated before implementing. With the guard absent, **exactly** the two IDOR tests failed while the other 9 `CancelImport` tests passed:

```
CancelImport_WithNullUserIdJob_ReturnsNotFoundForNonAdmin [FAIL]
CancelImport_NonOwnerGets404 [FAIL]
Failed: 2, Passed: 9, Total: 11
```

That confirms the pre-existing suite was **structurally blind** to this bug: every existing test stubbed `CancelJob("test-job", It.IsAny<string>())`, asserting that a cancel happened but never *for whom*. Those stubs now assert the real identity.

- [x] `CancelImport_NonOwnerGets404` — 404, and verifies the tracker is **never called** and the engine is never told to pause (a 404 alone wouldn't prove the victim's download survived)
- [x] `CancelImport_OwnerCanCancel`
- [x] `CancelImport_AdminCanCancelAnyJob`
- [x] `CancelImport_WithNullUserIdJob_ReturnsNotFoundForNonAdmin` (regression guard)
- [x] `CancelImport_WithNullUserIdJob_AdminCanCancel`
- [x] `CancelJob_WithNonOwner_DoesNotCancelToken` — asserts `token.IsCancellationRequested == false`; the return value and the token coming apart *is* the defect, so asserting the bool alone would not prove the fix
- [x] `CancelJob_WithAdminNonOwner_ReturnsTrue`
- [x] `CreateJob_RecordsOwnerOnJobStatus` (regression guard)
- [x] 6 existing `CancelImport` tests updated to assert real identity
- [x] `CancelImport_NonOwnerWithCompletedJob_ReturnsNotFound` — pins guard order (enumeration oracle)
- [x] `CancelJob_WhenAdminCancels_DualWritesWithOwnerId` — regression guard
- [x] `CancelJob_WithAdminAndUnknownJob_ReturnsFalse`
- [x] **Full backend suite: 1163/1163 green**
- [x] Pre-commit hook passed (build 0 warnings, 0 errors)

### Reviewer steps

1. `dotnet test backend/JwstDataAnalysis.sln` → 1160 pass.
2. To see the bug: revert the guard in `MastController.CancelImport` and re-run `--filter "FullyQualifiedName~CancelImport"` → 2 fail, 9 pass.
3. Manual, two accounts: A starts an import; B calls `POST /api/mast/import/cancel/{A's jobId}` → **404, and A's import keeps running** (watch the progress pill, not just the status code). A cancels A's own → succeeds.

## Documentation Checklist

- [x] No API surface change (same route, same verb, same success shape) — `docs/quick-reference.md` unaffected
- [x] No new/renamed files or endpoints — `docs/key-files.md` unaffected
- [x] No architecture or topology change — `docs/architecture/` unaffected
- [x] Plan documented in `docs/plans/features/backlog-quick-wins.md`, including an implementation note recording the `CreateJob` root cause

## Tech Debt Impact

- [x] **Reduces** — removes a latent trap: callers no longer have to remember to assign `UserId` after `CreateJob`
- [x] **Reduces** — fixes a pre-existing 404-on-own-job defect on the from-existing import path
- [x] **Reduces** — replaces `It.IsAny<string>()` identity stubs that made the cancel suite unable to catch auth regressions
- [ ] Adds tech debt
- [x] **Follow-up tracked** — #1775: admin-cancel semantics now differ between this path (admin may cancel any import) and `JobTracker.CancelJobAsync` (no admin override). Deliberately out of scope; product decision.

## Risk & Rollback

**Risk: MEDIUM** — auth-adjacent, and `CLAUDE.md` flags the auth flow as fragile.

- **Behaviour change:** a non-owner now gets 404 where they previously succeeded. That is the fix.
- **Behaviour change:** an unowned job (null `UserId`) is cancellable only by an admin. With the `CreateJob` fix new jobs are always owned; in-memory state means a restart clears any stragglers.
- **Blast radius:** `IImportJobTracker.CancelJob` arity changed. Single production call site (`MastController.cs:328`); all test call sites updated. Compile-time enforced, so no silent misses.
- **Not affected:** `JobsController.CancelJob` → `JobTracker.CancelJobAsync` already checked ownership correctly and is untouched.

**Rollback:** revert the commit. No migration, no schema change, no config change, no data touched — job state is in-memory only.

## Code review round 2 — findings addressed

An adversarial review pass was run against this branch. Two findings were **regressions in this PR** and are fixed in `102ea96`:

- **Admin cancel silently no-opped the unified tracker.** `CancelJob` dual-wrote with the *requester's* id, but `JobTracker.CancelJobAsync` rejects an owner mismatch — so an admin cancelling another user's import cancelled the in-memory job while the unified record stayed `running`. No cancelled SignalR push; the owner's UI hung until TTL. `DualWrite` swallows only exceptions, so the `false` return was completely invisible. Now dual-writes with the job's **owner**.
- **Guard ordering was unpinned.** The ownership check correctly precedes the `IsComplete` check (otherwise a non-owner probing a completed job gets `400 "Job is already complete"` plus its `stage` — an enumeration oracle). Moving it would have left every test green. Now pinned by `CancelImport_NonOwnerWithCompletedJob_ReturnsNotFound`.

Also added `CancelJob_WithAdminAndUnknownJob_ReturnsFalse` and the denial log now records the requester id.

## What this PR does NOT close

Stated plainly so the scope isn't overread:

- **#1782 — chained bypass via `ResumeImport`.** `ResumeImport` applies its ownership guard only when the ID resolves to an in-memory import job; otherwise it falls through to `ResumeFromDownloadJobId`, which has **no authorization at all**. So B can resume A's download (becoming its owner), then *legitimately* cancel it — pausing A's download despite this PR's guard. Root cause is a download-job-id vs import-job-id conflation that also silently empties the resumable list and 404s dismissal for every non-admin. Split out deliberately: the correct post-restart fix needs the engine to persist the owning user, which is a design decision that shouldn't block this.
- **#1783 — `POST /api/jobs/{id}/cancel`** reports an import as cancelled without signalling its CancellationToken. Pre-existing, owner-only, different subsystem.
- **#1775 — admin-cancel semantics** diverge between this path and `JobTracker.CancelJobAsync`.

This PR closes the direct cancel IDOR described in #1572. #1782 must land before "a user cannot disrupt another user's import" is true end to end.

Closes #1572
Refs #1775, #1782, #1783
