### PR TITLE
fix: import-job ownership, download-ID conflation and cancel lifecycle

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Controllers/JobsControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/JobsControllerTests.cs
@@ -155,6 +155,39 @@ public class JobsControllerTests
         result.Should().BeOfType<NotFoundResult>();
     }
 
+    // #1783: import jobs are dual-written into this tracker under the same id, but
+    // CancelJobAsync only flips unified state — it cannot reach the CancellationTokenSource
+    // that stops the download. The old behaviour reported a cancellation while the import
+    // ran to completion and wrote records.
+    [Fact]
+    public async Task CancelJob_RefusesImportJobs_AndPointsAtTheMastEndpoint()
+    {
+        mockJobTracker
+            .Setup(t => t.GetJobAsync("job-import", TestUserId))
+            .ReturnsAsync(new JobStatus { JobId = "job-import", JobType = "import", OwnerUserId = TestUserId });
+
+        var result = await sut.CancelJob("job-import");
+
+        var conflict = result.Should().BeOfType<ConflictObjectResult>().Subject;
+        conflict.Value!.ToString().Should().Contain("/api/mast/import/cancel/job-import");
+        mockJobTracker.Verify(t => t.CancelJobAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CancelJob_StillCancelsNonImportJobs()
+    {
+        mockJobTracker
+            .Setup(t => t.GetJobAsync("job-composite", TestUserId))
+            .ReturnsAsync(new JobStatus { JobId = "job-composite", JobType = "composite", OwnerUserId = TestUserId });
+        mockJobTracker
+            .Setup(t => t.CancelJobAsync("job-composite", TestUserId))
+            .ReturnsAsync(true);
+
+        var result = await sut.CancelJob("job-composite");
+
+        result.Should().BeOfType<NoContentResult>();
+    }
+
     [Fact]
     public async Task CancelJob_ReturnsUnauthorized_WhenNoUserClaim()
     {

--- a/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Controllers/MastControllerTests.cs
@@ -804,12 +804,14 @@ public class MastControllerTests
         mockMastService.Setup(s => s.GetResumableDownloadsAsync())
             .ReturnsAsync(resumableJobs);
 
-        // job-1 belongs to current user, job-2 to another user, job-3 not in tracker
-        mockJobTracker.Setup(j => j.GetJob("job-1"))
-            .Returns(new ImportJobStatus { JobId = "job-1", UserId = TestUserId });
-        mockJobTracker.Setup(j => j.GetJob("job-2"))
-            .Returns(new ImportJobStatus { JobId = "job-2", UserId = "other-user" });
-        mockJobTracker.Setup(j => j.GetJob("job-3"))
+        // job-1 belongs to current user, job-2 to another user, job-3 not in tracker.
+        // #1782: these are DOWNLOAD ids, so they resolve through the reverse index —
+        // mocking GetJob here matched nothing and every non-admin saw an empty list.
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("job-1"))
+            .Returns(new ImportJobStatus { JobId = "import-1", UserId = TestUserId });
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("job-2"))
+            .Returns(new ImportJobStatus { JobId = "import-2", UserId = "other-user" });
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("job-3"))
             .Returns((ImportJobStatus?)null);
 
         // Act
@@ -862,8 +864,8 @@ public class MastControllerTests
     public async Task DismissResumableDownload_OwnerCanDismiss()
     {
         // Arrange
-        mockJobTracker.Setup(j => j.GetJob("job-1"))
-            .Returns(new ImportJobStatus { JobId = "job-1", UserId = TestUserId });
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("job-1"))
+            .Returns(new ImportJobStatus { JobId = "import-1", UserId = TestUserId });
         mockMastService.Setup(s => s.DismissResumableDownloadAsync("job-1", false))
             .ReturnsAsync(true);
 
@@ -899,8 +901,8 @@ public class MastControllerTests
     public async Task DismissResumableDownload_NonOwnerGets404()
     {
         // Arrange
-        mockJobTracker.Setup(j => j.GetJob("job-1"))
-            .Returns(new ImportJobStatus { JobId = "job-1", UserId = "other-user" });
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("job-1"))
+            .Returns(new ImportJobStatus { JobId = "import-1", UserId = "other-user" });
 
         // Act
         var result = await sut.DismissResumableDownload("job-1");
@@ -916,7 +918,7 @@ public class MastControllerTests
     public async Task DismissResumableDownload_NotFoundInTracker_Returns404()
     {
         // Arrange
-        mockJobTracker.Setup(j => j.GetJob("unknown-job"))
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("unknown-job"))
             .Returns((ImportJobStatus?)null);
 
         // Act
@@ -1523,8 +1525,8 @@ public class MastControllerTests
     public async Task DismissResumableDownload_WhenServiceReturnsFalse_Returns404()
     {
         // Arrange
-        mockJobTracker.Setup(j => j.GetJob("job-1"))
-            .Returns(new ImportJobStatus { JobId = "job-1", UserId = TestUserId });
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("job-1"))
+            .Returns(new ImportJobStatus { JobId = "import-1", UserId = TestUserId });
         mockMastService.Setup(s => s.DismissResumableDownloadAsync("job-1", false))
             .ReturnsAsync(false);
 
@@ -1561,8 +1563,8 @@ public class MastControllerTests
     public async Task DismissResumableDownload_WithDeleteFiles_PassesFlagToService()
     {
         // Arrange
-        mockJobTracker.Setup(j => j.GetJob("job-1"))
-            .Returns(new ImportJobStatus { JobId = "job-1", UserId = TestUserId });
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("job-1"))
+            .Returns(new ImportJobStatus { JobId = "import-1", UserId = TestUserId });
         mockMastService.Setup(s => s.DismissResumableDownloadAsync("job-1", true))
             .ReturnsAsync(true);
 
@@ -1818,6 +1820,169 @@ public class MastControllerTests
         var response = okResult.Value.Should().BeOfType<MetadataRefreshResponse>().Subject;
         response.UpdatedCount.Should().Be(1);
         response.Message.Should().Contain("Failed");
+    }
+
+    // ========== #1782/#1784/#1785/#1787: import ownership and lifecycle ==========
+
+    /// <summary>
+    /// #1782: resuming by an ENGINE DOWNLOAD id used to run with no authorization at
+    /// all — it minted a fresh import job owned by the caller and pointed at someone
+    /// else's download, which then passed the #1572 cancel guard legitimately.
+    /// </summary>
+    [Fact]
+    public async Task ResumeImport_ByDownloadId_NonOwnerGets404()
+    {
+        mockJobTracker.Setup(j => j.GetJob("dl-victim")).Returns((ImportJobStatus?)null);
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("dl-victim"))
+            .Returns(new ImportJobStatus { JobId = "import-9", UserId = "other-user" });
+        mockMastService.Setup(s => s.GetResumableDownloadsAsync())
+            .ReturnsAsync(new ResumableJobsResponse
+            {
+                Jobs = [new ResumableJobSummary { JobId = "dl-victim", ObsId = "obs-1" }],
+                Count = 1,
+            });
+
+        var result = await sut.ResumeImport("dl-victim");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+        mockMastService.Verify(s => s.ResumeDownloadAsync(It.IsAny<string>()), Times.Never);
+        mockJobTracker.Verify(j => j.CreateJob(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// #1782: a download this backend has no record of has no recorded owner anywhere,
+    /// so it is admin-only rather than open to whoever guesses the id first.
+    /// </summary>
+    [Fact]
+    public async Task ResumeImport_ByUntrackedDownloadId_NonAdminGets404()
+    {
+        mockJobTracker.Setup(j => j.GetJob("dl-orphan")).Returns((ImportJobStatus?)null);
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("dl-orphan")).Returns((ImportJobStatus?)null);
+        mockMastService.Setup(s => s.GetResumableDownloadsAsync())
+            .ReturnsAsync(new ResumableJobsResponse
+            {
+                Jobs = [new ResumableJobSummary { JobId = "dl-orphan", ObsId = "obs-1" }],
+                Count = 1,
+            });
+
+        var result = await sut.ResumeImport("dl-orphan");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+        mockMastService.Verify(s => s.ResumeDownloadAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// #1782: the owner's own resume-by-download-id still works — the guard denies
+    /// strangers, not the person who started the download.
+    /// </summary>
+    [Fact]
+    public async Task ResumeImport_ByDownloadId_OwnerCanResume()
+    {
+        mockJobTracker.Setup(j => j.GetJob("dl-mine")).Returns((ImportJobStatus?)null);
+        mockJobTracker.Setup(j => j.GetJobByDownloadId("dl-mine"))
+            .Returns(new ImportJobStatus { JobId = "import-1", UserId = TestUserId });
+        mockJobTracker.Setup(j => j.CreateJob("obs-1", TestUserId)).Returns("import-new");
+        mockJobTracker.Setup(j => j.GetJob("import-new"))
+            .Returns(new ImportJobStatus { JobId = "import-new", UserId = TestUserId });
+        mockMastService.Setup(s => s.GetResumableDownloadsAsync())
+            .ReturnsAsync(new ResumableJobsResponse
+            {
+                Jobs = [new ResumableJobSummary { JobId = "dl-mine", ObsId = "obs-1" }],
+                Count = 1,
+            });
+
+        var result = await sut.ResumeImport("dl-mine");
+
+        Assert.IsType<OkObjectResult>(result);
+        mockMastService.Verify(s => s.ResumeDownloadAsync("dl-mine"), Times.Once);
+    }
+
+    /// <summary>
+    /// #1785: an unowned job (null UserId) is admin-only. Without the explicit null
+    /// test the comparison denies the real owner while reading as if it authorised them.
+    /// </summary>
+    [Fact]
+    public async Task ResumeImport_WithNullUserIdJob_ReturnsNotFoundForNonAdmin()
+    {
+        mockJobTracker.Setup(j => j.GetJob("job-null"))
+            .Returns(new ImportJobStatus
+            {
+                JobId = "job-null",
+                UserId = null,
+                IsResumable = true,
+                DownloadJobId = "dl-1",
+            });
+
+        var result = await sut.ResumeImport("job-null");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+        mockMastService.Verify(s => s.ResumeDownloadAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// #1785: same guard on the progress endpoint, which had the same omission.
+    /// </summary>
+    [Fact]
+    public void GetImportProgress_WithNullUserIdJob_ReturnsNotFoundForNonAdmin()
+    {
+        mockJobTracker.Setup(j => j.GetJob("job-null"))
+            .Returns(new ImportJobStatus { JobId = "job-null", UserId = null });
+
+        var result = sut.GetImportProgress("job-null");
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    /// <summary>
+    /// #1787: the IsComplete check and CancelJob are not atomic. When the import lands
+    /// in that window the response must say so rather than claim a cancellation that
+    /// never happened — the records exist either way.
+    /// </summary>
+    [Fact]
+    public async Task CancelImport_WhenJobCompletesDuringCancel_ReportsCompletion()
+    {
+        var job = new ImportJobStatus
+        {
+            JobId = "job-race",
+            ObsId = "obs-1",
+            UserId = TestUserId,
+            IsComplete = false,
+            Stage = ImportStages.Downloading,
+        };
+        var completed = new ImportJobStatus
+        {
+            JobId = "job-race",
+            ObsId = "obs-1",
+            UserId = TestUserId,
+            IsComplete = true,
+            Stage = ImportStages.Complete,
+        };
+
+        // First read (guard) sees a live job; the re-read after cancelling sees the
+        // background task's completion.
+        mockJobTracker.SetupSequence(j => j.GetJob("job-race"))
+            .Returns(job)
+            .Returns(completed);
+        mockJobTracker.Setup(j => j.CancelJob("job-race", TestUserId, false)).Returns(true);
+
+        var result = await sut.CancelImport("job-race");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        ok.Value!.ToString().Should().Contain("completed before cancellation");
+    }
+
+    /// <summary>
+    /// #1784: the response tells the client whether files exist, not where the server
+    /// keeps them.
+    /// </summary>
+    [Fact]
+    public void CheckExistingFiles_DoesNotLeakTheServerPath()
+    {
+        var result = sut.CheckExistingFiles("jw02733-o001_t001_nircam");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        ok.Value!.ToString().Should().NotContain("downloadDir");
+        ok.Value!.ToString().Should().NotContain("/app/data/mast");
     }
 
     /// <summary>

--- a/backend/JwstDataAnalysis.API.Tests/Services/ImportJobTrackerTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/ImportJobTrackerTests.cs
@@ -511,4 +511,67 @@ public class ImportJobTrackerTests
         job.Should().NotBeNull();
         job!.ObsId.Should().Be("obs-123");
     }
+
+    // #1782: engine download-job ids and import-job ids are separate spaces. Without a
+    // reverse index every caller that had only a download id resolved null and silently
+    // took the wrong branch — see the resumable list and dismiss paths.
+    [Fact]
+    public void GetJobByDownloadId_ResolvesTheOwningImportJob()
+    {
+        var jobId = sut.CreateJob("obs-123", TestUserId);
+        sut.SetDownloadJobId(jobId, "dl-abc");
+
+        var job = sut.GetJobByDownloadId("dl-abc");
+
+        job.Should().NotBeNull();
+        job!.JobId.Should().Be(jobId);
+        job.UserId.Should().Be(TestUserId);
+    }
+
+    [Fact]
+    public void GetJobByDownloadId_ReturnsNull_ForUnknownOrEmptyId()
+    {
+        sut.GetJobByDownloadId("never-seen").Should().BeNull();
+        sut.GetJobByDownloadId(string.Empty).Should().BeNull();
+    }
+
+    [Fact]
+    public void SetDownloadJobId_DropsThePreviousMapping()
+    {
+        // A resumed job is repointed at a new download; the old id must not keep
+        // resolving to it or an unrelated download inherits this job's owner.
+        var jobId = sut.CreateJob("obs-123", TestUserId);
+        sut.SetDownloadJobId(jobId, "dl-old");
+        sut.SetDownloadJobId(jobId, "dl-new");
+
+        sut.GetJobByDownloadId("dl-old").Should().BeNull();
+        sut.GetJobByDownloadId("dl-new").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void RemoveJob_ClearsTheDownloadIndex()
+    {
+        var jobId = sut.CreateJob("obs-123", TestUserId);
+        sut.SetDownloadJobId(jobId, "dl-abc");
+
+        sut.RemoveJob(jobId).Should().BeTrue();
+
+        sut.GetJobByDownloadId("dl-abc").Should().BeNull();
+    }
+
+    // #1786: RemoveJob cleaned two of the three dictionaries. The orphaned token was
+    // still findable, so a later cancel reported success and dual-wrote under the
+    // caller's id — which the unified tracker rejects, leaving the owner's UI hung.
+    [Fact]
+    public void RemoveJob_DisposesTheCancellationToken()
+    {
+        var jobId = sut.CreateJob("obs-123", TestUserId);
+        sut.GetCancellationToken(jobId).CanBeCanceled.Should().BeTrue();
+
+        sut.RemoveJob(jobId).Should().BeTrue();
+
+        // The token is gone, not merely unreachable through the job dictionary.
+        sut.GetCancellationToken(jobId).Should().Be(CancellationToken.None);
+        sut.CancelJob(jobId, TestUserId, isAdmin: true).Should().BeFalse();
+    }
 }

--- a/backend/JwstDataAnalysis.API/Controllers/JobsController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/JobsController.cs
@@ -74,17 +74,38 @@ namespace JwstDataAnalysis.API.Controllers
         /// Cancel a job. Only the owner can cancel.
         /// </summary>
         /// <param name="jobId">The job ID.</param>
-        /// <returns>204 on success, 404 if not found or not cancellable.</returns>
+        /// <returns>204 on success, 409 for import jobs (see #1783), 404 if not found or not cancellable.</returns>
         [HttpPost("{jobId}/cancel")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> CancelJob(string jobId)
         {
             var userId = GetCurrentUserId();
             if (userId is null)
             {
                 return Unauthorized();
+            }
+
+            // #1783: ImportJobTracker dual-writes every import into this tracker under the
+            // SAME id, so an import job id is a valid argument here — but CancelJobAsync
+            // only flips unified state and pushes a "cancelled" notification. It knows
+            // nothing about the CancellationTokenSource that actually stops the download,
+            // so the user was told the import had stopped while it ran to completion and
+            // wrote records. Refuse rather than half-cancel: the MAST endpoint signals the
+            // token AND pauses the engine-side download, and forking that sequence into a
+            // second controller is not worth it while the gateway is being retired
+            // (ADR-0001).
+            var job = await jobTracker.GetJobAsync(jobId, userId);
+            if (job is not null && string.Equals(job.JobType, "import", StringComparison.Ordinal))
+            {
+                return Conflict(new
+                {
+                    error = "Import jobs cannot be cancelled here",
+                    detail = $"Use POST /api/mast/import/cancel/{jobId}, which also stops the download.",
+                    jobId,
+                });
             }
 
             var cancelled = await jobTracker.CancelJobAsync(jobId, userId);

--- a/backend/JwstDataAnalysis.API/Controllers/MastController.cs
+++ b/backend/JwstDataAnalysis.API/Controllers/MastController.cs
@@ -298,8 +298,11 @@ namespace JwstDataAnalysis.API.Controllers
                 return NotFound(new { error = "Job not found", jobId });
             }
 
-            // Verify ownership: only the job creator or admin can view progress
-            if (!IsCurrentUserAdmin() && job.UserId != GetRequiredUserId())
+            // Verify ownership: only the job creator or admin can view progress.
+            // #1785: the null check matches CancelImport — an unowned job (UserId null)
+            // is admin-only, and without the explicit test the comparison would deny the
+            // legitimate owner while reading as if it had authorised them.
+            if (!IsCurrentUserAdmin() && (job.UserId is null || job.UserId != GetRequiredUserId()))
             {
                 return NotFound(new { error = "Job not found", jobId });
             }
@@ -359,6 +362,23 @@ namespace JwstDataAnalysis.API.Controllers
                 }
             }
 
+            // #1787: the IsComplete check above and CancelJob are not atomic — the
+            // background import can finish in between, in which case cancelling the token
+            // is a no-op on an already-finished task but still returns true. Re-read the
+            // stage so the client is not told an import was stopped when it landed.
+            var finalJob = jobTracker.GetJob(jobId);
+            if (finalJob?.Stage == ImportStages.Complete)
+            {
+                LogCancelledImportJob(jobId, job.ObsId);
+                return Ok(new
+                {
+                    message = "Import completed before cancellation took effect",
+                    jobId,
+                    obsId = job.ObsId,
+                    stage = ImportStages.Complete,
+                });
+            }
+
             LogCancelledImportJob(jobId, job.ObsId);
             return Ok(new { message = "Import cancelled", jobId, obsId = job.ObsId });
         }
@@ -378,8 +398,9 @@ namespace JwstDataAnalysis.API.Controllers
                 return await ResumeFromDownloadJobId(jobId);
             }
 
-            // Verify ownership: only the job creator or admin can resume
-            if (!IsCurrentUserAdmin() && job.UserId != GetRequiredUserId())
+            // Verify ownership: only the job creator or admin can resume.
+            // #1785: same null guard as CancelImport — see GetImportProgress above.
+            if (!IsCurrentUserAdmin() && (job.UserId is null || job.UserId != GetRequiredUserId()))
             {
                 return NotFound(new { error = "Job not found", jobId });
             }
@@ -572,12 +593,13 @@ namespace JwstDataAnalysis.API.Controllers
                 .Distinct()
                 .ToList();
 
+            // #1784: downloadDir is deliberately absent — the client needs to know
+            // whether files exist and how many, not where the server keeps them.
             return Ok(new
             {
                 exists = existingFiles.Count > 0,
                 fileCount = existingFiles.Count,
                 obsId,
-                downloadDir,
             });
         }
 
@@ -596,8 +618,14 @@ namespace JwstDataAnalysis.API.Controllers
                 if (!IsCurrentUserAdmin())
                 {
                     var userId = GetRequiredUserId();
+
+                    // #1782: j.JobId is an ENGINE DOWNLOAD id, not an import-job id, so
+                    // the old GetJob(j.JobId) lookup never matched and every non-admin saw
+                    // an empty list presented as "nothing to resume". Downloads this
+                    // backend has no record of (started before the current process) stay
+                    // hidden from non-admins — there is no owner to check them against.
                     result.Jobs = result.Jobs
-                        .Where(j => jobTracker.GetJob(j.JobId)?.UserId == userId)
+                        .Where(j => jobTracker.GetJobByDownloadId(j.JobId)?.UserId == userId)
                         .ToList();
                     result.Count = result.Jobs.Count;
                 }
@@ -619,11 +647,14 @@ namespace JwstDataAnalysis.API.Controllers
         {
             try
             {
-                // Verify ownership: only the job creator or admin can dismiss
+                // Verify ownership: only the job creator or admin can dismiss.
+                // #1782: jobId here is an ENGINE DOWNLOAD id — the old GetJob(jobId)
+                // lookup was keyed by import-job id and so returned null for everyone,
+                // 404ing the legitimate owner as reliably as an attacker.
                 if (!IsCurrentUserAdmin())
                 {
-                    var trackerJob = jobTracker.GetJob(jobId);
-                    if (trackerJob == null || trackerJob.UserId != GetRequiredUserId())
+                    var trackerJob = jobTracker.GetJobByDownloadId(jobId);
+                    if (trackerJob?.UserId is null || trackerJob.UserId != GetRequiredUserId())
                     {
                         return NotFound(new { error = "Job not found or could not be dismissed", jobId });
                     }
@@ -1048,9 +1079,29 @@ namespace JwstDataAnalysis.API.Controllers
                 }
 
                 var obsId = jobSummary.ObsId;
+                var currentUserId = GetRequiredUserId();
+
+                // #1782: this path used to run with NO authorization at all. It hands the
+                // caller a fresh import job pointed at someone else's download, which then
+                // passes the #1572 cancel guard legitimately — letting them pause a
+                // download they do not own, and filing the resulting records under their
+                // own user id.
+                //
+                // Downloads this backend still tracks are checked against their owner.
+                // Downloads it does not (started before this process) have no recorded
+                // owner anywhere — the engine's resumable state file does not carry one —
+                // so they are admin-only rather than open. Persisting the owner engine-side
+                // is the fix that would restore self-service recovery after a restart.
+                if (!IsCurrentUserAdmin())
+                {
+                    var owner = jobTracker.GetJobByDownloadId(downloadJobId);
+                    if (owner?.UserId is null || owner.UserId != currentUserId)
+                    {
+                        return NotFound(new { error = "Job not found", jobId = downloadJobId });
+                    }
+                }
 
                 // Create a new import tracker job
-                var currentUserId = GetRequiredUserId();
                 var importJobId = jobTracker.CreateJob(obsId, currentUserId);
                 jobTracker.SetDownloadJobId(importJobId, downloadJobId);
                 jobTracker.SetResumable(importJobId, true);

--- a/backend/JwstDataAnalysis.API/Services/IImportJobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/IImportJobTracker.cs
@@ -99,6 +99,16 @@ namespace JwstDataAnalysis.API.Services
         ImportJobStatus? GetJob(string jobId);
 
         /// <summary>
+        /// Get a job by the processing engine's download job ID (#1782).
+        /// Import job IDs and engine download job IDs are separate ID spaces; this is
+        /// the only way to attribute an engine-side download to the user who started it.
+        /// </summary>
+        /// <param name="downloadJobId">The processing engine download job ID.</param>
+        /// <returns>The owning import job, or null if this backend has no record of it
+        /// (e.g. the download predates the current process).</returns>
+        ImportJobStatus? GetJobByDownloadId(string downloadJobId);
+
+        /// <summary>
         /// Remove a job.
         /// </summary>
         /// <param name="jobId">The job ID.</param>

--- a/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
+++ b/backend/JwstDataAnalysis.API/Services/ImportJobTracker.cs
@@ -17,6 +17,12 @@ namespace JwstDataAnalysis.API.Services
         private readonly ConcurrentDictionary<string, ImportJobStatus> jobs = new();
         private readonly ConcurrentDictionary<string, CancellationTokenSource> cancellationTokens = new();
         private readonly ConcurrentDictionary<string, DateTime> lastDualWriteTime = new();
+
+        // #1782: engine download-job IDs and import-job IDs are separate ID spaces, and
+        // three call sites looked one up using the other — always producing null and
+        // silently taking the wrong branch. This is the missing reverse index:
+        // downloadJobId -> importJobId.
+        private readonly ConcurrentDictionary<string, string> downloadJobIndex = new();
         private readonly ILogger<ImportJobTracker> logger = logger;
         private readonly IJobTracker unifiedTracker = unifiedTracker;
         private readonly TimeSpan jobRetentionPeriod = TimeSpan.FromMinutes(30);
@@ -189,8 +195,38 @@ namespace JwstDataAnalysis.API.Services
         {
             if (jobs.TryGetValue(jobId, out var job))
             {
+                // Drop any previous mapping first: a resumed job can be pointed at a new
+                // download, and a stale entry would attribute that download to this job
+                // forever.
+                if (!string.IsNullOrEmpty(job.DownloadJobId))
+                {
+                    downloadJobIndex.TryRemove(job.DownloadJobId, out _);
+                }
+
                 job.DownloadJobId = downloadJobId;
+                if (!string.IsNullOrEmpty(downloadJobId))
+                {
+                    downloadJobIndex[downloadJobId] = jobId;
+                }
             }
+        }
+
+        public ImportJobStatus? GetJobByDownloadId(string downloadJobId)
+        {
+            if (string.IsNullOrEmpty(downloadJobId))
+            {
+                return null;
+            }
+
+            if (!downloadJobIndex.TryGetValue(downloadJobId, out var importJobId))
+            {
+                return null;
+            }
+
+            // The index can outlive its job by a moment (cleanup removes the job first),
+            // so confirm rather than assume.
+            jobs.TryGetValue(importJobId, out var job);
+            return job;
         }
 
         public void SetResumable(string jobId, bool isResumable)
@@ -255,7 +291,24 @@ namespace JwstDataAnalysis.API.Services
         public bool RemoveJob(string jobId)
         {
             lastDualWriteTime.TryRemove(jobId, out _);
-            return jobs.TryRemove(jobId, out _);
+
+            // #1786: the cancellation token used to be left behind, undisposed and
+            // still findable. A later admin cancel would then find the orphaned CTS,
+            // report success, and dual-write under the admin's id — which the unified
+            // tracker rejects on owner mismatch, so the real owner's UI never saw the
+            // cancellation. CleanupOldJobs already did this; RemoveJob did not.
+            if (cancellationTokens.TryRemove(jobId, out var cts))
+            {
+                cts.Dispose();
+            }
+
+            var removed = jobs.TryRemove(jobId, out var job);
+            if (job is not null && !string.IsNullOrEmpty(job.DownloadJobId))
+            {
+                downloadJobIndex.TryRemove(job.DownloadJobId, out _);
+            }
+
+            return removed;
         }
 
         /// <summary>
@@ -287,8 +340,13 @@ namespace JwstDataAnalysis.API.Services
 
             foreach (var jobId in oldJobs)
             {
-                jobs.TryRemove(jobId, out _);
+                jobs.TryRemove(jobId, out var removedJob);
                 lastDualWriteTime.TryRemove(jobId, out _);
+
+                if (removedJob is not null && !string.IsNullOrEmpty(removedJob.DownloadJobId))
+                {
+                    downloadJobIndex.TryRemove(removedJob.DownloadJobId, out _);
+                }
 
                 // Also clean up the cancellation token
                 if (cancellationTokens.TryRemove(jobId, out var cts))


### PR DESCRIPTION
## Summary

Six defects in the import-job path. Three of them (#1782) share a single root cause, so they are fixed by one mechanism.

**Root cause (#1782):** engine *download-job* IDs and in-memory *import-job* IDs are two different ID spaces. Three call sites looked one up using the other. `IImportJobTracker` was keyed only by import-job ID, so every one of those lookups returned `null` and silently took the wrong branch:

1. **Ownership bypass (security).** `ResumeImport` applies its ownership guard only when `GetJob(jobId)` resolves. For a download ID it never does, so control fell through to `ResumeFromDownloadJobId`, which performed **no authorization at all** — it minted a new import job owned by the caller pointing at someone else's download. The caller could then cancel "their" job, which calls `PauseDownloadAsync(job.DownloadJobId)` and pauses the *victim's* download — passing the #1572 guard legitimately. Records also landed under the wrong user.
2. **Resumable list empty for every non-admin.** The filter compared `GetJob(<download id>)?.UserId` — never a match — so the restart-recovery panel was permanently empty, presented as "nothing to resume" rather than an error.
3. **Dismiss 404s the real owner.** Same conflation; the guard was "secure" only by denying everybody who isn't an admin.

Plus three independent ones: #1785 (missing null guards), #1786 (leaked `CancellationTokenSource`), #1787 (TOCTOU on cancel), and #1784 (path disclosure), #1783 (cancel that doesn't cancel).

## Changes Made

**`ImportJobTracker` / `IImportJobTracker`**
- New `GetJobByDownloadId(string)`, backed by a `downloadJobId → importJobId` reverse index maintained in `SetDownloadJobId`. Re-pointing a job at a new download drops the old mapping, so a stale entry can never attribute an unrelated download to a user.
- Index entries are cleared in both `RemoveJob` and `CleanupOldJobs`.
- **#1786** `RemoveJob` now removes *and disposes* the `CancellationTokenSource`, matching what `CleanupOldJobs` already did. The orphan was not just a leak: a later cancel would find the token, report success, and dual-write under the caller's ID — which `JobTracker.CancelJobAsync` rejects on owner mismatch, leaving the owner's UI stuck at "running" until TTL.

**`MastController`**
- `ResumeFromDownloadJobId` resolves the owner first and denies non-owners. Downloads this backend has no record of are admin-only — see the explicit decision below.
- Resumable list filters via `GetJobByDownloadId`.
- `DismissResumableDownload` looks up via `GetJobByDownloadId`.
- **#1785** `ResumeImport` and `GetImportProgress` gain the `job.UserId is null` guard that `CancelImport` got in #1781.
- **#1787** `CancelImport` re-reads the job after `CancelJob` and reports "Import completed before cancellation took effect" (with `stage`) when the background task landed inside the window.
- **#1784** `CheckExistingFiles` no longer returns `downloadDir`. Nothing in the frontend or docs read it (grepped).

**`JobsController`**
- **#1783** `POST /api/jobs/{id}/cancel` now returns **409** for `import`-type jobs, naming the correct endpoint.

### Decision: the post-restart resume path

`ResumeFromDownloadJobId` exists so a user can recover a download after the *backend* restarts — but that restart is exactly what empties the in-memory tracker, so no reverse lookup can succeed and there is no owner to check against anywhere. The engine's resumable state file does not persist one.

I made that case **admin-only** rather than open. This is not a functional regression: defect 2 meant non-admins already saw an empty resumable list, so they had no way to obtain the ID in the first place. Restoring self-service recovery needs the engine to persist the owning user ID — filed as a follow-up rather than smuggled into this PR.

### Decision: refuse rather than route in `JobsController`

The issue offered "route it" (delegate to `IImportJobTracker`) or "reject it". Routing correctly means reproducing the full MastController sequence — signal the token *and* `PauseDownloadAsync` the engine-side download — in a second controller, i.e. two copies of the cancel semantics while the gateway is being retired under ADR-0001. Refusing is complete and honest. No frontend code calls this endpoint for imports (`mastService.cancelImport` uses the MAST route), so nothing breaks.

## Test Plan

- [x] `dotnet test` — **1177 passed**, 0 failed
- [x] `dotnet build` — 0 warnings, 0 errors (StyleCop clean)
- [x] 5 new `ImportJobTrackerTests`: reverse lookup resolves the owner; unknown/empty IDs return null; re-pointing drops the stale mapping; `RemoveJob` clears the index; `RemoveJob` disposes the token (asserted via `GetCancellationToken` returning `CancellationToken.None` and a subsequent admin cancel returning false)
- [x] 6 new `MastControllerTests`: non-owner resume-by-download-ID gets 404 and never reaches `ResumeDownloadAsync`/`CreateJob`; untracked download ID is admin-only; **the owner can still resume**; null-`UserId` job is admin-only on both resume and progress; cancel-during-completion reports completion; `CheckExistingFiles` response contains neither `downloadDir` nor the base path
- [x] 2 new `JobsControllerTests`: import job → 409 naming `/api/mast/import/cancel/{id}` with `CancelJobAsync` never called; non-import job still cancels
- [x] Four **existing** tests corrected: `GetResumableImports_UserSeesOnlyOwnJobs` and the three `DismissResumableDownload_*` tests mocked `GetJob(<download id>)`, encoding the very conflation being fixed. They now mock `GetJobByDownloadId` and use distinct import/download IDs so the two spaces cannot be confused again. One of them (`_WithDeleteFiles_`) failed against the fixed controller until corrected — confirming the tests were passing for the wrong reason.
- [ ] Manual: start an import, pause it, confirm it appears in the resumable panel as a non-admin, dismiss it

## Documentation Checklist

- [x] `IImportJobTracker` gains one documented method; XML docs written
- [x] `POST /api/jobs/{id}/cancel` gains a 409 response — `ProducesResponseType` attribute added so Swagger reflects it
- [x] `GET /api/mast/import/check-files/{obsId}` drops a response field — no docs referenced it (grepped `docs/`)
- [x] No model or schema changes

## Tech Debt Impact

- [x] Reduces debt — removes the download-ID/import-ID conflation entirely rather than patching each call site
- [x] Closes the test gap named in #1782: there were no positive-path tests for "owner sees their resumable jobs" or "owner can dismiss", which is why three defects presented as plausible empty/404 states
- [x] Adds 13 tests and corrects 4 that were asserting buggy behaviour

## Risk & Rollback

**Risk: medium** — this touches authorization on four endpoints and the ADR-0001 note applies (the gateway is being retired, so this code has a finite life).

Behaviour changes a user can observe, all intended:
- Non-admins now *see* their resumable downloads (previously always empty) and can dismiss them (previously 404).
- Resume-by-download-ID for downloads this backend does not track is now admin-only.
- Cancelling an import that finished mid-request reports completion instead of cancellation.
- `POST /api/jobs/{id}/cancel` on an import returns 409 instead of a false 204.

The reverse index is process-local and rebuilt naturally by `SetDownloadJobId`; nothing is persisted, so there is no migration and no state to roll back.

**Rollback:** revert the commit. The interface addition is additive — no caller outside this PR depends on it.

Closes #1782
Closes #1783
Closes #1784
Closes #1785
Closes #1786
Closes #1787

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
