### PR TITLE
fix: anonymous bulk import, pill count, context churn, empty state, null filters

### DIFF
--- a/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
+++ b/frontend/jwst-frontend/src/components/discovery/RecipeCard.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../../context/useAuth';
 import { checkDataAvailability } from '../../services/jwstDataService';
 import { formatInstruments } from '../../utils/instrumentDisplay';
-import { observationIdsForFilters } from '../../utils/observationUtils';
+import { observationIdsForFilters, buildFilterCoverage } from '../../utils/observationUtils';
 import type { CompositeRecipe } from '../../types/DiscoveryTypes';
 import type { MastObservationResult } from '../../types/MastTypes';
 import { CE_MODE } from '../../config/ce';
@@ -70,18 +70,11 @@ export function RecipeCard({
       .then((result) => {
         if (controller.signal.aborted) return;
 
-        // Check if every filter in the recipe has available data
-        const recipeFilters = new Set(recipe.filters.map((f) => f.toUpperCase()));
-        const availableFilters = new Set<string>();
-
-        for (const id of obsIds) {
-          const item = result.results[id];
-          if (item?.available && item.filter) {
-            availableFilters.add(item.filter.toUpperCase());
-          }
-        }
-
-        const allReady = [...recipeFilters].every((f) => availableFilters.has(f));
+        // #1682: same shared coverage builder TargetDetail uses, so the
+        // standalone pill and the grouped one cannot disagree. It carries the
+        // `item.filter ?? obs.filters` fallback this loop was missing.
+        const coverage = buildFilterCoverage(result.results, observations ?? []);
+        const allReady = recipe.filters.every((f) => coverage.has(f.toUpperCase()));
         setDataReady(allReady);
       })
       .catch(() => {

--- a/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
@@ -641,6 +641,9 @@ const MastSearch: React.FC = () => {
   const handleBulkImport = async () => {
     const obsIds = Array.from(selectedObs);
     if (obsIds.length === 0) return;
+    // #1648: the button is hidden for anonymous users, but a selection made
+    // before a session expired would otherwise fire N imports that all 401.
+    if (!isAuthenticated) return;
 
     // For single observation, use the existing single-import flow
     if (obsIds.length === 1) {

--- a/frontend/jwst-frontend/src/components/mast/ResultsTable.test.tsx
+++ b/frontend/jwst-frontend/src/components/mast/ResultsTable.test.tsx
@@ -74,4 +74,33 @@ describe('ResultsTable', () => {
     expect(screen.getByText('In Library')).toBeInTheDocument();
     expect(screen.getAllByText('Log in to import')).toHaveLength(1);
   });
+
+  // #1648: /archive became public in #1619, but only the per-row action grew an
+  // auth gate. Anonymous users could still select rows and fire a bulk import,
+  // which 401s every job and shows a wall of failures instead of a login hint.
+  it('hides the bulk-import button from anonymous users', () => {
+    renderTable({ isAuthenticated: false, selectedObs: new Set(['jw001']) });
+
+    expect(screen.queryByText(/Import Selected/)).not.toBeInTheDocument();
+  });
+
+  it('shows the bulk-import button once authenticated', () => {
+    renderTable({ isAuthenticated: true, selectedObs: new Set(['jw001']) });
+
+    expect(screen.getByText('Import Selected (1)')).toBeInTheDocument();
+  });
+
+  it('disables the selection checkboxes for anonymous users', () => {
+    renderTable({ isAuthenticated: false });
+
+    const boxes = screen.getAllByRole('checkbox');
+    expect(boxes).toHaveLength(2);
+    boxes.forEach((box) => expect(box).toBeDisabled());
+  });
+
+  it('leaves the selection checkboxes usable when authenticated', () => {
+    renderTable({ isAuthenticated: true });
+
+    screen.getAllByRole('checkbox').forEach((box) => expect(box).toBeEnabled());
+  });
 });

--- a/frontend/jwst-frontend/src/components/mast/ResultsTable.tsx
+++ b/frontend/jwst-frontend/src/components/mast/ResultsTable.tsx
@@ -78,7 +78,11 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
     <div className="search-results">
       <div className="results-header">
         <h3>Search Results ({searchResults.length})</h3>
-        {selectedObs.size > 0 && (
+        {/* #1648: /archive became public in #1619, but only the per-row action
+            grew an auth gate. Anonymous users could still select rows and fire
+            a bulk import, which 401s every job and leaves the panel in a failed
+            state with no hint that logging in is the answer. */}
+        {selectedObs.size > 0 && isAuthenticated && (
           <button
             className="btn-base btn-large bulk-import-btn"
             onClick={onBulkImport}
@@ -115,7 +119,10 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
                       type="checkbox"
                       checked={selectedObs.has(resultObsId)}
                       onChange={() => onToggleSelection(resultObsId)}
-                      disabled={!result.obs_id}
+                      disabled={!result.obs_id || !isAuthenticated}
+                      title={
+                        isAuthenticated ? undefined : 'Log in to select observations for import'
+                      }
                     />
                   </td>
                   <td className="col-obs-id" title={result.obs_id}>

--- a/frontend/jwst-frontend/src/context/ActiveImportsContext.tsx
+++ b/frontend/jwst-frontend/src/context/ActiveImportsContext.tsx
@@ -18,6 +18,8 @@ interface ActiveImportsProviderProps {
 }
 
 export function ActiveImportsProvider({ children }: ActiveImportsProviderProps) {
+  // #1650: the hook memoizes its own return value, so this reference is stable
+  // between progress ticks that do not change what consumers can see.
   const value = useActiveImports();
   return <ActiveImportsContext.Provider value={value}>{children}</ActiveImportsContext.Provider>;
 }

--- a/frontend/jwst-frontend/src/hooks/useActiveImports.test.ts
+++ b/frontend/jwst-frontend/src/hooks/useActiveImports.test.ts
@@ -381,6 +381,85 @@ describe('useActiveImports', () => {
     expect(hoisted.toastSuccessMock).toHaveBeenCalledWith('Import complete', expect.any(Object));
   });
 
+  // #1649: a completed job lingers in the map for a 2500ms success flash, so
+  // counting the map counted it as active. The pill then read "Importing 2"
+  // while only one import was actually in flight.
+  it('activeCount excludes a job that is only flashing its completion', () => {
+    vi.useFakeTimers();
+    hoisted.useAuthMock.mockReturnValue({ isAuthenticated: true });
+
+    const { result } = renderHook(() => useActiveImports());
+
+    act(() => {
+      result.current.registerJob('job-1');
+      result.current.registerJob('job-2');
+    });
+    expect(result.current.activeCount).toBe(2);
+
+    act(() => {
+      capturedCallbacks['job-1'].onCompleted?.({
+        jobId: 'job-1',
+        obsId: 'obs-1',
+        progress: 100,
+        stage: 'Complete',
+        message: 'Done',
+        isComplete: true,
+        startedAt: new Date().toISOString(),
+      });
+    });
+
+    // Still two jobs on screen (one is flashing), but only one is importing.
+    expect(result.current.jobs).toHaveLength(2);
+    expect(result.current.activeCount).toBe(1);
+
+    // After the flash window job-1 leaves the map entirely; job-2 is still
+    // importing, so the count is unchanged — it was only ever counting job-2.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.jobs).toHaveLength(1);
+    expect(result.current.activeCount).toBe(1);
+  });
+
+  // #1650: the hook returned a fresh object literal every render, so every
+  // SignalR progress tick re-rendered every context consumer — including
+  // MastSearch's 100-row results table.
+  it('returns a stable reference when a re-render changes nothing', () => {
+    hoisted.useAuthMock.mockReturnValue({ isAuthenticated: true });
+
+    const { result, rerender } = renderHook(() => useActiveImports());
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it('returns a new reference when progress actually changes', () => {
+    hoisted.useAuthMock.mockReturnValue({ isAuthenticated: true });
+
+    const { result } = renderHook(() => useActiveImports());
+    act(() => {
+      result.current.registerJob('job-1');
+    });
+    const before = result.current;
+
+    act(() => {
+      capturedCallbacks['job-1'].onProgress?.({
+        jobId: 'job-1',
+        obsId: 'obs-1',
+        progress: 42,
+        stage: 'Downloading',
+        message: 'x',
+        isComplete: false,
+        startedAt: new Date().toISOString(),
+      });
+    });
+
+    expect(result.current).not.toBe(before);
+    expect(result.current.aggregatePercent).toBe(42);
+  });
+
   it('on failure: fires an error toast and drops the job immediately', () => {
     hoisted.useAuthMock.mockReturnValue({ isAuthenticated: true });
 

--- a/frontend/jwst-frontend/src/hooks/useActiveImports.ts
+++ b/frontend/jwst-frontend/src/hooks/useActiveImports.ts
@@ -234,10 +234,25 @@ export function useActiveImports(): UseActiveImportsResult {
     return Math.round(sum / jobList.length);
   }, [jobList]);
 
-  return {
-    jobs: jobList,
-    aggregatePercent,
-    activeCount: jobList.length,
-    registerJob,
-  };
+  // #1649: jobs linger in the map for a 2500ms success flash after completing,
+  // so jobList.length counts them as active. That made the pill read
+  // "Importing 2 - 75%" when one had already landed and only one was in flight.
+  const activeCount = useMemo(
+    () => jobList.filter((job) => job.status !== 'complete').length,
+    [jobList]
+  );
+
+  // #1650: a new object literal here re-rendered every context consumer on
+  // every SignalR progress tick — including MastSearch's 100-row results table.
+  // jobList and registerJob are already stable, so this only changes when the
+  // values actually do.
+  return useMemo(
+    () => ({
+      jobs: jobList,
+      aggregatePercent,
+      activeCount,
+      registerJob,
+    }),
+    [jobList, aggregatePercent, activeCount, registerJob]
+  );
 }

--- a/frontend/jwst-frontend/src/pages/DiscoveryHome.tsx
+++ b/frontend/jwst-frontend/src/pages/DiscoveryHome.tsx
@@ -107,8 +107,17 @@ export function DiscoveryHome() {
           </TargetCardGrid>
         )}
 
+        {/* #1626: two different dead ends shared one message. Telling someone
+            who only clicked a filter chip that nothing matched "your search"
+            sends them to clear a search box they never typed in. */}
         {!loading && !error && targets.length > 0 && filteredTargets.length === 0 && (
-          <p className="discovery-no-matches">No targets match your search.</p>
+          <p className="discovery-no-matches">
+            {query.trim()
+              ? filter === 'all'
+                ? 'No targets match your search.'
+                : 'No targets match your search and the selected filter.'
+              : 'No targets match the selected filter.'}
+          </p>
         )}
 
         {!loading && !error && targets.length === 0 && (

--- a/frontend/jwst-frontend/src/pages/TargetDetail.test.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.test.tsx
@@ -109,6 +109,30 @@ describe('TargetDetail recipe grouping', () => {
     expect(screen.queryByText('Not in library', { selector: 'h3' })).not.toBeInTheDocument();
   });
 
+  // #1682: the availability endpoint can return an entry with a null filter —
+  // buildFilterCoverage and seed_ce both carry an `item.filter ?? obs.filters`
+  // fallback for exactly this. TargetDetail dropped those entries, so a recipe
+  // GuidedCreate showed as Ready landed under "Not in library" here.
+  it('treats an entry with a null filter as covered via the observation filter', async () => {
+    mockHappyPath({
+      'obs-f770w': { available: true, dataIds: ['a'.repeat(24)], filter: null },
+    });
+    renderPage();
+
+    const ready = await screen.findByText('Ready to render');
+    expect(ready.closest('section')?.textContent).toContain('MIRI recipe');
+  });
+
+  it('still ignores an unavailable entry with a null filter', async () => {
+    mockHappyPath({
+      'obs-f770w': { available: false, dataIds: [], filter: null },
+    });
+    renderPage();
+
+    await screen.findByText('Not in library', { selector: 'h3' });
+    expect(screen.queryByText('Ready to render')).not.toBeInTheDocument();
+  });
+
   it('no recipes ready renders only the Not in library section header', async () => {
     mockHappyPath({});
     renderPage();

--- a/frontend/jwst-frontend/src/pages/TargetDetail.tsx
+++ b/frontend/jwst-frontend/src/pages/TargetDetail.tsx
@@ -7,7 +7,11 @@ import { TargetDetailSkeleton } from '../components/discovery/TargetDetailSkelet
 import { TelescopeIcon } from '../components/icons/DashboardIcons';
 import { searchByTarget } from '../services/mastService';
 import { suggestRecipes } from '../services/discoveryService';
-import { toObservationInputs, observationIdsForFilters } from '../utils/observationUtils';
+import {
+  toObservationInputs,
+  observationIdsForFilters,
+  buildFilterCoverage,
+} from '../utils/observationUtils';
 import type { MastObservationResult } from '../types/MastTypes';
 import type { CompositeRecipe } from '../types/DiscoveryTypes';
 import { CE_MODE } from '../config/ce';
@@ -160,17 +164,17 @@ export function TargetDetail() {
     checkDataAvailability(unionIds, controller.signal)
       .then((result) => {
         if (controller.signal.aborted) return;
-        const availableFilters = new Set<string>();
-        for (const item of Object.values(result.results)) {
-          if (item?.available && item.filter) {
-            availableFilters.add(item.filter.toUpperCase());
-          }
-        }
+        // #1682: buildFilterCoverage applies the `item.filter ?? obs.filters`
+        // fallback that the hand-rolled loop here was missing, so an entry with
+        // a null filter was dropped and its recipe landed in "Not in library"
+        // while GuidedCreate showed the same recipe as Ready. Sharing the helper
+        // is what stops the two disagreeing again.
+        const coverage = buildFilterCoverage(result.results, observations);
         const map = new Map<string, boolean>();
         for (const { recipe } of idsPerRecipe) {
           map.set(
             recipe.name,
-            recipe.filters.every((f) => availableFilters.has(f.toUpperCase()))
+            recipe.filters.every((f) => coverage.has(f.toUpperCase()))
           );
         }
         setReadyByRecipe(map);


### PR DESCRIPTION
## Summary

Five frontend defects across the public archive page, the import pill, and discovery.

| Issue | Defect |
| --- | --- |
| #1648 | `/archive` became a public route in #1619. The per-row import action grew an auth gate ("Log in to import"); the **bulk** path did not. An anonymous user could tick rows and click "Import Selected (N)", which 401s every job and leaves a wall of failures with no hint that logging in is the answer. |
| #1649 | `activeCount` was `jobList.length`, but a completed job lingers in the map for a 2500ms success flash. Two imports where one had already landed showed "Importing 2 · 75%" instead of "Importing… 75%". |
| #1650 | `useActiveImports` returned a fresh object literal every render, so **every SignalR progress tick re-rendered every context consumer** — including `MastSearch`'s 100-row results table with per-row availability lookups. Visible jank during downloads. |
| #1626 | One empty-state message, two different dead ends: a search that matched nothing and a filter chip that matched nothing both said "No targets match your search." A user who only clicked "Best potential" is sent to clear a search box they never typed in. |
| #1682 | `TargetDetail` and `RecipeCard` each hand-rolled filter coverage with `if (item?.available && item.filter)`, dropping entries whose `filter` is null. `buildFilterCoverage` (used by GuidedCreate) and `seed_ce.py`'s `_entry_filter` both carry an `item.filter ?? obs.filters` fallback — two independent code paths handling it is what confirms the endpoint really does return null there. Result: a recipe GuidedCreate shows as **Ready** appeared under **"Not in library"** on the target page. |

## Changes Made

- **`ResultsTable.tsx`** — the bulk-import button renders only when authenticated; checkboxes are disabled with a title explaining why. Mirrors the per-row treatment.
- **`MastSearch.tsx`** — `handleBulkImport` returns early when unauthenticated. Defence in depth: the button is gone, but a selection made before a session expired would otherwise still fire N imports.
- **`useActiveImports.ts`** — `activeCount` filters out `status === 'complete'`, and the return value is wrapped in `useMemo`. The memo is placed **in the hook rather than the provider** (which is where #1650 suggested it): `jobList` and `registerJob` are already stable there, so it fixes every consumer of the hook rather than only those going through the context.
- **`DiscoveryHome.tsx`** — the empty state branches on `query` and `filter`, including the both-active case.
- **`TargetDetail.tsx` / `RecipeCard.tsx`** — both now call `buildFilterCoverage`, deleting the two hand-rolled loops. This is the fix that matters: the issue is a *divergence* between three implementations of one rule, so collapsing them onto the shared helper is what stops it recurring, rather than adding a third copy of the `??`.

## Test Plan

- [x] Full frontend suite via pre-commit hook — all green
- [x] `npx vitest run src/components/mast/ResultsTable.test.tsx` — 8 passed (4 new: button hidden when anonymous, shown when authenticated, checkboxes disabled/enabled accordingly)
- [x] `npx vitest run src/hooks/useActiveImports.test.ts` — 15 passed (3 new: `activeCount` excludes a job that is only flashing; a no-op re-render returns the **same reference**; a real progress event returns a new one)
- [x] `npx vitest run src/pages/TargetDetail.test.tsx` — 9 passed (2 new: a null-filter entry counts as covered via the observation filter; an *unavailable* null-filter entry still does not)
- [x] **Regression check**: restored the old hand-rolled coverage loop in `TargetDetail` and confirmed the null-filter test fails, then restored the fix
- [x] ESLint on all 7 changed files — 0 errors (13 pre-existing warnings on untouched lines)
- [ ] Manual: load `/archive` signed out → checkboxes disabled, no bulk button; start two imports and watch the pill as the first completes

## Documentation Checklist

- [x] No endpoint, DTO, or model changes
- [x] No new route or component; `UseActiveImportsResult` keeps its shape (`activeCount` is unchanged in type, only in meaning — documented at the definition)
- [x] Each change carries an inline comment naming the issue and the reasoning

## Tech Debt Impact

- [x] Reduces debt — removes two duplicate implementations of filter coverage, the exact divergence #1679, #1680 and #1681 each had to fix separately elsewhere
- [x] Adds 9 regression tests, one verified to fail without its fix
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: low.** All five are UI-layer changes with no API, auth-token, or storage surface touched.

The one behaviour change worth naming is #1648: anonymous visitors lose the ability to *select* rows on `/archive`. That is the intent — the selection only ever led to a 401 — but it is a visible reduction for signed-out users. Browsing, searching and per-row "Log in to import" are unchanged.

#1682 makes readiness detection strictly more permissive (entries that were dropped now count), so a recipe can move from "Not in library" to "Ready" but never the reverse. That is the reported bug's direction.

**Rollback:** revert the commit. No migration, config, or persisted state.

Closes #1626
Closes #1648
Closes #1649
Closes #1650
Closes #1682

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
