### PR TITLE
feat: surface the source catalog calibration runs already compute

### DIFF
--- a/docs/plans/features/quick/s1-surface-source-catalog.md
+++ b/docs/plans/features/quick/s1-surface-source-catalog.md
@@ -1,0 +1,72 @@
+# S1 — Surface the `_cat.ecsv` source catalog
+
+## Problem
+
+`Image3Pipeline`'s `source_catalog` step is on the executor allowlist
+(`calibration/executor.py:78`) and runs in all three seed recipes — `image3` is
+enabled with empty `step_overrides`, so the step fires at jwst defaults. It
+writes `<product>_cat.ecsv`: STScI-calibrated RA/Dec positions, aperture fluxes,
+AB magnitudes, and uncertainties.
+
+That file is then thrown away. `_persist_outputs` keeps only what matches
+`recipe.output_suffixes` (`["_i2d"]`), and `executor.py:744` does `rmtree` on the
+workdir. The app computes the only citable numbers it has and deletes them on
+every run.
+
+## Change
+
+Emit the catalog, then let it be saved to the library and read in the existing
+`TableViewer` — rather than building a second table UI.
+
+### 1. Emit
+
+Add `"_cat"` to `output_suffixes` in the three seed recipes.
+`_persist_outputs` matches on `path.stem.endswith(suffix)`, so `"_cat"` captures
+`<product>_cat.ecsv` with no code change. `RecipeStore.seed()` runs at startup
+(`processing-engine/main.py:57`) and `upsert()` replaces seed documents whole, so
+the change reaches existing recipe docs on next boot — no migration.
+
+### 2. Read ECSV in the table endpoints
+
+`app/analysis/routes.py` — `get_table_data` already converts to an
+`astropy.table.Table` internally; only HDU enumeration and column metadata are
+FITS-specific. Add a small adapter returning a uniform `(columns, table)` from
+either a FITS table HDU or an ECSV file, and branch both endpoints on the file
+extension. ECSV reports one synthetic HDU at index 0.
+
+`resolve_fits_path` needs no change — it validates traversal and existence, not
+extension.
+
+### 3. Let non-image outputs reach the library
+
+`app/jobs/routes.py` — `_PREVIEWABLE_SUFFIXES` stays FITS-only; it means *image
+preview* and that is still correct. Add `_TABULAR_SUFFIXES` and let
+`save_output_to_library` accept it.
+
+`level_for_suffix("_cat")` already returns `L3` — `library/levels.py` added
+`_cat` deliberately so a saved catalog is not levelless.
+
+### 4. Split "previewable" from "saveable" in the UI
+
+`src/pages/RunDetail.tsx` — one `previewable` flag currently gates both the image
+preview and the Save-to-library button, so a catalog cannot be saved at all.
+Split into `isPreviewable` (image) and `isTabular` (ECSV); tabular outputs get
+Save to library plus View catalog, which mounts the existing `TableViewer` on the
+resulting `dataId`. ASDF outputs keep the "not an image" hint.
+
+## Out of scope
+
+- Cross-matching or plotting the catalog (that is S7).
+- Any change to what the pipeline computes — the catalog already exists.
+- Pagination tuning: `_cat.ecsv` files are kB-scale, so the existing paging is
+  cosmetic here and is reused rather than special-cased.
+
+## Test plan
+
+- Python: table-info and table-data against an ECSV fixture; save-to-library
+  accepts a `_cat` output; the three seeds still validate against
+  `CalibrationRecipe`.
+- Frontend: an ECSV output offers Save and View but not image preview; FITS
+  outputs behave exactly as before.
+- Manual: run a seed recipe, confirm `_cat.ecsv` appears in Outputs, save it,
+  open it in the table viewer.

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -19,6 +19,16 @@ vi.mock('../services/calibrationService', () => ({
   downloadJobOutput: vi.fn(),
 }));
 
+// The table viewer has its own suite; here we only care that the page hands it
+// the dataId of the catalog that was just saved.
+vi.mock('../components/TableViewer', () => ({
+  default: ({ dataId, title }: { dataId: string; title: string }) => (
+    <div data-testid="table-viewer">
+      {dataId} {title}
+    </div>
+  ),
+}));
+
 import {
   getJob,
   getJobOutputPreview,
@@ -668,7 +678,30 @@ describe('RunDetail', () => {
       await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
       expect(screen.getByRole('button', { name: /jw001_i2d\.fits/ })).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /jw001_cat\.ecsv/ })).not.toBeInTheDocument();
-      expect(screen.getByText(/not an image/)).toBeInTheDocument();
+      // A catalog is not previewable, but calling it "not an image" undersells
+      // it — it is the citable half of the run (S1).
+      expect(screen.getByText(/source catalog/)).toBeInTheDocument();
+      expect(screen.queryByText(/not an image/)).not.toBeInTheDocument();
+    });
+
+    it('offers Save to library on a source catalog, not just on the image', async () => {
+      renderRun();
+      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+      // Two savable outputs now: the image and the catalog. Before S1 the
+      // catalog had no Save button at all, so it could never be read in-app.
+      expect(screen.getAllByRole('button', { name: 'Save to library' })).toHaveLength(2);
+    });
+
+    it('opens the saved catalog in the table viewer', async () => {
+      vi.mocked(saveJobOutputToLibrary).mockResolvedValue({ dataId: 'data-9', created: true });
+      renderRun();
+      await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+
+      // The catalog is the second output; save it, then view it.
+      await userEvent.click(screen.getAllByRole('button', { name: 'Save to library' })[1]);
+      await userEvent.click(await screen.findByRole('button', { name: 'View catalog' }));
+
+      expect(await screen.findByTestId('table-viewer')).toHaveTextContent('data-9');
     });
 
     it('opens the lightbox with the rendered preview when an output is clicked', async () => {
@@ -694,7 +727,9 @@ describe('RunDetail', () => {
 
       expect(screen.queryByRole('link', { name: 'Open in compositor' })).not.toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Save to library' }));
+      // Index 0 is the image; index 1 is the catalog, which saves too but hops
+      // to the table viewer instead of the compositor.
+      await userEvent.click(screen.getAllByRole('button', { name: 'Save to library' })[0]);
 
       expect(vi.mocked(saveJobOutputToLibrary)).toHaveBeenCalledWith('job-1', 0);
       expect(await screen.findByText('✓ In library')).toBeInTheDocument();
@@ -706,17 +741,19 @@ describe('RunDetail', () => {
       renderRun();
       await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
 
-      await userEvent.click(screen.getByRole('button', { name: 'Save to library' }));
+      await userEvent.click(screen.getAllByRole('button', { name: 'Save to library' })[0]);
 
-      expect(await screen.findByRole('button', { name: 'Save to library' })).toBeEnabled();
+      expect(screen.getAllByRole('button', { name: 'Save to library' })[0]).toBeEnabled();
       expect(screen.queryByText('✓ In library')).not.toBeInTheDocument();
     });
 
-    it('offers download for a catalog, which cannot be saved as an image', async () => {
+    it('offers download for every output, savable or not', async () => {
       renderRun();
       await waitFor(() => expect(screen.getByText('Outputs')).toBeInTheDocument());
+      // Download is the universal action; save is now offered on both the
+      // image and the catalog (S1), so the two counts match here.
       expect(screen.getAllByRole('button', { name: 'Download' })).toHaveLength(2);
-      expect(screen.getAllByRole('button', { name: 'Save to library' })).toHaveLength(1);
+      expect(screen.getAllByRole('button', { name: 'Save to library' })).toHaveLength(2);
     });
   });
 });

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -14,6 +14,7 @@ import { LogPanel } from '../components/wizard/LogPanel';
 import { EmptyState } from '../components/ui/EmptyState';
 import { ImagePreviewLightbox } from '../components/ui/ImagePreviewLightbox';
 import { StageTimeline } from '../components/calibration/StageTimeline';
+import TableViewer from '../components/TableViewer';
 import { estimateMinutes, formatEstimate, specFor } from '../components/calibration/stagePipeline';
 import {
   formatAgo,
@@ -42,12 +43,23 @@ import './CalibrateRun.css';
  */
 export const TICK_MS = 1000;
 
-/** Only FITS image products can be rendered or saved as library images;
- *  catalogs (.ecsv) and ASDF outputs are download-only. */
+/** Only FITS image products can be rendered as images; ASDF outputs are
+ *  download-only. */
 // Kept in lockstep with the backend allowlist _PREVIEWABLE_SUFFIXES
 // (.fits, .fit, .fits.gz) in processing-engine/app/jobs/routes.py.
 const PREVIEWABLE_RE = /\.(fits(\.gz)?|fit)$/i;
 const isPreviewable = (storageKey: string): boolean => PREVIEWABLE_RE.test(storageKey);
+
+/** Source catalogs have no image but are the citable half of a run, so they are
+ *  savable and readable in the table viewer — just not previewable. */
+// Lockstep with _TABULAR_SUFFIXES in processing-engine/app/jobs/routes.py.
+const TABULAR_RE = /\.ecsv$/i;
+const isTabular = (storageKey: string): boolean => TABULAR_RE.test(storageKey);
+
+/** What the backend will accept into the library (_LIBRARY_SUFFIXES). */
+const isSavable = (storageKey: string): boolean =>
+  isPreviewable(storageKey) || isTabular(storageKey);
+
 const basename = (key: string): string => key.split('/').pop() ?? key;
 
 /** Flatten run overrides into display rows, in the shape the config form uses. */
@@ -87,6 +99,10 @@ export default function RunDetail() {
   const [savedIds, setSavedIds] = useState<Record<number, string>>({});
   const [savingIndex, setSavingIndex] = useState<number | null>(null);
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  // The saved catalog currently open in the table viewer, which is keyed by
+  // library dataId rather than by output index — a catalog is only viewable
+  // once it has a library record.
+  const [catalog, setCatalog] = useState<{ dataId: string; title: string } | null>(null);
 
   // The heartbeat clock. Depends on a boolean rather than on `job` itself, so
   // the 1.5s poll doesn't tear down and rebuild the interval on every tick.
@@ -107,17 +123,21 @@ export default function RunDetail() {
   );
   // Stable identity so the lightbox's effects don't re-run on every poll tick.
   const closePreview = useCallback(() => setPreviewIndex(null), []);
+  const closeCatalog = useCallback(() => setCatalog(null), []);
 
-  const handleSave = async (index: number) => {
+  const handleSave = async (index: number, storageKey: string) => {
     if (!jobId) return;
     setSavingIndex(index);
     try {
       const { dataId, created } = await saveJobOutputToLibrary(jobId, index);
       setSavedIds((prev) => ({ ...prev, [index]: dataId }));
+      // A catalog goes to the table viewer, not the compositor, so the two
+      // saves promise different next steps.
+      const savedWhat = isTabular(storageKey)
+        ? 'Opens in the table viewer — positions, fluxes and magnitudes.'
+        : 'Opens in the full viewer, and can be used in a composite.';
       toast.success(created ? 'Saved to library' : 'Already in your library', {
-        description: created
-          ? 'Opens in the full viewer, and can be used in a composite.'
-          : 'This output was saved earlier — reusing that record.',
+        description: created ? savedWhat : 'This output was saved earlier — reusing that record.',
       });
     } catch (err: unknown) {
       toast.error('Could not save to library', {
@@ -399,6 +419,8 @@ export default function RunDetail() {
                   {job.result.outputs.map((output, i) => {
                     const sizeMb = (output.sizeBytes / 1024 / 1024).toFixed(1);
                     const previewable = isPreviewable(output.storageKey);
+                    const tabular = isTabular(output.storageKey);
+                    const savable = isSavable(output.storageKey);
                     const savedId = savedIds[i];
                     return (
                       <li key={output.storageKey}>
@@ -416,26 +438,44 @@ export default function RunDetail() {
                             <code>{output.storageKey}</code>
                           )}{' '}
                           ({sizeMb} MB)
-                          {!previewable && <span className="calibrate-hint"> · not an image</span>}
+                          {tabular && <span className="calibrate-hint"> · source catalog</span>}
+                          {!previewable && !tabular && (
+                            <span className="calibrate-hint"> · not an image</span>
+                          )}
                         </div>
                         <div className="calibrate-output-actions">
-                          {previewable &&
+                          {savable &&
                             (savedId ? (
                               <>
                                 <span className="calibrate-saved-badge">✓ In library</span>
-                                <Link
-                                  className="btn-base btn-compact"
-                                  to="/composite"
-                                  state={{ initialSelection: [savedId] }}
-                                >
-                                  Open in compositor
-                                </Link>
+                                {tabular ? (
+                                  <button
+                                    type="button"
+                                    className="btn-base btn-compact"
+                                    onClick={() =>
+                                      setCatalog({
+                                        dataId: savedId,
+                                        title: basename(output.storageKey),
+                                      })
+                                    }
+                                  >
+                                    View catalog
+                                  </button>
+                                ) : (
+                                  <Link
+                                    className="btn-base btn-compact"
+                                    to="/composite"
+                                    state={{ initialSelection: [savedId] }}
+                                  >
+                                    Open in compositor
+                                  </Link>
+                                )}
                               </>
                             ) : (
                               <button
                                 type="button"
                                 className="btn-base btn-compact"
-                                onClick={() => void handleSave(i)}
+                                onClick={() => void handleSave(i, output.storageKey)}
                                 disabled={savingIndex === i}
                               >
                                 {savingIndex === i ? 'Saving…' : 'Save to library'}
@@ -497,6 +537,16 @@ export default function RunDetail() {
           title={basename(job.result.outputs[previewIndex].storageKey)}
           onClose={closePreview}
           loadImage={loadPreview}
+        />
+      )}
+
+      {catalog && (
+        <TableViewer
+          key={catalog.dataId}
+          dataId={catalog.dataId}
+          title={catalog.title}
+          isOpen
+          onClose={closeCatalog}
         />
       )}
     </div>

--- a/processing-engine/app/analysis/routes.py
+++ b/processing-engine/app/analysis/routes.py
@@ -6,6 +6,7 @@ import logging
 import math
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from pathlib import Path
 
 import numpy as np
 from astropy.io import fits
@@ -417,6 +418,50 @@ def detect_sources_endpoint(request: SourceDetectionRequest):
         )
 
 
+#: Catalogs the calibration pipeline writes as ECSV rather than FITS
+#: (``Image3Pipeline``'s ``source_catalog`` step emits ``<product>_cat.ecsv``).
+#: astropy reads them into the same ``Table`` the FITS path produces, so only
+#: the HDU structure differs: an ECSV file is a single table, reported at
+#: index 0 so the viewer's HDU selector has something to select.
+ECSV_SUFFIXES = (".ecsv",)
+ECSV_HDU_INDEX = 0
+
+
+def _is_ecsv(path: Path) -> bool:
+    return path.suffix.lower() in ECSV_SUFFIXES
+
+
+def _ecsv_columns(table: Table) -> list[TableColumnInfo]:
+    """Column metadata for an ECSV table.
+
+    ECSV carries no TFORM/TDIM, so the dtype is the numpy dtype and an array
+    column is one whose cells have a shape beyond the row axis.
+    """
+    columns = []
+    for name in table.colnames:
+        col = table[name]
+        cell_shape = col.shape[1:]
+        columns.append(
+            TableColumnInfo(
+                name=name,
+                dtype=col.dtype.str,
+                unit=str(col.unit) if col.unit else None,
+                format=col.format,
+                is_array=bool(cell_shape),
+                array_shape=list(cell_shape) if cell_shape else None,
+            )
+        )
+    return columns
+
+
+def _read_ecsv(local_path: Path) -> Table:
+    try:
+        return Table.read(local_path, format="ascii.ecsv")
+    except Exception as exc:
+        logger.warning("Failed to read ECSV %s: %s", local_path.name, exc)
+        raise HTTPException(status_code=400, detail="File is not a readable ECSV table") from exc
+
+
 @router.get("/table-info", response_model=TableInfoResponse)
 def get_table_info(file_path: str):
     """
@@ -424,6 +469,23 @@ def get_table_info(file_path: str):
     """
     local_path = resolve_fits_path(file_path)
     logger.info(f"Getting table info for: {local_path.name}")
+
+    if _is_ecsv(local_path):
+        table = _read_ecsv(local_path)
+        columns = _ecsv_columns(table)
+        return TableInfoResponse(
+            file_name=local_path.name,
+            table_hdus=[
+                TableHduInfo(
+                    index=ECSV_HDU_INDEX,
+                    name=None,
+                    hdu_type="ECSV",
+                    n_rows=len(table),
+                    n_columns=len(columns),
+                    columns=columns,
+                )
+            ],
+        )
 
     table_hdus = []
     with fits.open(local_path, memmap=True) as hdul:
@@ -476,6 +538,84 @@ def get_table_info(file_path: str):
     )
 
 
+def _table_page(
+    table: Table,
+    columns: list[TableColumnInfo],
+    hdu_index: int,
+    hdu_name: str | None,
+    page: int,
+    page_size: int,
+    sort_column: str | None,
+    sort_direction: str | None,
+    search: str | None,
+) -> TableDataResponse:
+    """Search, sort, paginate and serialize a table.
+
+    Shared by the FITS and ECSV paths: by this point both are an astropy
+    ``Table`` plus its column metadata, and nothing below depends on which
+    format it was read from.
+    """
+    total_rows = len(table)
+    col_names = table.colnames
+
+    # Search filter: find rows where any cell contains the search term
+    if search and search.strip():
+        search_lower = search.strip().lower()
+        mask = np.zeros(len(table), dtype=bool)
+        for col_name in col_names:
+            try:
+                col_data = table[col_name]
+                str_vals = [_safe_str(val).lower() for val in col_data]
+                for idx, sv in enumerate(str_vals):
+                    if search_lower in sv:
+                        mask[idx] = True
+            except (ValueError, TypeError):
+                continue
+        table = table[mask]
+        total_rows = len(table)
+
+    # Sort
+    if sort_column and sort_column in col_names:
+        try:
+            table.sort(sort_column)
+            if sort_direction and sort_direction.lower() == "desc":
+                table.reverse()
+        except (ValueError, TypeError):
+            pass  # Skip sort if column is not sortable (e.g., array column)
+
+    # Paginate
+    start = page * page_size
+    end = min(start + page_size, len(table))
+    if start >= len(table) and len(table) > 0:
+        # Clamp to last page
+        page = max(0, (len(table) - 1) // page_size)
+        start = page * page_size
+        end = min(start + page_size, len(table))
+
+    page_table = table[start:end] if len(table) > 0 else table
+
+    # Serialize rows
+    rows = []
+    for row in page_table:
+        row_dict = {}
+        for col_name in col_names:
+            row_dict[col_name] = _serialize_cell(row[col_name])
+        rows.append(row_dict)
+
+    return TableDataResponse(
+        hdu_index=hdu_index,
+        hdu_name=hdu_name,
+        total_rows=total_rows,
+        total_columns=len(col_names),
+        page=page,
+        page_size=page_size,
+        columns=columns,
+        rows=rows,
+        sort_column=sort_column,
+        sort_direction=sort_direction,
+    )
+
+
 @router.get("/table-data", response_model=TableDataResponse)
 def get_table_data(
     file_path: str,
@@ -497,6 +637,25 @@ def get_table_data(
 
     local_path = resolve_fits_path(file_path)
     logger.info(f"Getting table data for: {local_path.name}, HDU {hdu_index}")
+
+    if _is_ecsv(local_path):
+        if hdu_index != ECSV_HDU_INDEX:
+            raise HTTPException(
+                status_code=400,
+                detail=f"HDU index {hdu_index} out of range (ECSV files hold a single table)",
+            )
+        table = _read_ecsv(local_path)
+        return _table_page(
+            table,
+            _ecsv_columns(table),
+            ECSV_HDU_INDEX,
+            None,
+            page,
+            page_size,
+            sort_column,
+            sort_direction,
+            search,
+        )
 
     with fits.open(local_path, memmap=True) as hdul:
         if hdu_index < 0 or hdu_index >= len(hdul):
@@ -540,64 +699,16 @@ def get_table_data(
                 )
             )
 
-        total_rows = len(table)
-        col_names = table.colnames
-
-        # Search filter: find rows where any cell contains the search term
-        if search and search.strip():
-            search_lower = search.strip().lower()
-            mask = np.zeros(len(table), dtype=bool)
-            for col_name in col_names:
-                try:
-                    col_data = table[col_name]
-                    str_vals = [_safe_str(val).lower() for val in col_data]
-                    for idx, sv in enumerate(str_vals):
-                        if search_lower in sv:
-                            mask[idx] = True
-                except (ValueError, TypeError):
-                    continue
-            table = table[mask]
-            total_rows = len(table)
-
-        # Sort
-        if sort_column and sort_column in col_names:
-            try:
-                table.sort(sort_column)
-                if sort_direction and sort_direction.lower() == "desc":
-                    table.reverse()
-            except (ValueError, TypeError):
-                pass  # Skip sort if column is not sortable (e.g., array column)
-
-        # Paginate
-        start = page * page_size
-        end = min(start + page_size, len(table))
-        if start >= len(table) and len(table) > 0:
-            # Clamp to last page
-            page = max(0, (len(table) - 1) // page_size)
-            start = page * page_size
-            end = min(start + page_size, len(table))
-
-        page_table = table[start:end] if len(table) > 0 else table
-
-        # Serialize rows
-        rows = []
-        for row in page_table:
-            row_dict = {}
-            for col_name in col_names:
-                row_dict[col_name] = _serialize_cell(row[col_name])
-            rows.append(row_dict)
-
-        return TableDataResponse(
-            hdu_index=hdu_index,
-            hdu_name=hdu.name if hdu.name != "" else None,
-            total_rows=total_rows,
-            total_columns=len(col_names),
-            page=page,
-            page_size=page_size,
-            columns=columns,
-            rows=rows,
-            sort_column=sort_column,
-            sort_direction=sort_direction,
+        return _table_page(
+            table,
+            columns,
+            hdu_index,
+            hdu.name if hdu.name != "" else None,
+            page,
+            page_size,
+            sort_column,
+            sort_direction,
+            search,
         )
 
 

--- a/processing-engine/app/analysis/routes.py
+++ b/processing-engine/app/analysis/routes.py
@@ -9,6 +9,7 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from pathlib import Path
 
 import numpy as np
+from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.io.fits import BinTableHDU, TableHDU
 from astropy.table import Table
@@ -88,6 +89,16 @@ def _serialize_cell(val):
     # Handle numpy masked values
     if hasattr(val, "mask") and np.ma.is_masked(val):
         return None
+
+    # Sky coordinates: a catalog's positions are its most-read column, and the
+    # default repr is a multi-line "<SkyCoord (ICRS): (ra, dec) in deg ...>"
+    # that reads as noise in a table cell and trips the 100-char truncation
+    # below. Decimal degrees are what a reader wants to copy out.
+    if isinstance(val, SkyCoord):
+        try:
+            return val.to_string("decimal", precision=6)
+        except (ValueError, TypeError, AttributeError):
+            return str(val)
 
     # Handle bytes
     if isinstance(val, bytes):
@@ -436,17 +447,23 @@ def _ecsv_columns(table: Table) -> list[TableColumnInfo]:
 
     ECSV carries no TFORM/TDIM, so the dtype is the numpy dtype and an array
     column is one whose cells have a shape beyond the row axis.
+
+    Not every column is a plain ``Column``: a real ``_cat.ecsv`` stores
+    ``sky_centroid`` as a ``SkyCoord`` mixin, which has no ``dtype``, no
+    ``unit`` and no ``format``. Those are the coordinates the catalog exists to
+    report, so the column has to survive — described by its class instead.
     """
     columns = []
     for name in table.colnames:
         col = table[name]
-        cell_shape = col.shape[1:]
+        dtype = getattr(col, "dtype", None)
+        cell_shape = tuple(getattr(col, "shape", (len(table),))[1:])
         columns.append(
             TableColumnInfo(
                 name=name,
-                dtype=col.dtype.str,
-                unit=str(col.unit) if col.unit else None,
-                format=col.format,
+                dtype=dtype.str if dtype is not None else type(col).__name__,
+                unit=str(col.unit) if getattr(col, "unit", None) else None,
+                format=getattr(col, "format", None),
                 is_array=bool(cell_shape),
                 array_shape=list(cell_shape) if cell_shape else None,
             )

--- a/processing-engine/app/calibration/seeds/miri-imaging.json
+++ b/processing-engine/app/calibration/seeds/miri-imaging.json
@@ -59,7 +59,8 @@
     "product_name": "miri-imaging"
   },
   "output_suffixes": [
-    "_i2d"
+    "_i2d",
+    "_cat"
   ],
   "created_by": null,
   "is_public": true

--- a/processing-engine/app/calibration/seeds/nircam-imaging.json
+++ b/processing-engine/app/calibration/seeds/nircam-imaging.json
@@ -60,7 +60,8 @@
     "product_name": "nircam-imaging"
   },
   "output_suffixes": [
-    "_i2d"
+    "_i2d",
+    "_cat"
   ],
   "created_by": null,
   "is_public": true

--- a/processing-engine/app/calibration/seeds/niriss-imaging.json
+++ b/processing-engine/app/calibration/seeds/niriss-imaging.json
@@ -58,7 +58,8 @@
     "product_name": "niriss-imaging"
   },
   "output_suffixes": [
-    "_i2d"
+    "_i2d",
+    "_cat"
   ],
   "created_by": null,
   "is_public": true

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -37,6 +37,16 @@ router = APIRouter(prefix="/api/jobs", tags=["Jobs"])
 # .ecsv, .asdf) are not previewable.
 _PREVIEWABLE_SUFFIXES = (".fits", ".fit", ".fits.gz")
 
+# Tabular products carry no image to render, but they are the citable half of a
+# run (``_cat.ecsv`` holds positions, fluxes, AB magnitudes and uncertainties),
+# so they are savable even though they are not previewable. The table viewer
+# reads them through /analysis/table-data once they have a library record.
+_TABULAR_SUFFIXES = (".ecsv",)
+
+# What may become a library record: an image to look at, or a table to read.
+# Deliberately narrower than download, which serves any output including .asdf.
+_LIBRARY_SUFFIXES = _PREVIEWABLE_SUFFIXES + _TABULAR_SUFFIXES
+
 # Library thumbnails are small; the full-size render is a separate concern.
 _THUMBNAIL_PX = 256
 
@@ -83,6 +93,16 @@ async def _resolve_output(
     job, output, storage_key = await _resolve_any_output(store, job_id, user, index)
     if not storage_key.lower().endswith(_PREVIEWABLE_SUFFIXES):
         raise HTTPException(status_code=415, detail="Output is not a previewable FITS image")
+    return job, output, storage_key
+
+
+async def _resolve_library_output(
+    store: JobStore, job_id: str, user: AuthenticatedUser, index: int
+) -> tuple[dict, dict, str]:
+    """As ``_resolve_any_output``, restricted to what can become a library record."""
+    job, output, storage_key = await _resolve_any_output(store, job_id, user, index)
+    if not storage_key.lower().endswith(_LIBRARY_SUFFIXES):
+        raise HTTPException(status_code=415, detail="Output cannot be saved to the library")
     return job, output, storage_key
 
 
@@ -155,6 +175,11 @@ async def _render_thumbnail(job_id: str, storage_key: str) -> bytes | None:
     A thumbnail is cosmetic — /library and the viewer both cope without one — so
     a render failure must never cost the user the save itself.
     """
+    # A catalog has no image to render. The except below would swallow the
+    # failure anyway, but attempting it costs a storage fetch and logs a
+    # renderer error for something that was never going to work.
+    if not storage_key.lower().endswith(_PREVIEWABLE_SUFFIXES):
+        return None
     try:
         response = await asyncio.to_thread(
             engine_preview,
@@ -201,7 +226,7 @@ async def save_output_to_library(
     ``/library``. Once saved the output has a real Mongo ``_id``, which is what
     the full ImageViewer and the compositor are keyed by.
     """
-    job, output, storage_key = await _resolve_output(store, job_id, user, index)
+    job, output, storage_key = await _resolve_library_output(store, job_id, user, index)
 
     # Always file under the job's owner, never the caller: an Admin saving
     # someone else's output must not claim it into their own library.

--- a/processing-engine/tests/test_calibration_recipes.py
+++ b/processing-engine/tests/test_calibration_recipes.py
@@ -150,7 +150,10 @@ class TestSeeds:
             assert recipe.source == "seed"
             assert recipe.id.startswith("seed-")
             assert recipe.mode == "imaging"
-            assert recipe.output_suffixes == ["_i2d"]
+            # Every seed keeps both the image and the catalog. Dropping "_cat"
+            # would silently go back to deleting the only citable numbers a run
+            # produces, which is exactly the bug S1 fixed.
+            assert recipe.output_suffixes == ["_i2d", "_cat"]
 
 
 @pytest.fixture()

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -409,13 +409,49 @@ class TestSaveOutputToLibrary:
         response = await client.post(f"/api/jobs/{job_id}/outputs/9/save", headers=bearer(USER))
         assert response.status_code == 404
 
-    async def test_non_fits_output_is_415(self, client: httpx.AsyncClient, store: JobStore) -> None:
-        catalog = JobOutput(
-            storage_key="calibration/job-1/jw001_cat.ecsv", suffix="_cat", size_bytes=64
+    async def test_unsavable_format_is_415(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        # Downloadable, but there is nothing to look at and nothing to read:
+        # neither an image nor a table, so it gets no library record.
+        asdf = JobOutput(
+            storage_key="calibration/job-1/jw001_cal.asdf", suffix="_cal", size_bytes=64
         )
-        job_id = await seed_succeeded_job(store, outputs=[catalog])
+        job_id = await seed_succeeded_job(store, outputs=[asdf])
         response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
         assert response.status_code == 415
+
+    async def test_saves_a_source_catalog(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        library,
+    ) -> None:
+        """A ``_cat.ecsv`` is savable even though it is not previewable (S1).
+
+        The catalog holds the run's citable numbers — positions, fluxes, AB
+        magnitudes and uncertainties — and needs a library record because the
+        table viewer is keyed by dataId.
+        """
+        # Deliberately NOT stubbing the renderer: a catalog must not attempt a
+        # thumbnail at all, so a real call here would be a bug.
+        catalog = JobOutput(
+            storage_key="calibration/job-1/nircam-imaging_cat.ecsv", suffix="_cat", size_bytes=64
+        )
+        job_id = await seed_succeeded_job(store, outputs=[catalog])
+
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        assert response.status_code == 201
+
+        doc = await library.find_one({"FilePath": "calibration/job-1/nircam-imaging_cat.ecsv"})
+        assert doc is not None
+        assert doc["FileName"] == "nircam-imaging_cat.ecsv"
+        # _cat is L3 in the level table, so the catalog files alongside the
+        # image it describes rather than landing levelless.
+        assert doc["ProcessingLevel"] == "L3"
+        # No image, so no thumbnail — the writer omits the field rather than
+        # storing a null — and the save still succeeded.
+        assert doc.get("ThumbnailData") is None
 
     async def test_creates_a_private_viewable_library_record(
         self,

--- a/processing-engine/tests/test_table_routes.py
+++ b/processing-engine/tests/test_table_routes.py
@@ -670,22 +670,33 @@ class TestTableDataEndpoint:
 
 @pytest.fixture
 def temp_catalog_ecsv(tmp_path):
-    """An ECSV source catalog shaped like Image3Pipeline's ``_cat`` output."""
+    """An ECSV source catalog shaped like Image3Pipeline's ``_cat`` output.
+
+    ``sky_centroid`` is a real ``SkyCoord`` mixin column, exactly as the jwst
+    pipeline writes it. That detail matters: an earlier version of this fixture
+    used two plain float columns named ``sky_centroid.ra``/``.dec``, which made
+    the tests pass while the endpoint raised
+    ``AttributeError: 'SkyCoord' object has no attribute 'dtype'`` against
+    every real catalog. Mixin columns have no dtype, unit or format.
+    """
+    from astropy.coordinates import SkyCoord
     from astropy.table import QTable
 
     filepath = tmp_path / "nircam-imaging_cat.ecsv"
     table = QTable(
         {
             "label": np.arange(1, 6),
-            "sky_centroid.ra": np.linspace(53.10, 53.14, 5),
-            "sky_centroid.dec": np.linspace(-27.80, -27.76, 5),
+            "sky_centroid": SkyCoord(
+                ra=np.linspace(53.10, 53.14, 5),
+                dec=np.linspace(-27.80, -27.76, 5),
+                unit="deg",
+            ),
             "aper_total_flux": np.linspace(1.0e-7, 5.0e-7, 5),
             "aper_total_flux_err": np.linspace(1.0e-9, 5.0e-9, 5),
             "aper_total_abmag": np.linspace(24.0, 26.0, 5),
         }
     )
     table["aper_total_flux"].unit = "Jy"
-    table["sky_centroid.ra"].unit = "deg"
     table.write(filepath, format="ascii.ecsv", overwrite=True)
     return filepath
 
@@ -712,7 +723,7 @@ class TestEcsvTableInfo:
         assert hdu_info["hdu_type"] == "ECSV"
         assert hdu_info["name"] is None
         assert hdu_info["n_rows"] == 5
-        assert hdu_info["n_columns"] == 6
+        assert hdu_info["n_columns"] == 5
 
     def test_carries_units(self, client, temp_catalog_ecsv, storage_patch):  # noqa: ARG002
         """Units are the point of the catalog — a flux with no unit is not citable."""
@@ -724,8 +735,34 @@ class TestEcsvTableInfo:
 
         columns = {c["name"]: c for c in response.json()["table_hdus"][0]["columns"]}
         assert columns["aper_total_flux"]["unit"] == "Jy"
-        assert columns["sky_centroid.ra"]["unit"] == "deg"
         assert columns["label"]["unit"] is None
+
+    def test_describes_the_skycoord_mixin_column(
+        self,
+        client,
+        temp_catalog_ecsv,  # noqa: ARG002
+        storage_patch,
+    ):
+        """A mixin column has no dtype; it must still be described, not crash.
+
+        Regression test for the live failure against a real ``_cat.ecsv``:
+        ``_ecsv_columns`` read ``col.dtype.str`` unconditionally and raised
+        ``AttributeError: 'SkyCoord' object has no attribute 'dtype'``, which
+        surfaced as a 500 from the engine and a 503 through the .NET proxy —
+        so the catalog could be saved but never opened.
+        """
+        with storage_patch:
+            response = client.get(
+                "/analysis/table-info",
+                params={"file_path": "nircam-imaging_cat.ecsv"},
+            )
+
+        assert response.status_code == 200
+        columns = {c["name"]: c for c in response.json()["table_hdus"][0]["columns"]}
+        sky = columns["sky_centroid"]
+        # Described by class, since there is no numpy dtype to report.
+        assert sky["dtype"] == "SkyCoord"
+        assert sky["is_array"] is False
 
     def test_malformed_ecsv_is_400(self, client, tmp_path, storage_patch):  # noqa: ARG002
         (tmp_path / "broken.ecsv").write_text("this is not an ECSV table\n", encoding="utf-8")
@@ -754,9 +791,33 @@ class TestEcsvTableData:
         assert data["hdu_index"] == 0
         assert data["hdu_name"] is None
         assert data["total_rows"] == 5
-        assert data["total_columns"] == 6
+        assert data["total_columns"] == 5
         assert len(data["rows"]) == 5
         assert data["rows"][0]["label"] == 1
+
+    def test_serializes_sky_coordinates_as_decimal_degrees(
+        self,
+        client,
+        temp_catalog_ecsv,  # noqa: ARG002
+        storage_patch,
+    ):
+        """Positions are the most-read column, so they must be readable.
+
+        The default ``SkyCoord`` repr is a multi-line
+        ``<SkyCoord (ICRS): (ra, dec) in deg ...>`` that reads as noise in a
+        table cell and hits the 100-char truncation in ``_serialize_cell``.
+        """
+        with storage_patch:
+            response = client.get(
+                "/analysis/table-data",
+                params={"file_path": "nircam-imaging_cat.ecsv", "hdu_index": 0},
+            )
+
+        cell = response.json()["rows"][0]["sky_centroid"]
+        assert "SkyCoord" not in cell
+        ra, dec = cell.split()
+        assert float(ra) == pytest.approx(53.10, abs=1e-4)
+        assert float(dec) == pytest.approx(-27.80, abs=1e-4)
 
     def test_sort_desc(self, client, temp_catalog_ecsv, storage_patch):  # noqa: ARG002
         with storage_patch:

--- a/processing-engine/tests/test_table_routes.py
+++ b/processing-engine/tests/test_table_routes.py
@@ -661,3 +661,142 @@ class TestTableDataEndpoint:
         data = response.json()
         assert data["total_rows"] == 1
         assert data["rows"][0]["label"] == "beta"
+
+
+# ---------------------------------------------------------------------------
+# ECSV source catalogs (S1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_catalog_ecsv(tmp_path):
+    """An ECSV source catalog shaped like Image3Pipeline's ``_cat`` output."""
+    from astropy.table import QTable
+
+    filepath = tmp_path / "nircam-imaging_cat.ecsv"
+    table = QTable(
+        {
+            "label": np.arange(1, 6),
+            "sky_centroid.ra": np.linspace(53.10, 53.14, 5),
+            "sky_centroid.dec": np.linspace(-27.80, -27.76, 5),
+            "aper_total_flux": np.linspace(1.0e-7, 5.0e-7, 5),
+            "aper_total_flux_err": np.linspace(1.0e-9, 5.0e-9, 5),
+            "aper_total_abmag": np.linspace(24.0, 26.0, 5),
+        }
+    )
+    table["aper_total_flux"].unit = "Jy"
+    table["sky_centroid.ra"].unit = "deg"
+    table.write(filepath, format="ascii.ecsv", overwrite=True)
+    return filepath
+
+
+class TestEcsvTableInfo:
+    """GET /analysis/table-info against an ECSV catalog."""
+
+    def test_reports_single_synthetic_hdu(self, client, temp_catalog_ecsv, storage_patch):  # noqa: ARG002
+        with storage_patch:
+            response = client.get(
+                "/analysis/table-info",
+                params={"file_path": "nircam-imaging_cat.ecsv"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["file_name"] == "nircam-imaging_cat.ecsv"
+        assert len(data["table_hdus"]) == 1
+
+        hdu_info = data["table_hdus"][0]
+        # ECSV has no HDU structure; index 0 is what the viewer's selector uses.
+        assert hdu_info["index"] == 0
+        assert hdu_info["hdu_type"] == "ECSV"
+        assert hdu_info["name"] is None
+        assert hdu_info["n_rows"] == 5
+        assert hdu_info["n_columns"] == 6
+
+    def test_carries_units(self, client, temp_catalog_ecsv, storage_patch):  # noqa: ARG002
+        """Units are the point of the catalog — a flux with no unit is not citable."""
+        with storage_patch:
+            response = client.get(
+                "/analysis/table-info",
+                params={"file_path": "nircam-imaging_cat.ecsv"},
+            )
+
+        columns = {c["name"]: c for c in response.json()["table_hdus"][0]["columns"]}
+        assert columns["aper_total_flux"]["unit"] == "Jy"
+        assert columns["sky_centroid.ra"]["unit"] == "deg"
+        assert columns["label"]["unit"] is None
+
+    def test_malformed_ecsv_is_400(self, client, tmp_path, storage_patch):  # noqa: ARG002
+        (tmp_path / "broken.ecsv").write_text("this is not an ECSV table\n", encoding="utf-8")
+
+        with storage_patch:
+            response = client.get(
+                "/analysis/table-info",
+                params={"file_path": "broken.ecsv"},
+            )
+
+        assert response.status_code == 400
+
+
+class TestEcsvTableData:
+    """GET /analysis/table-data against an ECSV catalog."""
+
+    def test_happy_path(self, client, temp_catalog_ecsv, storage_patch):  # noqa: ARG002
+        with storage_patch:
+            response = client.get(
+                "/analysis/table-data",
+                params={"file_path": "nircam-imaging_cat.ecsv", "hdu_index": 0},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["hdu_index"] == 0
+        assert data["hdu_name"] is None
+        assert data["total_rows"] == 5
+        assert data["total_columns"] == 6
+        assert len(data["rows"]) == 5
+        assert data["rows"][0]["label"] == 1
+
+    def test_sort_desc(self, client, temp_catalog_ecsv, storage_patch):  # noqa: ARG002
+        with storage_patch:
+            response = client.get(
+                "/analysis/table-data",
+                params={
+                    "file_path": "nircam-imaging_cat.ecsv",
+                    "hdu_index": 0,
+                    "sort_column": "label",
+                    "sort_direction": "desc",
+                },
+            )
+
+        assert response.status_code == 200
+        labels = [row["label"] for row in response.json()["rows"]]
+        assert labels == [5, 4, 3, 2, 1]
+
+    def test_pagination(self, client, temp_catalog_ecsv, storage_patch):  # noqa: ARG002
+        with storage_patch:
+            response = client.get(
+                "/analysis/table-data",
+                params={
+                    "file_path": "nircam-imaging_cat.ecsv",
+                    "hdu_index": 0,
+                    "page": 1,
+                    "page_size": 2,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_rows"] == 5
+        assert [row["label"] for row in data["rows"]] == [3, 4]
+
+    def test_nonzero_hdu_index_is_400(self, client, temp_catalog_ecsv, storage_patch):  # noqa: ARG002
+        """An ECSV file holds one table; asking for HDU 1 is a client error."""
+        with storage_patch:
+            response = client.get(
+                "/analysis/table-data",
+                params={"file_path": "nircam-imaging_cat.ecsv", "hdu_index": 1},
+            )
+
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary

Every calibration run computes a publication-quality source catalog and then
deletes it.

`Image3Pipeline`'s `source_catalog` step is on the executor allowlist
(`calibration/executor.py:78`) and runs in all three seed recipes — `image3` is
enabled with empty `step_overrides`, so the step fires at jwst defaults. It
writes `<product>_cat.ecsv`: STScI-calibrated RA/Dec positions, aperture fluxes,
**AB magnitudes, and uncertainties** — precisely the citable numbers the rest of
the app lacks. `_persist_outputs` then filters outputs by
`output_suffixes: ["_i2d"]`, and `executor.py:744` runs `rmtree` on the workdir.

This emits the catalog and makes it readable in the **existing** `TableViewer`,
rather than building a second table UI.

This is item **S1** of the simplification & science plan.

## Changes Made

**Emit the catalog**
- `calibration/seeds/{nircam,miri,niriss}-imaging.json` — add `"_cat"` to
  `output_suffixes`. `_persist_outputs` matches on `path.stem.endswith(suffix)`,
  so `"_cat"` captures `<product>_cat.ecsv` with no code change.
- No migration needed: `RecipeStore.seed()` runs at startup
  (`processing-engine/main.py:57`) and `upsert()` replaces seed documents whole,
  so the change reaches existing recipe docs on next boot.

**Read ECSV in the table endpoints** (`app/analysis/routes.py`)
- `get_table_data` already converted to an `astropy.table.Table` internally, so
  the search/sort/paginate/serialize block is now a shared `_table_page` helper
  used by both formats instead of living inside the FITS branch.
- ECSV reports a single synthetic HDU at index 0 (`hdu_type: "ECSV"`); a
  non-zero `hdu_index` is a 400, and an unreadable file is a 400.
- `resolve_fits_path` needed no change — it validates traversal and existence,
  not extension.

**Let non-image outputs reach the library** (`app/jobs/routes.py`)
- `_PREVIEWABLE_SUFFIXES` stays FITS-only — it means *image preview* and that is
  still correct. New `_TABULAR_SUFFIXES` / `_LIBRARY_SUFFIXES` and a
  `_resolve_library_output` let a catalog be saved.
- `_render_thumbnail` returns early for non-image outputs. It already swallowed
  the failure, but attempting it cost a storage fetch and logged a renderer
  error for something that was never going to work.
- `level_for_suffix("_cat")` already returned `L3` — `library/levels.py` added
  `_cat` deliberately so a saved catalog is not levelless. No change needed.

**Read mixin columns** (`app/analysis/routes.py`) — *second commit, found live*
- A real `_cat.ecsv` stores `sky_centroid` as a **`SkyCoord` mixin column**,
  which has no `dtype`, no `unit` and no `format`. `_ecsv_columns` read
  `col.dtype.str` unconditionally and raised
  `AttributeError: 'SkyCoord' object has no attribute 'dtype'` — a 500 from the
  engine, surfaced as a 503 through the .NET proxy. The catalog could be saved
  but never opened.
- Mixin columns are now described by their class name. Sky coordinates
  serialize as decimal degrees rather than the multi-line `SkyCoord` repr,
  which read as noise in a table cell and hit the 100-char truncation.
- The unit-test fixture built two plain float columns named
  `sky_centroid.ra`/`.dec`, which is why the suite passed while every real
  catalog failed. It now builds a real `SkyCoord`.

**Split previewable from savable** (`src/pages/RunDetail.tsx`)
- One `previewable` flag gated both the image preview *and* the Save button, so
  a catalog could not be saved at all. Now `isPreviewable` / `isTabular` /
  `isSavable`.
- A catalog shows "· source catalog", offers Save to library, then View catalog,
  which mounts the existing `TableViewer` on the resulting `dataId`. ASDF keeps
  the "· not an image" hint.
- The save toast promises the right next step per type (table viewer vs
  compositor).

## Test Plan

- [x] Python suite green against worktree code — **1890 passed**
- [x] **Verified end-to-end against a real calibration run** (see below)
- [x] `TestEcsvTableInfo` — synthetic HDU shape, units carried (`Jy`, `deg`),
      malformed ECSV is 400
- [x] `TestEcsvTableData` — happy path, sort desc, pagination, non-zero
      `hdu_index` is 400
- [x] `test_saves_a_source_catalog` — 201, filed as `L3`, no thumbnail
      attempted (the renderer is deliberately **not** stubbed, so a real call
      would fail the test)
- [x] `test_unsavable_format_is_415` — `.asdf` still rejected
- [x] Seed assertion updated to `["_i2d", "_cat"]` so a future edit that drops
      the catalog fails loudly
- [x] Frontend suite green — **1446 passed / 123 files**
- [x] `tsc --noEmit` clean; ESLint clean; Prettier and Ruff formatted
- [x] Pre-commit hooks passed in full

### Live end-to-end verification

Ran the MIRI Imaging seed recipe against the real stack, rebuilt from this
branch — MAST fetch of **45 exposures** (PID 1040 F770W), full
Detector1 → Image2 → Image3, **52 min**:

- `_cat.ecsv` **retained** — `miri-imaging_cat.ecsv`, 1,950,186 bytes,
  alongside the `_i2d`. The two prior runs in the same database produced only
  `_i2d`, so this is the bug fixed in situ.
- **Reseed needs no migration** — the three existing seed recipe documents
  picked up `["_i2d", "_cat"]` on container restart, and this run's own
  `recipe_snapshot` carried it.
- Run page shows the catalog as "· source catalog" with **Save to library**.
- Save → toast "Opens in the table viewer — positions, fluxes and magnitudes";
  re-save is idempotent ("reusing that record").
- **View catalog** opens the table viewer: **1,794 rows × 54 columns**,
  `aper_total_flux(Jy)`, AB and Vega magnitudes with errors, positions as
  `80.561670 -69.435950`, pagination across 18 pages, search and Export CSV.
- Sample row: RA 80.561670, Dec −69.435950, flux 6.812e-5 ± 9.583e-7 Jy,
  AB mag 19.3168 ± 0.0152 — the citable numbers the app previously deleted.

The first pass of this walkthrough is what surfaced the `SkyCoord` bug fixed in
the second commit.

Reviewer walkthrough:
1. Run any seed recipe from `/calibrate`.
2. On the run page, confirm `<product>_cat.ecsv` now appears under Outputs,
   labelled "· source catalog".
3. Click **Save to library** on it — the toast should mention the table viewer.
4. Click **View catalog** — the table viewer opens with RA/Dec, fluxes, AB
   magnitudes and their uncertainties, with units in the column headers.
5. Confirm the `_i2d` image still previews, saves, and hops to the compositor
   exactly as before.

> Note: verifying step 1 against a **rebuilt** engine matters — the running
> `jwst-processing` container bakes its code into the image and mounts only
> `data/`, so an un-rebuilt container will not have this change.

## Documentation Checklist

- [x] Plan recorded at `docs/plans/features/quick/s1-surface-source-catalog.md`
- [x] Rationale captured in code comments at each seam (why previewable and
      savable are now different questions; why ECSV has a synthetic HDU)
- [ ] No API reference changes — `table-info` / `table-data` gain a format, not
      a signature
- [ ] No architecture doc changes

## Tech Debt Impact

- [x] **Reduces** — the search/sort/paginate block was inlined in the FITS
      branch; it is now a single shared helper, so the ECSV path cannot drift
      from it
- [x] **Reduces** — `previewable` was overloaded to mean both "renderable" and
      "savable"; those are now separate, named questions
- [ ] Adds none

## Risk & Rollback

**Risk: low.** Additive. No existing endpoint signature, response shape, or FITS
behavior changes; the FITS path runs the same logic, just relocated into a
helper covered by the pre-existing tests.

The one behavioral change to existing data is that `POST
/api/jobs/{id}/outputs/{i}/save` now returns 201 instead of 415 for an `.ecsv`
output — strictly more permissive, and the endpoint remains ownership-checked
and server-side-keyed.

**Rollback:** revert the commit. Recipes revert to `["_i2d"]` on the next boot
via the same seed-upsert path. Catalogs saved to the library in the meantime
would remain as records pointing at `.ecsv` files, harmless but no longer
viewable in-app; delete them from `/library` if that matters.
