### PR TITLE
fix: stop client-supplied headers keying the rate limiter

### DIFF
--- a/backend/JwstDataAnalysis.API.Tests/Configuration/Ipv4MappedRateLimitConfigurationTests.cs
+++ b/backend/JwstDataAnalysis.API.Tests/Configuration/Ipv4MappedRateLimitConfigurationTests.cs
@@ -1,11 +1,13 @@
 // Copyright (c) JWST Data Analysis. All rights reserved.
 // Licensed under the MIT License.
 
+using System.IO;
 using System.Net;
 
 using AspNetCoreRateLimit;
 using JwstDataAnalysis.API.Configuration;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -82,8 +84,15 @@ namespace JwstDataAnalysis.API.Tests.Configuration
                 resolver => Assert.IsType<Ipv4MappedIpResolveContributor>(resolver));
         }
 
+        /// <summary>
+        /// Updated for #1620. This previously asserted our resolver count matched
+        /// the stock configuration's — i.e. that the header resolver was kept.
+        /// Keeping it is the defect: it let a client-supplied header key the rate
+        /// limiter, bypassing the ForwardedHeaders trust list. We now register
+        /// strictly fewer resolvers than stock, and the missing one is the header.
+        /// </summary>
         [Fact]
-        public void RegisterResolvers_WithRealIpHeader_KeepsConnectionAndHeaderResolvers()
+        public void RegisterResolvers_DropsTheHeaderResolverStockWouldRegister()
         {
             var stock = new RateLimitConfiguration(
                 CreateIpOptions(),
@@ -91,7 +100,11 @@ namespace JwstDataAnalysis.API.Tests.Configuration
             stock.RegisterResolvers();
             var configuration = CreateConfiguration();
 
-            Assert.Equal(stock.IpResolvers.Count, configuration.IpResolvers.Count);
+            Assert.Contains(stock.IpResolvers, resolver => resolver is IpHeaderResolveContributor);
+            Assert.Equal(stock.IpResolvers.Count - 1, configuration.IpResolvers.Count);
+            Assert.All(
+                configuration.IpResolvers,
+                resolver => Assert.IsNotType<IpHeaderResolveContributor>(resolver));
         }
 
         [Fact]
@@ -105,6 +118,189 @@ namespace JwstDataAnalysis.API.Tests.Configuration
 
             Assert.Equal(ipCount, configuration.IpResolvers.Count);
             Assert.Equal(clientCount, configuration.ClientResolvers.Count);
+        }
+
+        // ===== #1620: client-supplied headers must not key the rate limiter =====
+
+        /// <summary>
+        /// The defect, characterized against the stock configuration: with a
+        /// RealIpHeader the rate limiter reads that header itself, independent of
+        /// the ForwardedHeaders middleware and its RFC 1918 trust list. A client
+        /// connecting directly to Kestrel can set it freely and rotate its
+        /// rate-limit identity, evading the 5/hour register and 20/15m login limits.
+        /// </summary>
+        [Fact]
+        public void StockConfiguration_LetsForwardedForOverrideTheConnectionAddress()
+        {
+            var stock = new RateLimitConfiguration(
+                Options.Create(new IpRateLimitOptions { RealIpHeader = "X-Forwarded-For" }),
+                Options.Create(new ClientRateLimitOptions()));
+            stock.RegisterResolvers();
+            var context = ContextWith("203.0.113.7", ("X-Forwarded-For", "198.51.100.23"));
+
+            var resolved = ResolveThrough(stock.IpResolvers, context);
+
+            Assert.Equal("198.51.100.23", resolved);
+        }
+
+        /// <summary>
+        /// Deleting RealIpHeader from appsettings.json — the fix the issue
+        /// originally proposed — is NOT enough on its own: the option defaults to
+        /// X-Real-IP, so the header resolver stays registered and the bypass just
+        /// moves to a different header. This test exists to keep that fact visible.
+        /// </summary>
+        [Fact]
+        public void StockConfiguration_WithNoConfiguredHeader_StillReadsXRealIp()
+        {
+            Assert.Equal("X-Real-IP", new IpRateLimitOptions().RealIpHeader);
+
+            var stock = new RateLimitConfiguration(
+                Options.Create(new IpRateLimitOptions()),
+                Options.Create(new ClientRateLimitOptions()));
+            stock.RegisterResolvers();
+            var context = ContextWith("203.0.113.7", ("X-Real-IP", "198.51.100.23"));
+
+            var resolved = ResolveThrough(stock.IpResolvers, context);
+
+            Assert.Equal("198.51.100.23", resolved);
+        }
+
+        /// <summary>
+        /// The fix: our configuration drops the header resolver entirely, so no
+        /// client-supplied header can influence the key regardless of what
+        /// RealIpHeader is set to.
+        /// </summary>
+        [Theory]
+        [InlineData("X-Forwarded-For")]
+        [InlineData("X-Real-IP")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void OurConfiguration_IgnoresClientSuppliedHeaders(string? realIpHeader)
+        {
+            var configuration = CreateConfigurationWith(realIpHeader);
+            var context = ContextWith(
+                "203.0.113.7",
+                ("X-Forwarded-For", "198.51.100.23"),
+                ("X-Real-IP", "198.51.100.24"));
+
+            var resolved = ResolveThroughConfiguration(configuration, context);
+
+            Assert.Equal("203.0.113.7", resolved);
+        }
+
+        [Fact]
+        public void OurConfiguration_SpoofedHeadersCannotRotateTheRateLimitKey()
+        {
+            // The evasion this closes: same peer, different headers, must key the
+            // same bucket or the per-IP limits mean nothing.
+            var configuration = CreateConfigurationWith("X-Forwarded-For");
+
+            var first = ContextWith("203.0.113.7", ("X-Forwarded-For", "198.51.100.1"));
+            var second = ContextWith("203.0.113.7", ("X-Forwarded-For", "198.51.100.2"));
+
+            Assert.Equal(
+                ResolveThroughConfiguration(configuration, first),
+                ResolveThroughConfiguration(configuration, second));
+        }
+
+        [Fact]
+        public void OurConfiguration_RegistersNoHeaderResolver()
+        {
+            var configuration = CreateConfigurationWith("X-Forwarded-For");
+
+            Assert.NotEmpty(configuration.IpResolvers);
+            Assert.All(
+                configuration.IpResolvers,
+                resolver => Assert.IsNotType<IpHeaderResolveContributor>(resolver));
+        }
+
+        /// <summary>
+        /// A trusted proxy's forwarding still works — it arrives as the connection
+        /// address because ForwardedHeaders rewrote it upstream, which is the
+        /// behaviour this fix preserves rather than breaks.
+        /// </summary>
+        [Fact]
+        public void OurConfiguration_StillHonoursAnAddressPromotedByForwardedHeaders()
+        {
+            var configuration = CreateConfigurationWith("X-Forwarded-For");
+
+            // UseForwardedHeaders has already replaced RemoteIpAddress with the
+            // forwarded client, having validated the peer against the trust list.
+            var context = ContextWith("198.51.100.23", ("X-Forwarded-For", "198.51.100.23"));
+
+            Assert.Equal("198.51.100.23", ResolveThroughConfiguration(configuration, context));
+        }
+
+        /// <summary>
+        /// The shipped appsettings.json must not reintroduce RealIpHeader. The
+        /// resolver removal already makes it inert, but leaving the key in place
+        /// would misdescribe how the limiter works to the next reader.
+        /// </summary>
+        [Fact]
+        public void ShippedConfiguration_DoesNotSetRealIpHeader()
+        {
+            var section = LoadShippedIpRateLimitingSection();
+
+            Assert.True(
+                string.IsNullOrEmpty(section["RealIpHeader"]),
+                "appsettings.json must not set IpRateLimiting:RealIpHeader (#1620) — the rate "
+                + "limiter keys on Connection.RemoteIpAddress, which the ForwardedHeaders "
+                + "trust list in Program.cs gates.");
+        }
+
+        [Fact]
+        public void ShippedConfiguration_StillDefinesTheAuthRateLimits()
+        {
+            // Guard against "fixing" this by deleting the section wholesale.
+            var options = new IpRateLimitOptions();
+            LoadShippedIpRateLimitingSection().Bind(options);
+
+            Assert.Contains(options.GeneralRules, rule => rule.Endpoint == "post:/api/auth/register");
+            Assert.Contains(options.GeneralRules, rule => rule.Endpoint == "post:/api/auth/login");
+        }
+
+        private static DefaultHttpContext ContextWith(string peer, params (string Name, string Value)[] headers)
+        {
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = IPAddress.Parse(peer);
+            foreach (var (name, value) in headers)
+            {
+                context.Request.Headers[name] = value;
+            }
+
+            return context;
+        }
+
+        private static string? ResolveThrough(IList<IIpResolveContributor> resolvers, HttpContext context)
+        {
+            foreach (var resolver in resolvers)
+            {
+                var ip = resolver.ResolveIp(context);
+                if (!string.IsNullOrEmpty(ip))
+                {
+                    return ip;
+                }
+            }
+
+            return null;
+        }
+
+        private static IConfigurationSection LoadShippedIpRateLimitingSection()
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile(path, optional: false)
+                .Build();
+            return configuration.GetSection("IpRateLimiting");
+        }
+
+        private static Ipv4MappedRateLimitConfiguration CreateConfigurationWith(string? realIpHeader)
+        {
+            var configuration = new Ipv4MappedRateLimitConfiguration(
+                Options.Create(new IpRateLimitOptions { RealIpHeader = realIpHeader! }),
+                Options.Create(new ClientRateLimitOptions()));
+            configuration.RegisterResolvers();
+            return configuration;
         }
 
         private static Ipv4MappedIpResolveContributor WrapFixedResult(string? value)

--- a/backend/JwstDataAnalysis.API/Configuration/Ipv4MappedRateLimitConfiguration.cs
+++ b/backend/JwstDataAnalysis.API/Configuration/Ipv4MappedRateLimitConfiguration.cs
@@ -7,12 +7,33 @@ using Microsoft.Extensions.Options;
 namespace JwstDataAnalysis.API.Configuration
 {
     /// <summary>
-    /// Rate limit configuration that normalizes IPv6-mapped IPv4 client addresses
+    /// Rate limit configuration that does two things.
+    /// <para>
+    /// First (#1615): normalizes IPv6-mapped IPv4 client addresses
     /// (e.g. <c>::ffff:172.18.0.1</c> from the Docker bridge) to their plain IPv4
     /// form before whitelist matching and counter keying. AspNetCoreRateLimit's
     /// CIDR matching is address-family sensitive, so without this the IPv4
     /// whitelist entries in <c>appsettings.Development.json</c> never match
-    /// Docker traffic and dev/E2E requests get rate limited (issue #1615).
+    /// Docker traffic and dev/E2E requests get rate limited.
+    /// </para>
+    /// <para>
+    /// Second (#1620): removes the header-based IP resolver, so the rate limiter
+    /// keys strictly on <see cref="Microsoft.AspNetCore.Http.ConnectionInfo.RemoteIpAddress"/>.
+    /// That address is populated from <c>X-Forwarded-For</c> by the
+    /// ForwardedHeaders middleware, but ONLY when the immediate peer is inside the
+    /// RFC 1918 trust list configured in <c>Program.cs</c> — so the trust list
+    /// becomes the single gate on client-supplied addresses. Reading a header here
+    /// instead bypasses that gate: a client connecting directly to Kestrel could
+    /// set the header freely and rotate its rate-limit identity, evading the
+    /// 5/hour register and 20/15m login limits.
+    /// </para>
+    /// <para>
+    /// Deleting <c>RealIpHeader</c> from configuration is NOT sufficient on its
+    /// own: <c>IpRateLimitOptions.RealIpHeader</c> defaults to
+    /// <c>X-Real-IP</c>, so the resolver would still be registered and the bypass
+    /// would simply move to a different header. Removing the resolver is what
+    /// closes it, and it cannot be reopened by a configuration edit.
+    /// </para>
     /// </summary>
     public class Ipv4MappedRateLimitConfiguration : RateLimitConfiguration
     {
@@ -37,14 +58,22 @@ namespace JwstDataAnalysis.API.Configuration
             ClientResolvers.Clear();
             base.RegisterResolvers();
 
-            var wrapped = new List<IIpResolveContributor>(IpResolvers.Count);
+            // #1620: drop the header resolver. Everything the client can set is
+            // untrusted here; the ForwardedHeaders middleware is the only place
+            // allowed to promote a forwarded address, and only from a trusted peer.
+            var kept = new List<IIpResolveContributor>(IpResolvers.Count);
             foreach (var resolver in IpResolvers)
             {
-                wrapped.Add(new Ipv4MappedIpResolveContributor(resolver));
+                if (resolver is IpHeaderResolveContributor)
+                {
+                    continue;
+                }
+
+                kept.Add(new Ipv4MappedIpResolveContributor(resolver));
             }
 
             IpResolvers.Clear();
-            foreach (var resolver in wrapped)
+            foreach (var resolver in kept)
             {
                 IpResolvers.Add(resolver);
             }

--- a/backend/JwstDataAnalysis.API/Program.cs
+++ b/backend/JwstDataAnalysis.API/Program.cs
@@ -38,6 +38,9 @@ builder.Services.AddMemoryCache();
 builder.Services.Configure<IpRateLimitOptions>(builder.Configuration.GetSection("IpRateLimiting"));
 
 // Ipv4MappedRateLimitConfiguration normalizes IPv6-mapped IPv4 client addresses
+// and (#1620) drops the header-based IP resolver so the limiter keys only on
+// Connection.RemoteIpAddress — the address UseForwardedHeaders above populates
+// from X-Forwarded-For, and only for peers inside the trust list configured there.
 // (::ffff:a.b.c.d from the Docker bridge) so IPv4 whitelist CIDRs match (#1615)
 builder.Services.AddSingleton<IRateLimitConfiguration, Ipv4MappedRateLimitConfiguration>();
 builder.Services.AddInMemoryRateLimiting();

--- a/backend/JwstDataAnalysis.API/appsettings.json
+++ b/backend/JwstDataAnalysis.API/appsettings.json
@@ -65,7 +65,6 @@
   "IpRateLimiting": {
     "EnableEndpointRateLimiting": true,
     "StackBlockedRequests": false,
-    "RealIpHeader": "X-Forwarded-For",
     "ClientIdHeader": "X-ClientId",
     "HttpStatusCode": 429,
     "QuotaExceededResponse": {

--- a/docs/plans/features/quick/1615-rate-limit-ipv6-mapped-whitelist.md
+++ b/docs/plans/features/quick/1615-rate-limit-ipv6-mapped-whitelist.md
@@ -37,4 +37,6 @@ pass through untouched, and normalization also makes counter keys consistent).
 - Plain IPv4 and plain IPv6 (`::1`) pass through unchanged.
 - Non-IP resolver output (e.g. XFF list string) passes through unchanged.
 - Null/empty resolver output passes through.
-- Configuration wraps all base resolvers (connection + header when `RealIpHeader` set).
+- Configuration wraps the connection resolver. (Updated by #1620: the header
+  resolver is now dropped rather than wrapped — a client-supplied header must
+  never key the rate limiter, since that bypasses the ForwardedHeaders trust list.)


### PR DESCRIPTION
## Summary

`AspNetCoreRateLimit` was configured with `"RealIpHeader": "X-Forwarded-For"`, which makes the rate limiter read that header **itself** — independent of the `ForwardedHeaders` middleware and the RFC 1918 trust list that #453 established in `Program.cs`.

A client connecting directly to Kestrel (dev, or a misconfigured prod without a stripping proxy) can therefore set `X-Forwarded-For` to anything and rotate its per-IP rate-limit identity at will, evading the `5/hour` `post:/api/auth/register` and `20/15m` `post:/api/auth/login` limits.

## The issue's proposed fix is incomplete — verified, not assumed

The issue recommends removing `RealIpHeader` and relying on `Connection.RemoteIpAddress`. I wrote that fix first, then tested it against the library and found it **does not close the hole**:

```
Assert.Equal("X-Real-IP", new IpRateLimitOptions().RealIpHeader);   // passes
```

`RealIpHeader` **defaults to `X-Real-IP`**. Deleting the key from `appsettings.json` leaves the header resolver registered against that default, so the bypass simply moves from `X-Forwarded-For` to `X-Real-IP`. The resolver count is 2 either way — the option only names *which* header is trusted, it never controls *whether* one is.

There is a test pinning exactly this (`StockConfiguration_WithNoConfiguredHeader_StillReadsXRealIp`) so the shortcut isn't re-attempted later.

## Changes Made

- **`Ipv4MappedRateLimitConfiguration.RegisterResolvers()`** — drops any `IpHeaderResolveContributor` instead of wrapping it. The limiter now keys strictly on `Connection.RemoteIpAddress`. That address *is* populated from `X-Forwarded-For`, but by `UseForwardedHeaders()` (line 375, before `UseIpRateLimiting()` at line 410) and **only when the immediate peer is inside the RFC 1918 trust list** — so the trust list becomes the single gate on client-supplied addresses, and no configuration edit can reopen the hole.
- **`appsettings.json`** — `RealIpHeader` removed. Inert now that the resolver is gone, but leaving it would misdescribe how the limiter works to the next reader.
- **`Program.cs` / `docs/plans/features/quick/1615-...md`** — comments updated; the plan doc still claimed the config "wraps all base resolvers (connection + header)".

Chose the code-level fix over the issue's option 2 ("ensure the deployment proxy always overwrites XFF and document it") because that makes a security property depend on deployment discipline, and the CE/dev stacks expose Kestrel directly.

## Test Plan

- [x] `dotnet test` — **1202 passed**, 0 failed (1191 before, +11 here)
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] **Characterization first**: `StockConfiguration_LetsForwardedForOverrideTheConnectionAddress` proves the defect is real — peer `203.0.113.7`, header `198.51.100.23`, resolver returns the **header** value
- [x] `StockConfiguration_WithNoConfiguredHeader_StillReadsXRealIp` — proves the issue's suggested fix leaves an `X-Real-IP` bypass
- [x] `OurConfiguration_IgnoresClientSuppliedHeaders` — theory over `X-Forwarded-For`, `X-Real-IP`, `""` and `null`, both headers set at once; always resolves the peer address
- [x] `OurConfiguration_SpoofedHeadersCannotRotateTheRateLimitKey` — same peer, two different headers, one bucket
- [x] `OurConfiguration_RegistersNoHeaderResolver` and `RegisterResolvers_DropsTheHeaderResolverStockWouldRegister` — structural guards
- [x] `OurConfiguration_StillHonoursAnAddressPromotedByForwardedHeaders` — a **trusted** proxy's forwarding still works, so this tightens without breaking real deployments
- [x] `ShippedConfiguration_DoesNotSetRealIpHeader` + `ShippedConfiguration_StillDefinesTheAuthRateLimits` — read the real `appsettings.json`, so a later edit can't silently reintroduce the key or delete the limits
- [x] All 8 pre-existing #1615 IPv6-mapping tests still pass — Docker-bridge whitelist behaviour is unchanged
- [ ] Manual: `curl -H 'X-Forwarded-For: 1.2.3.4' …/api/auth/register` ×6 from one host → 6th returns 429

### One pre-existing test updated

`RegisterResolvers_WithRealIpHeader_KeepsConnectionAndHeaderResolvers` asserted our resolver count matched stock — i.e. that the header resolver was **kept**. Keeping it *is* the defect, so the assertion could not survive the fix. Replaced with `RegisterResolvers_DropsTheHeaderResolverStockWouldRegister`, which asserts stock registers a header resolver and we register exactly one fewer, with none of that type. Strictly stronger, and the XML doc records why it changed.

## Documentation Checklist

- [x] No endpoint, DTO, or model changes
- [x] `Ipv4MappedRateLimitConfiguration` XML docs rewritten to cover both responsibilities and the `X-Real-IP` trap
- [x] `Program.cs` comment updated at the DI registration
- [x] Stale claim corrected in the #1615 plan doc
- [x] No new configuration key — one removed

## Tech Debt Impact

- [x] Reduces debt — makes a security property structural rather than dependent on a config value being exactly right
- [x] Adds 11 tests, two of which document library behaviour that would otherwise have to be rediscovered
- [ ] N/A — no tech-debt issues closed

## Risk & Rollback

**Risk: medium — this is auth-adjacent rate limiting, so it deserves a post-merge look.**

The behaviour change: requests are now bucketed by the peer address (as rewritten by `ForwardedHeaders` for trusted peers) rather than by a header. Two cases to consider:

1. **Behind a trusted reverse proxy** (the compose/prod topology) — unchanged. `UseForwardedHeaders` promotes the real client IP into `RemoteIpAddress` before the limiter runs; covered by `OurConfiguration_StillHonoursAnAddressPromotedByForwardedHeaders`.
2. **Behind a proxy whose IP is *outside* the RFC 1918 trust list** — all traffic would now share one bucket (the proxy's address) and could hit the global `300/1m` limit collectively. That is a pre-existing misconfiguration of `KnownIPNetworks`, but this change makes it *visible* where before the spoofable header hid it. Worth confirming your production proxy's address falls inside the trust list before deploying.

Dev/E2E is unaffected: the #1615 IPv6-mapping and whitelist behaviour is untouched and still covered.

**Rollback:** revert the commit. No schema, migration, or persisted state.

Closes #1620

https://claude.ai/code/session_014bj8QLrcnWCyGJsYEMvWLH
