### PR TITLE
fix: point the calibration wizard at recipes that fetch their own data

### DIFF
--- a/frontend/jwst-frontend/src/pages/CalibrateNew.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateNew.test.tsx
@@ -92,4 +92,39 @@ describe('CalibrateNew', () => {
     renderNew();
     expect(await screen.findByText('Nothing to calibrate yet')).toBeInTheDocument();
   });
+
+  // #1802: the wizard is library-first, but the seed recipes fetch their own
+  // inputs from MAST. A user whose library holds nothing these recipes can
+  // consume hit a hard dead end while runnable recipes sat one page away.
+  it('points at recipes that fetch their own data when the library is empty', async () => {
+    vi.mocked(getAll).mockResolvedValue([] as never);
+    renderNew();
+
+    await screen.findByText('Nothing to calibrate yet');
+    expect(screen.getByRole('link', { name: 'Browse recipes' })).toHaveAttribute(
+      'href',
+      '/calibrate/recipes'
+    );
+  });
+
+  it('points at them from the bar too, where a non-empty but unusable library lands', async () => {
+    // The reported case: the library HAS files, so the empty state never
+    // renders — the bar is the only place the dead end is visible.
+    renderNew();
+
+    await screen.findByText(/Nothing selected yet/);
+    expect(
+      screen.getByRole('link', { name: /start from a recipe that fetches its own data/ })
+    ).toHaveAttribute('href', '/calibrate/recipes');
+  });
+
+  it('drops the hint once files are selected', async () => {
+    renderNew();
+    await screen.findByText('NGC 3132');
+
+    await userEvent.click(screen.getByRole('checkbox', { name: /Select all in NGC 3132/ }));
+
+    expect(screen.queryByText(/Nothing selected yet/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /start from a recipe/ })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/jwst-frontend/src/pages/CalibrateNew.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrateNew.tsx
@@ -112,10 +112,18 @@ export default function CalibrateNew() {
           </div>
 
           {items === null && <p role="status">Loading library…</p>}
+          {/* #1802: this wizard is library-first, but the seed recipes bring
+              their own inputs from MAST — so an empty library is a hard dead
+              end here while runnable recipes sit one page away, unmentioned. */}
           {items !== null && groups.length === 0 && (
             <EmptyState
               title="Nothing to calibrate yet"
-              description="Import observations from MAST first — they'll show up here grouped by target."
+              description="Import observations from MAST first — they'll show up here grouped by target. Some recipes bring their own data instead."
+              actions={
+                <Link className="btn-base btn-standard" to="/calibrate/recipes">
+                  Browse recipes
+                </Link>
+              }
             />
           )}
 
@@ -169,9 +177,18 @@ export default function CalibrateNew() {
 
           <div className="calibrate-new-bar">
             <span>
-              {selected.length === 0
-                ? 'Nothing selected yet'
-                : `${selected.length} file${selected.length === 1 ? '' : 's'} selected`}
+              {selected.length === 0 ? (
+                <>
+                  {'Nothing selected yet — or '}
+                  {/* #1802: the reported dead end is a library that HAS files
+                      but none these recipes can consume, so the empty state
+                      above never renders. This line is where it is felt. */}
+                  <Link to="/calibrate/recipes">start from a recipe that fetches its own data</Link>
+                  {'.'}
+                </>
+              ) : (
+                `${selected.length} file${selected.length === 1 ? '' : 's'} selected`
+              )}
             </span>
             <button
               type="button"


### PR DESCRIPTION
## Summary

The new-run wizard (`/calibrate` → **+ New run**) can only start a run from library data: step 1 lists library observations and **Choose recipe →** stays disabled with *"Nothing selected yet"* until something is checked.

But the three seed recipes supply their own inputs — their `input_source` is a `mast_query`, and the recipe detail page says so outright ("Data is fetched from MAST (proposal 1040) when the run starts"). Those runs are reachable only from **Recipes → Configure & run** (`/calibrate/recipes`), and nothing in the wizard points there.

A user whose library holds nothing those recipes can consume hits a hard dead end with three perfectly runnable recipes one page away.

## Changes Made

The issue offers three fixes, cheapest first, and notes that (1) alone removes the dead end. This is (1) — but placed in **two** spots rather than one:

- **The empty-library state** gains a "Browse recipes" action through `EmptyState`'s existing `actions` slot (the design-system CTA pattern, not a bare paragraph), and its description now mentions that some recipes bring their own data.
- **The selection bar** gains the same link inline, shown whenever nothing is selected.

The second placement is the one that actually fixes the reported case. The issue was found with a library containing 4 MIRI **MRS/IFU** `_uncal` exposures that the imaging recipes cannot consume — the library is **not** empty, so `groups.length === 0` is false and the empty state never renders. A link only in the empty state would have closed the issue without fixing the situation that produced it.

Options (2) recipe-first ordering and (3) surfacing self-supplying recipes inside step 1 are deliberately not attempted here: both restructure the wizard's flow, and the issue itself scopes them as more than is needed.

## Test Plan

- [x] `npx vitest run src/pages/CalibrateNew.test.tsx` — 7 passed (4 pre-existing + 3 new)
- [x] Full frontend suite via pre-commit hook — all green
- [x] `npx tsc --noEmit` clean; ESLint clean on both changed files
- [x] New tests: an empty library shows a "Browse recipes" link pointing at `/calibrate/recipes`; a **non-empty** library still shows the bar link (the reported case); the hint disappears once files are selected
- [ ] Manual: open `/calibrate/new` against a library with no usable `_uncal` files and confirm the path out is visible without scrolling

## Documentation Checklist

- [x] No endpoint, DTO, or model changes
- [x] No new route — both links target the existing `/calibrate/recipes`
- [x] Reasoning recorded inline at both sites, including why the bar placement is the load-bearing one

## Tech Debt Impact

- [x] Does not add tech debt — two links, no new state or props
- [x] Adds 3 tests to a page that had 4
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: low.** Two links and one description string. No API, state, or navigation-flow change; the wizard behaves identically once a file is selected.

**Rollback:** revert the commit.

Closes #1802

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
