### PR TITLE
chore: make the mkdocs preview server opt-in

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -227,7 +227,12 @@ services:
     networks:
       - jwst-network
 
+  # Live-preview server for the mkdocs site. Opt-in: it is not part of the
+  # normal dev loop, and CI publishes docs via `mkdocs build --strict` rather
+  # than this container. Start it only when you want the preview:
+  #   docker compose --profile docs up -d docs      (then http://localhost:8001)
   docs:
+    profiles: ["docs"]
     image: squidfunk/mkdocs-material:9
     container_name: jwst-docs
     restart: unless-stopped

--- a/scripts/generate-session-blog.sh
+++ b/scripts/generate-session-blog.sh
@@ -704,4 +704,8 @@ generate_milestones
 
 echo ""
 echo "Done! Generated $date_count posts."
-echo "View at: http://localhost:8001/blog/"
+if docker ps --format '{{.Names}}' | grep -q '^jwst-docs$'; then
+  echo "View at: http://localhost:8001/blog/"
+else
+  echo "To preview: docker compose --profile docs up -d docs  ->  http://localhost:8001/blog/"
+fi


### PR DESCRIPTION
## Summary

The mkdocs live-preview container was starting on every `docker compose up` and isn't part of the dev loop. CI publishes the site with `mkdocs build --strict`, which doesn't involve this container at all.

Evidence it wasn't being used: it had been sitting **`Exited (127)`** for some time and nobody noticed — I only found it because its stopped container held the `jwst-docs` name and blocked an isolated E2E stack from starting.

Rather than delete the service, this puts it behind a compose profile so the blog workflow can still get a preview on demand.

## Changes Made

| File | Change |
|---|---|
| `docker/docker-compose.yml` | Added `profiles: ["docs"]` to the `docs` service, with a comment showing how to start it |
| `scripts/generate-session-blog.sh` | Preview URL is now conditional — prints the start command when the container isn't running |

- Start the preview when wanted: `docker compose --profile docs up -d docs` → http://localhost:8001
- Follows the convention already in this file — the four seaweedfs services are profile-gated the same way (lines 184–225).

## Why a profile rather than deleting the service

Three scripts reference the docs server, and one of them is part of a workflow that *is* used:

| Consumer | Behaviour after this change |
|---|---|
| `scripts/generate-session-blog.sh:707` | Printed the preview URL unconditionally → would become a dead link. **Updated** to detect the container and otherwise print the start command. |
| `scripts/agent-stack.sh:418` | Only tests whether the container is running to render a status line. Works unchanged. |
| `scripts/agent-env-init.sh:34` | Only computes a port offset from 8001. Works unchanged. |

Nothing in `docker-compose.yml` has a `depends_on` for `docs`, so no service loses a dependency.

## Test Plan

- [x] `docker compose -f docker/docker-compose.yml config --services` → returns `mongodb, backend, processing-engine, frontend, mast-proxy`; **`docs` no longer listed**
- [x] `docker compose -f docker/docker-compose.yml --profile docs config --services` → **`docs` present**
- [x] `bash -n scripts/generate-session-blog.sh` → syntax OK
- [x] Verified no `depends_on: docs` anywhere in the compose files
- [x] Confirmed the two other script consumers only read the port or test for the running container
- [x] Removed the stale `Exited (127)` `jwst-docs` container locally
- [x] Pre-commit hook passed

## Documentation Checklist

- [x] Inline comment in `docker-compose.yml` documents the opt-in command
- [x] `generate-session-blog.sh` now tells the user how to start the preview instead of pointing at a dead URL
- [x] No endpoint, model, or controller touched — no `docs/` content changes
- [x] CI's `mkdocs build --strict` is unaffected; it never used this container

## Tech Debt Impact

- [x] **Reduces** — one less container in the default dev stack, and one less fixed container name to collide with (which is exactly how this surfaced)
- [x] **Neutral on capability** — the preview is still one flag away
- [ ] Adds tech debt

## Risk & Rollback

**Risk: minimal.** A compose profile flag and a conditional echo. Worst case is someone expecting the docs site on 8001 and having to run one command — which the blog script now prints for them.

Not addressed here: **why** the container was exiting 127. That's likely an entrypoint change in `squidfunk/mkdocs-material:9`. Since it's now opt-in and unused, I left it rather than fix something that isn't in the way — worth a look if you ever want the preview back.

**Rollback:** revert the single commit.

---

No linked issue — housekeeping found while running the E2E suite.
