### PR TITLE
fix: atomic RUNNING transition and filter-wide seed-gate availability

### DIFF
--- a/processing-engine/app/jobs/store.py
+++ b/processing-engine/app/jobs/store.py
@@ -100,14 +100,28 @@ class JobStore:
 
     async def set_status(self, job_id: str, status: JobStatus) -> None:
         # Active-only: a terminal job never goes back to running (see _active).
-        await self._col.update_one(_active(job_id), {"$set": _touch({"status": status.value})})
-        if status is JobStatus.RUNNING:
-            # Stamp started_at only on the FIRST running transition — a job
-            # returning from DOWNLOADING must not shift its start time.
-            await self._col.update_one(
-                {"job_id": job_id, "started_at": None, "status": {"$in": _ACTIVE_LIST}},
-                {"$set": {"started_at": _now_iso()}},
-            )
+        if status is not JobStatus.RUNNING:
+            await self._col.update_one(_active(job_id), {"$set": _touch({"status": status.value})})
+            return
+
+        # #1739: one round trip, so a poller (1.5s interval) can never observe
+        # status=running with started_at still null — a shape no client expects.
+        # $ifNull keeps the FIRST running transition's stamp, so a job returning
+        # from DOWNLOADING does not shift its start time. Pipeline-form update
+        # needs MongoDB 4.2+; we run 8.0.
+        now = _now_iso()
+        await self._col.update_one(
+            _active(job_id),
+            [
+                {
+                    "$set": {
+                        "status": status.value,
+                        "updated_at": now,
+                        "started_at": {"$ifNull": ["$started_at", now]},
+                    }
+                }
+            ],
+        )
 
     async def set_progress(
         self,

--- a/processing-engine/scripts/seed_ce.py
+++ b/processing-engine/scripts/seed_ce.py
@@ -386,6 +386,25 @@ def _to_observation_inputs(rows: list[dict]) -> list[dict]:
     return inputs
 
 
+def observation_ids_for_filters(rows: list[dict], filters: list[str]) -> list[str]:
+    """Every obs_id whose filter the recipe asks for, in MAST row order.
+
+    The engine-side twin of the frontend's observationIdsForFilters (#1679): a
+    filter counts as covered when ANY of its observations has library data, so
+    coverage must not depend on which observation MAST happened to list first.
+    """
+    wanted = {str(f).upper() for f in filters}
+    seen: set[str] = set()
+    ids: list[str] = []
+    for row in rows:
+        obs_id = row.get("obs_id")
+        row_filter = str(row.get("filters") or "").upper()
+        if obs_id and row_filter in wanted and obs_id not in seen:
+            seen.add(obs_id)
+            ids.append(obs_id)
+    return ids
+
+
 def _mongo_collection():
     from pymongo import MongoClient
 
@@ -455,7 +474,16 @@ def evaluate_all(
                     )
                 )
                 continue
-            availability = client.check_availability(recipe.get("observationIds") or [])
+            # #1681: check EVERY filter-matching observation, not just the
+            # recipe's pre-selected observationIds. Library data may sit under a
+            # different obs set than the MAST row-order winner the recipe chose
+            # (the Cas A case in #1679), and asking only about that one set
+            # reports every filter missing — failing a recipe the frontend
+            # correctly shows as "Ready to render". This mirrors
+            # observationIdsForFilters in the frontend.
+            availability = client.check_availability(
+                observation_ids_for_filters(rows, recipe.get("filters") or [])
+            )
             usable_ids = [
                 data_id
                 for entry in availability.values()

--- a/processing-engine/tests/test_jobs_store.py
+++ b/processing-engine/tests/test_jobs_store.py
@@ -81,6 +81,43 @@ class TestJobStore:
         assert doc["status"] == "succeeded"
         assert doc["finished_at"] is not None
 
+    async def test_running_status_and_started_at_land_together(self, store: JobStore) -> None:
+        # #1739: these were two round trips, so a poller could observe
+        # status=running with started_at still null — a shape no client expects.
+        # One pipeline update means no document ever has one without the other.
+        job = make_job()
+        await store.create(job)
+        await store.set_status(job.job_id, JobStatus.RUNNING)
+
+        doc = await store.get(job.job_id)
+        assert doc["status"] == "running"
+        assert doc["started_at"] is not None
+        assert doc["updated_at"] is not None
+
+    async def test_started_at_survives_a_return_to_running(self, store: JobStore) -> None:
+        # A job going DOWNLOADING -> RUNNING again must keep its original start
+        # time; $ifNull is what preserves it now that the guard filter is gone.
+        job = make_job()
+        await store.create(job)
+        await store.set_status(job.job_id, JobStatus.RUNNING)
+        first = (await store.get(job.job_id))["started_at"]
+
+        await store.set_status(job.job_id, JobStatus.DOWNLOADING)
+        await store.set_status(job.job_id, JobStatus.RUNNING)
+
+        doc = await store.get(job.job_id)
+        assert doc["status"] == "running"
+        assert doc["started_at"] == first
+
+    async def test_terminal_jobs_do_not_return_to_running(self, store: JobStore) -> None:
+        # The active-only filter still applies on the pipeline path.
+        job = make_job()
+        await store.create(job)
+        await store.mark_cancelled(job.job_id)
+        await store.set_status(job.job_id, JobStatus.RUNNING)
+
+        assert (await store.get(job.job_id))["status"] == "cancelled"
+
     async def test_cancel_only_active_owned_jobs(self, store: JobStore) -> None:
         job = make_job()
         await store.create(job)

--- a/processing-engine/tests/test_seed_ce.py
+++ b/processing-engine/tests/test_seed_ce.py
@@ -21,6 +21,7 @@ from scripts.seed_ce import (
     export_bundle,
     find_recipe,
     missing_filters,
+    observation_ids_for_filters,
     plan_fetch,
     transform_doc,
 )
@@ -360,6 +361,116 @@ class TestReviewHardening:
         assert not reports[0].passed
         assert reports[0].recipe == "(no recipes suggested)"
         assert docs == []
+
+
+class TestObservationIdsForFilters:
+    """#1681: the seed gate must ask about EVERY filter-matching observation.
+
+    The frontend was fixed this way in #1679 (the Cas A case): a recipe's
+    observationIds is a MAST row-order winner, but the library data can sit
+    under a different obs set entirely. Asking only about the recipe's chosen
+    set reports every filter missing and fails a recipe GuidedCreate correctly
+    shows as "Ready to render".
+    """
+
+    ROWS = [
+        {"obs_id": "jw01947-o015_t012", "filters": "F090W"},
+        {"obs_id": "jw01947-o001_t010", "filters": "F090W"},
+        {"obs_id": "jw01947-o002_t011", "filters": "F187N"},
+        {"obs_id": "jw01947-o003_t013", "filters": "F444W"},
+    ]
+
+    def test_includes_every_observation_matching_a_recipe_filter(self):
+        ids = observation_ids_for_filters(self.ROWS, ["F090W", "F187N"])
+        assert ids == [
+            "jw01947-o015_t012",
+            "jw01947-o001_t010",
+            "jw01947-o002_t011",
+        ]
+
+    def test_is_case_insensitive_like_the_frontend(self):
+        assert observation_ids_for_filters(self.ROWS, ["f444w"]) == ["jw01947-o003_t013"]
+
+    def test_skips_rows_without_an_obs_id_or_filter(self):
+        rows = [
+            {"obs_id": None, "filters": "F090W"},
+            {"obs_id": "jw-x", "filters": None},
+            {"obs_id": "jw-y", "filters": "F090W"},
+        ]
+        assert observation_ids_for_filters(rows, ["F090W"]) == ["jw-y"]
+
+    def test_deduplicates_repeated_observations(self):
+        rows = [
+            {"obs_id": "jw-dup", "filters": "F090W"},
+            {"obs_id": "jw-dup", "filters": "F090W"},
+        ]
+        assert observation_ids_for_filters(rows, ["F090W"]) == ["jw-dup"]
+
+    def test_evaluate_all_asks_about_all_matching_obs_not_just_the_recipe_set(self):
+        """The gate's regression: library data under a different obs set.
+
+        The recipe points at o015; the library holds the data under o001. The
+        old code asked only about o015 and failed the recipe.
+        """
+        rows = [
+            {
+                "obs_id": "jw01947-o015_t012",
+                "filters": "F090W",
+                "instrument_name": "NIRCAM",
+                "dataproduct_type": "image",
+            },
+            {
+                "obs_id": "jw01947-o001_t010",
+                "filters": "F090W",
+                "instrument_name": "NIRCAM",
+                "dataproduct_type": "image",
+            },
+        ]
+        asked: list[list[str]] = []
+
+        class FakeClient:
+            def search_target(self, _name):
+                return rows
+
+            def suggest_recipes(self, _name, _observations):
+                return [
+                    {
+                        "name": "Cas A",
+                        "filters": ["F090W"],
+                        "observationIds": ["jw01947-o015_t012"],
+                    }
+                ]
+
+            def check_availability(self, observation_ids):
+                asked.append(list(observation_ids))
+                # Only the obs set the library actually holds.
+                return {
+                    "jw01947-o001_t010": {
+                        "available": True,
+                        "dataIds": ["deadbeefdeadbeefdeadbeef"],
+                        "filter": "F090W",
+                    }
+                }
+
+            def estimate(self, _channels):
+                return {"status": "ok"}
+
+        class FakeCollection:
+            def find(self, _query):
+                return [
+                    {
+                        "_id": ObjectId("deadbeefdeadbeefdeadbeef"),
+                        "FilePath": "/data/x_i2d.fits",
+                        "FileSize": 10,
+                    }
+                ]
+
+        targets = [{"name": "Cas A", "mastSearchParams": {"target": "CAS A"}}]
+        reports, _docs = evaluate_all(FakeClient(), targets, FakeCollection())
+
+        assert asked == [["jw01947-o015_t012", "jw01947-o001_t010"]]
+        assert reports[0].missing_filters == []
+        assert reports[0].passed
 
 
 class TestEntryFilterEmptyString:


### PR DESCRIPTION
## Summary

Two engine-side correctness defects.

| Issue | Defect |
| --- | --- |
| #1739 | `JobStore.set_status` wrote `status` and `started_at` in two separate round trips. A client polling `GET /api/jobs/{id}` between them saw `status: "running"` with `started_at: null` — a shape the frontend never expects. `useCalibrationJob` polls at 1.5s, so the window is observable on a normally loaded system. |
| #1681 | The CE seed gate checked availability against `recipe.observationIds` only. Library data can live under a different obs set than the MAST row-order winner the recipe picked (the Cas A case), so `check_availability` came back empty, `missing_filters` reported every filter missing, and the gate **failed a recipe GuidedCreate correctly shows as "Ready to render"**. The frontend was fixed this way in #1679/#1680; the gate was left behind and diverged. |

## Scope change during review: #1763 removed from this PR

This branch originally also fixed #1763 (concurrent save-to-library creating duplicate records). While it was in review, **#1803 landed on main** and changed the ground underneath it:

- It moved the unique index from `(UserId, FileName)` to **`(UserId, FilePath)`** — which is exactly the index #1763 asked for. My partial `Tags: calibration` index is now a strict subset of it, i.e. dead weight.
- It added a deliberate `DuplicateKeyError` → **409** in the save route, with the rationale that "any surviving clash is now a genuine conflict".

That leaves one genuine open question rather than a bug I should quietly decide: because the index key is now identical to the route's own `find_by_path(storage_key, owner_id)` pre-check key, *every* duplicate reaching that catch is by definition the same file for the same owner — i.e. the double-click race, for which the idempotent answer (`return the existing record, created: false`) is arguably right and the 409 is arguably wrong.

Reversing a choice someone made deliberately, in a PR ostensibly about job-store atomicity, is not mine to make silently. **I removed the #1763 work entirely and re-raised the question on the issue.** #1763 stays open.

## Changes Made

- **`app/jobs/store.py` (#1739)** — `set_status` uses a single aggregation-pipeline update for the `RUNNING` case, setting `status`, `updated_at` and `started_at: {$ifNull: ["$started_at", now]}` together. `$ifNull` replaces the old second-query guard, preserving the *first* running transition's timestamp when a job returns from `DOWNLOADING`. Pipeline updates need MongoDB 4.2+; the stack runs 8.0.
- **`app/jobs/store.py`** — non-running transitions keep the plain `$set` path, and the active-only filter still applies, so a terminal job cannot be dragged back to running.
- **`scripts/seed_ce.py` (#1681)** — new `observation_ids_for_filters(rows, filters)`, the engine-side twin of the frontend's `observationIdsForFilters`: every obs_id whose filter the recipe asks for, deduplicated, in MAST row order.
- **`scripts/seed_ce.py`** — `evaluate_all` passes that set to `check_availability` instead of the recipe's pre-selected `observationIds`.

## Test Plan

- [x] Full engine suite after rebase onto current main: `docker exec jwst-processing python -m pytest -q` — **1925 passed**, 2 deselected
- [x] `ruff check` + `ruff format --check` clean (pre-commit)
- [x] 3 new `test_jobs_store.py` tests: running status and `started_at` land together; `started_at` survives a `DOWNLOADING → RUNNING` round trip; a terminal job still cannot return to running on the pipeline path
- [x] 5 new `test_seed_ce.py` tests: the helper covers all matching observations, is case-insensitive, skips rows missing an obs_id or filter, deduplicates; and an `evaluate_all` test reproducing the Cas A shape — recipe points at `o015`, library holds `o001` — asserting the gate now asks about **both** and passes the recipe
- [ ] Manual: run the CE seed gate against the live bundle and confirm the recipe count does not drop

## Documentation Checklist

- [x] No endpoint, DTO, or model changes
- [x] No new env var or index (the #1763 index is gone from this PR)
- [x] Both changes documented inline with their issue numbers

## Tech Debt Impact

- [x] Reduces debt — removes a two-round-trip write and a frontend/backend logic divergence that #1679 had already fixed on one side
- [x] Adds 8 regression tests
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: low.** Both changes are confined to the engine.

`set_status` relies on MongoDB 4.2+ pipeline updates; the compose stack pins `mongo:8.0`. The seed-gate change makes the gate strictly *more* permissive (it asks about more observations), so the failure direction is "a recipe that was wrongly failing now passes" — it cannot newly fail a recipe that passed before.

**Rollback:** revert the commit. No schema, migration, or storage-format change.

Closes #1681
Closes #1739

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
