### PR TITLE
chore: delete unused refreshAuth from AuthContext (Track A, 1/11)

### DIFF
--- a/frontend/jwst-frontend/src/context/AuthContext.tsx
+++ b/frontend/jwst-frontend/src/context/AuthContext.tsx
@@ -175,44 +175,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   /**
-   * Refresh the access token.
-   * Reads refresh token from localStorage to avoid stale closure issues.
-   * Retries once after 1s, then immediately deauths on failure.
-   */
-  const refreshAuth = useCallback(async (): Promise<boolean> => {
-    const currentRefreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
-    if (!currentRefreshToken) {
-      clearState();
-      return false;
-    }
-
-    const sessionId = sessionIdRef.current;
-    const doRefresh = () => authService.refreshToken({ refreshToken: currentRefreshToken });
-
-    try {
-      let response: TokenResponse;
-      try {
-        response = await doRefresh();
-      } catch {
-        await new Promise((resolve) => {
-          logoutDelayRef.current = setTimeout(resolve, 1000);
-        });
-        logoutDelayRef.current = null;
-        if (sessionIdRef.current !== sessionId) return false;
-        response = await doRefresh();
-      }
-      if (sessionIdRef.current !== sessionId) return false;
-      updateStateFromResponse(response);
-      return true;
-    } catch {
-      if (sessionIdRef.current !== sessionId) return false;
-      clearState();
-      toast.error('Session expired — please log in again.');
-      return false;
-    }
-  }, [updateStateFromResponse, clearState]);
-
-  /**
    * Login with username/password
    */
   const login = useCallback(
@@ -399,7 +361,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
     login,
     register,
     logout,
-    refreshAuth,
   };
 
   return <AuthContext value={value}>{children}</AuthContext>;

--- a/frontend/jwst-frontend/src/types/AuthTypes.ts
+++ b/frontend/jwst-frontend/src/types/AuthTypes.ts
@@ -53,5 +53,4 @@ export interface AuthContextType extends AuthState {
   login: (request: LoginRequest) => Promise<void>;
   register: (request: RegisterRequest) => Promise<void>;
   logout: () => Promise<void>;
-  refreshAuth: () => Promise<boolean>;
 }


### PR DESCRIPTION
## Summary

**Track A, PR 1 of 11** — deletion track. The goal is a smaller codebase, reviewable again. No design decisions; each PR independently revertable.

`refreshAuth` was exported on `AuthContextType` and wired into the provider value, but **nothing ever called it**. Every `useAuth()` consumer destructures `isAuthenticated`, `user`, `login`, `logout` or `register` — none takes `refreshAuth`.

Smallest PR in the track deliberately, to establish the review rhythm.

## Changes Made

| File | Change | Lines |
|---|---|---|
| `src/context/AuthContext.tsx` | Removed the `refreshAuth` `useCallback` (:182-213) and its entry in the provider value (:402) | −39 |
| `src/types/AuthTypes.ts` | Removed `refreshAuth` from the `AuthContextType` interface (:56) | −1 |

- No production behaviour changes — the removed function had zero callers.
- No test changes needed; nothing tested it.

## What is deliberately NOT touched

The three **live** refresh paths stay exactly as they are:

- `AuthContext.tsx` mount effect — re-authenticates a returning user whose access token expired.
- `AuthContext.tsx` 401 callback registered via `setTokenRefresher`.
- `apiClient.ts` `fallbackTokenRefresh` — the startup-window safety net.

Those three duplicate each other and share a race, but consolidating them requires design decisions (storage-key ownership, mutex semantics, how a non-React module updates React state). Tracked separately as #1844 for Track C. This PR is only the genuinely dead part.

## Test Plan

- [x] `grep -rn "refreshAuth" src/ e2e/` → **zero hits** after the change
- [x] `npm run lint` → **0 errors** (70 warnings, all pre-existing and unchanged in count)
- [x] `npm run build` (includes `tsc -b`) → clean. `noUnusedLocals`/`noUnusedParameters` are enabled, so any import or local orphaned by the removal would have failed the build.
- [x] `npx vitest run` → **1485 tests / 123 files pass**
- [x] Manually confirmed `logoutDelayRef`, `sessionIdRef`, `updateStateFromResponse` and `TokenResponse` are all still used by the three live paths — nothing orphaned
- [x] Pre-commit hook (lint + prettier + tsc + full unit suite) passed

## Documentation Checklist

- [x] No endpoint, model, or controller added or renamed — no `docs/` updates needed
- [x] No public API change — `refreshAuth` was never reachable outside the context type
- [ ] N/A — no new code, deletion only

## Tech Debt Impact

- [x] **Reduces** — removes a dead export from the auth surface, one fewer thing to reason about when #1844 consolidates the real refresh paths
- [ ] Adds tech debt
- [ ] Neutral

## Risk & Rollback

**Risk: minimal.** 40 deleted lines with zero callers, in a language with a compiler that verifies exactly that. `tsc` with `noUnusedLocals` is a stronger guarantee here than any test could be.

The only conceivable break would be an external consumer of the context type, which cannot exist — it is app-internal.

**Rollback:** revert the single commit. No migrations, no config, no persisted state.

Part of Track A. Related: #1844 (refresh path consolidation).

---

No linked issue — part of the Track A deletion epic #1847, which the final PR closes.
