### PR TITLE
fix: TableViewer ECSV numeric alignment and CSV export filename

### DIFF
--- a/frontend/jwst-frontend/src/components/TableViewer.test.tsx
+++ b/frontend/jwst-frontend/src/components/TableViewer.test.tsx
@@ -341,4 +341,73 @@ describe('TableViewer', () => {
     fireEvent.click(overlay!);
     expect(onClose).toHaveBeenCalledOnce();
   });
+
+  // #1805: ECSV catalogs report numpy dtype strings, not FITS format codes
+  it('marks numpy dtype columns as numeric', async () => {
+    const ecsvColumns: TableColumnInfo[] = [
+      { name: 'FLUX', dtype: '<f8', unit: 'Jy', format: null, isArray: false, arrayShape: null },
+      { name: 'LABEL', dtype: '<i8', unit: null, format: null, isArray: false, arrayShape: null },
+      { name: 'ID', dtype: '|u1', unit: null, format: null, isArray: false, arrayShape: null },
+      {
+        name: 'SRCNAME',
+        dtype: '<U12',
+        unit: null,
+        format: null,
+        isArray: false,
+        arrayShape: null,
+      },
+    ];
+    vi.mocked(getTableInfo).mockResolvedValueOnce({
+      fileName: 'cat.ecsv',
+      tableHdus: [
+        {
+          index: 1,
+          name: 'CATALOG',
+          hduType: 'BinTableHDU',
+          nRows: 2,
+          nColumns: 4,
+          columns: ecsvColumns,
+        },
+      ],
+    });
+    vi.mocked(getTableData).mockResolvedValueOnce({
+      ...mockTableData,
+      totalColumns: 4,
+      columns: ecsvColumns,
+      rows: [{ FLUX: 1.5, LABEL: 3, ID: 7, SRCNAME: 'a' }],
+    });
+    render(<TableViewer {...defaultProps} title="cat.ecsv" isOpen={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('FLUX')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('FLUX').closest('th')).toHaveClass('numeric');
+    expect(screen.getByText('LABEL').closest('th')).toHaveClass('numeric');
+    expect(screen.getByText('ID').closest('th')).toHaveClass('numeric');
+    // Unicode string columns stay non-numeric
+    expect(screen.getByText('SRCNAME').closest('th')).not.toHaveClass('numeric');
+  });
+
+  // #1806: the filename stem must lose .ecsv as well as .fits
+  it('strips the ECSV extension from the exported CSV filename', async () => {
+    vi.mocked(getTableInfo).mockResolvedValueOnce(mockTableInfo);
+    vi.mocked(getTableData).mockResolvedValueOnce(mockTableData);
+    let downloadName = '';
+    const clickSpy = vi
+      .spyOn(window.HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(function (this: { download: string }) {
+        downloadName = this.download;
+      });
+
+    render(<TableViewer {...defaultProps} title="nircam-imaging_cat.ecsv" isOpen={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('RA')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Export CSV'));
+    expect(downloadName).toBe('nircam-imaging_cat_page1-of-3.csv');
+    clickSpy.mockRestore();
+  });
 });

--- a/frontend/jwst-frontend/src/components/TableViewer.tsx
+++ b/frontend/jwst-frontend/src/components/TableViewer.tsx
@@ -192,7 +192,10 @@ const TableViewer: React.FC<TableViewerProps> = ({
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `${title.replace(/\.fits$/i, '')}_page${page + 1}-of-${totalPages}.csv`;
+    // #1806: titles can be FITS or ECSV product names — strip either so the
+    // download isn't named "<stem>.ecsv_page1-of-18.csv".
+    const stem = title.replace(/\.(fits(\.gz)?|fit|ecsv)$/i, '');
+    link.download = `${stem}_page${page + 1}-of-${totalPages}.csv`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -215,7 +218,11 @@ const TableViewer: React.FC<TableViewerProps> = ({
     const format = col.dtype.toUpperCase();
     // Extract the type character: strip leading digits, take first alpha char
     const typeChar = format.replace(/^[0-9]+/, '').charAt(0);
-    return numericCodes.has(typeChar);
+    if (numericCodes.has(typeChar)) return true;
+    // #1805: ECSV catalogs arrive with numpy dtype strings ('<f8', '>i4', '|u1')
+    // rather than FITS codes — the leading endian char defeats the check above.
+    // Case-sensitive on purpose: numpy spells string dtypes '<U12'/'|S8'.
+    return /^[<>|=]?[fiu]\d/.test(col.dtype);
   };
 
   if (!isOpen) return null;


### PR DESCRIPTION
## Summary

Two defects in `TableViewer` that only surface for ECSV source catalogs (opened through the same component since #1801):

- **#1805** — `isNumericColumn` was written for FITS format codes (`1E`, `1D`, `20A`). ECSV columns arrive as numpy dtype strings (`<f8`, `<i8`, `|u1`); stripping leading digits and taking the first character yields `<`, so every numeric catalog column (fluxes, AB magnitudes, uncertainties) was classified as text and rendered left-aligned.
- **#1806** — the CSV export filename only stripped a trailing `.fits`, so exporting a catalog produced `nircam-imaging_cat.ecsv_page1-of-18.csv`.

## Changes Made

- `TableViewer.tsx` — `isNumericColumn` now also matches numpy dtype strings via `/^[<>|=]?[fiu]\d/`. Deliberately case-sensitive: numpy spells string dtypes `<U12` / `|S8`, and a case-insensitive test would misclassify them as numeric. FITS handling is untouched.
- `TableViewer.tsx` — export filename regex broadened to `/\.(fits(\.gz)?|fit|ecsv)$/i`.
- `TableViewer.test.tsx` — two new tests: numpy dtype columns get the `numeric` class while `<U12` does not; the export filename drops `.ecsv`.

## Test Plan

- [x] `npx vitest run src/components/TableViewer.test.tsx` — 26 passed (24 pre-existing + 2 new)
- [x] Full frontend suite via pre-commit hook — 123 files, 1448 tests passed
- [x] `npx eslint` on both changed files — 0 errors (2 pre-existing non-null-assertion warnings, untouched lines)
- [x] TypeScript type check passed (pre-commit)
- [ ] Manual: open a run detail page for a completed calibration, click a `*_cat.ecsv` output → numeric columns right-aligned; click **Export CSV** → file named `<stem>_page1-of-N.csv`

## Documentation Checklist

- [x] No API/endpoint/model changes — no docs update needed
- [x] No new component or route introduced
- [x] Behaviour change is internal formatting only

## Tech Debt Impact

- [x] Does not add tech debt
- [x] Adds regression coverage for the ECSV path that previously had none
- [ ] N/A — no debt items closed

## Risk & Rollback

**Risk: low.** Both changes are display-only and confined to one component. The dtype regex is additive — every input that matched before still matches, so FITS tables are unaffected. Worst case is a numpy dtype family I have not anticipated staying left-aligned, i.e. today's behaviour.

**Rollback:** revert the commit; no migration, no config, no API surface involved.

Closes #1805
Closes #1806

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
