### PR TITLE
fix: CI pin drift, stale pip cache, broken bcrypt pairing, shared nginx zone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,22 @@ jobs:
       if: needs.detect-changes.outputs.code == 'true'
       # Pin to the version in processing-engine/requirements-dev.txt so CI lint
       # can't drift to a newer ruff than local/Docker. (#1468)
-      run: pip install ruff==0.15.12
+      run: pip install ruff==0.16.0
+
+    # #1603: the pin above drifted five patch releases behind requirements-dev.txt
+    # before anyone noticed, because nothing checked. A comment saying "keep these
+    # in sync" is not a control; this is.
+    - name: Assert Ruff Pin Matches requirements-dev.txt
+      if: needs.detect-changes.outputs.code == 'true'
+      run: |
+        pinned=$(ruff --version | awk '{print $2}')
+        declared=$(sed -n 's/^ruff==//p' processing-engine/requirements-dev.txt)
+        if [ "$pinned" != "$declared" ]; then
+          echo "::error::CI lints with ruff $pinned but requirements-dev.txt declares $declared."
+          echo "Update the 'Install Ruff' step in .github/workflows/ci.yml to match."
+          exit 1
+        fi
+        echo "Ruff pin matches requirements-dev.txt ($declared)"
 
     - name: Lint Processing Engine (Ruff)
       if: needs.detect-changes.outputs.code == 'true'
@@ -203,7 +218,13 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
-        cache-dependency-path: processing-engine/requirements-dev.txt
+        # #1563: requirements-dev.txt starts with "-r requirements.txt", so the
+        # installed set depends on BOTH files. Hashing only one meant a bump in
+        # requirements.txt reused stale wheels and the job passed against the
+        # old version — a silent failure.
+        cache-dependency-path: |
+          processing-engine/requirements.txt
+          processing-engine/requirements-dev.txt
 
     - name: Install Python Dependencies
       run: |

--- a/.github/workflows/composite-memory-test.yml
+++ b/.github/workflows/composite-memory-test.yml
@@ -28,7 +28,10 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-          cache-dependency-path: processing-engine/requirements-dev.txt
+          # #1563: both files determine the installed set — see ci.yml.
+          cache-dependency-path: |
+            processing-engine/requirements.txt
+            processing-engine/requirements-dev.txt
 
       - name: Install Python dependencies
         working-directory: processing-engine

--- a/frontend/jwst-frontend/nginx-ce.conf
+++ b/frontend/jwst-frontend/nginx-ce.conf
@@ -25,7 +25,15 @@ limit_req_zone $binary_remote_addr zone=ce_render:10m rate=1r/s;
 # FITS arrays but are NOT behind the engine's render semaphore — cap them
 # tighter than the general API so parallel viewers can't stack memory.
 limit_req_zone $binary_remote_addr zone=ce_preview:10m rate=3r/s;
-limit_conn_zone $binary_remote_addr zone=ce_conn:10m;
+# #1667: one zone PER TIER, not one shared zone. An nginx connection zone
+# counts per key (client IP) across every location that references it, so a
+# single ce_conn made the tighter per-endpoint limits behave as one global
+# per-IP ceiling: an active render plus three library previews reached 4 and
+# blocked the next preview, even though no individual budget was exhausted.
+limit_conn_zone $binary_remote_addr zone=ce_conn_api:10m;
+limit_conn_zone $binary_remote_addr zone=ce_conn_mast:10m;
+limit_conn_zone $binary_remote_addr zone=ce_conn_preview:10m;
+limit_conn_zone $binary_remote_addr zone=ce_conn_render:10m;
 
 server {
     listen 3000;
@@ -75,7 +83,7 @@ server {
 
     location /api/ {
         limit_req zone=ce_api burst=20 nodelay;
-        limit_conn ce_conn 10;
+        limit_conn ce_conn_api 10;
         proxy_pass http://processing-engine:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -90,7 +98,7 @@ server {
     # MAST search passthrough — tighter limit (outbound amplification vector)
     location /api/mast/ {
         limit_req zone=ce_mast burst=5 nodelay;
-        limit_conn ce_conn 5;
+        limit_conn ce_conn_mast 5;
         proxy_pass http://processing-engine:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -106,7 +114,7 @@ server {
     # semaphore; regex location outranks the /api/ prefix match.
     location ~ ^/api/jwstdata/[^/]+/(preview|histogram|pixeldata|cubeinfo)$ {
         limit_req zone=ce_preview burst=10 nodelay;
-        limit_conn ce_conn 4;
+        limit_conn ce_conn_preview 4;
         proxy_pass http://processing-engine:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -121,7 +129,7 @@ server {
     # Composite render — 600s ceiling (see timeout note at the top)
     location = /api/composite/generate-nchannel {
         limit_req zone=ce_render burst=3 nodelay;
-        limit_conn ce_conn 4;
+        limit_conn ce_conn_render 4;
         proxy_pass http://processing-engine:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/processing-engine/requirements.txt
+++ b/processing-engine/requirements.txt
@@ -43,7 +43,12 @@ boto3>=1.43.36
 # Async MongoDB driver, JWT, and password hashing.
 motor==3.7.1
 pyjwt==2.13.0
-passlib[bcrypt]==1.7.4
+# bcrypt directly, NOT via passlib (#1625). passlib 1.7.4 (last released 2020,
+# unmaintained) reads bcrypt.__about__.__version__, which bcrypt dropped in
+# 4.0.0 — with bcrypt 5.0.0 that is not merely a PasslibHashWarning: hashing
+# raises outright. Verified in the dev container before removing it. Nothing
+# imported passlib yet, so the ADR-0001 auth work starts on bcrypt's own API
+# (hashpw/checkpw/gensalt) rather than on a dead wrapper pinned to a 2022 bcrypt.
 bcrypt==5.0.0
 
 # NOTE: test/lint tooling (pytest, pytest-asyncio, pytest-cov, httpx, ruff) lives


### PR DESCRIPTION
## Summary

Four configuration defects. Each one is a control that looks like it is working and isn't.

| Issue | Defect |
| --- | --- |
| #1603 | `ci.yml` hard-pinned `ruff==0.15.12` while `requirements-dev.txt` had moved to `0.16.0`. CI linted with rules five-plus releases behind local and Docker, so code that fails lint on a developer's machine could merge. The pin's own comment says it should track `requirements-dev.txt`. |
| #1563 | `cache-dependency-path` hashed only `requirements-dev.txt`. That file starts with `-r requirements.txt`, so the installed package set depends on **both** — a bump in `requirements.txt` left the cache key unchanged, the runner served stale wheels, and the job **passed against the old version**. Silent by construction. |
| #1625 | `passlib[bcrypt]==1.7.4` alongside `bcrypt==5.0.0`. passlib reads `bcrypt.__about__.__version__`, dropped in bcrypt 4.0.0. |
| #1667 | `nginx-ce.conf` shared a single `limit_conn` zone across four locations. An nginx connection zone counts **per key (client IP) across every location that references it**, so the tighter per-endpoint limits behaved as one global per-IP ceiling. |

## Changes Made

**#1603** — pin updated to `0.16.0`, plus the drift guard the issue asked for: a step that compares `ruff --version` against the version declared in `requirements-dev.txt` and fails with an actionable `::error::` if they differ. The existing "keep these in sync" comment had already failed once; a comment is not a control. Written with `sed` rather than `grep -P` so it is verifiable locally on macOS as well as on the GNU-grep runners.

**#1563** — both files now key the cache, in `ci.yml` and `composite-memory-test.yml`. GitHub Actions hashes all listed paths, so either file changing invalidates the cache.

**#1625** — `passlib` removed; `bcrypt==5.0.0` kept.

This goes further than the issue's suggested fix (pin `bcrypt<4.0.0`), so the reasoning matters:

- I reproduced it in the dev container first. It is **not** merely a `PasslibHashWarning`: with bcrypt 5.0.0, `CryptContext(schemes=['bcrypt']).hash(...)` raises `ValueError: password cannot be longer than 72 bytes`. The pairing is broken, not noisy.
- `grep` across `processing-engine/` finds **zero** imports of passlib — it is declared and unused. Nothing to migrate.
- The alternative pins a 2022 bcrypt to keep a library last released in 2020 and unmaintained, as the foundation for the ADR-0001 auth work that has not been written yet.
- Verified `bcrypt.hashpw` / `checkpw` / `gensalt` work cleanly under `warnings.simplefilter('error')` in the container.

**#1667** — one zone per tier (`ce_conn_api`, `ce_conn_mast`, `ce_conn_preview`, `ce_conn_render`), each keeping its existing limit. Concretely, this unblocks the scenario in the issue: an active render plus three library previews reached 4 on the shared counter and rejected the next preview with a 429 even though no individual budget was exhausted.

## Test Plan

- [x] `nginx -t` against the modified config inside the running `jwst-ce-frontend` container — "syntax is ok / test is successful"; the container's own config was restored afterwards
- [x] Reproduced #1625 live: `docker exec jwst-processing python -c "…CryptContext…"` raised `AttributeError: module 'bcrypt' has no attribute '__about__'` followed by `ValueError: password cannot be longer than 72 bytes`
- [x] Verified the replacement: `bcrypt.hashpw` / `checkpw` round-trip cleanly under `warnings.simplefilter('error')` (True for the right password, False for the wrong one)
- [x] Confirmed no source imports passlib (`grep -rn "passlib\|bcrypt" processing-engine --include="*.py"` → only the requirements file)
- [x] Verified the drift-guard shell locally: `sed -n 's/^ruff==//p' processing-engine/requirements-dev.txt` → `0.16.0`, matching `ruff --version` in the container (`ruff 0.16.0`)
- [x] Pre-commit hooks pass
- [ ] Verified in CI on this PR: the new guard step runs green, and the Python job's cache key changes (both are only observable on the runner)

## Documentation Checklist

- [x] No endpoint, model, or controller changes
- [x] Dependency removal recorded in `requirements.txt` with the reasoning inline, including that it was verified rather than inferred
- [x] Each workflow change carries an inline comment naming the issue

## Tech Debt Impact

- [x] Reduces debt — removes an unmaintained, unused, actively broken dependency
- [x] Converts a "keep these in sync" comment into an enforced check
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: low–medium.**

- The ruff bump (0.15.12 → 0.16.0 in CI) may surface lint findings that the stale pin was hiding. That is the point, and it shows up on this PR's own CI run rather than in production. If the newer ruff flags pre-existing code, that is a real finding to fix, not a reason to re-pin.
- The nginx change **relaxes** limits (counters that were shared are now independent), so no request pattern that worked before can start failing. Each per-endpoint number is unchanged; validated with `nginx -t`.
- Removing passlib is the one change with a "what if" — the answer is that nothing imports it and its current pairing raises. Restoring it is one line if the auth work later prefers a `CryptContext`, though it would need a bcrypt downgrade too.

**Rollback:** revert the commit. No code, schema, or runtime state involved; the nginx change takes effect on the next CE image build.

Closes #1563
Closes #1603
Closes #1625
Closes #1667

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
