### PR TITLE
fix: OOM reporting, unguarded FITS endpoints, and duplicate-key scan noise

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Services/DataScanServiceTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Services/DataScanServiceTests.cs
@@ -113,6 +113,73 @@ public class DataScanServiceTests
         mockThumbnailQueue.Verify(q => q.EnqueueBatch(It.IsAny<List<string>>()), Times.Once);
     }
 
+    /// <summary>
+    /// #1676: the scan deduped on FilePath while the unique index is on
+    /// (UserId, FileName). A record written under a different FilePath — a file
+    /// moved between observation directories, or imported by the MAST path with
+    /// a different key — passed the FilePath check and then hit E11000 on
+    /// insert, inflating errorCount and burying real failures.
+    /// </summary>
+    [Fact]
+    public async Task ScanAndImportAsync_SameFileNameUnderADifferentPath_SkipsWithoutError()
+    {
+        var storageKey = "mast/jw02733001001/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([storageKey]);
+
+        // Same FileName, different FilePath — invisible to the FilePath check.
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync(
+        [
+            new JwstDataModel
+            {
+                Id = "abc",
+                FileName = "jw02733001001_02101_00001_nrca1_cal.fits",
+                FilePath = "mast/some-other-observation/jw02733001001_02101_00001_nrca1_cal.fits",
+            },
+        ]);
+        mockStorage.Setup(s => s.GetSizeAsync(storageKey, It.IsAny<CancellationToken>())).ReturnsAsync(2048L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        var sut = CreateSut();
+
+        var result = await sut.ScanAndImportAsync();
+
+        result.ErrorCount.Should().Be(0);
+        result.ImportedCount.Should().Be(0);
+        result.SkippedCount.Should().Be(1);
+        // The insert that would have thrown E11000 is never attempted.
+        mockMongo.Verify(m => m.CreateAsync(It.IsAny<JwstDataModel>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScanAndImportAsync_TwoFilesSharingAName_ImportsOneAndSkipsTheOther()
+    {
+        // The (UserId, FileName) index permits only one, so the scan must not
+        // report the second as an error either.
+        var keyA = "mast/obs-a/jw02733001001_02101_00001_nrca1_cal.fits";
+        var keyB = "mast/obs-b/jw02733001001_02101_00001_nrca1_cal.fits";
+        SetupS3Storage([keyA, keyB]);
+
+        mockMongo.Setup(m => m.GetAsync()).ReturnsAsync([]);
+        mockMongo.Setup(m => m.CreateAsync(It.IsAny<JwstDataModel>())).Returns(Task.CompletedTask);
+        mockStorage
+            .Setup(s => s.GetSizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2048L);
+        mockMast
+            .Setup(m => m.SearchByObservationIdAsync(It.IsAny<MastObservationSearchRequest>()))
+            .ReturnsAsync(BuildMastResponse("jw02733001001"));
+
+        var sut = CreateSut();
+
+        var result = await sut.ScanAndImportAsync();
+
+        result.ImportedCount.Should().Be(1);
+        result.SkippedCount.Should().Be(1);
+        result.ErrorCount.Should().Be(0);
+        mockMongo.Verify(m => m.CreateAsync(It.IsAny<JwstDataModel>()), Times.Once);
+    }
+
     [Fact]
     public async Task ScanAndImportAsync_S3_DuplicateFile_SkipsImport()
     {

--- a/backend/JwstDataAnalysis.API/Services/DataScanService.cs
+++ b/backend/JwstDataAnalysis.API/Services/DataScanService.cs
@@ -7,6 +7,8 @@ using JwstDataAnalysis.API.Controllers;
 using JwstDataAnalysis.API.Models;
 using JwstDataAnalysis.API.Services.Storage;
 
+using MongoDB.Driver;
+
 namespace JwstDataAnalysis.API.Services
 {
     public sealed partial class DataScanService(
@@ -44,6 +46,17 @@ namespace JwstDataAnalysis.API.Services
                 .Where(d => !string.IsNullOrEmpty(d.FilePath))
                 .GroupBy(d => d.FilePath!)
                 .ToDictionary(g => g.Key, g => g.First());
+
+            // #1676: the scan deduped on FilePath, but the unique index is on
+            // (UserId, FileName) — two different keys. A file whose record was
+            // written under a different FilePath (moved between observation
+            // directories, or imported by the MAST path with a different key)
+            // passed the FilePath check and then hit E11000 on insert. Harmless
+            // in outcome, but it inflated errorCount and buried real failures.
+            var existingByOwnerAndName = existingData
+                .Where(d => !string.IsNullOrEmpty(d.FileName))
+                .Select(d => UniqueKeyFor(d.UserId, d.FileName!))
+                .ToHashSet(StringComparer.Ordinal);
 
             // Discover FITS files — local filesystem scan or S3 prefix listing
             List<string> storageKeys;
@@ -233,7 +246,30 @@ namespace JwstDataAnalysis.API.Services
                             ImageInfo = CreateImageMetadata(obsMeta),
                         };
 
-                        await mongoDBService.CreateAsync(jwstData);
+                        // #1676: the record may already exist under a different
+                        // FilePath. Skipping here is the same outcome the insert
+                        // would produce, without the E11000 noise.
+                        if (existingByOwnerAndName.Contains(UniqueKeyFor(jwstData.UserId, fileName)))
+                        {
+                            skippedFiles.Add(fileName);
+                            continue;
+                        }
+
+                        try
+                        {
+                            await mongoDBService.CreateAsync(jwstData);
+                        }
+                        catch (MongoWriteException ex)
+                            when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+                        {
+                            // Another writer won the race, or a pre-existing record
+                            // the pre-scan snapshot did not see. The doc exists —
+                            // that is a skip, not a scan failure.
+                            skippedFiles.Add(fileName);
+                            continue;
+                        }
+
+                        existingByOwnerAndName.Add(UniqueKeyFor(jwstData.UserId, fileName));
                         importedFiles.Add(fileName);
                         importedIds.Add(jwstData.Id);
                     }
@@ -519,6 +555,15 @@ namespace JwstDataAnalysis.API.Services
 
             return metadata;
         }
+
+        /// <summary>
+        /// The key the (UserId, FileName) unique index enforces (#1676).
+        /// A null UserId is a real, distinct value in that index — scan-imported
+        /// records have none — so it maps to a fixed sentinel rather than being
+        /// conflated with the empty string a user id could theoretically be.
+        /// </summary>
+        private static string UniqueKeyFor(string? userId, string fileName) =>
+            $"{userId ?? "\0<null>"}\u001f{fileName}";
 
         [GeneratedRegex(@"jw(\d{5})(\d{3})(\d{3})_(\d{5})_(\d{5})_([a-z0-9]+)", RegexOptions.IgnoreCase, "en-US")]
         private static partial Regex JwstFileNameRegex();

--- a/docs/architecture/concurrency-model.md
+++ b/docs/architecture/concurrency-model.md
@@ -249,7 +249,7 @@ Per-IP rate limiting via AspNetCoreRateLimit:
 | Concurrent mosaic jobs | 10 queued, 1 processing | Processing Engine (1 worker) |
 | Concurrent MAST downloads | 2 | MAST Proxy (2 workers) |
 | Max FITS file size | 10 GB | `MAX_FITS_FILE_SIZE_MB` |
-| Max array elements | 100M–200M | `MAX_FITS_ARRAY_ELEMENTS` |
+| Max array elements | 200M | `MAX_FITS_ARRAY_ELEMENTS` |
 | Max mosaic output | 64M pixels | `MAX_MOSAIC_OUTPUT_PIXELS` |
 | Processing Engine memory | 4 GB | Docker `mem_limit` |
 | SignalR connections | ~1000 | ASP.NET default |

--- a/processing-engine/app/analysis/routes.py
+++ b/processing-engine/app/analysis/routes.py
@@ -17,7 +17,11 @@ from fastapi import APIRouter, HTTPException
 
 from app.processing.background import estimate_background
 from app.processing.detection import detect_sources, sources_to_dict
-from app.storage.helpers import resolve_fits_path
+from app.storage.helpers import (
+    resolve_fits_path,
+    validate_fits_array_size,
+    validate_fits_file_size,
+)
 
 from .models import (
     RegionStatisticsRequest,
@@ -174,10 +178,14 @@ def compute_region_statistics(request: RegionStatisticsRequest):
 
     # Resolve storage key to local path (works with local or S3 storage)
     local_path = resolve_fits_path(request.file_path)
+    validate_fits_file_size(local_path)
     logger.info(f"Computing region statistics for: {local_path.name}")
 
     with fits.open(local_path) as hdul:
-        # Find image data
+        # Find image data.
+        # #1573: the shape comes from the HEADER and is checked BEFORE
+        # .astype(np.float64) — a 2GB int16 HDU became ~16GB of RAM with no
+        # guard firing at all on this route.
         data = None
         if request.hdu_index >= 0:
             if request.hdu_index >= len(hdul):
@@ -186,12 +194,14 @@ def compute_region_statistics(request: RegionStatisticsRequest):
                     detail=f"HDU index {request.hdu_index} out of range (file has {len(hdul)} HDUs)",
                 )
             hdu = hdul[request.hdu_index]
-            if hdu.data is not None and len(hdu.data.shape) >= 2:
+            if hdu.shape is not None and len(hdu.shape) >= 2:
+                validate_fits_array_size(hdu.shape)
                 data = hdu.data.astype(np.float64)
         else:
             # Find first image HDU
             for hdu in hdul:
-                if hdu.data is not None and len(hdu.data.shape) >= 2:
+                if hdu.shape is not None and len(hdu.shape) >= 2:
+                    validate_fits_array_size(hdu.shape)
                     data = hdu.data.astype(np.float64)
                     break
 
@@ -265,10 +275,14 @@ def detect_sources_endpoint(request: SourceDetectionRequest):
 
     # Resolve storage key to local path
     local_path = resolve_fits_path(request.file_path)
+    validate_fits_file_size(local_path)
     logger.info(f"Detecting sources in: {local_path.name}")
 
     with fits.open(local_path) as hdul:
-        # Find image data
+        # Find image data.
+        # #1573: header shape first. The 50MP analysis cap further down runs
+        # AFTER .astype(np.float64) and after the cube-slice reduction, so the
+        # allocation it exists to prevent has already happened by then.
         data = None
         if request.hdu_index >= 0:
             if request.hdu_index >= len(hdul):
@@ -277,11 +291,13 @@ def detect_sources_endpoint(request: SourceDetectionRequest):
                     detail=f"HDU index {request.hdu_index} out of range (file has {len(hdul)} HDUs)",
                 )
             hdu = hdul[request.hdu_index]
-            if hdu.data is not None and len(hdu.data.shape) >= 2:
+            if hdu.shape is not None and len(hdu.shape) >= 2:
+                validate_fits_array_size(hdu.shape)
                 data = hdu.data.astype(np.float64)
         else:
             for hdu in hdul:
-                if hdu.data is not None and len(hdu.data.shape) >= 2:
+                if hdu.shape is not None and len(hdu.shape) >= 2:
+                    validate_fits_array_size(hdu.shape)
                     data = hdu.data.astype(np.float64)
                     break
 

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -45,7 +45,7 @@ from app.processing.enhancement import (
 )
 from app.processing.filters import astropy_gaussian_filter
 from app.render.render_gate import render_slot as _render_slot
-from app.storage.helpers import resolve_fits_path
+from app.storage.helpers import resolve_fits_path, validate_fits_file_size
 
 from .auto_stretch import auto_stretch_params
 from .cache import CompositeCache
@@ -627,6 +627,12 @@ def _detect_channel_instruments(
     Returns:
         List of instrument names (e.g. "NIRCAM", "MIRI") or None per channel.
     """
+    # #1573 deliberately does NOT add validate_fits_file_size here. This helper
+    # reads one HEADER per channel and never materializes pixel data, and its
+    # contract is to degrade to None on any read failure — so a size guard could
+    # only turn an over-size file into silently-missing instrument metadata, not
+    # into a 413. The load-bearing guard is in _compute_common_wcs, which
+    # enumerates every file the pipeline goes on to read.
     instruments: list[str | None] = []
     for ch_config in channels:
         try:
@@ -671,6 +677,11 @@ def _compute_common_wcs(
     for idx, ch_config in enumerate(request.channels):
         ch_name = ch_config.label or f"ch{idx}"
         local_paths = _sort_files_by_quality([resolve_fits_path(fp) for fp in ch_config.file_paths])
+        # #1573: the mosaic routes enforce this and the composite ones did not,
+        # so /composite/generate-nchannel, /analyze-channels and /estimate were
+        # the way past the file-size cap.
+        for local_path in local_paths:
+            validate_fits_file_size(local_path)
         all_channel_info.append((ch_name, local_paths))
         logger.info(f"Channel {ch_name}: {len(local_paths)} file(s)")
 
@@ -901,6 +912,16 @@ def _reproject_all_channels(
                     load_fn=_make_load_fn(per_file_budget),
                     background_match=request.background_neutralization,
                 )
+            except MemoryError as e:
+                # #1580: OOM here is the expected failure mode, not a sign that
+                # the inputs are incompatible. 413 matches the budget guardrail
+                # above so clients handle both the same way.
+                raise HTTPException(
+                    status_code=413,
+                    detail=(
+                        "Ran out of memory while reprojecting. Reduce inputs (fewer files / fewer channels) or request a smaller output, or raise the engine's memory budget."
+                    ),
+                ) from e
             except Exception as e:
                 raise HTTPException(
                     status_code=400,

--- a/processing-engine/app/mosaic/mosaic_engine.py
+++ b/processing-engine/app/mosaic/mosaic_engine.py
@@ -94,6 +94,11 @@ def load_fits_2d_with_wcs_and_header(file_path: Path) -> tuple[np.ndarray, WCS, 
         return data, wcs_celestial, header
 
 
+#: Shared wording for an out-of-memory reprojection (#1580). Mirrors the
+#: composite budget detail: say what to change, not just what broke.
+_OUT_OF_MEMORY_DETAIL = "Ran out of memory while reprojecting. Reduce inputs (fewer files / fewer channels) or request a smaller output, or raise the engine's memory budget."
+
+
 def generate_mosaic(
     file_data: list[tuple[np.ndarray, WCS]],
     combine_method: str = "mean",
@@ -127,6 +132,11 @@ def generate_mosaic(
     # Find optimal output WCS covering all inputs
     try:
         wcs_out, shape_out = find_optimal_celestial_wcs(input_data)
+    except MemoryError as e:
+        # #1580: OOM is this engine's single most likely failure here — it is why
+        # the memory-budget machinery exists. Reporting it as "input files may be
+        # incompatible" sends operators down entirely the wrong path.
+        raise MosaicError(_OUT_OF_MEMORY_DETAIL, status_code=413) from e
     except Exception as e:
         raise MosaicError(f"Could not determine common WCS for input files: {e}") from e
 
@@ -162,6 +172,9 @@ def generate_mosaic(
             reproject_function=reproject_interp,
             combine_function=combine_func,
         )
+    except MemoryError as e:
+        # #1580: as above — a 413 the caller can act on, not a generic 500.
+        raise MosaicError(_OUT_OF_MEMORY_DETAIL, status_code=413) from e
     except Exception as e:
         raise MosaicError(f"Mosaic reprojection failed: {e}") from e
 

--- a/processing-engine/app/render/routes.py
+++ b/processing-engine/app/render/routes.py
@@ -10,7 +10,6 @@ The CE /api shims resolve dataIds and call these handler functions directly.
 import base64
 import io
 import logging
-import os
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -30,42 +29,15 @@ from app.processing.enhancement import (
 )
 from app.processing.filters import reduce_noise
 from app.processing.statistics import compute_histogram, compute_percentiles
-from app.storage.helpers import resolve_fits_path
+from app.storage.helpers import resolve_fits_path, validate_fits_array_size
 
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Render"])
 
-# Resource limits for FITS processing (configurable via environment)
-MAX_FITS_ARRAY_ELEMENTS = int(
-    os.environ.get("MAX_FITS_ARRAY_ELEMENTS", "200000000")
-)  # Default 200M pixels
-
-
-def validate_fits_array_size(shape: tuple) -> None:
-    """
-    Validate that FITS array dimensions won't exceed memory limits.
-    Called BEFORE loading data into memory to prevent allocation attacks.
-
-    Args:
-        shape: Array shape tuple from HDU header
-
-    Raises:
-        HTTPException: 413 if array would exceed maximum elements
-    """
-    total_elements = 1
-    for dim in shape:
-        total_elements *= dim
-
-    if total_elements > MAX_FITS_ARRAY_ELEMENTS:
-        logger.warning(
-            f"FITS array too large: {total_elements:,} elements (max {MAX_FITS_ARRAY_ELEMENTS:,})"
-        )
-        raise HTTPException(
-            status_code=413,
-            detail=f"Image too large: {total_elements:,} pixels exceeds maximum {MAX_FITS_ARRAY_ELEMENTS:,}",
-        )
+# Resource limits for FITS processing now live in app/storage/helpers.py so every
+# FITS-reading endpoint can reach them, not just this module (#1573).
 
 
 class ThumbnailRequest(BaseModel):

--- a/processing-engine/app/storage/helpers.py
+++ b/processing-engine/app/storage/helpers.py
@@ -62,6 +62,38 @@ def resolve_fits_path(key: str) -> Path:
     return local_path
 
 
+#: #1573: lives here, beside validate_fits_file_size, because it was previously
+#: private to the render routes and every other FITS-reading endpoint silently
+#: went unguarded. Import it from one place so a new endpoint gets it by habit.
+MAX_FITS_ARRAY_ELEMENTS = int(os.environ.get("MAX_FITS_ARRAY_ELEMENTS", "200000000"))
+
+
+def validate_fits_array_size(shape: tuple, max_elements: int = MAX_FITS_ARRAY_ELEMENTS) -> None:
+    """Reject an HDU whose element count would blow the memory budget.
+
+    Must be called with the shape from the HEADER, before touching ``hdu.data``
+    — the allocation is the thing being prevented, so a check that runs after
+    materialization is decoration.
+
+    Raises:
+        HTTPException: 413 if the array would exceed the maximum.
+    """
+    total_elements = 1
+    for dim in shape:
+        total_elements *= dim
+
+    if total_elements > max_elements:
+        logger.warning(
+            "FITS array too large: %s elements (max %s)",
+            f"{total_elements:,}",
+            f"{max_elements:,}",
+        )
+        raise HTTPException(
+            status_code=413,
+            detail=f"Image too large: {total_elements:,} pixels exceeds maximum {max_elements:,}",
+        )
+
+
 def validate_fits_file_size(local_path: Path, max_bytes: int = MAX_FITS_FILE_SIZE_BYTES) -> None:
     """
     Validate that a local FITS file doesn't exceed the maximum allowed size.

--- a/processing-engine/tests/test_mosaic_engine.py
+++ b/processing-engine/tests/test_mosaic_engine.py
@@ -20,6 +20,7 @@ from astropy.wcs import WCS
 from fastapi.testclient import TestClient
 from PIL import Image
 
+from app.exceptions import MosaicError
 from app.mosaic.mosaic_engine import (
     generate_mosaic,
     get_footprints,
@@ -167,6 +168,48 @@ class TestGenerateMosaic:
         assert wcs_out.has_celestial
         # Mosaic should be wider than individual files due to offset
         assert mosaic.shape[1] >= 50
+
+    def test_out_of_memory_during_reprojection_is_a_413_not_a_generic_failure(self):
+        """#1580: OOM is this engine's most likely failure here — it is why the
+        memory-budget machinery exists. Reporting it as "input files may be
+        incompatible" sends operators down entirely the wrong path."""
+        file_data = self._make_file_data(n=2)
+
+        with (
+            patch("app.mosaic.mosaic_engine.reproject_and_coadd", side_effect=MemoryError()),
+            pytest.raises(MosaicError) as exc,
+        ):
+            generate_mosaic(file_data, combine_method="mean")
+
+        assert exc.value.status_code == 413
+        assert "memory" in str(exc.value).lower()
+        assert "incompatible" not in str(exc.value).lower()
+
+    def test_out_of_memory_computing_the_common_wcs_is_also_a_413(self):
+        file_data = self._make_file_data(n=2)
+
+        with (
+            patch("app.mosaic.mosaic_engine.find_optimal_celestial_wcs", side_effect=MemoryError()),
+            pytest.raises(MosaicError) as exc,
+        ):
+            generate_mosaic(file_data, combine_method="mean")
+
+        assert exc.value.status_code == 413
+
+    def test_a_non_memory_reprojection_failure_still_reports_incompatible_inputs(self):
+        # The broad handler stays — only MemoryError is peeled off ahead of it.
+        file_data = self._make_file_data(n=2)
+
+        with (
+            patch(
+                "app.mosaic.mosaic_engine.reproject_and_coadd", side_effect=ValueError("bad wcs")
+            ),
+            pytest.raises(MosaicError) as exc,
+        ):
+            generate_mosaic(file_data, combine_method="mean")
+
+        assert exc.value.status_code == 500
+        assert "reprojection failed" in str(exc.value).lower()
 
     def test_mosaic_combine_methods(self):
         file_data = self._make_file_data(n=2)

--- a/processing-engine/tests/test_region_statistics.py
+++ b/processing-engine/tests/test_region_statistics.py
@@ -242,3 +242,83 @@ class TestRegionStatisticsEndpoint:
         assert data["mean"] == 5.0
         # 50*50 - 10*10 = 2400 valid pixels
         assert data["pixel_count"] == 2400
+
+
+class TestArraySizeGuard:
+    """#1573: region-statistics had NO array-size check at all before
+    ``hdu.data.astype(np.float64)`` — a 2GB int16 HDU became ~16GB of RAM with
+    no guard firing. detect-sources had a 50MP cap, but it ran AFTER
+    materialization, so the allocation it exists to prevent had already
+    happened. Both now check the HEADER shape first.
+    """
+
+    @pytest.fixture
+    def client(self):
+        from main import app
+
+        return TestClient(app)
+
+    @pytest.fixture
+    def storage_patch(self, tmp_path):
+        return patch(
+            _STORAGE_PATCH_TARGET,
+            return_value=LocalStorage(base_path=str(tmp_path)),
+        )
+
+    @pytest.fixture
+    def small_fits(self, tmp_path):
+        from astropy.io import fits as astropy_fits
+
+        hdu = astropy_fits.PrimaryHDU(np.ones((32, 32), dtype=np.float64))
+        hdu.writeto(tmp_path / "small.fits")
+        return tmp_path / "small.fits"
+
+    def test_region_statistics_rejects_an_oversize_hdu_before_materializing(
+        self,
+        client,
+        small_fits,  # noqa: ARG002
+        storage_patch,
+        monkeypatch,
+    ):
+        # Cap of 1 element: the real file is tiny, so a 413 here can only come
+        # from the header-shape check.
+        monkeypatch.setattr("app.analysis.routes.validate_fits_array_size.__defaults__", (1,))
+        with storage_patch:
+            response = client.post(
+                "/analysis/region-statistics",
+                json={
+                    "file_path": "small.fits",
+                    "region_type": "rectangle",
+                    "rectangle": {"x": 0, "y": 0, "width": 4, "height": 4},
+                },
+            )
+        assert response.status_code == 413
+        assert "too large" in response.json()["detail"].lower()
+
+    def test_detect_sources_rejects_an_oversize_hdu_before_materializing(
+        self,
+        client,
+        small_fits,  # noqa: ARG002
+        storage_patch,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.analysis.routes.validate_fits_array_size.__defaults__", (1,))
+        with storage_patch:
+            response = client.post(
+                "/analysis/detect-sources",
+                json={"file_path": "small.fits"},
+            )
+        assert response.status_code == 413
+        assert "too large" in response.json()["detail"].lower()
+
+    def test_a_normal_file_still_passes(self, client, small_fits, storage_patch):  # noqa: ARG002
+        with storage_patch:
+            response = client.post(
+                "/analysis/region-statistics",
+                json={
+                    "file_path": "small.fits",
+                    "region_type": "rectangle",
+                    "rectangle": {"x": 0, "y": 0, "width": 4, "height": 4},
+                },
+            )
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary

Three defects where a guard or an error message was in place but not doing its job.

| Issue | Defect |
| --- | --- |
| #1580 | `MemoryError` during reprojection was caught by broad `except Exception` handlers and relabelled "Mosaic reprojection failed / input files may be incompatible" (500) or "The input files may be incompatible" (400). OOM is this engine's **single most likely failure** here — it is why the memory-budget machinery exists — so the message points operators at exactly the wrong thing. |
| #1573 | The documented DoS guards were wired to a subset of endpoints. `validate_fits_array_size` lived in `app/render/routes.py` and nothing else imported it: `region-statistics` had **no array check at all** (a 2GB int16 HDU becomes ~16GB after `.astype(np.float64)`), and `detect-sources`' 50MP cap ran *after* materialization and cube-slice reduction — after the allocation it exists to prevent. Composite paths also skipped the file-size guard the mosaic routes enforce. Plus doc drift on the 200M default. |
| #1676 | A routine rescan reported 24 errors, 10+ of them Mongo `DuplicateKey`. The scan dedups on `FilePath`; the unique index is on `(UserId, FileName)`. Two different keys — a record written under a different `FilePath` passes the check and then hits E11000. Harmless in outcome, but it inflated `errorCount` and buried that run's real failures. |

## Changes Made

**#1580** — `MemoryError` is peeled off ahead of the broad handler in `find_optimal_celestial_wcs`, `reproject_and_coadd` and the composite streaming combine, raising 413 with wording that matches the existing composite budget detail: say what to change, not just what broke. The broad handlers stay for everything else.

**#1573**
- `MAX_FITS_ARRAY_ELEMENTS` and `validate_fits_array_size` move to `app/storage/helpers.py`, beside `validate_fits_file_size` — one import site, so a new endpoint picks it up by habit rather than by archaeology.
- `region-statistics` and `detect-sources` call it with `hdu.shape` **from the header**, before `.astype(np.float64)`. Both also now enforce the file-size cap.
- `_compute_common_wcs` enforces `validate_fits_file_size` per resolved file, closing the gap on `/composite/generate-nchannel`, `/analyze-channels` and `/estimate`.
- `docs/architecture/concurrency-model.md` said "100M–200M"; the code default is 200M.

**Deviation from the issue, stated plainly:** it also lists `_detect_channel_instruments` as a gap. I added the guard there, found it broke two tests, and on inspection removed it rather than rewrite them. That helper reads **one header per channel**, never materializes pixel data, and its documented contract is to degrade to `None` on any read failure — so a size guard there could only turn an over-size file into silently-missing instrument metadata, never into a 413. The load-bearing guard is `_compute_common_wcs`, which enumerates every file the pipeline goes on to read. The reasoning is recorded in a comment at the site so the "gap" is not re-filed.

**#1676** — dedup now uses the index's own key. `UniqueKeyFor(userId, fileName)` maps a null `UserId` (which scan-imported records have) to a sentinel rather than conflating it with an empty string, and uses a unit-separator so a filename containing the delimiter cannot forge a collision. Behind that, a `DuplicateKeyException` on insert is caught and counted as a **skip**, covering a concurrent writer or a record the pre-scan snapshot missed.

## Test Plan

- [x] Full engine suite: `docker exec jwst-processing python -m pytest -q` — **1933 passed**, 2 deselected
- [x] `ruff check` + `ruff format --check` clean across `app/` and `tests/` (169 files)
- [x] Full backend suite: `dotnet test` — `DataScanService` filter 67 passed; `dotnet build` 0 warnings
- [x] 3 new `test_mosaic_engine.py` tests: `MemoryError` from `reproject_and_coadd` → 413 whose message says "memory" and **not** "incompatible"; same from `find_optimal_celestial_wcs` → 413; a `ValueError` still yields the 500 "reprojection failed" path, proving only `MemoryError` was peeled off
- [x] 3 new `test_region_statistics.py` tests: with the cap lowered to 1 element, both `region-statistics` and `detect-sources` return 413 for a 32×32 file — a size that cannot trip the file-size cap, so the 413 can only come from the header-shape check — and a normal request still returns 200
- [x] 2 new `DataScanServiceTests`: a record with the same `FileName` under a **different** `FilePath` is skipped with `ErrorCount == 0` and `CreateAsync` **never called**; two scanned files sharing a name import one and skip the other, again with no errors
- [ ] Manual: run the scan twice on an unchanged data dir and confirm the second run reports 0 errors

## Documentation Checklist

- [x] `docs/architecture/concurrency-model.md` corrected to the real 200M default
- [x] `AGENTS.md` and `docs/setup-guide.md` already said 200M — verified, no change needed
- [x] No endpoint or DTO changes; two endpoints gain a 413 they should always have had
- [x] `validate_fits_array_size` relocation documented at its new home

## Tech Debt Impact

- [x] Reduces debt — a limit that lives beside its sibling and is imported by every FITS reader, instead of being private to one module
- [x] Closes the test gap #1573 names as the reason it persisted: there were no tests feeding an over-limit HDU to either analysis endpoint
- [x] Adds 8 regression tests
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: medium.** Two endpoints that previously accepted any file can now return 413. That is the intent, and the threshold is the documented 200M default already applied to `/preview`, `/histogram` and `/pixeldata` — so a file rejected by `region-statistics` was already rejected by the preview the user would have opened it with. No in-repo fixture is anywhere near the cap (the engine suite passes unchanged).

The scan change makes the dedup **stricter**: a file whose name already exists under any path is skipped rather than attempted. That matches what the unique index would have enforced anyway; the only difference is it is now reported as a skip instead of an error.

`MemoryError` → 413 changes a status code clients may branch on. Nothing in the frontend keys on 400-vs-413 for these paths (the composite budget guard already returns 413 for the same underlying condition).

**Rollback:** revert the commit. No schema, migration, or persisted-state change.

Closes #1573
Closes #1580
Closes #1676

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
