### PR TITLE
feat: opt-in all-users run listing so admins can find the runs they can open

### DIFF
--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.css
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.css
@@ -113,3 +113,19 @@
   gap: 0.5rem;
   flex-wrap: wrap;
 }
+
+/* Admin-only all-users toggle and the owner label it turns on (#1807). */
+.runs-all-users {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.runs-row-owner {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}

--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.test.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.test.tsx
@@ -2,7 +2,7 @@
  * Run history (#1734) — the first consumer of the engine's job list.
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CalibrationRuns from './CalibrationRuns';
@@ -11,7 +11,10 @@ import type { CalibrationJob } from '../types/CalibrationTypes';
 vi.mock('../services/calibrationService', () => ({
   listJobs: vi.fn(),
 }));
-const authState = { isAuthenticated: true };
+const authState: { isAuthenticated: boolean; user: { role: string } | null } = {
+  isAuthenticated: true,
+  user: { role: 'User' },
+};
 vi.mock('../context/useAuth', () => ({ useAuth: () => authState }));
 
 import { listJobs } from '../services/calibrationService';
@@ -44,6 +47,7 @@ function renderRuns() {
 describe('CalibrationRuns', () => {
   beforeEach(() => {
     authState.isAuthenticated = true;
+    authState.user = { role: 'User' };
   });
 
   it('keeps navigation and points anonymous visitors at the public recipes', async () => {
@@ -103,5 +107,55 @@ describe('CalibrationRuns', () => {
     vi.mocked(listJobs).mockRejectedValue(new Error('engine unreachable'));
     renderRuns();
     expect(await screen.findByText('engine unreachable')).toBeInTheDocument();
+  });
+
+  // #1807: get_job and the output routes have an Admin bypass; this list did
+  // not. An admin could OPEN any run but never FIND one, because job ids are
+  // UUIDs — so admin observability was unusable in practice.
+  describe('admin visibility', () => {
+    it('does not offer the all-users view to a normal user', async () => {
+      vi.mocked(listJobs).mockResolvedValue([]);
+      renderRuns();
+
+      await screen.findByText('No calibration runs yet');
+      expect(screen.queryByLabelText('All users')).not.toBeInTheDocument();
+      expect(vi.mocked(listJobs)).toHaveBeenCalledWith(50, false);
+    });
+
+    it('offers it to an admin, still defaulting to their own runs', async () => {
+      authState.user = { role: 'Admin' };
+      vi.mocked(listJobs).mockResolvedValue([]);
+      renderRuns();
+
+      expect(await screen.findByLabelText('All users')).not.toBeChecked();
+      // Opt-in: an admin's own history is the default view.
+      expect(vi.mocked(listJobs)).toHaveBeenCalledWith(50, false);
+    });
+
+    it("asks for every user's runs and labels whose each one is", async () => {
+      authState.user = { role: 'Admin' };
+      vi.mocked(listJobs).mockResolvedValue([]);
+      renderRuns();
+
+      vi.mocked(listJobs).mockResolvedValue([
+        job({ jobId: 'run-mine', userId: 'admin-a' }),
+        job({ jobId: 'run-theirs', userId: 'user-b' }),
+      ]);
+      fireEvent.click(await screen.findByLabelText('All users'));
+
+      await waitFor(() => expect(vi.mocked(listJobs)).toHaveBeenCalledWith(50, true));
+      // Rows are no longer all the caller's, so each says whose it is.
+      expect(await screen.findByText('user-b')).toBeInTheDocument();
+      expect(screen.getByText('admin-a')).toBeInTheDocument();
+    });
+
+    it('shows no owner labels in the default single-user view', async () => {
+      authState.user = { role: 'Admin' };
+      vi.mocked(listJobs).mockResolvedValue([job({ jobId: 'run-mine', userId: 'admin-a' })]);
+      renderRuns();
+
+      await screen.findByText('run-mine');
+      expect(screen.queryByText('admin-a')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/jwst-frontend/src/pages/CalibrationRuns.tsx
+++ b/frontend/jwst-frontend/src/pages/CalibrationRuns.tsx
@@ -27,7 +27,7 @@ function elapsed(job: CalibrationJob): string {
   return `${Math.floor(mins / 60)}h ${mins % 60}m`;
 }
 
-export function RunRow({ job }: { job: CalibrationJob }) {
+export function RunRow({ job, showOwner = false }: { job: CalibrationJob; showOwner?: boolean }) {
   const outputs = job.result?.outputs.length ?? 0;
   return (
     <li className={`runs-row runs-row-${job.status}`}>
@@ -36,6 +36,9 @@ export function RunRow({ job }: { job: CalibrationJob }) {
         <Link className="runs-row-link" to={`/calibrate/runs/${job.jobId}`}>
           {job.jobId}
         </Link>
+        {/* #1807: in the all-users view the rows are no longer all the
+            caller's, so each one has to say whose it is. */}
+        {showOwner && job.userId && <span className="runs-row-owner">{job.userId}</span>}
         <div className="runs-row-meta">
           {job.status === 'queued'
             ? 'Waiting — the engine runs one calibration at a time'
@@ -53,7 +56,11 @@ export function RunRow({ job }: { job: CalibrationJob }) {
 export default function CalibrationRuns() {
   const [jobs, setJobs] = useState<CalibrationJob[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, user } = useAuth();
+  const isAdmin = user?.role === 'Admin';
+  // #1807: opt-in. Merging every user's runs into an admin's own history by
+  // default would make their personal list unusable.
+  const [allUsers, setAllUsers] = useState(false);
 
   useEffect(() => {
     // Runs are per-user, so an anonymous visitor has none to fetch. Recipes
@@ -62,7 +69,7 @@ export default function CalibrationRuns() {
     if (!isAuthenticated) return undefined;
     let cancelled = false;
     const load = () => {
-      listJobs()
+      listJobs(50, isAdmin && allUsers)
         .then((list) => {
           if (!cancelled) setJobs(list);
         })
@@ -77,7 +84,7 @@ export default function CalibrationRuns() {
       cancelled = true;
       clearInterval(timer);
     };
-  }, [isAuthenticated]);
+  }, [isAuthenticated, isAdmin, allUsers]);
 
   const active = jobs?.filter((j) => ACTIVE.has(j.status)) ?? [];
   const past = jobs?.filter((j) => !ACTIVE.has(j.status)) ?? [];
@@ -96,6 +103,22 @@ export default function CalibrationRuns() {
           </p>
         </div>
         <div className="calibration-runs-actions">
+          {/* #1807: an admin can OPEN any run but could not FIND one — job ids
+              are UUIDs, and this list had no admin bypass while get_job did.
+              Explicit toggle, not an implicit merge. */}
+          {isAdmin && (
+            <label className="runs-all-users">
+              <input
+                type="checkbox"
+                checked={allUsers}
+                onChange={(e) => {
+                  setAllUsers(e.target.checked);
+                  setJobs(null);
+                }}
+              />
+              All users
+            </label>
+          )}
           <Link className="btn-base btn-compact" to="/calibrate/attempts">
             Compare attempts
           </Link>
@@ -141,7 +164,7 @@ export default function CalibrationRuns() {
           </h2>
           <ul className="runs-list">
             {active.map((job) => (
-              <RunRow key={job.jobId} job={job} />
+              <RunRow key={job.jobId} job={job} showOwner={isAdmin && allUsers} />
             ))}
           </ul>
         </section>
@@ -154,7 +177,7 @@ export default function CalibrationRuns() {
           </h2>
           <ul className="runs-list">
             {past.map((job) => (
-              <RunRow key={job.jobId} job={job} />
+              <RunRow key={job.jobId} job={job} showOwner={isAdmin && allUsers} />
             ))}
           </ul>
         </section>

--- a/frontend/jwst-frontend/src/services/calibrationService.ts
+++ b/frontend/jwst-frontend/src/services/calibrationService.ts
@@ -47,8 +47,16 @@ export async function getJob<T = Record<string, unknown>>(jobId: string): Promis
  * The engine has exposed this since the jobs slice landed; nothing consumed it
  * until the run-history page (#1734), which is why a run could be orphaned.
  */
-export async function listJobs(limit = 50): Promise<CalibrationJob[]> {
-  const response = await engineClient.get<{ jobs: CalibrationJob[] }>(`/api/jobs?limit=${limit}`);
+/**
+ * The caller's runs, or every user's when `allUsers` is set (#1807).
+ *
+ * Opt-in by design: the engine rejects `all=true` from a non-admin rather than
+ * quietly returning their own list, so this must only be set from a control
+ * that is itself admin-gated.
+ */
+export async function listJobs(limit = 50, allUsers = false): Promise<CalibrationJob[]> {
+  const query = `limit=${limit}${allUsers ? '&all=true' : ''}`;
+  const response = await engineClient.get<{ jobs: CalibrationJob[] }>(`/api/jobs?${query}`);
   return response.jobs;
 }
 

--- a/frontend/jwst-frontend/src/types/CalibrationTypes.ts
+++ b/frontend/jwst-frontend/src/types/CalibrationTypes.ts
@@ -91,6 +91,8 @@ export interface CalibrationJobOutput {
 
 export interface CalibrationJob {
   jobId: string;
+  /** Owner of the run. Only meaningful in the admin all-users view (#1807). */
+  userId?: string;
   type: string;
   status: 'queued' | 'downloading' | 'running' | 'succeeded' | 'failed' | 'cancelled';
   cancelRequested: boolean;

--- a/processing-engine/app/jobs/routes.py
+++ b/processing-engine/app/jobs/routes.py
@@ -125,8 +125,31 @@ async def list_jobs(
     user: AuthenticatedUser = Depends(require_user),
     store: JobStore = Depends(get_job_store),
     limit: int = 50,
+    all: bool = False,  # noqa: A002 -- query-string name; `all` is what the client sends
 ):
-    jobs = await store.list_for_user(user.user_id, limit=min(max(limit, 1), 200))
+    """List the caller's runs, or every user's when an Admin asks with ?all=true.
+
+    #1807: admin visibility was inconsistent — get_job and the output routes
+    have an Admin bypass, this one did not, so an admin could OPEN any run but
+    never FIND one (job ids are UUIDs). It failed safe, which is why it went
+    unnoticed, but it made admin observability unusable in practice.
+
+    Opt-in rather than implicit: silently merging every user's runs into an
+    admin's own history would make their personal list unusable and would be a
+    surprising default. Non-admins passing all=true are rejected rather than
+    quietly given their own list — a filter that silently does nothing is how
+    this class of bug starts.
+
+    Cancel keeps its documented no-bypass rule: admins observe, they do not
+    interfere.
+    """
+    capped = min(max(limit, 1), 200)
+    if all:
+        if user.role != "Admin":
+            raise HTTPException(status_code=403, detail="all=true requires the Admin role")
+        jobs = await store.list_all(limit=capped)
+    else:
+        jobs = await store.list_for_user(user.user_id, limit=capped)
     return {"jobs": [to_wire(j) for j in jobs]}
 
 

--- a/processing-engine/app/jobs/store.py
+++ b/processing-engine/app/jobs/store.py
@@ -77,6 +77,16 @@ class JobStore:
         )
         return await cursor.to_list(length=limit)
 
+    async def list_all(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Every user's runs, newest first — the Admin observe path (#1807).
+
+        Deliberately a separate method rather than an optional user_id on
+        list_for_user: the normal path must not have a code path in it that can
+        return other people's runs if an argument is threaded wrong.
+        """
+        cursor = self._col.find({}, {"_id": 0}).sort("created_at", -1).limit(limit)
+        return await cursor.to_list(length=limit)
+
     async def request_cancel(self, job_id: str, user_id: str) -> bool:
         """Flag an active, owned job for cancellation. Returns False when the
         job doesn't exist, isn't owned by ``user_id``, or already finished."""

--- a/processing-engine/tests/test_jobs_routes.py
+++ b/processing-engine/tests/test_jobs_routes.py
@@ -34,6 +34,7 @@ ROLE_URI = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
 
 USER = "user-a"
 OTHER = "user-b"
+ADMIN_USER = "admin-a"
 
 
 @pytest.fixture(autouse=True)
@@ -243,6 +244,68 @@ class TestOwnership:
         assert response.status_code == 200
         jobs = response.json()["jobs"]
         assert [j["jobId"] for j in jobs] == [mine]
+
+
+class TestAdminRunVisibility:
+    """#1807: admin visibility was inconsistent — get_job and the output routes
+    have an Admin bypass, the LIST route did not. An admin could open any run
+    but never find one, because job ids are UUIDs. It failed safe, which is why
+    it went unnoticed, and it made admin observability unusable in practice.
+    """
+
+    async def test_default_listing_is_still_only_your_own_runs(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        await seed_job(store, user_id=USER)
+        await seed_job(store, user_id=OTHER)
+
+        response = await client.get("/api/jobs", headers=bearer(USER))
+
+        assert response.status_code == 200
+        jobs = response.json()["jobs"]
+        assert len(jobs) == 1
+        assert all(j["userId"] == USER for j in jobs)
+
+    async def test_admin_default_listing_is_also_only_their_own(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        # Opt-in, not implicit: silently merging every user's runs into an
+        # admin's own history would make their personal list unusable.
+        await seed_job(store, user_id=ADMIN_USER)
+        await seed_job(store, user_id=OTHER)
+
+        response = await client.get("/api/jobs", headers=bearer(ADMIN_USER, role="Admin"))
+
+        jobs = response.json()["jobs"]
+        assert len(jobs) == 1
+        assert jobs[0]["userId"] == ADMIN_USER
+
+    async def test_admin_can_ask_for_every_users_runs(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        await seed_job(store, user_id=ADMIN_USER)
+        await seed_job(store, user_id=OTHER)
+
+        response = await client.get("/api/jobs?all=true", headers=bearer(ADMIN_USER, role="Admin"))
+
+        assert response.status_code == 200
+        jobs = response.json()["jobs"]
+        assert len(jobs) == 2
+        # The owner travels on the wire so the UI can label rows that are not
+        # the caller's.
+        assert {j["userId"] for j in jobs} == {ADMIN_USER, OTHER}
+
+    async def test_non_admin_asking_for_all_is_refused_not_quietly_ignored(
+        self, client: httpx.AsyncClient, store: JobStore
+    ) -> None:
+        # A filter that silently does nothing is how this class of bug starts.
+        await seed_job(store, user_id=USER)
+        await seed_job(store, user_id=OTHER)
+
+        response = await client.get("/api/jobs?all=true", headers=bearer(USER))
+
+        assert response.status_code == 403
+        assert "Admin" in response.json()["detail"]
 
 
 class TestCancel:


### PR DESCRIPTION
## Summary

Admin visibility of calibration runs was inconsistent: an admin could **open** any run but could not **find** one.

| Route | Admin bypass |
| --- | --- |
| `GET /api/jobs/{job_id}` | yes |
| `GET /api/jobs/{id}/outputs/{i}` preview / download / save | yes (`_resolve_any_output`) |
| `POST /api/jobs/{job_id}/cancel` | no — **deliberate**, and commented as such |
| `GET /api/jobs` (run history) | **no** — and the only one with no comment explaining the choice |

Job ids are UUIDs, so without a listing there is no way to discover a run to open. The codebase already states a coherent policy — *admins observe, they do not interfere* — and the run list is squarely the "observe" case. Cancel's omission is documented; this one was silent, which is what marks it as an oversight rather than a decision.

It fails safe, by showing less. That is why it went unnoticed, and why it is a usability defect rather than a security one.

## Changes Made

**`app/jobs/store.py`** — new `list_all(limit)`. Deliberately a separate method rather than an optional `user_id` on `list_for_user`: the normal path must not contain a code path that can return other people's runs if an argument is threaded wrong.

**`app/jobs/routes.py`** — `GET /api/jobs?all=true`, Admin only.
- **Opt-in, not implicit.** Silently merging every user's runs into an admin's own history would make their personal list unusable and would be a surprising default. With a flag, the caller asks for the wider view.
- **A non-admin passing `all=true` gets 403**, rather than quietly receiving their own list. A filter that silently does nothing is how this class of bug starts — it is exactly the shape of the defect being fixed.
- `to_wire` already camelCases `user_id` → `userId`, so the owner reaches the client with no model change.

**`CalibrationRuns.tsx` / `calibrationService.ts`** — an Admin-only "All users" checkbox; when it is on, each row is labelled with its owner, since the rows are no longer all the caller's. Toggling clears the list first so the 10-second refresh cannot briefly mix the two views.

**Cancel is untouched.** The observe/interfere split is right, and the issue says so.

## Test Plan

- [x] Full engine suite: `docker exec jwst-processing python -m pytest -q` — **1906 passed**, 2 deselected
- [x] `npx vitest run src/pages/CalibrationRuns.test.tsx` — 10 passed (6 pre-existing + 4 new)
- [x] Full frontend suite via pre-commit hook — all green
- [x] `ruff check` / `ruff format --check` clean; ESLint clean; `tsc --noEmit` clean
- [x] 4 new engine tests: the default listing is still only your own; an **admin's** default listing is also only their own (the opt-in property); `?all=true` as an admin returns every user's runs **with `userId` on the wire**; `?all=true` as a non-admin returns **403**, not a silently-filtered list
- [x] 4 new frontend tests: a normal user is not offered the toggle and the service is called with `false`; an admin is offered it, unchecked, still defaulting to their own; checking it re-requests with `true` and renders both owners; the default view shows **no** owner labels
- [ ] Manual: sign in as the seeded `admin` account, open `/calibrate`, tick "All users" and confirm another user's run appears and opens

## Documentation Checklist

- [x] `GET /api/jobs` gains an `all` query parameter — documented in the route's docstring, including why it is opt-in and why non-admins are rejected rather than filtered
- [x] `JobStore.list_all` documented, including why it is separate from `list_for_user`
- [x] No model or schema change — `userId` was already on the wire via `to_wire`
- [x] No new route or page

## Tech Debt Impact

- [x] Reduces debt — makes the four job routes consistent about the admin bypass, and leaves a comment on the one that deliberately lacks it (cancel), so the next reader does not have to re-derive the policy
- [x] Adds 8 tests to a path that had no admin-visibility coverage at all
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: medium — this widens what an Admin can see, so it deserves post-merge attention.**

Concretely: an Admin who explicitly ticks "All users" now sees other users' run ids, statuses and owner ids. They could already open any of those runs by id (`get_job` has had the bypass all along) and already had full access to their outputs; what changes is discoverability, which is the point. No non-admin capability changes, and the 403 path is tested.

`list_for_user` is unmodified, so the default path is byte-for-byte the previous behaviour.

**Rollback:** revert the commit. No schema, migration, or persisted state; `list_all` is additive.

Closes #1807

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
