### PR TITLE
fix: calibration UI resilience — partial loads, polling retry, thumbnail fallback

### DIFF
--- a/frontend/jwst-frontend/src/components/mast/MastSearch.test.tsx
+++ b/frontend/jwst-frontend/src/components/mast/MastSearch.test.tsx
@@ -151,6 +151,31 @@ describe('MastSearch', () => {
       );
     });
 
+    it('does not carry the raw-data level into a different search mode', async () => {
+      // #1766: the offer flips the calibration-level toggle on the user's
+      // behalf. Switching search type resets every other piece of search
+      // state, so leaving this one set silently returns L1/L2 results where
+      // the UI implies L3-only.
+      await searchTarget();
+      fireEvent.click(await screen.findByRole('button', { name: /Search including raw data/ }));
+      await waitFor(() =>
+        expect(vi.mocked(mastService.searchByTarget).mock.lastCall?.[0]).toMatchObject({
+          calibLevel: [1, 2, 3],
+        })
+      );
+
+      fireEvent.click(screen.getByLabelText(/Program ID/i));
+      fireEvent.change(screen.getByPlaceholderText(/Program ID/i), {
+        target: { value: '2733' },
+      });
+      fireEvent.click(screen.getByText('Search MAST'));
+      await waitFor(() =>
+        expect(vi.mocked(mastService.searchByProgram).mock.lastCall?.[0]).toMatchObject({
+          calibLevel: [3],
+        })
+      );
+    });
+
     it('stays quiet on an observation-ID search, which always returns every level', async () => {
       renderMastSearch();
       fireEvent.click(screen.getByLabelText(/Observation ID/i));

--- a/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
@@ -99,6 +99,10 @@ const MastSearch: React.FC = () => {
     setLastSearch(null);
     setError(null);
     setCurrentPage(1);
+    // #1766: the raw-fallback offer turns this on for one search without the
+    // user ever touching the toggle. Carrying it into a different search mode
+    // silently returns L1/L2 results where the UI implies L3-only.
+    setShowAllCalibLevels(false);
   };
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;

--- a/frontend/jwst-frontend/src/hooks/useCalibrationJob.test.ts
+++ b/frontend/jwst-frontend/src/hooks/useCalibrationJob.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCalibrationJob } from './useCalibrationJob';
 import type { CalibrationJob } from '../types/CalibrationTypes';
@@ -102,6 +102,48 @@ describe('useCalibrationJob', () => {
         expect(callsAtGiveUp).toBe(5);
         await vi.advanceTimersByTimeAsync(10_000);
         expect(vi.mocked(getJob).mock.calls.length).toBe(callsAtGiveUp);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('retry() resumes polling on the same job after giving up', async () => {
+      // #1741: reloading the page also works, but it discards the log tail the
+      // user may have scrolled into — the recovery should cost less than that.
+      vi.mocked(getJob).mockRejectedValue(new Error('network down'));
+      vi.useFakeTimers();
+      try {
+        const { result } = renderHook(() => useCalibrationJob('j1'));
+        await vi.advanceTimersByTimeAsync(1600 * 5);
+        await vi.waitFor(() => expect(result.current.stopped).toBe(true));
+        const callsAtGiveUp = vi.mocked(getJob).mock.calls.length;
+
+        vi.mocked(getJob).mockResolvedValue(makeJob('running'));
+        act(() => result.current.retry());
+
+        await vi.waitFor(() => expect(result.current.job?.status).toBe('running'));
+        expect(result.current.stopped).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(vi.mocked(getJob).mock.calls.length).toBeGreaterThan(callsAtGiveUp);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('retry() gives the failure budget back rather than one extra attempt', async () => {
+      vi.mocked(getJob).mockRejectedValue(new Error('network down'));
+      vi.useFakeTimers();
+      try {
+        const { result } = renderHook(() => useCalibrationJob('j1'));
+        await vi.advanceTimersByTimeAsync(1600 * 5);
+        await vi.waitFor(() => expect(result.current.stopped).toBe(true));
+
+        act(() => result.current.retry());
+        // A fresh budget: four more failures still count as "retrying".
+        await vi.advanceTimersByTimeAsync(1600 * 3);
+        expect(result.current.stopped).toBe(false);
+        await vi.advanceTimersByTimeAsync(1600);
+        await vi.waitFor(() => expect(result.current.stopped).toBe(true));
       } finally {
         vi.useRealTimers();
       }

--- a/frontend/jwst-frontend/src/hooks/useCalibrationJob.ts
+++ b/frontend/jwst-frontend/src/hooks/useCalibrationJob.ts
@@ -7,7 +7,7 @@
  * GET /api/jobs/{id} is the right tool (ADR-0001 divergence, documented).
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getJob } from '../services/calibrationService';
 import type { CalibrationJob } from '../types/CalibrationTypes';
 import { TERMINAL_JOB_STATUSES } from '../types/CalibrationTypes';
@@ -27,6 +27,12 @@ export interface UseCalibrationJobResult {
    * the silence it was built to explain.
    */
   stopped: boolean;
+  /**
+   * Resume polling after it gave up (#1741). Reloading the page works too, but
+   * a run page can be scrolled deep into a log tail and a reload throws that
+   * away — the recovery should cost less than the failure did.
+   */
+  retry: () => void;
 }
 
 interface Snapshot {
@@ -44,6 +50,8 @@ export function useCalibrationJob(jobId: string | null): UseCalibrationJobResult
     stopped: false,
   });
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Bumped by retry() to re-run the polling effect with a fresh failure count.
+  const [attempt, setAttempt] = useState(0);
 
   // Reset during render when the job id changes (React's documented
   // derived-state pattern) — avoids a synchronous setState inside the effect.
@@ -86,12 +94,17 @@ export function useCalibrationJob(jobId: string | null): UseCalibrationJobResult
       cancelled = true;
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [jobId]);
+  }, [jobId, attempt]);
+
+  const retry = useCallback(() => {
+    setSnapshot((prev) => ({ ...prev, error: null, stopped: false }));
+    setAttempt((n) => n + 1);
+  }, []);
 
   const job = snapshot.key === jobId ? snapshot.job : null;
   const error = snapshot.key === jobId ? snapshot.error : null;
   const stopped = snapshot.key === jobId && snapshot.stopped;
   const isTerminal =
     job !== null && (TERMINAL_JOB_STATUSES as readonly string[]).includes(job.status);
-  return { job, isTerminal, error, stopped };
+  return { job, isTerminal, error, stopped, retry };
 }

--- a/frontend/jwst-frontend/src/pages/CalibrateRun.css
+++ b/frontend/jwst-frontend/src/pages/CalibrateRun.css
@@ -81,6 +81,18 @@
   color: var(--danger, #ff6b6b);
 }
 
+/* Inline recovery action inside a message paragraph (#1741) — reads as part of
+   the sentence rather than as a separate control. */
+.calibrate-link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .calibrate-status {
   margin: 0.5rem 0;
 }

--- a/frontend/jwst-frontend/src/pages/CalibrationAttempts.css
+++ b/frontend/jwst-frontend/src/pages/CalibrationAttempts.css
@@ -55,6 +55,17 @@
   background: rgba(0, 0, 0, 0.3);
 }
 
+/* Placeholder for products the engine could not render (#1765) — quiet, so a
+   missing preview reads as "nothing to show" rather than as a failure. */
+.attempt-thumb-missing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.5));
+  border: 1px dashed var(--border-color, rgba(255, 255, 255, 0.12));
+}
+
 /* The differing setting is the reason these are side by side, so it leads. */
 .attempt-settings {
   font-weight: 600;

--- a/frontend/jwst-frontend/src/pages/CalibrationAttempts.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationAttempts.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
@@ -68,6 +68,24 @@ describe('CalibrationAttempts', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('snr_threshold = 5')).toBeInTheDocument();
     expect(screen.getByText('snr_threshold = 10')).toBeInTheDocument();
+  });
+
+  it('falls back to a placeholder when a thumbnail fails to load', async () => {
+    // #1765: the engine returns no thumbnail when a render fails — deliberate,
+    // so a bad render never blocks a save. Without a fallback the card shows
+    // the browser's broken-image glyph.
+    vi.mocked(getAll).mockResolvedValue([
+      output({ id: 'a', metadata: { source: 'calibration', run_overrides: { j: { p: 1 } } } }),
+      output({ id: 'b', metadata: { source: 'calibration', run_overrides: { j: { p: 2 } } } }),
+    ] as never);
+    renderPage();
+    const thumbs = await screen.findAllByRole('img');
+    expect(thumbs).toHaveLength(2);
+    fireEvent.error(thumbs[0]);
+    await waitFor(() => expect(screen.getByLabelText('No preview')).toBeInTheDocument());
+    // Only the failing card degrades — the placeholder replaces one <img>,
+    // and the second card still renders a real one.
+    expect(document.querySelectorAll('img.attempt-thumb')).toHaveLength(1);
   });
 
   it('does not list a lone run — one attempt is not a comparison', async () => {

--- a/frontend/jwst-frontend/src/pages/CalibrationAttempts.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationAttempts.tsx
@@ -57,14 +57,26 @@ export function AttemptCard({
 }) {
   const { item } = attempt;
   const action = advanceActionFor(item);
+  // #1765: the engine returns no thumbnail when a render fails (deliberately —
+  // a thumbnail must never block a save), so a 404 here is an ordinary case for
+  // early-level products. Without a fallback every such card shows the
+  // browser's broken-image glyph.
+  const [thumbFailed, setThumbFailed] = useState(false);
   return (
     <li className="attempt-card">
-      <img
-        className="attempt-thumb"
-        src={`${API_BASE_URL}/api/jwstdata/${item.id}/thumbnail`}
-        alt={item.fileName}
-        loading="lazy"
-      />
+      {thumbFailed ? (
+        <div className="attempt-thumb attempt-thumb-missing" role="img" aria-label="No preview">
+          <span aria-hidden="true">No preview</span>
+        </div>
+      ) : (
+        <img
+          className="attempt-thumb"
+          src={`${API_BASE_URL}/api/jwstdata/${item.id}/thumbnail`}
+          alt={item.fileName}
+          loading="lazy"
+          onError={() => setThumbFailed(true)}
+        />
+      )}
       <div className="attempt-body">
         <p className="attempt-settings">{settingSummary(attempt, differing)}</p>
         <p className="attempt-meta">{new Date(attempt.createdAt).toLocaleString()}</p>

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.test.tsx
@@ -111,6 +111,24 @@ describe('CalibrationGallery', () => {
     );
     expect(screen.getByText('engine unreachable')).toBeInTheDocument();
   });
+
+  it('still renders recipes when only capabilities fail', async () => {
+    // #1740: capabilities drive the disabled banner and version badge only.
+    // Losing them used to reject the whole Promise.all and replace a perfectly
+    // good recipe list with an error screen.
+    vi.mocked(listRecipes).mockResolvedValue([seedRecipe]);
+    vi.mocked(getCapabilities).mockRejectedValue(new Error('CORS blocked'));
+    render(
+      <MemoryRouter>
+        <CalibrationGallery />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByTestId('calibration-recipe-card')).toBeInTheDocument());
+    expect(screen.queryByText("Couldn't load calibration recipes")).not.toBeInTheDocument();
+    // The version badge is simply absent — no fabricated version, no banner.
+    expect(screen.queryByText(/Pipeline v/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/runs are disabled on this deployment/)).not.toBeInTheDocument();
+  });
 });
 
 describe('CalibrationGallery import', () => {

--- a/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationGallery.tsx
@@ -95,16 +95,23 @@ export default function CalibrationGallery() {
 
   useEffect(() => {
     let cancelled = false;
-    Promise.all([listRecipes(), getCapabilities()])
-      .then(([recipeList, caps]) => {
+    // #1740: settled, not all — capabilities only drive the disabled banner and
+    // the pipeline-version badge, so losing them must not throw away a recipe
+    // list that arrived fine and replace the gallery with an error screen.
+    void Promise.allSettled([listRecipes(), getCapabilities()]).then(
+      ([recipeResult, capsResult]) => {
         if (cancelled) return;
-        setRecipes(recipeList);
-        setCapabilities(caps);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setError(err instanceof Error ? err.message : 'Failed to load recipes');
-      });
+        if (recipeResult.status === 'fulfilled') {
+          setRecipes(recipeResult.value);
+        } else {
+          const reason = recipeResult.reason;
+          setError(reason instanceof Error ? reason.message : 'Failed to load recipes');
+        }
+        if (capsResult.status === 'fulfilled') {
+          setCapabilities(capsResult.value);
+        }
+      }
+    );
     return () => {
       cancelled = true;
     };

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -3,7 +3,7 @@
  * with the progress/outputs UI — the run now has its own page and URL.
  */
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
@@ -299,6 +299,28 @@ describe('RunDetail', () => {
       // spying on globalThis.setInterval after fake timers have replaced it
       // pins an implementation detail and finds nothing under some orderings.
       expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('offers a way back after polling gives up', async () => {
+      // #1741: reloading works, but throws away a log tail the user may have
+      // scrolled into — the recovery should cost less than the failure did.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.mocked(getJob).mockRejectedValue(new Error('network down'));
+      renderRun();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+      await screen.findByText(/Lost contact with the engine/);
+
+      vi.mocked(getJob).mockResolvedValue(runningJob());
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Resume watching' }));
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      expect(screen.queryByText(/Lost contact with the engine/)).not.toBeInTheDocument();
+      expect(screen.getByRole('timer')).toBeInTheDocument();
     });
 
     it('stops the clock and says so when polling gives up', async () => {

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -84,6 +84,7 @@ export default function RunDetail() {
     isTerminal,
     error: pollError,
     stopped: pollStopped,
+    retry: retryPolling,
   } = useCalibrationJob(jobId ?? null);
   const navigate = useNavigate();
 
@@ -330,9 +331,18 @@ export default function RunDetail() {
         <h2 id="progress-heading">Run progress</h2>
         {pollError && (
           <p className={pollStopped ? 'calibrate-error' : 'calibrate-hint'} role="alert">
-            {pollStopped
-              ? `Lost contact with the engine (${pollError}). This page has stopped watching — reload to reconnect. The run itself may still be going.`
-              : `${pollError} (retrying…)`}
+            {pollStopped ? (
+              <>
+                {`Lost contact with the engine (${pollError}). This page has stopped watching — the run itself may still be going. `}
+                {/* #1741: reloading also works, but it throws away the log tail
+                    the user may have scrolled into. */}
+                <button type="button" className="calibrate-link-button" onClick={retryPolling}>
+                  Resume watching
+                </button>
+              </>
+            ) : (
+              `${pollError} (retrying…)`
+            )}
           </p>
         )}
         {!job && !pollError && <p role="status">Loading run…</p>}


### PR DESCRIPTION
## Summary

Four independent resilience defects in the calibration UI. Each one turns a small, expected failure into a disproportionate loss of function.

| Issue | Defect |
| --- | --- |
| #1740 | `CalibrationGallery` loaded recipes and engine capabilities with `Promise.all`. A failing `getCapabilities()` — CORS, a slow endpoint, a disabled engine — rejected the whole thing, so a recipe list that had loaded perfectly was discarded and the user got "Couldn't load calibration recipes". |
| #1741 | `useCalibrationJob` gives up after 5 consecutive poll failures (7.5s). #1770 added the `stopped` flag so the page stops lying about watching, but the only recovery offered was a full page reload — which discards a log tail the user may have scrolled deep into. |
| #1765 | `AttemptCard`'s thumbnail `<img>` had no `onError`. The engine deliberately returns no thumbnail when a render fails (a bad render must never block a save), so a 404 is the *expected* case for early-level products — and every such card rendered the browser's broken-image glyph. |
| #1766 | `changeSearchType` resets results, last search, error and page — but not `showAllCalibLevels`, which the raw-data fallback offer sets on the user's behalf. Switching search mode afterwards silently returned L1/L2/L3 results while the UI implied L3-only. |

## Changes Made

- **`CalibrationGallery.tsx`** — `Promise.allSettled`. A recipe failure still produces the error screen; a capabilities failure now just means no version badge and no disabled banner, which is exactly what those fields drive.
- **`useCalibrationJob.ts`** — new `retry()` in the hook result. It clears the error, clears `stopped`, and bumps an `attempt` counter that re-runs the polling effect with a fresh failure budget.
- **`RunDetail.tsx` / `CalibrateRun.css`** — the "lost contact" message now ends in an inline **Resume watching** button instead of instructing the user to reload.
- **`CalibrationAttempts.tsx` / `.css`** — `onError` swaps the thumbnail for a quiet dashed "No preview" placeholder (`role="img"`, labelled), sized identically so the grid does not reflow.
- **`MastSearch.tsx`** — `changeSearchType` also resets `showAllCalibLevels`.

## Test Plan

- [x] `npx vitest run src/hooks/useCalibrationJob.test.ts` — 7 passed (2 new: retry resumes polling; retry restores the full failure budget rather than granting one extra attempt)
- [x] `npx vitest run src/pages/CalibrationGallery.test.tsx` — 7 passed (1 new: recipes render when only capabilities fail, with no banner and no fabricated version)
- [x] `npx vitest run src/pages/CalibrationAttempts.test.tsx` — 9 passed (1 new: `fireEvent.error` on one thumbnail swaps only that card to the placeholder)
- [x] `npx vitest run src/components/mast/MastSearch.test.tsx` — 12 passed (1 new: take the raw-data offer on a target search, switch to a program search → `calibLevel: [3]`)
- [x] **Regression check**: reverted the `setShowAllCalibLevels(false)` line and confirmed the new #1766 test fails with `expected { programId: '2733' } to match { calibLevel: [3] }`, then restored it
- [x] Full frontend suite via pre-commit — 123 files, **1451 tests passed**
- [x] ESLint on all five changed source files — 0 errors (5 pre-existing warnings on untouched lines)
- [ ] Manual: open `/calibrate/recipes` with the engine's capabilities endpoint blocked → recipes still list; open `/calibrate/attempts` with a thumbnail-less output → placeholder, not broken glyph

## Documentation Checklist

- [x] No endpoint, DTO, or model changes — no API docs affected
- [x] No new route or component; `useCalibrationJob`'s public result type gains one documented field (`retry`)
- [x] Each change carries an inline comment naming the issue and the reasoning

## Tech Debt Impact

- [x] Reduces debt — replaces three all-or-nothing failure paths with degraded-but-useful ones
- [x] Adds 5 regression tests, one of which is verified to fail without its fix
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: low.** All four changes are additive at the UI layer, with no API, storage, or auth surface touched.

The one behaviour change a user could notice is #1766: after taking the raw-data offer, switching search mode now returns L3-only again. That is the documented default and what the search form's own checkbox displays — the previous behaviour was the surprise.

`retry()` re-runs the same polling effect the hook already ran on mount, so there is no new request shape; worst case it fails again and reports `stopped` a second time.

**Rollback:** revert the commit. No migration, config, or persisted state involved.

Closes #1740
Closes #1741
Closes #1765
Closes #1766

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
