### PR TITLE
feat: name Level-3 products after the data, key library records by path

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/MongoDBServiceDeduplicationTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/MongoDBServiceDeduplicationTests.cs
@@ -35,10 +35,12 @@ public class MongoDBServiceDeduplicationTests
     [Fact]
     public async Task DeduplicateRecordsAsync_RemovesDuplicates_KeepsBestRecord()
     {
-        // Arrange: aggregation returns one group with 3 duplicates (grouped by UserId + FileName)
+        // Arrange: aggregation returns one group with 3 duplicates (grouped by UserId + FilePath).
+        // Grouping is keyed on FilePath in lockstep with idx_userId_filePath_unique (#1803) —
+        // two records sharing a name but not a path are distinct files and must both survive.
         var aggResult = new BsonDocument
         {
-            { "_id", new BsonDocument { { "UserId", "user1" }, { "FileName", "test_file.fits" } } },
+            { "_id", new BsonDocument { { "UserId", "user1" }, { "FilePath", "uploads/test_file.fits" } } },
             { "count", 3 },
             { "ids", new BsonArray { "id1", "id2", "id3" } },
         };
@@ -47,19 +49,19 @@ public class MongoDBServiceDeduplicationTests
 
         // The three records — id2 is public so should be kept
         var record1 = TestDataFixtures.CreateSampleData(id: "id1");
-        record1.FileName = "test_file.fits";
+        record1.FilePath = "uploads/test_file.fits";
         record1.IsPublic = false;
         record1.UploadDate = DateTime.UtcNow.AddHours(-2);
         record1.Metadata = new Dictionary<string, object> { { "key1", "val1" } };
 
         var record2 = TestDataFixtures.CreateSampleData(id: "id2");
-        record2.FileName = "test_file.fits";
+        record2.FilePath = "uploads/test_file.fits";
         record2.IsPublic = true;
         record2.UploadDate = DateTime.UtcNow.AddHours(-1);
         record2.Metadata = new Dictionary<string, object> { { "key1", "val1" }, { "key2", "val2" } };
 
         var record3 = TestDataFixtures.CreateSampleData(id: "id3");
-        record3.FileName = "test_file.fits";
+        record3.FilePath = "uploads/test_file.fits";
         record3.IsPublic = false;
         record3.UploadDate = DateTime.UtcNow;
         record3.Metadata = new Dictionary<string, object>();

--- a/backend/JwstDataAnalysis.API/Services/MongoDBService.Log.cs
+++ b/backend/JwstDataAnalysis.API/Services/MongoDBService.Log.cs
@@ -29,8 +29,8 @@ namespace JwstDataAnalysis.API.Services
 
         // Deduplication operations (65xx)
         [LoggerMessage(EventId = 6501, Level = LogLevel.Information,
-            Message = "Deduplicated file '{FileName}': removed {Count} duplicate(s), kept record {KeptId}")]
-        private partial void LogDeduplicatedRecords(string fileName, int count, string keptId);
+            Message = "Deduplicated file '{FilePath}': removed {Count} duplicate(s), kept record {KeptId}")]
+        private partial void LogDeduplicatedRecords(string filePath, int count, string keptId);
 
         [LoggerMessage(EventId = 6502, Level = LogLevel.Information,
             Message = "Deduplication complete: removed {TotalDeleted} duplicate record(s)")]

--- a/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
+++ b/backend/JwstDataAnalysis.API/Services/MongoDBService.cs
@@ -79,6 +79,21 @@ namespace JwstDataAnalysis.API.Services
                     // Index doesn't exist — nothing to drop
                 }
 
+                // Migration (#1803): the per-user unique key moves from FileName to FilePath.
+                // Level-3 products are named after the data, so re-running a recipe on the
+                // same target legitimately reproduces a name; keying on the storage key lets
+                // those coexist as the distinct files they are. Must be dropped before the
+                // replacement is created, or the old index keeps rejecting the new writes.
+                try
+                {
+                    await jwstDataCollection.Indexes.DropOneAsync("idx_userId_fileName_unique");
+                    LogLegacyIndexDropped("idx_userId_fileName_unique");
+                }
+                catch (MongoDB.Driver.MongoCommandException)
+                {
+                    // Index doesn't exist — nothing to drop
+                }
+
                 var indexModels = new List<CreateIndexModel<JwstDataModel>>
                 {
                     // Single field indexes for commonly filtered fields
@@ -133,12 +148,18 @@ namespace JwstDataAnalysis.API.Services
                             .Text(x => x.Description),
                         new CreateIndexOptions { Name = "idx_text_search", Background = true }),
 
-                    // Unique compound index on (UserId, FileName) to prevent duplicate records per user
+                    // Unique compound index on (UserId, FilePath) to prevent duplicate records
+                    // per user. Keyed on FilePath, not FileName: a stored file's identity is
+                    // its storage key. Two runs of one recipe write two real files, so they
+                    // are two records — under the old (UserId, FileName) index the second save
+                    // failed with a duplicate-key 500 (#1803), because Level-3 products are
+                    // named after the data, and re-running the same target legitimately
+                    // reproduces a name.
                     new(
                         Builders<JwstDataModel>.IndexKeys
                             .Ascending(x => x.UserId)
-                            .Ascending(x => x.FileName),
-                        new CreateIndexOptions { Name = "idx_userId_fileName_unique", Unique = true, Background = true }),
+                            .Ascending(x => x.FilePath),
+                        new CreateIndexOptions { Name = "idx_userId_filePath_unique", Unique = true, Background = true }),
                 };
 
                 await jwstDataCollection.Indexes.CreateManyAsync(indexModels);
@@ -152,22 +173,28 @@ namespace JwstDataAnalysis.API.Services
         }
 
         /// <summary>
-        /// Removes duplicate records (by UserId + FileName), keeping the best record per group.
+        /// Removes duplicate records (by UserId + FilePath), keeping the best record per group.
         /// Prefers records with IsPublic=true, then richest metadata, then oldest UploadDate.
-        /// Must be called before creating the unique compound index on (UserId, FileName).
+        /// Must be called before creating the unique compound index on (UserId, FilePath).
         /// </summary>
+        /// <remarks>
+        /// Grouped by FilePath, in lockstep with idx_userId_filePath_unique. This runs on every
+        /// startup, so grouping by FileName here while the index allows repeated names would
+        /// delete the extra records on the next boot — silently, and after the user was told
+        /// the save succeeded. Two records sharing a name but not a path are distinct files.
+        /// </remarks>
         public async Task<int> DeduplicateRecordsAsync()
         {
             var totalDeleted = 0;
 
             try
             {
-                // Aggregation: group by (UserId, FileName), keep groups with count > 1
+                // Aggregation: group by (UserId, FilePath), keep groups with count > 1
                 var pipeline = new BsonDocument[]
                 {
                     new("$group", new BsonDocument
                     {
-                        { "_id", new BsonDocument { { "UserId", "$UserId" }, { "FileName", "$FileName" } } },
+                        { "_id", new BsonDocument { { "UserId", "$UserId" }, { "FilePath", "$FilePath" } } },
                         { "count", new BsonDocument("$sum", 1) },
                         { "ids", new BsonDocument("$push", "$_id") },
                     }),
@@ -180,7 +207,7 @@ namespace JwstDataAnalysis.API.Services
                 foreach (var group in duplicateGroups)
                 {
                     var groupKey = group["_id"].AsBsonDocument;
-                    var fileName = groupKey["FileName"].AsString;
+                    var filePath = groupKey["FilePath"].AsString;
                     var ids = group["ids"].AsBsonArray
                         .Select(id => id.IsObjectId ? id.AsObjectId.ToString() : id.AsString)
                         .ToList();
@@ -204,7 +231,7 @@ namespace JwstDataAnalysis.API.Services
                         var deleteResult = await jwstDataCollection.DeleteManyAsync(deleteFilter);
                         totalDeleted += (int)deleteResult.DeletedCount;
 
-                        LogDeduplicatedRecords(fileName, (int)deleteResult.DeletedCount, keeper.Id);
+                        LogDeduplicatedRecords(filePath, (int)deleteResult.DeletedCount, keeper.Id);
                     }
                 }
 

--- a/docs/plans/features/derived-product-names.md
+++ b/docs/plans/features/derived-product-names.md
@@ -1,0 +1,102 @@
+# Derived product names + FilePath identity (#1803)
+
+Implements options 4 and 3 from [#1803](https://github.com/Snoww3d/jwst-data-analysis/issues/1803).
+
+## Problem
+
+`Save to library` returned a 500 on the second run of any recipe.
+
+`jwst_data` had a unique index on `(UserId, FileName)`, while
+`save_output_to_library` checked for a re-save by **FilePath**. The storage key
+embeds the job id, so a second run had a different FilePath but an identical
+FileName: the guard passed, the insert hit the index, and `DuplicateKeyError`
+escaped as a 500.
+
+Identical because the filename came from the recipe, not the data:
+
+```json
+"association": { "rule": "DMS_Level3_Base", "product_name": "miri-imaging" }
+```
+
+Every run of MIRI Imaging — any target, any settings — wrote
+`miri-imaging_i2d.fits`.
+
+## Two problems, kept separate
+
+- **Provenance** ("did this app make it, or did it come from MAST?") belongs in
+  the name.
+- **Repeat runs** do not. Two runs of the same data produce products with the
+  same identity; only the *settings* differ, and settings are run metadata.
+  Encoding them in the filename means inventing a slug.
+
+## Option 4 — name products after the data
+
+New `app/calibration/product_naming.py` derives, from the run's own exposures:
+
+```
+jw{program}-{acid}_{instrument}_{optical elements}
+jw01040-a3001_miri_f770w
+```
+
+`acid` is the association candidate ID, and it carries provenance.
+`jwst.associations.lib.acid` defines `oXXX` for PPS-planned OBSERVATION, `c1XXX`
+for MOSAIC, and `a3XXX` for **DISCOVERED** — associations built
+programmatically, which is what `asn_from_list` does here.
+
+| Origin | Product name |
+| --- | --- |
+| MAST download | `jw01040-o001_t001_miri_f770w_i2d.fits` |
+| This app | `jw01040-a3001_miri_f770w_i2d.fits` |
+
+Decisions:
+
+- **Optical elements are sorted alphabetically**, matching the archive —
+  existing library records read `nircam_clear-f200w` (FILTER=F200W, PUPIL=CLEAR)
+  and `nircam_f444w-f470n` (FILTER=F444W, PUPIL=F470N). Both sorted, not
+  filter-then-pupil.
+- **No `t###` target field.** It is assigned by PPS and cannot be known from the
+  exposures; emitting a plausible-looking `t001` would invent an identifier.
+- **Multi-observation → `a3000`.** A mosaic across visits has no single
+  observation to be named after.
+- **Mixed filters → no optics segment.** Naming a colour association after one
+  of its filters would mislead.
+- **Never raises.** An unreadable header falls back to the recipe's own name —
+  the previous behaviour. A naming failure must not cost a multi-hour run.
+
+Derived **once**, in `_execute`, because the same string must reach both the
+association (which names the files) and the `_persist_outputs` prefix (which
+finds them again). Deriving twice risks them disagreeing.
+
+## Option 3 — identity is the storage key
+
+- `idx_userId_fileName_unique` → **`idx_userId_filePath_unique`**, with an
+  explicit drop of the old index alongside the existing `idx_fileName_unique`
+  migration.
+- **`DeduplicateRecordsAsync` now groups by `(UserId, FilePath)`.** This is the
+  trap: it runs on every startup, so leaving it on FileName while the index
+  permits repeated names would delete the extra records on the next boot —
+  silently, after the user was told the save succeeded.
+- `DuplicateKeyError` → **409** with a real message, instead of a 500 the UI
+  could only render as "InternalServerError".
+
+No data migration needed. Checked against the live dev database: 1,524 records,
+0 missing FilePath, 0 duplicate `(UserId, FilePath)`.
+
+## Out of scope
+
+- Showing `_variant_description` in the library list so repeat runs are told
+  apart by their settings. Worth a follow-up; the description is already written.
+- Renaming existing records. Old records keep their names; nothing is
+  retroactive.
+- `MastController.GetByFileNameAsync` does a global `FirstOrDefault` on FileName
+  and is now looser than it looks. Not touched here — filed separately.
+
+## Test plan
+
+- `tests/test_product_naming.py` — derivation, alphabetical optics, multi-obs,
+  mixed filters, the `a3` provenance marker, no fabricated target, and every
+  fallback path including an unreadable file.
+- Output is fed through the real `Association` validator, since it becomes a
+  filename.
+- `test_duplicate_key_is_409_not_500` — regression for the 500.
+- .NET dedup tests updated to the FilePath grouping key.

--- a/processing-engine/app/calibration/executor.py
+++ b/processing-engine/app/calibration/executor.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Any
 
 from app.calibration.models import CalibrationRecipe
+from app.calibration.product_naming import derive_product_name
 from app.jobs.models import JobOutput, JobResult
 from app.jobs.runner import JobCancelled, JobContext
 from app.storage.factory import get_storage_provider
@@ -630,6 +631,14 @@ async def run_calibration_job(
         for path in input_paths:
             validate_fits_file_size(path)
 
+        # Name the products after the data, not the recipe. Derived once, from
+        # the run's own inputs, because the same string has to reach two
+        # places: the association (which is what jwst names its files after)
+        # and the output prefix below (which is how those files are found
+        # again). Deriving it twice would risk them disagreeing.
+        product_name = derive_product_name(input_paths, recipe.association.product_name)
+        logger.info("Job %s: product name %r", ctx.job_id, product_name)
+
         await ctx.set_progress(message="waiting for a run slot")
         semaphore = _get_semaphore()
         await asyncio.to_thread(semaphore.acquire)
@@ -672,7 +681,7 @@ async def run_calibration_job(
                             stage.name,
                             current,
                             merged_by_stage[stage.name],
-                            recipe,
+                            product_name,
                             workdir,
                             None if combining else _file_progress(handler, ctx, stage.name),
                         ),
@@ -723,7 +732,7 @@ async def run_calibration_job(
         # chain Image2 also emits per-exposure _i2d files into the workdir,
         # which are intermediates, not the recipe's declared output.
         terminal = stages[-1].name
-        prefix = recipe.association.product_name if terminal == "image3" else None
+        prefix = product_name if terminal == "image3" else None
         outputs = _persist_outputs(ctx.job_id, workdir, recipe.output_suffixes, name_prefix=prefix)
         if not outputs:
             raise RuntimeError(
@@ -768,7 +777,7 @@ async def _run_stage(
     stage_name: str,
     input_paths: list[Path],
     steps: dict,
-    recipe: CalibrationRecipe,
+    product_name: str,
     workdir: Path,
     progress_callback=None,
 ) -> list[Path]:
@@ -779,9 +788,7 @@ async def _run_stage(
         # "file 1 of 4" here would be a fabricated position; the caller has
         # already published total_files with current_file cleared to null,
         # which honestly reads as "combining 4 files".
-        await asyncio.to_thread(
-            _run_image3_sync, input_paths, steps, recipe.association.product_name, workdir
-        )
+        await asyncio.to_thread(_run_image3_sync, input_paths, steps, product_name, workdir)
         return input_paths  # terminal stage; outputs collected by suffix later
     await asyncio.to_thread(
         _run_per_file_stage_sync, stage_name, input_paths, steps, workdir, progress_callback

--- a/processing-engine/app/calibration/product_naming.py
+++ b/processing-engine/app/calibration/product_naming.py
@@ -1,0 +1,141 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""Derive a Level-3 product name from the exposures a run consumed.
+
+Recipes used to carry a constant ``association.product_name`` (``"miri-imaging"``),
+so every run of a recipe wrote ``miri-imaging_i2d.fits`` no matter what was
+observed. Two consequences, both real:
+
+* the filename encoded nothing about the data — ``save_output_to_library``
+  already had to note that "an image3 output is named after the recipe, so it
+  encodes no observation at all";
+* a second run collided with the first on the ``(UserId, FileName)`` unique
+  index and failed to save.
+
+This module builds the name from the exposures instead, following the DMS
+Level-3 convention::
+
+    jw{program}-{acid}_{instrument}_{optical elements}
+    jw01040-a3001_miri_f770w
+
+``acid`` is the association candidate ID, and it is where provenance lives.
+``jwst.associations.lib.acid`` defines ``oXXX`` for PPS-planned OBSERVATION
+candidates, ``c1XXX`` for MOSAIC, and ``a3XXX`` for DISCOVERED — associations
+built programmatically rather than planned. That is exactly what
+``asn_from_list`` does here, so ``a3`` marks a product this app produced while
+MAST downloads keep their ``o``/``c`` candidates. A reader can tell the two
+apart at a glance, and no arbitrary suffix is involved.
+
+Deliberately omitted: the ``t###`` target field of the full DMS convention.
+That number is assigned by PPS and cannot be known from the exposures. Emitting
+a plausible-looking ``t001`` would be inventing an identifier, which is not
+something a science tool should do to a filename.
+"""
+
+import logging
+import re
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+
+#: DISCOVERED-association candidate type: built by software, not planned by PPS.
+ACID_DISCOVERED = "a3"
+
+#: Used when the exposures span more than one observation, so no single
+#: observation number describes the product (a mosaic across visits).
+MULTI_OBSERVATION = "000"
+
+#: Mirrors the Association.product_name validator: letters, digits, '-', '_'.
+_ILLEGAL = re.compile(r"[^A-Za-z0-9_-]+")
+_MAX_LEN = 80
+
+
+def _clean(value: object) -> str:
+    """Lowercase a header value and drop anything the validator would reject."""
+    if value is None:
+        return ""
+    return _ILLEGAL.sub("", str(value).strip().lower())
+
+
+def _optical_elements(header) -> str:
+    """The filter/pupil combination, alphabetically ordered.
+
+    Alphabetical is what the archive does — MAST products in the library read
+    ``nircam_clear-f200w`` (FILTER=F200W, PUPIL=CLEAR) and
+    ``nircam_f444w-f470n`` (FILTER=F444W, PUPIL=F470N). Both are sorted, not
+    filter-then-pupil. Instruments without a pupil wheel yield the filter alone.
+    """
+    elements = {
+        _clean(header.get(key))
+        for key in ("FILTER", "PUPIL", "GRATING", "BAND")
+        if _clean(header.get(key))
+    }
+    # N/A is how the pipeline spells "this wheel does not apply".
+    elements.discard("na")
+    return "-".join(sorted(elements))
+
+
+def _read_header(path: Path):
+    from astropy.io import fits
+
+    with fits.open(path, memmap=True) as hdul:
+        return dict(hdul[0].header)
+
+
+def derive_product_name(input_paths: list[Path], fallback: str) -> str:
+    """Build a Level-3 product name from the exposures, or return ``fallback``.
+
+    Never raises: a naming failure must not cost the user a multi-hour run, so
+    an unreadable or header-less input falls back to the recipe's own name —
+    which is the pre-existing behaviour, collisions and all.
+    """
+    programs: set[str] = set()
+    observations: set[str] = set()
+    instruments: set[str] = set()
+    elements: set[str] = set()
+
+    for path in input_paths:
+        try:
+            header = _read_header(path)
+        except Exception:  # noqa: BLE001 -- naming is best-effort, see docstring
+            logger.warning("Could not read header for naming: %s", path.name)
+            continue
+        programs.add(_clean(header.get("PROGRAM")))
+        observations.add(_clean(header.get("OBSERVTN")))
+        instruments.add(_clean(header.get("INSTRUME")))
+        if optics := _optical_elements(header):
+            elements.add(optics)
+
+    programs.discard("")
+    observations.discard("")
+    instruments.discard("")
+
+    # Program and instrument are what make the name meaningful. Without them
+    # the result would be a decorated constant, so prefer the recipe's name.
+    if len(programs) != 1 or len(instruments) != 1:
+        logger.info(
+            "Falling back to recipe product name %r (programs=%s instruments=%s)",
+            fallback,
+            sorted(programs),
+            sorted(instruments),
+        )
+        return fallback
+
+    program = programs.pop().zfill(5)
+    instrument = instruments.pop()
+
+    if len(observations) == 1:
+        acid = f"{ACID_DISCOVERED}{observations.pop().zfill(3)}"
+    else:
+        # A mosaic spanning visits has no single observation to name it after.
+        acid = f"{ACID_DISCOVERED}{MULTI_OBSERVATION}"
+
+    parts = [f"jw{program}-{acid}", instrument]
+    # Several filters in one association is legitimate for a colour mosaic;
+    # naming it after one of them would be misleading, so leave optics out.
+    if len(elements) == 1:
+        parts.append(elements.pop())
+
+    return "_".join(parts)[:_MAX_LEN]

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -12,9 +12,11 @@ Wire shape is camelCase (``app.db.casing``); documents are snake_case.
 """
 
 import asyncio
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from fastapi.responses import FileResponse
+from pymongo.errors import DuplicateKeyError
 
 from app.auth.deps import AuthenticatedUser, require_user
 from app.db.casing import snake_to_camel_keys
@@ -30,6 +32,8 @@ from app.library.writer import JwstDataWriteRepository
 from app.render.routes import generate_preview as engine_preview
 from app.storage.helpers import resolve_fits_path
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/jobs", tags=["Jobs"])
 
@@ -272,23 +276,34 @@ async def save_output_to_library(
     parents = await writer.parents_for(input_ids)
     derived_from = derived_from_for_output(parents, file_name)
 
-    data_id = await writer.create_from_calibration_output(
-        file_path=storage_key,
-        file_name=file_name,
-        size_bytes=int(output.get("size_bytes") or 0),
-        user_id=owner_id,
-        metadata=metadata,
-        thumbnail=await _render_thumbnail(job_id, storage_key),
-        description=_variant_description(request, level),
-        processing_level=None if level == UNKNOWN else level,
-        derived_from=derived_from,
-        observation_base_id=observation_base_id_for_output(parents, file_name),
-        # The lineage view draws its edges from ParentId, not DerivedFrom, so
-        # without this a saved output appears in the tree as a disconnected
-        # root — the very view this provenance work exists to feed.
-        parent_id=derived_from[0] if len(derived_from) == 1 else None,
-        exposure_id=exposure_id_from(file_name),
-    )
+    try:
+        data_id = await writer.create_from_calibration_output(
+            file_path=storage_key,
+            file_name=file_name,
+            size_bytes=int(output.get("size_bytes") or 0),
+            user_id=owner_id,
+            metadata=metadata,
+            thumbnail=await _render_thumbnail(job_id, storage_key),
+            description=_variant_description(request, level),
+            processing_level=None if level == UNKNOWN else level,
+            derived_from=derived_from,
+            observation_base_id=observation_base_id_for_output(parents, file_name),
+            # The lineage view draws its edges from ParentId, not DerivedFrom, so
+            # without this a saved output appears in the tree as a disconnected
+            # root — the very view this provenance work exists to feed.
+            parent_id=derived_from[0] if len(derived_from) == 1 else None,
+            exposure_id=exposure_id_from(file_name),
+        )
+    except DuplicateKeyError as exc:
+        # A name clash is something the caller can understand and act on, not a
+        # server fault. Before the index moved to (UserId, FilePath) this
+        # escaped as a 500 and the UI could only say "InternalServerError"
+        # (#1803). Any surviving clash is now a genuine conflict.
+        logger.warning("Duplicate key saving %s for %s: %s", file_name, owner_id, exc)
+        raise HTTPException(
+            status_code=409,
+            detail=f"A library record for {file_name} already exists",
+        ) from exc
     return {"dataId": data_id, "created": True}
 
 

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -421,6 +421,37 @@ class TestSaveOutputToLibrary:
         response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
         assert response.status_code == 415
 
+    async def test_duplicate_key_is_409_not_500(
+        self,
+        client: httpx.AsyncClient,
+        store: JobStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A name clash is a client-visible conflict, not a server fault (#1803).
+
+        Before this, DuplicateKeyError escaped the route and the UI could only
+        report "InternalServerError", which told the user nothing about what
+        had gone wrong or what to do next.
+        """
+        from pymongo.errors import DuplicateKeyError
+
+        async def _boom(_self, **_kwargs):
+            raise DuplicateKeyError("E11000 duplicate key error")
+
+        monkeypatch.setattr(
+            "app.library.writer.JwstDataWriteRepository.create_from_calibration_output",
+            _boom,
+        )
+        monkeypatch.setattr(
+            "app.jobs.routes.engine_preview",
+            lambda **_: Response(content=b"\x89PNG", media_type="image/png"),
+        )
+        job_id = await seed_succeeded_job(store, outputs=[_fits_output()])
+
+        response = await client.post(f"/api/jobs/{job_id}/outputs/0/save", headers=bearer(USER))
+        assert response.status_code == 409
+        assert "already exists" in response.json()["detail"]
+
     async def test_saves_a_source_catalog(
         self,
         client: httpx.AsyncClient,

--- a/processing-engine/tests/test_product_naming.py
+++ b/processing-engine/tests/test_product_naming.py
@@ -1,0 +1,196 @@
+# Copyright (c) JWST Data Analysis. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for Level-3 product naming (#1803, option 4)."""
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from app.calibration.product_naming import ACID_DISCOVERED, derive_product_name
+
+
+FALLBACK = "miri-imaging"
+
+
+def _exposure(tmp_path, name, **cards):
+    """A minimal exposure carrying the header keywords naming reads."""
+    path = tmp_path / name
+    hdu = fits.PrimaryHDU(np.zeros((2, 2), dtype=np.float32))
+    for key, value in cards.items():
+        hdu.header[key] = value
+    hdu.writeto(path, overwrite=True)
+    return path
+
+
+class TestDeriveProductName:
+    def test_names_after_the_data(self, tmp_path):
+        paths = [
+            _exposure(
+                tmp_path,
+                f"exp{i}.fits",
+                PROGRAM="1040",
+                OBSERVTN="001",
+                INSTRUME="MIRI",
+                FILTER="F770W",
+            )
+            for i in range(3)
+        ]
+        assert derive_product_name(paths, FALLBACK) == "jw01040-a3001_miri_f770w"
+
+    def test_program_is_zero_padded_to_five(self, tmp_path):
+        path = _exposure(
+            tmp_path, "e.fits", PROGRAM="1040", OBSERVTN="1", INSTRUME="MIRI", FILTER="F770W"
+        )
+        name = derive_product_name([path], FALLBACK)
+        assert name.startswith("jw01040-")
+        # ...and the observation to three, so candidates sort lexically.
+        assert f"-{ACID_DISCOVERED}001_" in name
+
+    def test_optical_elements_are_alphabetical(self, tmp_path):
+        """Matches the archive: nircam_clear-f200w, nircam_f444w-f470n."""
+        clear = _exposure(
+            tmp_path,
+            "a.fits",
+            PROGRAM="1226",
+            OBSERVTN="002",
+            INSTRUME="NIRCAM",
+            FILTER="F200W",
+            PUPIL="CLEAR",
+        )
+        assert derive_product_name([clear], FALLBACK) == "jw01226-a3002_nircam_clear-f200w"
+
+        narrow = _exposure(
+            tmp_path,
+            "b.fits",
+            PROGRAM="1226",
+            OBSERVTN="002",
+            INSTRUME="NIRCAM",
+            FILTER="F444W",
+            PUPIL="F470N",
+        )
+        assert derive_product_name([narrow], FALLBACK) == "jw01226-a3002_nircam_f444w-f470n"
+
+    def test_na_wheel_is_not_an_element(self, tmp_path):
+        path = _exposure(
+            tmp_path,
+            "e.fits",
+            PROGRAM="1040",
+            OBSERVTN="001",
+            INSTRUME="MIRI",
+            FILTER="F770W",
+            PUPIL="N/A",
+        )
+        assert derive_product_name([path], FALLBACK) == "jw01040-a3001_miri_f770w"
+
+    def test_multiple_observations_collapse_to_a3000(self, tmp_path):
+        """A mosaic spanning visits has no single observation to be named after."""
+        paths = [
+            _exposure(
+                tmp_path,
+                f"o{obs}.fits",
+                PROGRAM="1040",
+                OBSERVTN=obs,
+                INSTRUME="MIRI",
+                FILTER="F770W",
+            )
+            for obs in ("001", "002")
+        ]
+        assert derive_product_name(paths, FALLBACK) == "jw01040-a3000_miri_f770w"
+
+    def test_mixed_filters_drop_the_optics(self, tmp_path):
+        """Naming a multi-filter association after one filter would be wrong."""
+        paths = [
+            _exposure(
+                tmp_path,
+                f"{filt}.fits",
+                PROGRAM="1040",
+                OBSERVTN="001",
+                INSTRUME="MIRI",
+                FILTER=filt,
+            )
+            for filt in ("F770W", "F1000W")
+        ]
+        assert derive_product_name(paths, FALLBACK) == "jw01040-a3001_miri"
+
+    def test_marks_app_generated_products(self, tmp_path):
+        """a3 is the DISCOVERED candidate type — how MAST products differ from ours.
+
+        A MAST download of the same programme reads jw01040-o001_...; anything
+        this app builds reads jw01040-a3001_..., so provenance is legible in the
+        filename without an arbitrary suffix.
+        """
+        path = _exposure(
+            tmp_path, "e.fits", PROGRAM="1040", OBSERVTN="001", INSTRUME="MIRI", FILTER="F770W"
+        )
+        name = derive_product_name([path], FALLBACK)
+        assert f"-{ACID_DISCOVERED}" in name
+        assert "-o001" not in name
+
+    def test_no_fabricated_target_id(self, tmp_path):
+        """t### is assigned by PPS and cannot be known here; inventing one would lie."""
+        path = _exposure(
+            tmp_path, "e.fits", PROGRAM="1040", OBSERVTN="001", INSTRUME="MIRI", FILTER="F770W"
+        )
+        assert "_t0" not in derive_product_name([path], FALLBACK)
+
+
+class TestFallback:
+    def test_unreadable_input_falls_back(self, tmp_path):
+        (tmp_path / "broken.fits").write_text("not a FITS file", encoding="utf-8")
+        assert derive_product_name([tmp_path / "broken.fits"], FALLBACK) == FALLBACK
+
+    def test_missing_keywords_fall_back(self, tmp_path):
+        path = _exposure(tmp_path, "bare.fits")
+        assert derive_product_name([path], FALLBACK) == FALLBACK
+
+    def test_mixed_instruments_fall_back(self, tmp_path):
+        """Not a coherent Level-3 product; the recipe's own name is more honest."""
+        paths = [
+            _exposure(tmp_path, f"{inst}.fits", PROGRAM="1040", OBSERVTN="001", INSTRUME=inst)
+            for inst in ("MIRI", "NIRCAM")
+        ]
+        assert derive_product_name(paths, FALLBACK) == FALLBACK
+
+    def test_empty_input_falls_back(self):
+        assert derive_product_name([], FALLBACK) == FALLBACK
+
+    def test_never_raises(self, tmp_path):
+        """A naming failure must not cost the user a multi-hour run."""
+        missing = tmp_path / "does-not-exist.fits"
+        assert derive_product_name([missing], FALLBACK) == FALLBACK
+
+
+class TestValidatorCompatibility:
+    """The result feeds Association.product_name, whose validator is strict."""
+
+    @pytest.mark.parametrize(
+        "cards",
+        [
+            {"PROGRAM": "1040", "OBSERVTN": "001", "INSTRUME": "MIRI", "FILTER": "F770W"},
+            {"PROGRAM": "01040", "OBSERVTN": "1", "INSTRUME": "mIrI", "FILTER": "f770w"},
+        ],
+    )
+    def test_output_is_a_legal_product_name(self, tmp_path, cards):
+        from app.calibration.models import Association
+
+        path = _exposure(tmp_path, "e.fits", **cards)
+        name = derive_product_name([path], FALLBACK)
+        # Raises ValidationError if the charset or length is wrong.
+        assert Association(product_name=name).product_name == name
+
+    def test_odd_header_values_are_scrubbed(self, tmp_path):
+        """Header text reaches a filename, so anything illegal must be stripped."""
+        from app.calibration.models import Association
+
+        path = _exposure(
+            tmp_path,
+            "e.fits",
+            PROGRAM="1040",
+            OBSERVTN="001",
+            INSTRUME="MIRI",
+            FILTER="F770W/OPEN",
+        )
+        name = derive_product_name([path], FALLBACK)
+        assert "/" not in name
+        assert Association(product_name=name).product_name == name


### PR DESCRIPTION
## Summary

`Save to library` returned a **500 on the second run of any recipe**.

`jwst_data` has a unique index on `(UserId, FileName)`, but
`save_output_to_library` checks for a re-save by **FilePath**. The storage key
embeds the job id, so a second run has a different path and an identical name:
the guard passes, the insert hits the index, and `DuplicateKeyError` escapes as
a 500 the UI can only render as "InternalServerError".

The names were identical because they came from the **recipe**, not the data:

```json
"association": { "rule": "DMS_Level3_Base", "product_name": "miri-imaging" }
```

Every run of MIRI Imaging — any target, any settings — wrote
`miri-imaging_i2d.fits`. `save_output_to_library` already had to note that an
image3 output "encodes no observation at all".

Implements options **4** and **3** from #1803. Found while verifying #1801
end-to-end.

## Changes Made

### Option 4 — name products after the data

New `app/calibration/product_naming.py`:

```
jw{program}-{acid}_{instrument}_{optical elements}
jw01040-a3001_miri_f770w
```

`acid` is the association candidate ID, and it is **where provenance lives**.
`jwst.associations.lib.acid` defines `oXXX` for PPS-planned OBSERVATION, `c1XXX`
for MOSAIC, and `a3XXX` for **DISCOVERED** — associations built
programmatically, which is exactly what `asn_from_list` does here.

| Origin | Product name |
| --- | --- |
| MAST download | `jw01040-`**`o001`**`_t001_miri_f770w_i2d.fits` |
| This app | `jw01040-`**`a3001`**`_miri_f770w_i2d.fits` |

Legible at a glance, canonical JWST grammar, no arbitrary suffix.

Decisions worth reviewing:

- **Optical elements sorted alphabetically**, matching the archive — existing
  library records read `nircam_clear-f200w` (FILTER=F200W, PUPIL=CLEAR) and
  `nircam_f444w-f470n` (FILTER=F444W, PUPIL=F470N). Both sorted, not
  filter-then-pupil.
- **No `t###` target field.** PPS assigns it; it cannot be known from the
  exposures. Emitting a plausible `t001` would invent an identifier, which a
  science tool should not do to a filename.
- **Multi-observation → `a3000`** — a mosaic across visits has no single
  observation to be named after.
- **Mixed filters → no optics segment** — naming a colour association after one
  of its filters would mislead.
- **Never raises** — an unreadable header falls back to the recipe's own name,
  i.e. the previous behaviour. A naming failure must not cost a multi-hour run.

Derived **once** in `_execute`: the same string must reach both the association
(which names the files) and the `_persist_outputs` prefix (which finds them
again). Deriving it twice risks them disagreeing and the run reporting "produced
no outputs".

### Option 3 — a stored file's identity is its storage key

- `idx_userId_fileName_unique` → **`idx_userId_filePath_unique`**, dropped
  explicitly beside the existing `idx_fileName_unique` migration.
- **`DeduplicateRecordsAsync` regrouped to `(UserId, FilePath)`.** This is the
  trap in the change: it runs on *every startup*, so leaving it on FileName
  while the index permits repeated names would delete the extra records on the
  next boot — silently, after the user was told the save succeeded.
- `DuplicateKeyError` → **409** with a usable message. A name clash is a
  client-visible condition, not a server fault.

## Test Plan

- [x] Python suite — **1907 passed**
- [x] .NET suite — **1163 passed**
- [x] `tests/test_product_naming.py` (16 cases): derivation, alphabetical
      optics, `N/A` wheels, multi-observation, mixed filters, the `a3`
      provenance marker, no fabricated target id
- [x] Every fallback path: unreadable file, missing keywords, mixed
      instruments, empty input, nonexistent path
- [x] Derived names fed through the real `Association` validator — they become
      filenames, so an illegal charset must fail loudly in tests, not in a run
- [x] `test_duplicate_key_is_409_not_500` — regression for the reported 500
- [x] .NET dedup tests updated to the FilePath grouping key
- [x] `dotnet build` clean, 0 warnings; ruff lint + format clean

Reviewer walkthrough:
1. Run a seed recipe. Output should now be named e.g.
   `jw01040-a3001_miri_f770w_i2d.fits`, not `miri-imaging_i2d.fits`.
2. Save it to the library — succeeds.
3. Run the **same recipe again** and save that output. Previously a 500; now it
   saves as a second, distinct record.
4. Restart the backend and confirm both records survive — this is the
   dedup-grouping trap above.
5. Confirm a MAST-imported product still reads `...-o001_...`, so the two
   origins remain distinguishable.

> Note: verify against a **rebuilt** engine and backend — the containers bake
> their code in and mount only `data/`.

## Documentation Checklist

- [x] Plan at `docs/plans/features/derived-product-names.md`
- [x] Naming rules, the `a3` rationale and every judgment call documented in the
      module docstring
- [x] The dedup/index lockstep documented at both sites, so a future edit to one
      is warned about the other
- [ ] No API signature changes — the save endpoint gains a 409, loses a 500

## Tech Debt Impact

- [x] **Reduces** — removes the contradiction between an index that forbade
      duplicate names and a codebase that generated them by design
- [x] **Reduces** — filenames now carry program, instrument and filter instead
      of a recipe slug, so `level_for_filename` is no longer at risk from a
      recipe called e.g. `ngc_calibration`
- [x] **Documents** — `MastController.GetByFileNameAsync` does a global
      `FirstOrDefault` on FileName and is looser than it appears now that names
      may repeat. Left untouched here and called out as follow-up

## Risk & Rollback

**Risk: medium** — touches a unique index and a startup job that deletes rows.

Mitigations: no data migration is required (checked live — 1,524 records, 0
missing FilePath, 0 duplicate `(UserId, FilePath)`), the index drop is
idempotent and matches an existing migration pattern, and the dedup grouping
moves in the same commit as the index so the two cannot disagree.

Naming changes only affect **new** outputs; existing records keep their names
and paths.

**Rollback:** revert the commit. The old index is recreated on next startup.
Records saved meanwhile could then collide on `(UserId, FileName)` — startup
dedup would resolve those by keeping the best record per group, so the rollback
is safe but lossy for repeat-run variants saved in the interim.

Closes #1803
