### PR TITLE
fix: close three WCS gaps left open by S3

### DIFF
--- a/frontend/jwst-frontend/src/utils/coordinateUtils.test.ts
+++ b/frontend/jwst-frontend/src/utils/coordinateUtils.test.ts
@@ -173,6 +173,28 @@ describe('pixelToWCS', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(pixelToWCS(10, 10, null as any)).toBeNull();
   });
+
+  it('declines non-TAN projections rather than reporting a wrong position', () => {
+    // The inverse here is gnomonic (TAN) only. Applying it to SIN or ARC
+    // would return a plausible-looking but wrong sky position, so it must
+    // decline — matching the guard wcsGridUtils.skyToPixel already has.
+    const sinWCS: WCSParams = { ...testWCS, ctype1: 'RA---SIN', ctype2: 'DEC--SIN' };
+    expect(pixelToWCS(60, 60, sinWCS)).toBeNull();
+
+    const arcWCS: WCSParams = { ...testWCS, ctype1: 'RA---ARC', ctype2: 'DEC--ARC' };
+    expect(pixelToWCS(60, 60, arcWCS)).toBeNull();
+  });
+
+  it('still accepts TAN variants and headers with no ctype', () => {
+    // SIP-flavoured TAN is still TAN for the affine part.
+    const sipWCS: WCSParams = { ...testWCS, ctype1: 'RA---TAN-SIP', ctype2: 'DEC--TAN-SIP' };
+    expect(pixelToWCS(60, 60, sipWCS)).not.toBeNull();
+
+    // An empty ctype is treated as "unspecified", not "wrong projection" —
+    // TAN is the overwhelmingly common default and the old behaviour.
+    const noCtype: WCSParams = { ...testWCS, ctype1: '', ctype2: '' };
+    expect(pixelToWCS(60, 60, noCtype)).not.toBeNull();
+  });
 });
 
 describe('formatRA', () => {

--- a/frontend/jwst-frontend/src/utils/coordinateUtils.ts
+++ b/frontend/jwst-frontend/src/utils/coordinateUtils.ts
@@ -80,6 +80,12 @@ export function pixelToWCS(
     return null;
   }
 
+  // The inverse below is TAN (gnomonic) only. Reporting a position for SIN,
+  // ARC or any other projection would be confidently wrong, so decline it —
+  // same guard wcsGridUtils.skyToPixel already applies.
+  if (wcs.ctype1 && !wcs.ctype1.includes('TAN')) return null;
+  if (wcs.ctype2 && !wcs.ctype2.includes('TAN')) return null;
+
   // Convert to 0-indexed relative to reference pixel
   const dx = x - wcs.crpix1;
   const dy = y - wcs.crpix2;

--- a/processing-engine/app/composite/routes.py
+++ b/processing-engine/app/composite/routes.py
@@ -317,8 +317,12 @@ def downscale_for_composite(
         header["CD2_1"] *= scale
         header["CD2_2"] *= scale
     if "CRPIX1" in header:
-        header["CRPIX1"] *= factor
-        header["CRPIX2"] *= factor
+        # CRPIX is 1-based, so the reference pixel has to be moved into
+        # 0-based space before scaling and back afterwards. Plain
+        # multiplication is off by (1 - factor) pixels — half a pixel at 2x.
+        # Matches the convention in mosaic/routes.py.
+        header["CRPIX1"] = (header["CRPIX1"] - 1) * factor + 1
+        header["CRPIX2"] = (header["CRPIX2"] - 1) * factor + 1
 
     new_wcs = WCS(header, naxis=2).celestial
     return downscaled, new_wcs

--- a/processing-engine/app/render/routes.py
+++ b/processing-engine/app/render/routes.py
@@ -29,7 +29,7 @@ from app.processing.enhancement import (
 )
 from app.processing.filters import reduce_noise
 from app.processing.statistics import compute_histogram, compute_percentiles
-from app.science.wcs import wcs_params_from_header
+from app.science.wcs import axis3_scale_params, wcs_params_from_header
 from app.storage.helpers import resolve_fits_path, validate_fits_array_size
 
 
@@ -826,9 +826,6 @@ def get_cube_info(data_id: str, file_path: str):
         if header is not None:
             # Try to get CTYPE3 to determine what the third axis represents
             ctype3 = str(header.get("CTYPE3", "")).strip()
-            crval3 = header.get("CRVAL3")
-            cdelt3 = header.get("CDELT3") or header.get("CD3_3")
-            crpix3 = header.get("CRPIX3", 1.0)
             cunit3 = str(header.get("CUNIT3", "")).strip()
 
             # Determine axis label based on CTYPE3
@@ -861,12 +858,13 @@ def get_cube_info(data_id: str, file_path: str):
                 else:
                     slice_unit = cunit3
 
-            # Build axis3 info if we have the basic WCS parameters
-            if crval3 is not None and cdelt3 is not None:
+            # Build axis3 info if the header declares a usable third axis.
+            # astropy resolves CD3_3 / PC3_3+CDELT3 / CDELT3 into one step, so
+            # a rotated or PC-spelled cube reports the right slice spacing.
+            axis3_scale = axis3_scale_params(header)
+            if axis3_scale is not None:
                 axis3_info = {
-                    "crval3": float(crval3),
-                    "cdelt3": float(cdelt3),
-                    "crpix3": float(crpix3) if crpix3 is not None else 1.0,
+                    **axis3_scale,
                     "cunit3": cunit3,
                     "ctype3": ctype3,
                 }

--- a/processing-engine/app/science/wcs.py
+++ b/processing-engine/app/science/wcs.py
@@ -18,6 +18,22 @@ from astropy.wcs.utils import proj_plane_pixel_scales
 logger = logging.getLogger(__name__)
 
 
+def _parse(header) -> WCS | None:
+    """Parse a full (all-axes) WCS from a header, or None if it cannot be read."""
+    if header is None:
+        return None
+
+    try:
+        with warnings.catch_warnings():
+            # Headers routinely need datfix/obsfix nudges; astropy applies them
+            # and says so. Nothing actionable for a coordinate readout.
+            warnings.simplefilter("ignore", FITSFixedWarning)
+            return WCS(header)
+    except Exception as e:  # astropy raises a wide range on malformed headers
+        logger.warning(f"Could not parse WCS from header: {e}")
+        return None
+
+
 def celestial_wcs(header) -> WCS | None:
     """Parse the celestial (RA/Dec) WCS out of a FITS header.
 
@@ -28,22 +44,47 @@ def celestial_wcs(header) -> WCS | None:
     Returns:
         A 2-axis `WCS`, or None when the header carries no celestial solution.
     """
+    wcs = _parse(header)
+    if wcs is None or not wcs.has_celestial:
+        return None
+    return wcs.celestial
+
+
+def axis3_scale_params(header) -> dict | None:
+    """Reference point and step for a data cube's third axis.
+
+    The third axis is usually spectral (wavelength, frequency, velocity) but
+    may be time. Like the celestial axes, its step can be spelled `CD3_3`,
+    `PC3_3` x `CDELT3`, or `CDELT3` alone; astropy resolves all three, so the
+    step is read off the pixel scale matrix rather than guessed from keywords.
+
+    Args:
+        header: FITS header, or any dict-like of FITS keywords.
+
+    Returns:
+        Dict with `crval3`, `cdelt3` and `crpix3`, or None when the header
+        declares no usable third axis.
+    """
     if header is None:
         return None
 
-    try:
-        with warnings.catch_warnings():
-            # Headers routinely need datfix/obsfix nudges; astropy applies them
-            # and says so. Nothing actionable for a coordinate readout.
-            warnings.simplefilter("ignore", FITSFixedWarning)
-            wcs = WCS(header)
-
-        if not wcs.has_celestial:
-            return None
-        return wcs.celestial
-    except Exception as e:  # astropy raises a wide range on malformed headers
-        logger.warning(f"Could not parse WCS from header: {e}")
+    # astropy defaults a missing CRVAL to 0 and a missing step to 1, which would
+    # turn "no third axis" into a plausible-looking linear one. Require the
+    # header to actually declare the axis before trusting the parse.
+    has_reference = "CRVAL3" in header
+    has_step = any(key in header for key in ("CDELT3", "CD3_3", "PC3_3"))
+    if not (has_reference and has_step):
         return None
+
+    wcs = _parse(header)
+    if wcs is None or wcs.naxis < 3:
+        return None
+
+    return {
+        "crval3": float(wcs.wcs.crval[2]),
+        "cdelt3": float(wcs.pixel_scale_matrix[2][2]),
+        "crpix3": float(wcs.wcs.crpix[2]),
+    }
 
 
 def wcs_params_from_header(header) -> dict | None:

--- a/processing-engine/tests/test_composite_downscale.py
+++ b/processing-engine/tests/test_composite_downscale.py
@@ -638,3 +638,40 @@ class TestCacheHitVerdict:
         assert verdict.output_shape == (4000, 4000)
         assert verdict.original_shape == (10000, 10000)
         assert "force-downscaled" in verdict.detail.lower()
+
+
+class TestDownscaleWcsReferencePixel:
+    """CRPIX is 1-based, so scaling it needs the -1/+1 round trip."""
+
+    def test_image_corners_keep_their_sky_position(self):
+        """A given patch of sky must stay where it was.
+
+        Downscaling maps 0-based pixel p to p * factor, so the same sky
+        position has to come back out. Plain `CRPIX *= factor` shifts the
+        whole grid by (1 - factor) pixels — half a pixel at 2x — which
+        silently biases any position measured off a composite.
+        """
+        wcs = _make_wcs(naxis1=1000, naxis2=1000)
+        data = np.zeros((1000, 1000), dtype=np.float32)
+
+        # Budget of 250k pixels on a 1M-pixel image -> factor 0.5
+        _, new_wcs = downscale_for_composite(data, wcs, max_pixels=250_000)
+        factor = 0.5
+
+        for old_px, old_py in [(0.0, 0.0), (999.0, 999.0), (250.0, 700.0)]:
+            old_sky = wcs.all_pix2world([[old_px, old_py]], 0)[0]
+            new_sky = new_wcs.all_pix2world([[old_px * factor, old_py * factor]], 0)[0]
+            assert new_sky[0] == pytest.approx(old_sky[0], abs=1e-9), f"RA at {old_px},{old_py}"
+            assert new_sky[1] == pytest.approx(old_sky[1], abs=1e-9), f"Dec at {old_px},{old_py}"
+
+    def test_crpix_uses_the_one_based_transform(self):
+        wcs = _make_wcs(naxis1=1000, naxis2=1000)
+        data = np.zeros((1000, 1000), dtype=np.float32)
+
+        _, new_wcs = downscale_for_composite(data, wcs, max_pixels=250_000)
+
+        factor = 0.5
+        expected = (wcs.wcs.crpix[0] - 1) * factor + 1
+        assert new_wcs.wcs.crpix[0] == pytest.approx(expected, abs=1e-9)
+        # The naive form would land half a pixel away.
+        assert new_wcs.wcs.crpix[0] != pytest.approx(wcs.wcs.crpix[0] * factor, abs=1e-9)

--- a/processing-engine/tests/test_science_wcs.py
+++ b/processing-engine/tests/test_science_wcs.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from app.science.wcs import celestial_wcs, wcs_params_from_header
+from app.science.wcs import axis3_scale_params, celestial_wcs, wcs_params_from_header
 
 
 # A real JWST _i2d header shape: PC matrix + CDELT, no CD keywords.
@@ -167,3 +167,77 @@ class TestWcsParamsFromHeader:
             assert type(params[key]) is float, key
         assert type(params["ctype1"]) is str
         assert type(params["ctype2"]) is str
+
+
+def _cube_header(**overrides) -> dict:
+    """A 3D cube header: celestial pair plus a spectral third axis."""
+    header = {
+        "WCSAXES": 3,
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CTYPE3": "WAVE",
+        "CRPIX1": 50.0,
+        "CRPIX2": 50.0,
+        "CRPIX3": 1.0,
+        "CRVAL1": 10.0,
+        "CRVAL2": 20.0,
+        "CRVAL3": 5.0e-06,
+        "CDELT1": -1e-4,
+        "CDELT2": 1e-4,
+        "CDELT3": 2.5e-09,
+        "CUNIT3": "m",
+    }
+    header.update(overrides)
+    return header
+
+
+class TestAxis3ScaleParams:
+    def test_reads_a_plain_cdelt_cube(self):
+        params = axis3_scale_params(_cube_header())
+        assert np.isclose(params["crval3"], 5.0e-06)
+        assert np.isclose(params["cdelt3"], 2.5e-09)
+        assert np.isclose(params["crpix3"], 1.0)
+
+    def test_pc3_3_scales_the_step(self):
+        """PC3_3 x CDELT3 is the real step — reading CDELT3 alone misses it."""
+        params = axis3_scale_params(_cube_header(PC3_3=2.0))
+        assert np.isclose(params["cdelt3"], 5.0e-09)
+
+    def test_cd3_3_spelling_is_supported(self):
+        header = _cube_header()
+        del header["CDELT3"]
+        header["CD3_3"] = 2.5e-09
+        # A CD-spelled cube uses CD for every axis, not a CDELT/CD mixture.
+        header["CD1_1"] = header.pop("CDELT1")
+        header["CD2_2"] = header.pop("CDELT2")
+        params = axis3_scale_params(header)
+        assert np.isclose(params["cdelt3"], 2.5e-09)
+
+    def test_degenerate_zero_step_returns_none(self):
+        """A zero step makes the transform singular; wcslib rejects it.
+
+        Every slice would share one coordinate, so declining to report an
+        axis is right. Matches the old behaviour, now for a stated reason.
+        """
+        assert axis3_scale_params(_cube_header(CDELT3=0.0)) is None
+
+    def test_header_without_third_axis_returns_none(self):
+        assert axis3_scale_params(JWST_I2D_HEADER) is None
+
+    def test_reference_without_step_returns_none(self):
+        header = _cube_header()
+        del header["CDELT3"]
+        assert axis3_scale_params(header) is None
+
+    def test_step_without_reference_returns_none(self):
+        header = _cube_header()
+        del header["CRVAL3"]
+        assert axis3_scale_params(header) is None
+
+    def test_none_header_returns_none(self):
+        assert axis3_scale_params(None) is None
+
+    def test_values_are_json_safe_primitives(self):
+        params = axis3_scale_params(_cube_header())
+        for key in ("crval3", "cdelt3", "crpix3"):
+            assert type(params[key]) is float, key


### PR DESCRIPTION
## Summary

Closes the three WCS gaps found while auditing coverage after #1826 / PR #1827 (S3).

All three are the same failure mode as that bug: **code that is correct for the headers it was written against, and quietly wrong for a variant nobody tested.** None affect current JWST imaging data — all three are latent. #1826 is the evidence that latent WCS bugs here do not announce themselves; it shipped a 15″ error in a hover tooltip and nobody noticed for months.

## Changes Made

| Area | File | Change |
|---|---|---|
| Cube spectral axis | `app/science/wcs.py` | New `axis3_scale_params`; extracted shared `_parse` |
| Cube spectral axis | `app/render/routes.py` | `/cubeinfo` reads the step via astropy instead of `CDELT3 or CD3_3` |
| Projection guard | `frontend/.../utils/coordinateUtils.ts` | `pixelToWCS` declines non-TAN instead of returning a wrong position |
| Half-pixel shift | `app/composite/routes.py` | `CRPIX` scaled with the 1-based transform, matching mosaic |
| Tests | `tests/test_science_wcs.py`, `tests/test_composite_downscale.py`, `coordinateUtils.test.ts` | 13 new cases |

- Added `axis3_scale_params(header)` so the cube slice step resolves `CD3_3`, `PC3_3`×`CDELT3` and `CDELT3`-only uniformly.
- Factored the shared FITS-warning-suppressing parse into `_parse`, used by both `celestial_wcs` and the new helper.
- Added the missing TAN projection guard to `pixelToWCS`, matching `wcsGridUtils.skyToPixel`.
- Fixed the 1-based `CRPIX` transform in composite downscale to match `mosaic/routes.py`.

### 1. Cube third axis was still hand-parsed

S3's `celestial_wcs` deliberately reduces to the two sky axes, so the third axis — wavelength, frequency, velocity or time on a data cube — was never covered:

```python
cdelt3 = header.get("CDELT3") or header.get("CD3_3")   # never PC3_3
```

A cube spelled `PC3_3` × `CDELT3` with `PC3_3 != 1` reported its slice spacing off by that factor, which drives the wavelength labels on the cube slice control.

New `axis3_scale_params(header)` reads the step off `pixel_scale_matrix[2][2]`, so `CD3_3`, `PC3_3`×`CDELT3` and `CDELT3`-only all resolve. `celestial_wcs` and the new helper now share one `_parse` so there is a single place that swallows FITS warnings.

A degenerate zero step is still declined, but now for a stated reason — wcslib rejects it as a singular transform — rather than by accidentally falling through a falsy `or`. Same outcome as before, pinned by a test.

### 2. `pixelToWCS` applied TAN math to any projection

`wcsGridUtils.skyToPixel` correctly declines non-TAN input. `coordinateUtils.pixelToWCS` had no such guard and applied the gnomonic inverse to whatever arrived — so for a SIN or ARC header the grid overlay correctly drew nothing while the hover readout printed a confidently wrong position. Two implementations of one concept disagreeing about their own preconditions.

Added the same guard, with the same "empty ctype means unspecified, not wrong" allowance, so existing headers without a `CTYPE` behave exactly as before.

### 3. Composite downscale shifted the WCS by half a pixel

```python
header["CRPIX1"] *= factor          # composite — off by (1 - factor)
new_wcs.wcs.crpix = (crpix - 1) * scale + 1   # mosaic — correct
```

`CRPIX` is 1-based. Composite now uses the mosaic convention. Invisible in a rendered image; wrong for anything measured off a composite.

## Test Plan

- [x] `test_science_wcs.py` — 9 new cases for `axis3_scale_params`: plain CDELT cube, `PC3_3` scaling the step, `CD3_3` spelling, degenerate zero step, missing-axis / reference-without-step / step-without-reference, `None` header, JSON-safe primitives.
- [x] `test_composite_downscale.py` — 2 new cases. **Verified red before the fix** (`250.0` vs expected `250.5` — exactly the predicted half pixel), green after. The first version of one test was tautological (it evaluated the new WCS at its own reference pixel and passed even unfixed); rewritten to check that three real image positions keep their sky coordinates.
- [x] `coordinateUtils.test.ts` — 2 new cases: SIN and ARC decline; `TAN-SIP` and empty-ctype still accepted.
- [x] Frontend suite: **1485 tests / 123 files pass**, tsc + ESLint clean (pre-commit).
- [x] Ruff lint + format clean.
- [x] **Regression isolation** — ran the identical pre-existing test population against `origin/main` app code and this branch's app code, same mounts, same filters. **1783 passed on both**, with the same 130 pre-existing Mongo-dependent errors. The 130 are collection/setup errors in `test_jobs_routes.py`, reproducible on unmodified code; they are not introduced here.

To reproduce the isolation check:

```bash
# extract main's app code
git archive origin/main -o /tmp/mainapp.tar -- processing-engine/app
mkdir -p /tmp/mainapp && tar -xf /tmp/mainapp.tar -C /tmp/mainapp

FILTERS="--ignore=tests/test_jobs_store.py --ignore=tests/test_science_wcs.py -k 'not ReferencePixel'"

# baseline, then this branch — expect identical counts
docker run --rm -v /tmp/mainapp/processing-engine/app:/app/app:ro \
  -v "$PWD/processing-engine/tests:/app/tests:ro" -w /app \
  docker-processing-engine python -m pytest -q --no-cov $FILTERS
```

## Documentation Checklist

- [x] Docstrings on `axis3_scale_params` and `_parse` explain the three FITS spellings and why the presence gate exists
- [x] Inline comments at each fix state the failure mode, not just the change
- [ ] No endpoint, model, or controller added or renamed — no `docs/` API updates needed

## Tech Debt Impact

- [x] **Reduces** — removes the last hand-rolled WCS keyword parse in the engine; all WCS numerics now go through `app/science/wcs.py`
- [x] **Reduces** — composite and mosaic downscale paths now agree on the pixel convention instead of silently differing
- [x] **Reduces** — the two client-side projection implementations now agree on their preconditions
- [ ] Adds tech debt
- [ ] Neutral

## Risk & Rollback

**Risk: low.** Three small, independent changes, each covered by a test that was verified to fail without it.

The one behavioural narrowing is intentional: `pixelToWCS` now returns `null` for non-TAN projections instead of a wrong number. No JWST imaging product is affected — they are all TAN — and the grid overlay already behaved this way, so this makes the two agree rather than introducing new behaviour.

`axis3_scale_params` keeps a small keyword-presence gate (`CRVAL3` plus one of `CDELT3`/`CD3_3`/`PC3_3`) before trusting the parse, because astropy defaults a missing reference to 0 and a missing step to 1 — which would turn "no third axis" into a plausible-looking linear one. The gate is presence-only; none of the arithmetic reads keywords.

**Rollback:** revert the single commit. No migrations, no config, no persisted state.

Closes #1839
