### PR TITLE
fix: harden calibration executor — env-var validation, .fits.gz outputs, output sizing

### DIFF
--- a/processing-engine/app/calibration/executor.py
+++ b/processing-engine/app/calibration/executor.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from app.calibration.models import CalibrationRecipe
 from app.calibration.product_naming import derive_product_name
+from app.config import nonnegative_float_env, positive_float_env, positive_int_env
 from app.jobs.models import JobOutput, JobResult
 from app.jobs.runner import JobCancelled, JobContext
 from app.storage.factory import get_storage_provider
@@ -103,13 +104,27 @@ DENIED_PARAMS = frozenset(
     }
 )
 
-MAX_CALIBRATION_INPUTS = int(os.environ.get("MAX_CALIBRATION_INPUTS", "50"))
+# #1776: validated read — a typo'd or non-positive value fails at import with
+# the offending variable named, rather than a bare "invalid literal for int()".
+MAX_CALIBRATION_INPUTS = positive_int_env("MAX_CALIBRATION_INPUTS", 50)
 
 OUTPUT_PREFIX = "calibration"
 
 
 def _work_root() -> Path:
     return Path(os.environ.get("CALIBRATION_WORK_DIR", "/app/data/calibration-work"))
+
+
+def _product_stem(path: Path) -> str:
+    """Stem used for suffix matching, tolerant of double extensions.
+
+    ``Path.stem`` strips only the final extension, so ``jw01234_i2d.fits.gz``
+    yields ``jw01234_i2d.fits`` and never matches the ``_i2d`` handoff suffix.
+    The pipeline emits compressed products for some configurations, and the
+    mismatch silently dropped every one of them (#1777).
+    """
+    name = path.name.removesuffix(".gz")
+    return Path(name).stem
 
 
 _semaphore: threading.BoundedSemaphore | None = None
@@ -120,8 +135,10 @@ def _get_semaphore() -> threading.BoundedSemaphore:
     # admission tier (unlike composite's synchronous request-scoped renders).
     global _semaphore
     if _semaphore is None:
-        limit = int(os.environ.get("MAX_CONCURRENT_CALIBRATIONS", "1"))
-        _semaphore = threading.BoundedSemaphore(max(1, limit))
+        # #1778: 0 or a negative limit used to be clamped up to 1 silently,
+        # hiding the misconfiguration instead of reporting it.
+        limit = positive_int_env("MAX_CONCURRENT_CALIBRATIONS", 1)
+        _semaphore = threading.BoundedSemaphore(limit)
     return _semaphore
 
 
@@ -179,7 +196,10 @@ def merge_overrides(recipe_overrides: dict, run_overrides: dict) -> dict:
 
 
 def check_disk_floor(path: Path) -> None:
-    floor_gb = float(os.environ.get("CALIBRATION_MIN_FREE_DISK_GB", "10"))
+    # #1778: validated read. 0 is a legitimate "don't gate on free space"
+    # (the test suite uses it); negative and nan are not — nan would make the
+    # comparison below always false while looking like a real threshold.
+    floor_gb = nonnegative_float_env("CALIBRATION_MIN_FREE_DISK_GB", 10.0)
     free_gb = shutil.disk_usage(path).free / 1e9
     if free_gb < floor_gb:
         raise RecipeValidationError(
@@ -463,7 +483,8 @@ def _file_progress(handler: _JobLogHandler, ctx: JobContext, stage_name: str):
 
 
 def _heartbeat_seconds() -> float:
-    return float(os.environ.get("CALIBRATION_HEARTBEAT_S", "30"))
+    # #1778: a 0/negative interval turns the heartbeat into a busy loop.
+    return positive_float_env("CALIBRATION_HEARTBEAT_S", 30.0)
 
 
 async def _heartbeat(ctx: JobContext) -> None:
@@ -491,7 +512,8 @@ async def _heartbeat(ctx: JobContext) -> None:
 def _stage_timeout_seconds() -> float:
     # Relaxed-threshold posture (like the CE render timeout): generous
     # per-stage ceiling so slow-but-progressing runs aren't killed.
-    return float(os.environ.get("CALIBRATION_TIMEOUT_S", "14400"))
+    # #1778: a 0/negative timeout would fail every stage on the first tick.
+    return positive_float_env("CALIBRATION_TIMEOUT_S", 14400.0)
 
 
 def _download_mast_inputs_sync(query, dest: Path, progress_callback=None) -> list[Path]:
@@ -795,7 +817,7 @@ async def _run_stage(
     )
     produced_suffix = {"detector1": "_rate", "image2": "_cal"}[stage_name]
     produced = sorted(
-        p for p in workdir.iterdir() if p.is_file() and p.stem.endswith(produced_suffix)
+        p for p in workdir.iterdir() if p.is_file() and _product_stem(p).endswith(produced_suffix)
     )
     if not produced:
         raise RuntimeError(f"stage {stage_name} produced no {produced_suffix} files")
@@ -864,14 +886,18 @@ def _persist_outputs(
     storage = get_storage_provider()
     outputs: list[JobOutput] = []
     for path in sorted(workdir.iterdir()):
-        suffix = next((s for s in suffixes if path.stem.endswith(s)), None)
+        suffix = next((s for s in suffixes if _product_stem(path).endswith(s)), None)
         if suffix is None or not path.is_file():
             continue
         if name_prefix is not None and not path.name.startswith(name_prefix):
             continue
         key = f"{OUTPUT_PREFIX}/{job_id}/{path.name}"
+        # #1779: size is read BEFORE handing the file to storage — a provider
+        # that moves rather than copies leaves no source path to stat, which
+        # would fail the whole run after some outputs were already written.
+        size_bytes = path.stat().st_size
         storage.write_from_path(key, path)
-        outputs.append(JobOutput(storage_key=key, suffix=suffix, size_bytes=path.stat().st_size))
+        outputs.append(JobOutput(storage_key=key, suffix=suffix, size_bytes=size_bytes))
     return outputs
 
 

--- a/processing-engine/app/config.py
+++ b/processing-engine/app/config.py
@@ -98,6 +98,23 @@ def positive_float_env(name: str, default: float) -> float:
     return value
 
 
+def nonnegative_float_env(name: str, default: float) -> float:
+    """Read ``name`` as a float >= 0. Raises EnvVarError if negative or non-finite.
+
+    The float mirror of nonnegative_int_env, for knobs where 0 is a deliberate
+    "off" (a disk-space FLOOR of 0 means "don't gate on free space") but a
+    negative or ``nan`` value is always a misconfiguration — ``nan`` in
+    particular makes every comparison against it false, which reads as "off"
+    while looking like a real threshold.
+    """
+    value = float_env(name, default)
+    if not math.isfinite(value) or value < 0:
+        raise EnvVarError(
+            f"Environment variable {name}={value} must be zero or a positive, finite number."
+        )
+    return value
+
+
 # Browser origins allowed to call the engine directly. Kept in sync with the
 # .NET gateway's default (docker/.env.example): 127.0.0.1 and localhost are
 # distinct origins to a browser, so both spellings must be listed.

--- a/processing-engine/tests/test_calibration_executor.py
+++ b/processing-engine/tests/test_calibration_executor.py
@@ -453,6 +453,44 @@ class TestRunStage3Job:
         assert "too many inputs" in doc["error"]
 
     @pytest.mark.usefixtures("fake_pipeline")
+    async def test_gzipped_products_are_persisted(
+        self, store: JobStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # #1777: Path.stem of "x_i2d.fits.gz" is "x_i2d.fits", so suffix
+        # matching used to skip every compressed product and report success
+        # with an empty output list.
+        def _gzip_output(input_paths, steps, product_name, workdir):
+            (Path(workdir) / f"{product_name}_i2d.fits.gz").write_bytes(b"GZIPPED")
+
+        monkeypatch.setattr(executor, "_run_image3_sync", _gzip_output)
+        doc = await _run_to_terminal(store, make_recipe(), ["k"], {})
+        assert doc["status"] == "succeeded"
+        [output] = doc["result"]["outputs"]
+        assert output["suffix"] == "_i2d"
+        assert output["storage_key"].endswith("test-product_i2d.fits.gz")
+
+    @pytest.mark.usefixtures("fake_pipeline")
+    async def test_output_size_survives_a_storage_backend_that_moves(
+        self, store: JobStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # #1779: a provider that renames rather than copies leaves no source
+        # path to stat, which used to fail the run after outputs were written.
+        class MovingStorage:
+            def __init__(self) -> None:
+                self.written: dict[str, bytes] = {}
+
+            def write_from_path(self, key: str, local_path: Path) -> None:
+                self.written[key] = local_path.read_bytes()
+                local_path.unlink()
+
+        moving = MovingStorage()
+        monkeypatch.setattr(executor, "get_storage_provider", lambda: moving)
+        doc = await _run_to_terminal(store, make_recipe(), ["k"], {})
+        assert doc["status"] == "succeeded"
+        [output] = doc["result"]["outputs"]
+        assert output["size_bytes"] == len(b"FAKE_I2D")
+
+    @pytest.mark.usefixtures("fake_pipeline")
     async def test_disk_floor_blocks_run(
         self, store: JobStore, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/processing-engine/tests/test_config_env_helpers.py
+++ b/processing-engine/tests/test_config_env_helpers.py
@@ -9,6 +9,7 @@ from app.config import (
     cors_origins_env,
     float_env,
     int_env,
+    nonnegative_float_env,
     nonnegative_int_env,
     positive_float_env,
     positive_int_env,
@@ -24,6 +25,7 @@ def clean_env(monkeypatch):
         "TEST_POS_VAR",
         "TEST_POS_FLOAT_VAR",
         "TEST_NONNEG_VAR",
+        "TEST_NONNEG_FLOAT_VAR",
     ):
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
@@ -143,6 +145,43 @@ class TestPositiveFloatEnv:
         clean_env.setenv("TEST_POS_FLOAT_VAR", value)
         with pytest.raises(EnvVarError, match="positive, finite"):
             positive_float_env("TEST_POS_FLOAT_VAR", 15.0)
+
+
+class TestNonNegativeFloatEnv:
+    """0 is a deliberate "off" for a floor/threshold; negative and nan are not.
+
+    The disk-space floor (#1778) is the caller: 0 means "don't gate on free
+    space", while nan would make every comparison against it false — off in
+    effect, but looking like a configured threshold.
+    """
+
+    @pytest.mark.usefixtures("clean_env")
+    def test_returns_default_when_unset(self):
+        assert nonnegative_float_env("TEST_NONNEG_FLOAT_VAR", 10.0) == 10.0
+
+    def test_accepts_zero(self, clean_env):
+        clean_env.setenv("TEST_NONNEG_FLOAT_VAR", "0")
+        assert nonnegative_float_env("TEST_NONNEG_FLOAT_VAR", 10.0) == 0.0
+
+    def test_accepts_positive(self, clean_env):
+        clean_env.setenv("TEST_NONNEG_FLOAT_VAR", "2.5")
+        assert nonnegative_float_env("TEST_NONNEG_FLOAT_VAR", 10.0) == 2.5
+
+    def test_rejects_negative(self, clean_env):
+        clean_env.setenv("TEST_NONNEG_FLOAT_VAR", "-1")
+        with pytest.raises(EnvVarError, match="zero or a positive, finite"):
+            nonnegative_float_env("TEST_NONNEG_FLOAT_VAR", 10.0)
+
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+    def test_rejects_non_finite(self, clean_env, value):
+        clean_env.setenv("TEST_NONNEG_FLOAT_VAR", value)
+        with pytest.raises(EnvVarError, match="zero or a positive, finite"):
+            nonnegative_float_env("TEST_NONNEG_FLOAT_VAR", 10.0)
+
+    def test_raises_on_non_numeric(self, clean_env):
+        clean_env.setenv("TEST_NONNEG_FLOAT_VAR", "plenty")
+        with pytest.raises(EnvVarError, match="TEST_NONNEG_FLOAT_VAR='plenty'"):
+            nonnegative_float_env("TEST_NONNEG_FLOAT_VAR", 10.0)
 
 
 class TestCorsOriginsEnv:


### PR DESCRIPTION
## Summary

Four independent defects in `processing-engine/app/calibration/executor.py`, all filed during review of #1771/#1772. They share a theme: input the executor trusts without checking — env vars, filenames, and the filesystem after a write.

| Issue | Defect |
| --- | --- |
| #1776 | `MAX_CALIBRATION_INPUTS` used a raw `int()` cast at module level. A typo (`50 `, `5files`, `none`) crashed engine startup with `invalid literal for int()` — no mention of which variable was at fault. |
| #1778 | Three more raw casts accepted `0` and negatives: `MAX_CONCURRENT_CALIBRATIONS=0` (clamped up silently), `CALIBRATION_MIN_FREE_DISK_GB=0` (disk guard permanently passes), `CALIBRATION_HEARTBEAT_S=0` (busy loop), `CALIBRATION_TIMEOUT_S=0` (every stage times out on the first tick). |
| #1777 | Suffix matching used `Path.stem`, which strips only the final extension: the stem of `jw01234_i2d.fits.gz` is `jw01234_i2d.fits`, which never ends with `_i2d`. Compressed pipeline products were silently dropped and the run reported **success with an empty output list**. The same pattern in `_run_stage` would fail an intermediate stage that produced `.fits.gz`. |
| #1779 | `path.stat().st_size` was read *after* `storage.write_from_path()`. A backend that moves rather than copies leaves no source to stat, raising `FileNotFoundError` mid-persist — the job is marked failed with some outputs already in storage and unreferenced. |

## Changes Made

- **`executor.py`** — all four env vars now go through the validated helpers in `app/config.py`, which name the offending variable in the error.
- **`executor.py`** — new `_product_stem()` helper strips a trailing `.gz` before taking the stem; used by both `_run_stage` (intermediate handoff) and `_persist_outputs` (final products).
- **`executor.py`** — `_persist_outputs` captures `st_size` before calling into storage.
- **`config.py`** — new `nonnegative_float_env()`, mirroring the existing `nonnegative_int_env()`. Used for the disk floor, where `0` is a legitimate "don't gate on free space" (the test suite relies on it) but a negative or `nan` value is always a misconfiguration — `nan` in particular makes every comparison false, reading as "off" while looking like a real threshold. The other three vars use `positive_*` since none has a meaningful zero.

## Test Plan

- [x] `docker exec jwst-processing python -m pytest tests/test_calibration_executor.py -q` — 64 passed (62 pre-existing + 2 new)
- [x] `docker exec jwst-processing python -m pytest tests/test_config_env_helpers.py -q` — 39 passed (33 pre-existing + 6 new)
- [x] Full engine suite: `docker exec jwst-processing python -m pytest -q` — **1917 passed**, 2 deselected
- [x] `ruff check` + `ruff format --check` clean (pre-commit hook)
- [x] New regression test: a fake `Image3Pipeline` emitting `<product>_i2d.fits.gz` now yields exactly one persisted output with suffix `_i2d` (fails on `main`)
- [x] New regression test: a storage double that `unlink()`s the source after writing still records the correct `size_bytes` (raises `FileNotFoundError` on `main`)
- [ ] Manual: start the engine with `MAX_CALIBRATION_INPUTS=abc` → startup fails with `Environment variable MAX_CALIBRATION_INPUTS='abc' is not a valid integer`

## Documentation Checklist

- [x] No endpoint, model, or controller changes — no API docs to update
- [x] No new env var introduced; four existing ones become strictly validated
- [x] Behaviour change is documented inline at each call site with the issue number

## Tech Debt Impact

- [x] Reduces debt — removes the last raw `int()`/`float()` env casts in the calibration path, completing the pattern `app/config.py` was written for
- [x] Adds two regression tests covering previously untested failure modes
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: low–medium.** The env-var changes are strictly more validating: a deployment that today runs with a *malformed* value would now fail fast at startup instead of misbehaving. That is the intent, but it is a behaviour change for anyone running with `MAX_CONCURRENT_CALIBRATIONS=0` or a negative timeout. `docker/.env.example` sets none of these to a rejected value, and the disk floor keeps accepting `0`, so no in-repo configuration breaks.

The `_product_stem` change is additive — every filename that matched before still matches; only `.gz` names newly match.

**Rollback:** revert the commit. No schema, migration, or storage-format change; existing job documents are unaffected.

Closes #1776
Closes #1777
Closes #1778
Closes #1779

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
