### PR TITLE
fix: parse WCS with astropy so the sky readout is right for JWST images (S3)

### DIFF
--- a/docs/plans/features/quick/s3-astropy-wcs.md
+++ b/docs/plans/features/quick/s3-astropy-wcs.md
@@ -1,0 +1,85 @@
+# S3 — Replace hand-rolled WCS with `astropy.wcs.WCS`
+
+**Branch**: `fix/s3-astropy-wcs`
+**Track**: S (Science) — Simplification & Science Plan, item S3
+**Effort**: <1 hr · **Risk**: Low
+
+## Problem
+
+`render/routes.py` builds the `wcs` payload for the viewer's RA/Dec readout by
+hand-reading twelve FITS keywords. It only understands the `CD` matrix and
+`CDELT`; it never looks at `PC_i_j`.
+
+Real JWST `_i2d` products carry `PC` + `CDELT` and **no `CD` keywords at all**.
+Verified against `jw01192-o010_t002_miri_f560w_i2d.fits`:
+
+```
+CDELT1 = CDELT2 = 3.0808e-05
+PC1_1 = -0.29512   PC1_2 = 0.95546
+PC2_1 =  0.95546   PC2_2 = 0.29512     (~107 deg rotation)
+```
+
+The current code emits `cd1_1 = CDELT1`, `cd1_2 = cd2_1 = 0`,
+`cd2_2 = CDELT2` — an unrotated matrix with the wrong sign on axis 1.
+The correct matrix (astropy `pixel_scale_matrix`) is:
+
+```
+[[-9.0919e-06, 2.9436e-05],
+ [ 2.9436e-05, 9.0919e-06]]
+```
+
+So the viewer's sky readout is wrong for every JWST image in the library — the
+error grows with distance from the reference pixel and is tens of arcseconds
+across a typical frame, in the wrong direction.
+
+`processing/avm.py:extract_wcs_for_avm` has the identical defect from the same
+hand-rolled parse: it derives `rotation = atan2(-cd2_1, cd2_2)`, which is always
+`0` when `cd2_1` falls back to `0`. Every AVM-embedded preview claims north-up.
+Same root cause, same fix — repaired in this PR rather than left next to a
+correct helper.
+
+## Approach
+
+Add `app/science/wcs.py` — astropy parses the header, we marshal the result.
+`app/science/` is the home S2a's `ScienceImage` loader will grow into.
+
+- `celestial_wcs(header) -> WCS | None` — `WCS(header).celestial`, warnings
+  suppressed, `None` when `has_celestial` is false.
+- `wcs_params_from_header(header) -> dict | None` — the viewer payload, with
+  `cd1_1..cd2_2` taken from `pixel_scale_matrix` (astropy resolves
+  `PC`+`CDELT`, `CD`, or `CDELT`-only into one matrix) and `cdelt1/2` from
+  `proj_plane_pixel_scales` (true on-sky scale magnitudes).
+
+The payload keeps its existing shape, so `coordinateUtils.pixelToWCS` and the
+`WCSParams` type are untouched. The client keeps doing the TAN inverse — hover
+readout has to be interactive — it just finally gets correct inputs.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `processing-engine/app/science/__init__.py` | new package |
+| `processing-engine/app/science/wcs.py` | new — `celestial_wcs`, `wcs_params_from_header` |
+| `processing-engine/app/render/routes.py` | replace the 15-line hand-rolled block with `wcs_params_from_header(header)` |
+| `processing-engine/app/processing/avm.py` | `extract_wcs_for_avm` derives scale + rotation from `celestial_wcs` |
+| `processing-engine/tests/test_science_wcs.py` | new — helper unit tests |
+| `processing-engine/tests/test_avm_embedding.py` | add PC-matrix rotation cases |
+
+## Out of scope
+
+- **SIP distortion.** `WCS(header)` reads SIP, but a 6-number affine cannot
+  carry it. JWST `_i2d` products have no SIP; `_cal` products may, where the
+  readout error is sub-pixel. Not addressed here.
+- **Non-TAN projections.** The client's inverse is TAN-only. `CTYPE` is in the
+  payload; nothing reads it yet.
+- The other 10 "first HDU with data" sites — that is S2a.
+
+## Test plan
+
+1. `test_science_wcs.py` red before the helper exists, green after.
+2. Regression: PC+CDELT header yields the rotated matrix, not the diagonal.
+3. Regression for #1235: `CTYPE1=RA---TAN`, `CRVAL1=0`, `CRPIX1=0` still
+   returns params (not `None`).
+4. Header with no celestial keywords returns `None`.
+5. Live check against a real `_i2d` file in the running container: payload
+   matrix matches astropy's `pixel_scale_matrix` to float precision.

--- a/frontend/jwst-frontend/src/types/JwstDataTypes.ts
+++ b/frontend/jwst-frontend/src/types/JwstDataTypes.ts
@@ -190,18 +190,21 @@ export interface MetadataRefreshAllResponse {
   message: string;
 }
 
-// WCS (World Coordinate System) parameters for coordinate transformation
+// WCS (World Coordinate System) parameters for coordinate transformation.
+// Resolved server-side by astropy, so cd1_1..cd2_2 is always the full
+// pixel-to-sky matrix regardless of whether the FITS header spelled it as
+// CD, PC + CDELT, or CDELT alone.
 export interface WCSParams {
   crpix1: number; // Reference pixel X
   crpix2: number; // Reference pixel Y
   crval1: number; // Reference RA (degrees)
   crval2: number; // Reference Dec (degrees)
-  cdelt1: number; // Pixel scale X (degrees/pixel)
-  cdelt2: number; // Pixel scale Y (degrees/pixel)
-  cd1_1: number; // CD matrix element
-  cd1_2: number; // CD matrix element
-  cd2_1: number; // CD matrix element
-  cd2_2: number; // CD matrix element
+  cdelt1: number; // On-sky pixel scale X (degrees/pixel, magnitude)
+  cdelt2: number; // On-sky pixel scale Y (degrees/pixel, magnitude)
+  cd1_1: number; // Pixel-to-sky matrix, includes rotation and sky flip
+  cd1_2: number;
+  cd2_1: number;
+  cd2_2: number;
   ctype1: string; // Coordinate type X (e.g., "RA---TAN")
   ctype2: string; // Coordinate type Y (e.g., "DEC--TAN")
 }

--- a/processing-engine/app/processing/avm.py
+++ b/processing-engine/app/processing/avm.py
@@ -221,7 +221,7 @@ def extract_wcs_for_avm(
     """Extract and scale WCS parameters from a FITS header for AVM embedding.
 
     The preview image is typically resized from the original FITS dimensions,
-    so we need to adjust CRPIX and CDELT/CD matrix values accordingly.
+    so the reported pixel scale is adjusted by the resize ratio.
 
     Args:
         header: FITS header (dict-like).

--- a/processing-engine/app/processing/avm.py
+++ b/processing-engine/app/processing/avm.py
@@ -14,7 +14,10 @@ import logging
 import math
 import xml.etree.ElementTree as ET
 
+from astropy.wcs.utils import proj_plane_pixel_scales
 from PIL import Image, PngImagePlugin
+
+from app.science.wcs import celestial_wcs
 
 
 logger = logging.getLogger(__name__)
@@ -231,39 +234,39 @@ def extract_wcs_for_avm(
         Dictionary with AVM-ready WCS fields, or empty dict if WCS not available.
     """
     try:
-        crpix1 = float(header.get("CRPIX1", 0))
-        crval1 = float(header.get("CRVAL1", 0))
-        crval2 = float(header.get("CRVAL2", 0))
-
-        # Treat WCS as missing only when projection type is also absent —
-        # observations near RA=0 (CRVAL1=0) with CRPIX1=0 are valid but were
-        # previously rejected by `crpix1 == 0 and crval1 == 0`. (#1235)
-        ctype1 = str(header.get("CTYPE1", ""))
-        if not ctype1 and crpix1 == 0 and crval1 == 0:
+        # astropy resolves CD / PC+CDELT / CDELT-only into one matrix. The
+        # previous hand-rolled parse read CD only, so a PC-matrix header — what
+        # every JWST _i2d product uses — fell back to CDELT and reported
+        # rotation 0 for images that are in fact strongly rotated.
+        wcs = celestial_wcs(header)
+        if wcs is None:
             return {}
 
-        # Get pixel scale from CD matrix or CDELT
-        cd1_1 = float(header.get("CD1_1", header.get("CDELT1", 0)))
-        cd2_1 = float(header.get("CD2_1", 0))
-        cd2_2 = float(header.get("CD2_2", header.get("CDELT2", 0)))
-
-        if cd1_1 == 0 and cd2_2 == 0:
-            return {}
+        crval1, crval2 = (float(v) for v in wcs.wcs.crval)
+        matrix = wcs.pixel_scale_matrix
 
         # Compute scale ratios for the resize
         scale_x = original_width / output_width if output_width > 0 else 1.0
         scale_y = original_height / output_height if output_height > 0 else 1.0
 
-        # Adjust pixel scale (degrees/pixel becomes larger when image is smaller)
-        scaled_cd1_1 = cd1_1 * scale_x
-        scaled_cd2_1 = cd2_1 * scale_x
-        scaled_cd2_2 = cd2_2 * scale_y
+        # On-sky degrees/pixel per axis, then adjusted for the resize (a smaller
+        # image means more sky per pixel). These are magnitudes — orientation
+        # lives in the rotation below.
+        pixel_scales = proj_plane_pixel_scales(wcs)
+        scaled_scale_x = float(pixel_scales[0]) * scale_x
+        scaled_scale_y = float(pixel_scales[1]) * scale_y
 
-        # Compute rotation from CD matrix (degrees, measured N through E)
-        rotation = math.degrees(math.atan2(-scaled_cd2_1, scaled_cd2_2))
+        # A negative determinant is the usual sky handedness (RA increasing to
+        # the left); AVM expresses that as a negative Spatial.Scale on axis 1.
+        if matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0] < 0:
+            scaled_scale_x = -scaled_scale_x
+
+        # Rotation from the matrix (degrees, measured N through E). Same
+        # convention as before — it now gets the correct matrix.
+        rotation = math.degrees(math.atan2(-matrix[1][0] * scale_x, matrix[1][1] * scale_y))
 
         # Coordinate frame from CTYPE
-        ctype1 = str(header.get("CTYPE1", ""))
+        ctype1 = str(wcs.wcs.ctype[0])
         coord_frame = "ICRS"
         if "FK5" in ctype1.upper():
             coord_frame = "FK5"
@@ -275,8 +278,8 @@ def extract_wcs_for_avm(
         return {
             "ra": crval1,
             "dec": crval2,
-            "scale_x": scaled_cd1_1,
-            "scale_y": scaled_cd2_2,
+            "scale_x": scaled_scale_x,
+            "scale_y": scaled_scale_y,
             "rotation": rotation,
             "coordinate_frame": coord_frame,
         }

--- a/processing-engine/app/render/routes.py
+++ b/processing-engine/app/render/routes.py
@@ -29,6 +29,7 @@ from app.processing.enhancement import (
 )
 from app.processing.filters import reduce_noise
 from app.processing.statistics import compute_histogram, compute_percentiles
+from app.science.wcs import wcs_params_from_header
 from app.storage.helpers import resolve_fits_path, validate_fits_array_size
 
 
@@ -745,37 +746,13 @@ def get_pixel_data(
         # Get preview shape after any downsampling
         preview_height, preview_width = data.shape
 
-        # Extract WCS parameters from header if available
-        wcs_params = None
-        if header is not None:
-            try:
-                wcs_params = {
-                    "crpix1": float(header.get("CRPIX1", 0)),
-                    "crpix2": float(header.get("CRPIX2", 0)),
-                    "crval1": float(header.get("CRVAL1", 0)),
-                    "crval2": float(header.get("CRVAL2", 0)),
-                    "cdelt1": float(header.get("CDELT1", header.get("CD1_1", 0))),
-                    "cdelt2": float(header.get("CDELT2", header.get("CD2_2", 0))),
-                    "cd1_1": float(header.get("CD1_1", header.get("CDELT1", 0))),
-                    "cd1_2": float(header.get("CD1_2", 0)),
-                    "cd2_1": float(header.get("CD2_1", 0)),
-                    "cd2_2": float(header.get("CD2_2", header.get("CDELT2", 0))),
-                    "ctype1": str(header.get("CTYPE1", "")),
-                    "ctype2": str(header.get("CTYPE2", "")),
-                }
-                # Treat WCS as missing only when the projection isn't set
-                # (CTYPE1 absent) AND the reference values look defaulted.
-                # The previous `crpix1==0 and crval1==0` check rejected
-                # observations near RA=0 with CRPIX1=0 — rare but valid. (#1235)
-                if (
-                    not wcs_params["ctype1"]
-                    and wcs_params["crpix1"] == 0
-                    and wcs_params["crval1"] == 0
-                ):
-                    wcs_params = None
-            except (ValueError, KeyError) as e:
-                logger.warning(f"Could not extract WCS parameters: {e}")
-                wcs_params = None
+        # Extract WCS parameters from header if available. astropy resolves
+        # CD / PC+CDELT / CDELT-only into one matrix — JWST _i2d products use
+        # PC+CDELT, which the previous hand-rolled parse read as unrotated.
+        # A header with no celestial solution yields None, which also keeps the
+        # #1235 case working: a real pointing near RA=0 with CRPIX1=0 has a
+        # CTYPE and so is still returned.
+        wcs_params = wcs_params_from_header(header)
 
         # Get units from header
         units = str(header.get("BUNIT", "")) if header is not None else ""

--- a/processing-engine/app/science/__init__.py
+++ b/processing-engine/app/science/__init__.py
@@ -1,0 +1,5 @@
+"""Science-grade readers and coordinate helpers shared across the engine.
+
+Everything in here treats a FITS file as science data rather than as an image
+format: real astropy WCS, real units, real error and quality planes.
+"""

--- a/processing-engine/app/science/wcs.py
+++ b/processing-engine/app/science/wcs.py
@@ -1,0 +1,86 @@
+"""Celestial WCS parsing, delegated to astropy.
+
+FITS spells the pixel-to-sky transform three interchangeable ways: a ``CD``
+matrix, a ``PC`` matrix scaled by ``CDELT``, or ``CDELT`` alone. Real JWST
+``_i2d`` products use the second, and hand-rolled readers that only know about
+``CD`` silently drop the rotation. astropy resolves all three (plus SIP, the
+``PC``/``CD`` precedence rules, and the alternate-axis conventions) into a
+single matrix, so we parse once here and everything else reads the result.
+"""
+
+import logging
+import warnings
+
+from astropy.wcs import WCS, FITSFixedWarning
+from astropy.wcs.utils import proj_plane_pixel_scales
+
+
+logger = logging.getLogger(__name__)
+
+
+def celestial_wcs(header) -> WCS | None:
+    """Parse the celestial (RA/Dec) WCS out of a FITS header.
+
+    Args:
+        header: FITS header, or any dict-like of FITS keywords. May describe
+            more than two axes — the celestial pair is extracted.
+
+    Returns:
+        A 2-axis `WCS`, or None when the header carries no celestial solution.
+    """
+    if header is None:
+        return None
+
+    try:
+        with warnings.catch_warnings():
+            # Headers routinely need datfix/obsfix nudges; astropy applies them
+            # and says so. Nothing actionable for a coordinate readout.
+            warnings.simplefilter("ignore", FITSFixedWarning)
+            wcs = WCS(header)
+
+        if not wcs.has_celestial:
+            return None
+        return wcs.celestial
+    except Exception as e:  # astropy raises a wide range on malformed headers
+        logger.warning(f"Could not parse WCS from header: {e}")
+        return None
+
+
+def wcs_params_from_header(header) -> dict | None:
+    """Build the viewer's WCS payload from a FITS header.
+
+    The shape matches the frontend `WCSParams` type. `cd1_1`..`cd2_2` are the
+    full pixel-to-sky matrix in degrees/pixel with rotation and any sky flip
+    included, whichever way the header happened to spell it.
+
+    Args:
+        header: FITS header, or any dict-like of FITS keywords.
+
+    Returns:
+        Dict of WCS parameters, or None when the header has no celestial WCS.
+    """
+    wcs = celestial_wcs(header)
+    if wcs is None:
+        return None
+
+    matrix = wcs.pixel_scale_matrix
+    crpix1, crpix2 = wcs.wcs.crpix
+    crval1, crval2 = wcs.wcs.crval
+    # True on-sky scale per axis — magnitudes, since the matrix above already
+    # carries orientation. Kept for consumers that want arcsec/pixel.
+    cdelt1, cdelt2 = proj_plane_pixel_scales(wcs)
+
+    return {
+        "crpix1": float(crpix1),
+        "crpix2": float(crpix2),
+        "crval1": float(crval1),
+        "crval2": float(crval2),
+        "cdelt1": float(cdelt1),
+        "cdelt2": float(cdelt2),
+        "cd1_1": float(matrix[0][0]),
+        "cd1_2": float(matrix[0][1]),
+        "cd2_1": float(matrix[1][0]),
+        "cd2_2": float(matrix[1][1]),
+        "ctype1": str(wcs.wcs.ctype[0]),
+        "ctype2": str(wcs.wcs.ctype[1]),
+    }

--- a/processing-engine/tests/test_avm_embedding.py
+++ b/processing-engine/tests/test_avm_embedding.py
@@ -192,6 +192,55 @@ class TestExtractWcsForAvm:
         result = extract_wcs_for_avm(header, 1024, 1024, 512, 512)
         assert result == {}
 
+    def test_pc_matrix_rotation_is_reported(self):
+        """A PC+CDELT header — what JWST _i2d products use — is rotated.
+
+        The old CD-only parse fell back to CDELT, leaving CD2_1 at 0, so every
+        AVM packet claimed rotation 0 no matter how the image was oriented.
+        """
+        header = {
+            "CTYPE1": "RA---TAN",
+            "CTYPE2": "DEC--TAN",
+            "CRPIX1": 518.83,
+            "CRPIX2": 590.68,
+            "CRVAL1": 85.216,
+            "CRVAL2": -2.4917,
+            "CDELT1": 3.08077556750194e-05,
+            "CDELT2": 3.08077556750194e-05,
+            "PC1_1": -0.2951182660246448,
+            "PC1_2": 0.9554607313011911,
+            "PC2_1": 0.9554607313011911,
+            "PC2_2": 0.2951182660246448,
+        }
+        result = extract_wcs_for_avm(header, 1040, 1182, 1040, 1182)
+
+        assert abs(result["rotation"]) > 1.0, "rotation must not be reported as north-up"
+        # atan2(-PC2_1, PC2_2) for this pointing
+        assert abs(result["rotation"] - (-72.83)) < 0.1
+        # Scale is the true on-sky value, negative on axis 1 for sky handedness
+        assert abs(result["scale_x"] - (-3.08077556750194e-05)) < 1e-12
+        assert abs(result["scale_y"] - 3.08077556750194e-05) < 1e-12
+
+    def test_pc_matrix_scale_tracks_the_resize(self):
+        header = {
+            "CTYPE1": "RA---TAN",
+            "CTYPE2": "DEC--TAN",
+            "CRPIX1": 512.0,
+            "CRPIX2": 512.0,
+            "CRVAL1": 10.0,
+            "CRVAL2": 20.0,
+            "CDELT1": 1e-5,
+            "CDELT2": 1e-5,
+            "PC1_1": -1.0,
+            "PC1_2": 0.0,
+            "PC2_1": 0.0,
+            "PC2_2": 1.0,
+        }
+        result = extract_wcs_for_avm(header, 1024, 1024, 256, 256)
+        assert abs(result["scale_x"] - (-1e-5 * 4)) < 1e-12
+        assert abs(result["scale_y"] - (1e-5 * 4)) < 1e-12
+        assert abs(result["rotation"]) < 1e-9
+
     def test_wcs_at_celestial_origin_accepted(self):
         """A valid WCS pointing at RA=0 with CRPIX1=0 is no longer rejected (#1235)."""
         header = {
@@ -228,6 +277,7 @@ class TestExtractWcsForAvm:
             "CDELT1": -0.001,
             "CDELT2": 0.001,
             "CTYPE1": "RA---TAN",
+            "CTYPE2": "DEC--TAN",
         }
         result = extract_wcs_for_avm(header, 200, 200, 100, 100)
         assert result["ra"] == 90.0
@@ -243,6 +293,7 @@ class TestExtractWcsForAvm:
             "CD1_1": -1e-4,
             "CD2_2": 1e-4,
             "CTYPE1": "RA---TAN-FK5",
+            "CTYPE2": "DEC--TAN-FK5",
         }
         result = extract_wcs_for_avm(header, 512, 512, 512, 512)
         assert result["coordinate_frame"] == "FK5"
@@ -258,10 +309,29 @@ class TestExtractWcsForAvm:
             "CD2_1": 0.0,
             "CD2_2": 3e-5,
             "CTYPE1": "RA---TAN",
+            "CTYPE2": "DEC--TAN",
         }
         result = extract_wcs_for_avm(header, 512, 512, 512, 512)
         assert result["scale_x"] == pytest.approx(-3e-5, abs=1e-12)
         assert result["scale_y"] == pytest.approx(3e-5, abs=1e-12)
+
+    def test_half_specified_celestial_axes_rejected(self):
+        """CTYPE1 without CTYPE2 is not a celestial WCS.
+
+        The old hand-rolled parse happily produced coordinates from it. wcslib
+        rejects the pair as unmatched, and returning nothing beats returning a
+        fabricated position.
+        """
+        header = {
+            "CRPIX1": 256.0,
+            "CRPIX2": 256.0,
+            "CRVAL1": 100.0,
+            "CRVAL2": -20.0,
+            "CD1_1": -3e-5,
+            "CD2_2": 3e-5,
+            "CTYPE1": "RA---TAN",
+        }
+        assert extract_wcs_for_avm(header, 512, 512, 512, 512) == {}
 
 
 class TestParseAvmMetadataJson:

--- a/processing-engine/tests/test_science_wcs.py
+++ b/processing-engine/tests/test_science_wcs.py
@@ -1,0 +1,169 @@
+"""Tests for the astropy-backed WCS helpers in app.science.wcs."""
+
+import numpy as np
+
+from app.science.wcs import celestial_wcs, wcs_params_from_header
+
+
+# A real JWST _i2d header shape: PC matrix + CDELT, no CD keywords.
+# Values lifted from jw01192-o010_t002_miri_f560w_i2d.fits (~107 deg rotation).
+JWST_I2D_HEADER = {
+    "CTYPE1": "RA---TAN",
+    "CTYPE2": "DEC--TAN",
+    "CRPIX1": 518.8269680140714,
+    "CRPIX2": 590.6839111081091,
+    "CRVAL1": 85.21620289475666,
+    "CRVAL2": -2.491669730412056,
+    "CDELT1": 3.08077556750194e-05,
+    "CDELT2": 3.08077556750194e-05,
+    "PC1_1": -0.2951182660246448,
+    "PC1_2": 0.9554607313011911,
+    "PC2_1": 0.9554607313011911,
+    "PC2_2": 0.2951182660246448,
+}
+
+# The equivalent CD-matrix spelling of the same pointing.
+CD_HEADER = {
+    "CTYPE1": "RA---TAN",
+    "CTYPE2": "DEC--TAN",
+    "CRPIX1": 512.0,
+    "CRPIX2": 512.0,
+    "CRVAL1": 180.5,
+    "CRVAL2": -45.2,
+    "CD1_1": -1e-5,
+    "CD1_2": 0.0,
+    "CD2_1": 0.0,
+    "CD2_2": 1e-5,
+}
+
+
+class TestCelestialWcs:
+    def test_returns_wcs_for_celestial_header(self):
+        w = celestial_wcs(JWST_I2D_HEADER)
+        assert w is not None
+        assert w.naxis == 2
+        assert w.has_celestial
+
+    def test_returns_none_without_celestial_keywords(self):
+        assert celestial_wcs({"NAXIS": 2, "BUNIT": "MJy/sr"}) is None
+
+    def test_returns_none_for_none_header(self):
+        assert celestial_wcs(None) is None
+
+    def test_reduces_a_cube_header_to_its_celestial_axes(self):
+        header = dict(JWST_I2D_HEADER)
+        header.update(
+            {
+                "WCSAXES": 3,
+                "CTYPE3": "WAVE",
+                "CRPIX3": 1.0,
+                "CRVAL3": 5.0,
+                "CDELT3": 0.01,
+            }
+        )
+        w = celestial_wcs(header)
+        assert w is not None
+        assert w.naxis == 2
+
+
+class TestWcsParamsFromHeader:
+    def test_pc_matrix_rotation_survives(self):
+        """The regression this whole change exists for.
+
+        The hand-rolled parse read CD only, fell back to CDELT, and produced a
+        diagonal (unrotated) matrix for every JWST _i2d product.
+        """
+        params = wcs_params_from_header(JWST_I2D_HEADER)
+        assert params is not None
+
+        expected = celestial_wcs(JWST_I2D_HEADER).pixel_scale_matrix
+        assert np.isclose(params["cd1_1"], expected[0][0])
+        assert np.isclose(params["cd1_2"], expected[0][1])
+        assert np.isclose(params["cd2_1"], expected[1][0])
+        assert np.isclose(params["cd2_2"], expected[1][1])
+
+        # Off-diagonal terms carry the rotation — the old code zeroed them.
+        assert abs(params["cd1_2"]) > 1e-6
+        assert abs(params["cd2_1"]) > 1e-6
+        # And axis 1 is sky-flipped, which CDELT1 alone did not express.
+        assert params["cd1_1"] < 0
+
+    def test_reference_point_is_passed_through(self):
+        params = wcs_params_from_header(JWST_I2D_HEADER)
+        assert np.isclose(params["crpix1"], JWST_I2D_HEADER["CRPIX1"])
+        assert np.isclose(params["crpix2"], JWST_I2D_HEADER["CRPIX2"])
+        assert np.isclose(params["crval1"], JWST_I2D_HEADER["CRVAL1"])
+        assert np.isclose(params["crval2"], JWST_I2D_HEADER["CRVAL2"])
+        assert params["ctype1"] == "RA---TAN"
+        assert params["ctype2"] == "DEC--TAN"
+
+    def test_cdelt_is_the_on_sky_pixel_scale(self):
+        params = wcs_params_from_header(JWST_I2D_HEADER)
+        # Magnitudes, so a rotated frame still reports its true scale.
+        assert np.isclose(params["cdelt1"], 3.08077556750194e-05)
+        assert np.isclose(params["cdelt2"], 3.08077556750194e-05)
+
+    def test_cd_matrix_header_is_unchanged_by_astropy(self):
+        params = wcs_params_from_header(CD_HEADER)
+        assert np.isclose(params["cd1_1"], -1e-5)
+        assert np.isclose(params["cd2_2"], 1e-5)
+        assert np.isclose(params["cd1_2"], 0.0)
+        assert np.isclose(params["cd2_1"], 0.0)
+
+    def test_cdelt_only_header_is_supported(self):
+        params = wcs_params_from_header(
+            {
+                "CTYPE1": "RA---TAN",
+                "CTYPE2": "DEC--TAN",
+                "CRPIX1": 50.0,
+                "CRPIX2": 50.0,
+                "CRVAL1": 10.0,
+                "CRVAL2": 20.0,
+                "CDELT1": -1e-4,
+                "CDELT2": 1e-4,
+            }
+        )
+        assert np.isclose(params["cd1_1"], -1e-4)
+        assert np.isclose(params["cd2_2"], 1e-4)
+
+    def test_ra_zero_at_crpix_zero_still_returns_params(self):
+        """Regression for #1235 — a valid pointing near RA=0 is not 'no WCS'."""
+        params = wcs_params_from_header(
+            {
+                "CTYPE1": "RA---TAN",
+                "CTYPE2": "DEC--TAN",
+                "CRPIX1": 0.0,
+                "CRPIX2": 0.0,
+                "CRVAL1": 0.0,
+                "CRVAL2": 0.0,
+                "CDELT1": -1e-4,
+                "CDELT2": 1e-4,
+            }
+        )
+        assert params is not None
+        assert params["crval1"] == 0.0
+        assert params["crpix1"] == 0.0
+
+    def test_header_without_wcs_returns_none(self):
+        assert wcs_params_from_header({"NAXIS": 2, "BUNIT": "MJy/sr"}) is None
+
+    def test_none_header_returns_none(self):
+        assert wcs_params_from_header(None) is None
+
+    def test_all_values_are_json_safe_primitives(self):
+        params = wcs_params_from_header(JWST_I2D_HEADER)
+        for key in (
+            "crpix1",
+            "crpix2",
+            "crval1",
+            "crval2",
+            "cdelt1",
+            "cdelt2",
+            "cd1_1",
+            "cd1_2",
+            "cd2_1",
+            "cd2_2",
+        ):
+            assert type(params[key]) is float, key
+        assert type(params["ctype1"]) is str
+        assert type(params["ctype2"]) is str


### PR DESCRIPTION
## Summary

Item **S3** of the Simplification & Science Plan: replace the hand-rolled WCS parse in `render/routes.py` with `astropy.wcs.WCS`.

This was filed as a cleanup. It turned out to be a live correctness bug affecting every JWST image in the library.

The old parse read the `CD` matrix and `CDELT`, but never `PC_i_j`. Real JWST `_i2d` products carry `PC` + `CDELT` and **no `CD` keywords at all**, so the parse fell through to `CDELT` and emitted an unrotated matrix with the wrong sign on axis 1.

Measured on `jw01192-o010_t002_miri_f560w_i2d.fits` (~107° rotation) through the actual `/pixeldata` endpoint:

|         | before (main) | after (this branch) |
|---------|--------|-------|
| `cd1_1` | `3.0808e-05`  | `-9.0919e-06` |
| `cd1_2` | `0`           | `2.9436e-05`  |
| `cd2_1` | `0`           | `2.9436e-05`  |
| `cd2_2` | `3.0808e-05`  | `9.0919e-06`  |

Feeding both through the frontend's own TAN inverse and comparing against astropy:

| pixel | error before | error after |
|-------|--------|-------|
| 1,1 | 14.8″ | 0.000″ |
| 260,300 | 7.9″ | 0.000″ |
| 520,591 | 0.2″ | 0.000″ |
| 1040,1182 | 15.2″ | 0.000″ |

Small near the reference pixel, tens of arcseconds at the corners, and pointing the wrong way.

`processing/avm.py:extract_wcs_for_avm` had the identical defect from the same parse: `rotation = atan2(-cd2_1, cd2_2)` with a `cd2_1` that always fell back to `0`, so every AVM-embedded export claimed north-up. Verified live — the embedded XMP went from `Spatial.Rotation 0` to `-70.66`. Fixed here rather than left sitting beside a correct helper.

## Changes Made

- **New `processing-engine/app/science/wcs.py`** — `celestial_wcs(header)` and `wcs_params_from_header(header)`. astropy resolves `CD` / `PC`+`CDELT` / `CDELT`-only into one matrix, along with the precedence rules and alternate-axis conventions, so the parse happens once and both callers read the result. `app/science/` is the package S2a's `ScienceImage` loader will grow into.
- **`render/routes.py`** — 30 lines of keyword marshalling replaced with one call.
- **`processing/avm.py`** — scale from `proj_plane_pixel_scales`, sky handedness from the matrix determinant, rotation from the resolved matrix using the existing convention.
- **`JwstDataTypes.ts`** — comment-only. Documents that the matrix is astropy-resolved and that `cdelt` is now a magnitude.
- **Tests** — new `test_science_wcs.py` (13 cases), plus PC-rotation cases in `test_avm_embedding.py`.

The response payload keeps its exact shape, so `coordinateUtils.pixelToWCS`, `wcsGridUtils`, and the `WCSParams` type are unchanged. The client keeps doing the TAN inverse — hover readout has to be interactive — it just finally gets correct inputs.

### Behaviour change worth flagging

Three AVM test fixtures set `CTYPE1` without `CTYPE2`. That is not a valid celestial WCS and wcslib rejects the pair as unmatched. The old hand-rolled parse produced coordinates from it anyway. Fixtures corrected to include `CTYPE2`, and the stricter behaviour is now pinned by a new test (`test_half_specified_celestial_axes_rejected`) rather than left implicit. No real FITS file is affected — a celestial WCS always carries both.

The `#1235` case still works: a genuine pointing near RA=0 with `CRPIX1=0` has a `CTYPE`, so astropy finds it. Covered by `test_ra_zero_at_crpix_zero_still_returns_params`.

`cdelt1`/`cdelt2` are now on-sky magnitudes rather than signed keyword values. Every frontend consumer uses them only inside a fallback branch guarded on the whole CD matrix being zero — unreachable now, since a non-null payload implies a valid transform — and `getPixelScaleArcsec` already wraps them in `Math.abs`.

## Test Plan

- [x] `test_science_wcs.py` — 13 cases: PC rotation preserved, CD headers unchanged, CDELT-only supported, cube header reduced to celestial axes, `#1235` regression, `None`/no-WCS handling, JSON-safe primitives.
- [x] `test_avm_embedding.py` — 28 cases pass, including two new PC-matrix rotation cases and the half-specified-axes rejection.
- [x] Full processing-engine suite: **1796 passed**. The 155 errors are all `test_jobs_store.py`, which needs MongoDB; confirmed identical on unmodified image code.
- [x] Frontend: **1483 tests / 123 files pass**, tsc clean, ESLint clean (pre-commit hook).
- [x] Ruff lint + format clean.
- [x] **Live check against a real JWST file** — engine run with this branch's code, `/pixeldata` returns the rotated matrix above; the frontend's own TAN inverse then agrees with astropy to 0.000″ at all four corners. Same endpoint on stock `main` returns the unrotated matrix.
- [x] **Live AVM check** — `/preview?embed_avm=true` returns 200 and the embedded XMP now carries `Spatial.Rotation -70.66` and a negative `Spatial.Scale[0]`.

To reproduce the live check:

```bash
docker run -d --name s3check -p 8099:8000 -e PYTHONPATH=/app \
  -v "$PWD/processing-engine/app:/app/app:ro" \
  -v "$PWD/processing-engine/main.py:/app/main.py:ro" \
  -v "$PWD/data:/app/data" -w /app docker-processing-engine \
  uvicorn main:app --host 0.0.0.0 --port 8000

curl -s "http://localhost:8099/pixeldata/test?file_path=mast/jw01192-o010_t002_miri_f560w/jw01192-o010_t002_miri_f560w_i2d.fits&max_size=256" | jq .wcs
# expect cd1_2 and cd2_1 to be ~2.94e-05, not 0

docker rm -f s3check
```

Then in the app: open that observation in the viewer, hover near a corner, and confirm the RA/Dec readout matches the same pixel in DS9 or Aladin.

## Out of Scope

- **SIP distortion** — `WCS(header)` reads it, but a 6-number affine cannot carry it. JWST `_i2d` products have no SIP; `_cal` products may, where the residual is sub-pixel.
- **Non-TAN projections** — the client inverse is TAN-only. `CTYPE` is in the payload; nothing reads it yet.
- **Anisotropic preview resize** — when width and height are scaled by different ratios the AVM rotation is skewed, since AVM cannot express shear. Pre-existing, and the same convention as before.
- The other 10 "first HDU with data" sites — that is S2a.

## Documentation Checklist

- [x] Plan file added: `docs/plans/features/quick/s3-astropy-wcs.md`
- [x] Docstrings on both new public helpers explain the three FITS spellings and why the parse is centralised
- [x] `WCSParams` type comments updated for the new `cdelt` semantics
- [ ] No endpoint, model, or controller added or renamed — no `docs/` API updates needed

## Tech Debt Impact

- [x] **Reduces** — removes one of the two hand-rolled WCS parses called out in the Simplification & Science Plan; both call sites now share one astropy-backed helper
- [x] **Reduces** — creates `app/science/`, the landing zone for S2a's `ScienceImage` loader, so that work does not have to invent a home
- [ ] Adds tech debt
- [ ] Neutral

## Risk & Rollback

**Risk: low.** Server-side only; the response contract is byte-compatible and no frontend logic changed. The new code path is narrower than the old one — a malformed header now yields `None` (no readout) where it previously yielded fabricated coordinates, and `celestial_wcs` catches broadly so a bad header cannot 500 the endpoint, which the previous narrow `except (ValueError, KeyError)` could not guarantee.

The one behavioural narrowing is the half-specified `CTYPE` case described above, which cannot occur in a valid FITS file.

**Rollback:** revert the two commits. No migrations, no config, no persisted state — the WCS payload is computed per request.

Closes #1826
