### PR TITLE
fix: viewer token refresh, polling-timeout ghosts, back-to-back imports, framing

### DIFF
--- a/frontend/jwst-frontend/src/components/ImageComparisonViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageComparisonViewer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { API_BASE_URL } from '../config/api';
+import { apiClient } from '../services/apiClient';
 import type { ImageSelection } from './ComparisonImagePicker';
 import './ImageComparisonViewer.css';
 
@@ -23,26 +23,16 @@ const COLORMAPS = [
   { value: 'rainbow', label: 'Rainbow' },
 ];
 
-function buildPreviewUrl(dataId: string, colormap: string): string {
+function buildPreviewEndpoint(dataId: string, colormap: string): string {
   return (
-    `${API_BASE_URL}/api/jwstdata/${dataId}/preview?` +
-    `cmap=${colormap}&width=1200&height=1200&stretch=zscale`
+    `/api/jwstdata/${dataId}/preview?` + `cmap=${colormap}&width=1200&height=1200&stretch=zscale`
   );
 }
 
-async function fetchAuthBlob(url: string): Promise<string> {
-  const token = localStorage.getItem('jwst_auth_token');
-  const response = await fetch(url, {
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-  });
-  if (!response.ok) {
-    const detail = await response
-      .json()
-      .then((d) => d.detail)
-      .catch(() => null);
-    throw new Error(detail || `Preview failed (${response.status})`);
-  }
-  const blob = await response.blob();
+// #1574: apiClient, not raw fetch — it pre-flights a token refresh and retries
+// once on 401, which a comparison left open past token expiry needs.
+async function fetchPreviewObjectUrl(endpoint: string): Promise<string> {
+  const blob = await apiClient.getBlob(endpoint);
   return URL.createObjectURL(blob);
 }
 
@@ -111,8 +101,8 @@ const ImageComparisonViewer: React.FC<ImageComparisonViewerProps> = ({
       setLoadingA(true);
       setErrorA(null);
       try {
-        const url = buildPreviewUrl(imageA.dataId, colormap);
-        const blobUrl = await fetchAuthBlob(url);
+        const url = buildPreviewEndpoint(imageA.dataId, colormap);
+        const blobUrl = await fetchPreviewObjectUrl(url);
         if (!revoked) setBlobUrlA(blobUrl);
       } catch (err) {
         if (!revoked) {
@@ -127,8 +117,8 @@ const ImageComparisonViewer: React.FC<ImageComparisonViewerProps> = ({
       setLoadingB(true);
       setErrorB(null);
       try {
-        const url = buildPreviewUrl(imageB.dataId, colormap);
-        const blobUrl = await fetchAuthBlob(url);
+        const url = buildPreviewEndpoint(imageB.dataId, colormap);
+        const blobUrl = await fetchPreviewObjectUrl(url);
         if (!revoked) setBlobUrlB(blobUrl);
       } catch (err) {
         if (!revoked) {

--- a/frontend/jwst-frontend/src/components/ImageViewer.test.tsx
+++ b/frontend/jwst-frontend/src/components/ImageViewer.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import ImageViewer from './ImageViewer';
+import { apiClient } from '../services/apiClient';
 
 // Mock canvas
 HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
@@ -155,5 +156,32 @@ describe('ImageViewer', () => {
     render(<ImageViewer {...defaultProps} isOpen={true} />);
     // Breadcrumb shows default target name when no metadata loaded
     expect(screen.getByText('Unknown Target')).toBeInTheDocument();
+  });
+
+  // #1574: the viewer used raw fetch with a localStorage token read, skipping
+  // apiClient's pre-flight refresh and 401-retry. It is the screen users leave
+  // open longest, so a lapsed access token became an unrecoverable
+  // "Preview failed (401)" on every re-render.
+  it('loads the preview through apiClient, not a raw fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    render(<ImageViewer {...defaultProps} isOpen={true} />);
+
+    await waitFor(() =>
+      expect(vi.mocked(apiClient.getBlob)).toHaveBeenCalledWith(
+        expect.stringContaining(`/api/jwstdata/${defaultProps.dataId}/preview?`)
+      )
+    );
+    // The endpoint is relative — apiClient owns the base URL and the headers.
+    const endpoint = vi.mocked(apiClient.getBlob).mock.calls[0][0];
+    expect(endpoint.startsWith('/api/')).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it('surfaces a preview failure instead of leaving a blank frame', async () => {
+    vi.mocked(apiClient.getBlob).mockRejectedValueOnce(new Error('Preview failed (401)'));
+    render(<ImageViewer {...defaultProps} isOpen={true} />);
+
+    expect(await screen.findByText('Preview failed (401)')).toBeInTheDocument();
   });
 });

--- a/frontend/jwst-frontend/src/components/ImageViewer.tsx
+++ b/frontend/jwst-frontend/src/components/ImageViewer.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import './ImageViewer.css';
 import './FitsViewer.css';
-import { API_BASE_URL } from '../config/api';
 import { CE_MODE } from '../config/ce';
 import StretchControls, { StretchParams } from './StretchControls';
 import HistogramPanel, { HistogramData, PercentileData, HistogramStats } from './HistogramPanel';
@@ -446,8 +445,12 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     const fetchPreview = async () => {
       setLoading(true);
       setError(null);
-      const url =
-        `${API_BASE_URL}/api/jwstdata/${dataId}/preview?` +
+      // #1574: apiClient, not raw fetch — it pre-flights a token refresh and
+      // retries once on 401. The viewer is the screen users leave open longest,
+      // which is exactly where a lapsed access token used to become an
+      // unrecoverable "Preview failed (401)" on every re-render.
+      const endpoint =
+        `/api/jwstdata/${dataId}/preview?` +
         `cmap=${colormap}` +
         `&width=1200&height=1200` +
         `&stretch=${stretchParams.stretch}` +
@@ -460,18 +463,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
         `&smoothSigma=${smoothingParams.sigma}` +
         `&smoothSize=${smoothingParams.size}`;
       try {
-        const token = localStorage.getItem('jwst_auth_token');
-        const response = await fetch(url, {
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
-        });
-        if (!response.ok) {
-          const detail = await response
-            .json()
-            .then((d) => d.detail)
-            .catch(() => null);
-          throw new Error(detail || `Preview failed (${response.status})`);
-        }
-        const blob = await response.blob();
+        const blob = await apiClient.getBlob(endpoint);
         if (revoked) return;
         setBlobUrl((prev) => {
           if (prev) URL.revokeObjectURL(prev);
@@ -1148,13 +1140,39 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     setCurvePreset('linear');
   }, []);
 
+  // #1574: the FITS download used to be a bare window.open, which sends NO
+  // auth header at all — a cross-tab GET to a protected endpoint. Fetch the
+  // blob through apiClient (refresh + 401 retry) and hand it to a download
+  // link, the same shape handleExport already uses.
+  const [isDownloadingFits, setIsDownloadingFits] = useState(false);
+  const handleDownloadFits = async () => {
+    if (isDownloadingFits) return;
+    setIsDownloadingFits(true);
+    try {
+      const blob = await apiClient.getBlob(`/api/jwstdata/${dataId}/file`);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = title || `${dataId}.fits`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setTimeout(() => URL.revokeObjectURL(url), 100);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to download FITS file');
+    } finally {
+      setIsDownloadingFits(false);
+    }
+  };
+
   // Handle export with options (PNG or JPEG)
   const handleExport = async (options: ExportOptions) => {
     if (isExporting) return;
     setIsExporting(true);
     try {
-      const exportUrl =
-        `${API_BASE_URL}/api/jwstdata/${dataId}/preview?` +
+      // #1574: same reason as the preview fetch above.
+      const exportEndpoint =
+        `/api/jwstdata/${dataId}/preview?` +
         `cmap=${colormap}` +
         `&width=${options.width}` +
         `&height=${options.height}` +
@@ -1167,13 +1185,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
         `&quality=${options.quality}` +
         `&embedAvm=${options.embedAvm}`;
 
-      const token = localStorage.getItem('jwst_auth_token');
-      const response = await fetch(exportUrl, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
-      if (!response.ok) throw new Error(`Export failed: ${response.status}`);
-
-      const blob = await response.blob();
+      const blob = await apiClient.getBlob(exportEndpoint);
       const filename = generateExportFilename(metadata, title, options.format, imageInfo);
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
@@ -1361,9 +1373,8 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
                 <button
                   className="btn-base btn-icon"
                   title="Download FITS"
-                  onClick={() =>
-                    window.open(`${API_BASE_URL}/api/jwstdata/${dataId}/file`, '_blank')
-                  }
+                  onClick={() => void handleDownloadFits()}
+                  disabled={isDownloadingFits}
                 >
                   <Icons.Download />
                 </button>

--- a/frontend/jwst-frontend/src/components/WhatsNewPanel.tsx
+++ b/frontend/jwst-frontend/src/components/WhatsNewPanel.tsx
@@ -68,6 +68,9 @@ const WhatsNewPanel: React.FC = () => {
     activeJobId,
     activeObsId ?? undefined
   );
+
+  // #1578: the last job whose completion this component has handled.
+  const handledCompletionRef = useRef<string | null>(null);
   const LIMIT = 20;
 
   useEffect(() => {
@@ -148,14 +151,18 @@ const WhatsNewPanel: React.FC = () => {
     }
   }, [jobProgress]);
 
-  // Handle completion (only fires when isComplete changes). No completion
-  // callback/toast here — `useActiveImports` (the global header pill's hook)
-  // is the single source of import-completion toasts. See useActiveImports.ts.
+  // Handle completion. No completion callback/toast here — `useActiveImports`
+  // (the global header pill's hook) is the single source of import-completion
+  // toasts. See useActiveImports.ts.
+  //
+  // #1578: gated on the JOB rather than the isComplete boolean — see the same
+  // effect in MastSearch for why the boolean alone drops back-to-back imports.
   useEffect(() => {
-    if (jobIsComplete && jobProgress) {
-      setImporting(null);
-    }
-  }, [jobIsComplete]); // eslint-disable-line react-hooks/exhaustive-deps -- intentionally only fire on completion transition
+    if (!jobIsComplete || !jobProgress) return;
+    if (handledCompletionRef.current === jobProgress.jobId) return;
+    handledCompletionRef.current = jobProgress.jobId;
+    setImporting(null);
+  }, [jobIsComplete, jobProgress]);
 
   // Reset failed thumbnails when filters change (adjust state during render)
   const [prevFetchFilters, setPrevFetchFilters] = useState({ daysBack, instrument });

--- a/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.tsx
+++ b/frontend/jwst-frontend/src/components/guided/ExportFramingPanel.tsx
@@ -244,12 +244,18 @@ export function ExportFramingPanel({
   // the user's zoom.
   const prevFrameRef = useRef({ targetW, targetH });
   useEffect(() => {
+    const frameChanged =
+      prevFrameRef.current.targetW !== targetW || prevFrameRef.current.targetH !== targetH;
+    // #1690: record the frame BEFORE the bounds guard. Changing the preset
+    // while the preview is still loading used to leave the ref on the old
+    // dimensions, so the next rotation — the first run with real bounds — read
+    // frameChanged as true and did a full zoom/pan reset instead of the
+    // zoom-preserving rotation path.
+    prevFrameRef.current = { targetW, targetH };
+
     const bounds = boundsRef.current;
     if (!bounds) return;
     const fit = computeAutoFit(bounds.width, bounds.height, targetW, targetH, rotation);
-    const frameChanged =
-      prevFrameRef.current.targetW !== targetW || prevFrameRef.current.targetH !== targetH;
-    prevFrameRef.current = { targetW, targetH };
     if (frameChanged) {
       setCropZoom(fit.zoom);
       setCropCenterX(fit.centerX);

--- a/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
+++ b/frontend/jwst-frontend/src/components/mast/MastSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { toast } from '../ui/toast';
 import {
   MastSearchType,
@@ -82,6 +82,9 @@ const MastSearch: React.FC = () => {
     activeObsId ?? undefined
   );
 
+  // #1578: the last job whose completion this component has handled.
+  const handledCompletionRef = useRef<string | null>(null);
+
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
@@ -149,15 +152,23 @@ const MastSearch: React.FC = () => {
     }
   }, [jobProgress]);
 
-  // Handle completion (only fires when isComplete changes). No success toast
-  // here — `useActiveImports` (the global header pill's hook) is the single
-  // source of import-completion toasts, with last-job-in-batch aggregation
-  // so bulk imports don't spam one toast per job. See useActiveImports.ts.
+  // Handle completion. No success toast here — `useActiveImports` (the global
+  // header pill's hook) is the single source of import-completion toasts, with
+  // last-job-in-batch aggregation so bulk imports don't spam one toast per job.
+  // See useActiveImports.ts.
+  //
+  // #1578: gated on the JOB, not on the isComplete boolean. useJobProgress
+  // resets isComplete during render when jobId changes, so on a fast
+  // A-completes -> B-starts -> B-completes sequence a [jobIsComplete]-only
+  // effect can fire against stale progress or not fire at all. The ref makes it
+  // exactly-once per job and lets the real dependencies be declared, which is
+  // what removes the suppression (#1417/#1311).
   useEffect(() => {
-    if (jobIsComplete && jobProgress) {
-      setImporting(null);
-    }
-  }, [jobIsComplete]); // eslint-disable-line react-hooks/exhaustive-deps -- intentionally only fire on completion transition
+    if (!jobIsComplete || !jobProgress) return;
+    if (handledCompletionRef.current === jobProgress.jobId) return;
+    handledCompletionRef.current = jobProgress.jobId;
+    setImporting(null);
+  }, [jobIsComplete, jobProgress]);
 
   const handleResumeFromPanel = (job: ResumableJobSummary) => {
     // Remove from the resumable list immediately

--- a/frontend/jwst-frontend/src/hooks/useJobProgress.test.ts
+++ b/frontend/jwst-frontend/src/hooks/useJobProgress.test.ts
@@ -326,6 +326,58 @@ describe('subscribeToJobProgress — timeout behavior', () => {
       expect(onFailed.mock.calls[0][0].error).toMatch(/timed out/i);
     });
 
+    // #1579: the polling-timeout branch fired onFailed inline instead of going
+    // through fireTimeoutFailure, so `cancelled` stayed false and the SignalR
+    // subscription stayed live. A late event could then ghost-update a job the
+    // consumer had already been told failed — and setState after unmount.
+    it('ignores SignalR events after the polling timeout fires', async () => {
+      const { getImportProgress } = await import('../services/mastService');
+      vi.mocked(getImportProgress).mockResolvedValue({
+        jobId: 'job-1',
+        obsId: 'obs-1',
+        progress: 50,
+        stage: 'Running',
+        message: 'Still going',
+        isComplete: false,
+        startedAt: new Date().toISOString(),
+      });
+
+      const onFailed = vi.fn();
+      const onProgress = vi.fn();
+      const onCompleted = vi.fn();
+      subscribeToJobProgress(
+        'job-1',
+        { onFailed, onProgress, onCompleted },
+        { pollingTimeoutMs: 5 * 60 * 1000, pollIntervalMs: 1000 }
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      for (let i = 0; i < 302; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+      expect(onFailed).toHaveBeenCalledTimes(1);
+
+      onProgress.mockClear();
+
+      // Late SignalR traffic for the same job must not resurrect it.
+      signalRCallbacks.onProgress?.({
+        jobId: 'job-1',
+        progressPercent: 80,
+        stage: 'Processing',
+        message: 'Late event',
+      });
+      signalRCallbacks.onCompleted?.({
+        jobId: 'job-1',
+        progressPercent: 100,
+        stage: 'Complete',
+        message: 'Late completion',
+      });
+
+      expect(onProgress).not.toHaveBeenCalled();
+      expect(onCompleted).not.toHaveBeenCalled();
+      expect(onFailed).toHaveBeenCalledTimes(1);
+    });
+
     it('should default pollingTimeoutMs to 30 minutes', async () => {
       const { getImportProgress } = await import('../services/mastService');
       const mockGetProgress = vi.mocked(getImportProgress);

--- a/frontend/jwst-frontend/src/hooks/useJobProgress.ts
+++ b/frontend/jwst-frontend/src/hooks/useJobProgress.ts
@@ -414,20 +414,14 @@ export function subscribeToJobProgress(
     async function poll(): Promise<void> {
       if (cancelled || signalRDelivered) return;
 
-      // Safety: stop polling after configured duration to prevent infinite hang
+      // Safety: stop polling after configured duration to prevent infinite hang.
+      // #1579: routed through fireTimeoutFailure rather than firing onFailed
+      // inline. The inline version left `cancelled` false and the SignalR
+      // subscription live, so a late event could ghost-update a job the
+      // consumer had already been told failed — and setState after unmount.
       if (Date.now() - pollingStartTime > maxPollingDuration) {
         const minutes = Math.round(maxPollingDuration / 60_000);
-        const timeoutStatus: ImportJobStatus = {
-          jobId,
-          obsId: options?.obsId ?? currentStatus?.obsId ?? '',
-          progress: currentStatus?.progress ?? 0,
-          stage: 'Failed',
-          message: `Polling timed out after ${minutes} minutes`,
-          isComplete: true,
-          error: `Polling timed out after ${minutes} minutes`,
-          startedAt: currentStatus?.startedAt ?? new Date().toISOString(),
-        };
-        callbacks.onFailed?.(timeoutStatus);
+        fireTimeoutFailure(`Polling timed out after ${minutes} minutes`);
         return;
       }
 

--- a/frontend/jwst-frontend/src/services/ApiError.ts
+++ b/frontend/jwst-frontend/src/services/ApiError.ts
@@ -58,7 +58,9 @@ function looksLikeHtml(text: string): boolean {
 function extractMessage(data: unknown): string | undefined {
   if (typeof data !== 'object' || data === null) return undefined;
   const obj = data as Record<string, unknown>;
-  for (const key of ['error', 'message', 'details'] as const) {
+  // `detail` is FastAPI's field — the processing engine speaks it, and the
+  // viewers used to read it by hand off a raw fetch (#1574).
+  for (const key of ['error', 'message', 'details', 'detail'] as const) {
     const value = obj[key];
     if (typeof value === 'string' && value.trim()) return value;
   }


### PR DESCRIPTION
## Summary

Four defects in long-lived job and viewer sessions — the cases that only show up after something has been open a while.

| Issue | Defect |
| --- | --- |
| #1574 | `ImageViewer` and `ImageComparisonViewer` bypassed `apiClient` with raw `fetch` + a direct `localStorage.getItem('jwst_auth_token')`, skipping `ensureFreshToken()` and the 401-retry-after-refresh logic. The FITS download was a bare `window.open`, sending **no auth header at all**. The FITS viewer is exactly the screen users leave open longest (background-tab throttling lets the scheduled refresh lapse), so after expiry every re-render, stretch change, slice change and export showed "Preview failed (401)" with no recovery — with a valid refresh token sitting in localStorage. |
| #1579 | The `maxPollingDuration` branch fired `onFailed` inline instead of going through `fireTimeoutFailure`. It never set `cancelled = true`, never cleared the timers, never unsubscribed from SignalR — so a "failed" job could ghost-update to progress or success afterwards, and setState-after-unmount was live. |
| #1578 | The completion effects in `MastSearch` and `WhatsNewPanel` depended only on `jobIsComplete` while reading `jobProgress` (masked by an `eslint-disable`). `useJobProgress` resets `isComplete` during render when `jobId` changes, so on a fast A-completes → B-starts → B-completes sequence the handler could fire against stale progress or not fire at all. |
| #1690 | `ExportFramingPanel` updated `prevFrameRef` only *after* the `if (!bounds) return` guard. Change the preset while the preview is still loading and the ref keeps the old dimensions; the next rotation — the first run with real bounds — reads `frameChanged` as true and does a **full zoom/pan reset** instead of the zoom-preserving rotation path #1688 added. |

## Changes Made

**#1574** — all four call sites route through `apiClient.getBlob`, which pre-flights the refresh and retries once on 401:
- `ImageViewer` preview fetch and export fetch, now passing **relative** endpoints (apiClient owns the base URL and headers).
- `ImageComparisonViewer`'s `fetchAuthBlob` → `fetchPreviewObjectUrl`, and `buildPreviewUrl` → `buildPreviewEndpoint`.
- The FITS download becomes `handleDownloadFits`: fetch the blob through `apiClient`, build a download link — the same shape `handleExport` already used — with a disabled state and an error surfaced through the existing viewer error path instead of a silent cross-tab 401.
- `API_BASE_URL` is no longer imported by either viewer, so the raw-URL pattern cannot quietly come back.
- `extractMessage` in `ApiError.ts` gains `detail` to its key list. The raw fetches read FastAPI's `detail` field by hand; without this, moving to `apiClient` would have *downgraded* those messages to the generic status text. Small but load-bearing.

**#1579** — the polling-timeout branch now calls `fireTimeoutFailure`, which was written for exactly this and already sets `cancelled`, clears the timers and unsubscribes.

**#1578** — both effects track the last handled job id in a ref and gate on it, so completion is handled exactly once per job. `jobProgress` joins the dependency array and the `eslint-disable` comments are gone — which is what #1417/#1311 were waiting on.

**#1690** — `prevFrameRef` is recorded before the bounds guard.

## Test Plan

- [x] Full frontend suite via pre-commit hook — all green
- [x] `npx vitest run src/hooks/useJobProgress.test.ts` — 20 passed (1 new: after the polling timeout, late SignalR `onProgress` **and** `onCompleted` for the same job invoke nothing and do not re-fire `onFailed`)
- [x] **Regression check**: restored the inline `onFailed` and confirmed the new #1579 test fails, then restored the fix
- [x] `npx vitest run src/components/ImageViewer.test.tsx` — 4 passed (2 new: the preview loads via `apiClient.getBlob` with a **relative** endpoint and `globalThis.fetch` is never called; a rejected preview surfaces its message rather than leaving a blank frame)
- [x] `npx vitest run src/components/mast src/components/WhatsNewPanel.test.tsx src/components/guided` — 86 passed
- [x] `npx tsc --noEmit` clean
- [x] ESLint on all changed files — 0 errors (6 pre-existing warnings on untouched lines)
- [ ] Manual: open the viewer, force-expire the access token, change stretch → preview reloads instead of 401; click Download FITS → file downloads rather than opening a 401 tab
- [ ] Manual: on the result step, change the export preset while the composite is still generating, wait for it, then rotate → zoom preserved

## Documentation Checklist

- [x] No endpoint, DTO, or model changes
- [x] `ApiError.extractMessage` gains one recognised field — documented inline with why
- [x] No new component or route

## Tech Debt Impact

- [x] Reduces debt — removes the last raw-fetch/localStorage-token call sites in the viewers, the "silent auth downgrade" class CLAUDE.md's "auth flow is currently fragile" warning refers to
- [x] Removes two `eslint-disable react-hooks/exhaustive-deps` suppressions, unblocking the held #1311 plugin bump (#1417)
- [x] Adds 3 regression tests, one verified to fail without its fix
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: medium** — this touches auth-adjacent code, which CLAUDE.md flags as fragile. Nothing about the token contract changes: the viewers now use the same `apiClient` path every other call already uses, rather than a parallel one. The change is a removal of a divergence, not a new mechanism.

Two behaviour changes to watch:
- The FITS download no longer opens a tab; it downloads via a link. Same as the existing export button, but visibly different.
- Preview error text now comes from `ApiError` rather than a hand-parsed body. The `detail` addition keeps engine messages intact; a body with neither `detail` nor `error`/`message` falls back to the friendly status text, which is strictly better than the old `Preview failed (500)`.

**Note for the reviewer:** `ExportFramingPanel.tsx` has uncommitted local changes in the primary working copy. This branch is cut from `origin/main`, so the fix may need a trivial merge there.

**Rollback:** revert the commit. No API, storage, or persisted-state changes.

Closes #1574
Closes #1578
Closes #1579
Closes #1690

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
