### PR TITLE
fix: surface real API errors instead of raw JSON, XML bodies and silence

### DIFF
--- a/frontend/jwst-frontend/src/components/MosaicWizard.tsx
+++ b/frontend/jwst-frontend/src/components/MosaicWizard.tsx
@@ -122,9 +122,9 @@ export const MosaicWizard: React.FC<MosaicWizardProps> = ({
         // Surface specific error messages (e.g. "File too large") instead of generic ones
         let errorMessage = 'Failed to load footprints';
         if (ApiError.isApiError(err)) {
-          // For 413 (file too large), use the error field which has the user-facing message
-          // For 503 (engine down), details has the underlying reason
-          errorMessage = err.status === 413 ? err.message : err.details || err.message;
+          // #1684: displayMessage, never details — details is the raw
+          // stringified body and belongs in code, not on screen.
+          errorMessage = err.status === 413 ? err.message : err.displayMessage;
         } else if (err instanceof Error) {
           errorMessage = err.message;
         }

--- a/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
@@ -423,7 +423,13 @@ const MastSearch: React.FC = () => {
       }
 
       // Handle "cannot resume - no files" error
-      if (ApiError.isApiError(err) && err.details?.includes('Please start a new import')) {
+      // #1687: read the backend's `suggestion` field rather than substring-matching
+      // the whole stringified body — the phrase lives in `suggestion`, which
+      // extractMessage never promotes to `message`.
+      if (
+        ApiError.isApiError(err) &&
+        err.field('suggestion')?.includes('Please start a new import')
+      ) {
         const errorMessage = err.message || 'Cannot resume';
         setImportProgress((prev) =>
           prev

--- a/frontend/jwst-frontend/src/components/wizard/MosaicPreviewStep.tsx
+++ b/frontend/jwst-frontend/src/components/wizard/MosaicPreviewStep.tsx
@@ -300,7 +300,8 @@ export const MosaicPreviewStep = ({
     } catch (err) {
       let msg = 'Failed to start FITS save';
       if (ApiError.isApiError(err)) {
-        msg = err.details || err.message;
+        // #1684: displayMessage, never the raw stringified body.
+        msg = err.displayMessage;
       } else if (err instanceof Error) {
         msg = err.message;
       }
@@ -378,7 +379,8 @@ export const MosaicPreviewStep = ({
     } catch (err) {
       let msg = 'Failed to start export';
       if (ApiError.isApiError(err)) {
-        msg = err.details || err.message;
+        // #1684: displayMessage, never the raw stringified body.
+        msg = err.displayMessage;
       } else if (err instanceof Error) {
         msg = err.message;
       }

--- a/frontend/jwst-frontend/src/pages/MosaicPage.tsx
+++ b/frontend/jwst-frontend/src/pages/MosaicPage.tsx
@@ -151,7 +151,8 @@ export function MosaicPage() {
 
         let errorMessage = 'Failed to load footprints';
         if (ApiError.isApiError(err)) {
-          errorMessage = err.status === 413 ? err.message : err.details || err.message;
+          // #1684: displayMessage, never the raw stringified body.
+          errorMessage = err.status === 413 ? err.message : err.displayMessage;
         } else if (err instanceof Error) {
           errorMessage = err.message;
         }

--- a/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.test.tsx
@@ -3,7 +3,7 @@
  * with the progress/outputs UI — the run now has its own page and URL.
  */
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
@@ -30,6 +30,7 @@ vi.mock('../components/TableViewer', () => ({
 }));
 
 import {
+  cancelJob,
   getJob,
   getJobOutputPreview,
   saveJobOutputToLibrary,
@@ -155,6 +156,39 @@ describe('RunDetail', () => {
    * page whose whole job is to make that silence legible, and the graceful
    * degradation for runs recorded before the engine reported any of it.
    */
+  describe('cancelling', () => {
+    it('says so when the cancel request fails', async () => {
+      // #1780: the old handler only re-enabled the button, which is
+      // indistinguishable from a click that never registered — while the run
+      // keeps burning the resources the user thinks they reclaimed.
+      vi.mocked(getJob).mockResolvedValue(runningJob());
+      vi.mocked(cancelJob).mockRejectedValue(new Error('network down'));
+      renderRun();
+
+      const button = await screen.findByRole('button', { name: 'Cancel run' });
+      fireEvent.click(button);
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(
+        /Couldn't cancel this run: network down/
+      );
+      // ...and the button is usable again, so "try again" is actionable.
+      expect(screen.getByRole('button', { name: 'Cancel run' })).toBeEnabled();
+    });
+
+    it('shows no error when the cancel request succeeds', async () => {
+      vi.mocked(getJob).mockResolvedValue(runningJob());
+      vi.mocked(cancelJob).mockResolvedValue({ cancelRequested: true });
+      renderRun();
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Cancel run' }));
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Cancelling…' })).toBeInTheDocument()
+      );
+      expect(screen.queryByText(/Couldn't cancel this run/)).not.toBeInTheDocument();
+    });
+  });
+
   describe('heartbeat and progress detail', () => {
     const STARTED_AT = '2026-07-24T00:00:01Z';
     const startedMs = Date.parse(STARTED_AT);

--- a/frontend/jwst-frontend/src/pages/RunDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/RunDetail.tsx
@@ -96,6 +96,10 @@ export default function RunDetail() {
   );
 
   const [cancelling, setCancelling] = useState(false);
+  // #1780: a failed cancel used to only re-enable the button, which is
+  // indistinguishable from a click that never registered — and the run keeps
+  // burning resources the user believes they reclaimed.
+  const [cancelError, setCancelError] = useState<string | null>(null);
   const [savedIds, setSavedIds] = useState<Record<number, string>>({});
   const [savingIndex, setSavingIndex] = useState<number | null>(null);
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
@@ -405,12 +409,25 @@ export default function RunDetail() {
                 className="btn-base btn-compact"
                 onClick={() => {
                   setCancelling(true);
-                  cancelJob(job.jobId).catch(() => setCancelling(false));
+                  setCancelError(null);
+                  cancelJob(job.jobId).catch((err: unknown) => {
+                    setCancelling(false);
+                    setCancelError(
+                      err instanceof Error
+                        ? `Couldn't cancel this run: ${err.message}. It is still running — try again.`
+                        : "Couldn't cancel this run. It is still running — try again."
+                    );
+                  });
                 }}
                 disabled={cancelling || job.cancelRequested}
               >
                 {cancelling || job.cancelRequested ? 'Cancelling…' : 'Cancel run'}
               </button>
+            )}
+            {cancelError && (
+              <p className="calibrate-error" role="alert">
+                {cancelError}
+              </p>
             )}
             {job.status === 'succeeded' && job.result && (
               <div className="calibrate-result" role="status">

--- a/frontend/jwst-frontend/src/services/ApiError.test.ts
+++ b/frontend/jwst-frontend/src/services/ApiError.test.ts
@@ -19,6 +19,54 @@ const mockResponse = (status: number, statusText: string, body: unknown, isJson 
   }) as unknown as Response;
 
 describe('ApiError', () => {
+  describe('displayMessage', () => {
+    // #1684: banners were rendering `err.details || err.message`, which puts the
+    // raw stringified body on screen and would leak any internal field the
+    // backend later adds.
+    it('appends the backend suggestion to the message', async () => {
+      const response = mockResponse(409, 'Conflict', {
+        error: 'Cannot resume - download state lost',
+        suggestion: 'Please start a new import',
+      });
+
+      const error = await ApiError.fromResponse(response);
+
+      expect(error.displayMessage).toBe(
+        'Cannot resume - download state lost Please start a new import'
+      );
+      expect(error.displayMessage).not.toContain('{');
+    });
+
+    it('is just the message when there is no suggestion', async () => {
+      const response = mockResponse(400, 'Bad Request', { error: 'Validation failed' });
+
+      const error = await ApiError.fromResponse(response);
+
+      expect(error.displayMessage).toBe('Validation failed');
+    });
+
+    it('is just the message when there is no body at all', () => {
+      const error = new ApiError('Something broke', 500, 'Internal Server Error');
+
+      expect(error.displayMessage).toBe('Something broke');
+    });
+  });
+
+  describe('field', () => {
+    it('returns undefined for a missing field, a non-JSON details, or no details', () => {
+      const error = new ApiError('m', 400, 'Bad Request', '{"error":"x"}');
+      expect(error.field('suggestion')).toBeUndefined();
+      expect(new ApiError('m', 400, 'Bad Request', 'not json').field('error')).toBeUndefined();
+      expect(new ApiError('m', 400, 'Bad Request').field('error')).toBeUndefined();
+    });
+
+    it('ignores non-string and blank values', () => {
+      const error = new ApiError('m', 400, 'Bad Request', '{"a":5,"b":"   "}');
+      expect(error.field('a')).toBeUndefined();
+      expect(error.field('b')).toBeUndefined();
+    });
+  });
+
   describe('constructor', () => {
     it('should set all fields correctly', () => {
       const error = new ApiError('Something went wrong', 404, 'Not Found', 'Resource missing');
@@ -226,6 +274,51 @@ describe('ApiError', () => {
 
       expect(error.message).toBe('Cannot resume - download state lost and no files found');
       expect(error.details).toContain('Please start a new import');
+    });
+
+    it('should set details for JSON sent without a json content-type', async () => {
+      // #1687: the isJson branch always set details; this one did not, so a
+      // proxy stripping the content-type silently disabled MastSearch's
+      // resumability check while the message still looked correct.
+      const response = mockResponse(
+        409,
+        'Conflict',
+        '{"error":"Cannot resume - download state lost","suggestion":"Please start a new import"}',
+        false
+      );
+
+      const error = await ApiError.fromResponse(response);
+
+      expect(error.message).toBe('Cannot resume - download state lost');
+      expect(error.details).toContain('Please start a new import');
+      expect(error.field('suggestion')).toBe('Please start a new import');
+    });
+
+    it('should surface an XML error body instead of discarding it as HTML', async () => {
+      // #1686: a bare startsWith('<') catch-all classified XML/VOTable — which
+      // MAST returns on query errors — as an HTML error page, so the real
+      // message was replaced by the generic unavailable text.
+      const response = mockResponse(400, 'Bad Request', '<error>Access denied</error>', false);
+
+      const error = await ApiError.fromResponse(response);
+
+      expect(error.message).toBe('<error>Access denied</error>');
+    });
+
+    it('should still discard a real HTML error page', async () => {
+      const response = mockResponse(
+        502,
+        'Bad Gateway',
+        '<!DOCTYPE html><html><body><h1>502 Bad Gateway</h1></body></html>',
+        false
+      );
+
+      const error = await ApiError.fromResponse(response);
+
+      expect(error.message).toBe(
+        'The service is temporarily unavailable. Please try again in a moment.'
+      );
+      expect(error.details).toBeUndefined();
     });
 
     it('should extract a message from JSON sent without a json content-type', async () => {

--- a/frontend/jwst-frontend/src/services/ApiError.ts
+++ b/frontend/jwst-frontend/src/services/ApiError.ts
@@ -41,12 +41,15 @@ export function friendlyStatusMessage(status: number, statusText?: string): stri
  */
 function looksLikeHtml(text: string): boolean {
   const trimmed = text.trimStart().toLowerCase();
+  // #1686: deliberately NO bare startsWith('<') catch-all. It made every check
+  // above it dead code and classified XML, VOTable (MAST returns these on query
+  // errors) and SVG as HTML — so the real error was discarded and the user got
+  // the generic "temporarily unavailable" instead.
   return (
     trimmed.startsWith('<!doctype') ||
     trimmed.startsWith('<html') ||
     trimmed.startsWith('<head') ||
-    trimmed.startsWith('<body') ||
-    trimmed.startsWith('<')
+    trimmed.startsWith('<body')
   );
 }
 
@@ -76,6 +79,37 @@ export class ApiError extends Error {
     this.status = status;
     this.statusText = statusText;
     this.details = details;
+  }
+
+  /**
+   * The string to put in front of a user (#1684).
+   *
+   * `details` is the full stringified body — it exists so consumers can inspect
+   * fields the message does not carry, not to be rendered. Several banners were
+   * showing `err.details || err.message`, which puts raw JSON on screen and
+   * would leak any internal field the backend ever adds. This returns the clean
+   * message, plus the backend's `suggestion` when there is one, since that is
+   * the actionable half of most of our error bodies.
+   */
+  get displayMessage(): string {
+    const suggestion = this.field('suggestion');
+    return suggestion ? `${this.message} ${suggestion}` : this.message;
+  }
+
+  /**
+   * A single string field from the error body, if the body was JSON and carried
+   * one. Preferred over hand-parsing `details` at the call site.
+   */
+  field(name: string): string | undefined {
+    if (!this.details) return undefined;
+    try {
+      const parsed: unknown = JSON.parse(this.details);
+      if (typeof parsed !== 'object' || parsed === null) return undefined;
+      const value = (parsed as Record<string, unknown>)[name];
+      return typeof value === 'string' && value.trim() ? value : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   /**
@@ -137,6 +171,14 @@ export class ApiError extends Error {
         const extracted = extractMessage(parsed);
         if (extracted) {
           message = extracted;
+          // #1687: mirror the isJson branch. Consumers inspect fields the
+          // extracted message does not carry — MastSearch reads `suggestion`
+          // out of details to decide whether a paused import is resumable —
+          // and a proxy dropping the content-type must not silently disable
+          // that check.
+          if (typeof parsed === 'object' && parsed !== null) {
+            details = JSON.stringify(parsed);
+          }
         } else if (parsed === undefined && text.length <= MAX_TEXT_MESSAGE_LENGTH) {
           message = text;
         }


### PR DESCRIPTION
## Summary

Four defects in the path a backend error takes to reach the user. Each one loses information at a different point.

| Issue | Defect |
| --- | --- |
| #1686 | `looksLikeHtml` ended with a bare `trimmed.startsWith('<')`. That made the four preceding HTML-marker checks dead code and classified **any** `<`-prefixed body as an HTML error page — XML, VOTable (what MAST returns on query errors), SVG. Those bodies are discarded and replaced with "The service is temporarily unavailable", so the real error is never seen. |
| #1687 | The `else if (text && !isHtml)` branch sets `message` from a parsed JSON body but never sets `details` — unlike the `isJson` branch, which always does. A proxy that strips `Content-Type: application/json` therefore leaves `details` undefined while the message still looks right, silently disabling `MastSearch`'s "cannot resume" detection. The user is left able to attempt a resume the backend has already refused. |
| #1684 | Four mosaic error banners rendered `err.details \|\| err.message`. `details` is the **full stringified body**, so a structured error surfaces as `{"error":"...","suggestion":"..."}` on screen — and would leak any internal field (path, trace) the backend ever adds. |
| #1780 | The run page's Cancel handler was `.catch(() => setCancelling(false))`. A failed cancel just re-enables the button, which is indistinguishable from a click that never registered — while the run keeps consuming the resources the user believes they reclaimed. |

## Changes Made

**`ApiError.ts`**
- `looksLikeHtml` keeps only the four document-marker checks. XML and other non-HTML bodies now fall through to the plaintext path and are surfaced (subject to the existing length cap). A comment marks the catch-all as deliberately absent so it does not come back.
- The non-JSON-content-type branch now sets `details = JSON.stringify(parsed)` when the body parsed to an object, mirroring the `isJson` branch.
- New `get displayMessage()` — the message plus the backend's `suggestion` when present. `suggestion` is the actionable half of most of our error bodies and was previously reaching users only as part of the ugly JSON, so this is not an information loss relative to the old banner.
- New `field(name)` — one string field out of the JSON body, or undefined. This is what consumers actually wanted when they reached for `details`.

**Consumers**
- `MosaicWizard`, `MosaicPage`, `MosaicPreviewStep` (×2) render `err.displayMessage`. The `status === 413` special case is untouched.
- `MastSearch` uses `err.field('suggestion')?.includes('Please start a new import')` instead of substring-matching the entire stringified body. Verified against `MastController.cs:478`, which is where that phrase actually lives.

**`RunDetail.tsx` (#1780)** — a failed cancel now sets a `role="alert"` message naming the underlying error and stating the run is still going, and re-enables the button so "try again" is actionable.

`details` keeps its existing contract throughout — it is still the full body, still populated by the `isJson` path. Nothing renders it any more.

## Test Plan

- [x] `npx vitest run src/services/ApiError.test.ts` — 30 passed (22 pre-existing + 8 new)
- [x] `npx vitest run src/pages/RunDetail.test.tsx` — 44 passed (42 + 2 new)
- [x] Affected suites (`src/services`, `src/components/mast`, `src/components/wizard`, `MosaicPage`, `RunDetail`) — 25 files, 329 tests passed
- [x] Full frontend suite via pre-commit hook — all green
- [x] ESLint on all 8 changed files — 0 errors (13 pre-existing warnings on untouched lines)
- [x] New tests cover: JSON without a json content-type sets `details` **and** `field('suggestion')`; an XML body is surfaced verbatim; a real `<!DOCTYPE html>` page is still discarded with no `details`; `displayMessage` appends the suggestion and contains no `{`; `displayMessage` degrades to the bare message with no suggestion and with no body at all; `field()` returns undefined for missing fields, non-JSON details, absent details, non-string values and blank strings
- [x] New RunDetail tests: a rejected `cancelJob` produces an alert naming the error and leaves the button enabled; a successful cancel shows no error and moves to "Cancelling…"
- [ ] Manual: trigger a 502 through nginx and confirm the friendly message still appears rather than the HTML page

## Documentation Checklist

- [x] No endpoint or DTO changes
- [x] `ApiError` gains two documented public members (`displayMessage`, `field`); the `details` contract is unchanged and its docstring still describes it
- [x] No new component or route

## Tech Debt Impact

- [x] Reduces debt — replaces substring-matching a stringified JSON blob with a real field accessor, and removes a catch-all that made four checks above it unreachable
- [x] Adds 10 regression tests, including the proxy-strips-content-type case #1687 called out as untested
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: low–medium.** The behaviour change users see is strictly more information: XML error bodies that were being swallowed now appear, and mosaic banners show a clean sentence instead of raw JSON.

The one case worth naming: a body that starts with `<` but is neither HTML nor a useful message (say, a bare XML fragment from an intermediary) will now be shown rather than replaced by the friendly fallback. The existing `MAX_TEXT_MESSAGE_LENGTH` cap still applies, so it cannot be a full page, and a genuine HTML error page still matches one of the four document markers — covered by a test.

`MastSearch`'s resume check now reads a named field instead of the whole body. That is narrower by design; verified against the backend response that produces it.

**Rollback:** revert the commit. No API, storage, or state changes.

Closes #1684
Closes #1686
Closes #1687
Closes #1780

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
